### PR TITLE
ci: lint pull requests with ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+name: lint
+
+# Lint every pull request. ruff config lives in pyproject.toml ([tool.ruff]).
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: ruff check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "0.15.18"   # keep in sync with local dev
+          args: check


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs a lint check on every pull request.

## What
- `.github/workflows/lint.yml` — triggers on `pull_request`, runs `ruff check`
  via the official `astral-sh/ruff-action`, using the existing `[tool.ruff]`
  config in `pyproject.toml`.
- ruff pinned to **0.15.18** to match local dev, so CI and local results agree.
- `permissions: contents: read` only — the job needs nothing more.

## Scope
Lint only. `ruff format` is **not** enforced: the current tree isn't
ruff-formatted (10 files would be reformatted), so adding a format gate now
would fail on pre-existing code. That can be a separate cleanup PR if wanted.

Verified `ruff check .` passes locally on the current tree.