### PR TITLE
style: ruff format the tree + enforce format in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v4.0.0
+      - name: ruff check (lint)
+        uses: astral-sh/ruff-action@v4.0.0
         with:
           version: "0.15.18"   # keep in sync with local dev
           args: check
+      - name: ruff format (style)
+        uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "0.15.18"
+          args: format --check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,9 @@ class FakeClient:
         self._error = error
         self.calls = 0
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def extract_facts(
+        self, *, source_text: str, schema_hint: str = ""
+    ) -> list[ExtractedFact]:
         self.calls += 1
         if self._error is not None:
             raise self._error

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -12,13 +12,19 @@ from verinote.web import create_app  # noqa: E402
 
 def _client(tmp_path) -> TestClient:
     cfg = Config(
-        root=tmp_path, db_path=tmp_path / "kb.sqlite",
-        provider="anthropic", model="m", api_key=None, base_url=None,
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
     )
     app = create_app(cfg)
     client = TestClient(app)
     store = app.state.store
-    client.fact_id = store.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
+    client.fact_id = store.add_fact(
+        "A", "is_a", "B", status="needs_review", confidence=0.9
+    )
     return client
 
 
@@ -47,7 +53,9 @@ def test_toggle_endpoint_swaps_row(tmp_path):
 
 def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
     monkeypatch.setattr(
-        webapp, "get_client", lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)])
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
     )
     c = _client(tmp_path)
     r = c.post(

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -16,10 +16,42 @@ _DEMO_FACTS = [
     # Obviously-fictional placeholder data: it only demonstrates the status
     # lifecycle and the (subject, relation, object) shape. Do NOT put real
     # organisations, people, or grant references here.
-    ("Example Org", "is_a", "participant", "needs_review", 0.95, "sources/example-grant.txt", "participant"),
-    ("Example Org", "established_on", "2020-01-01", "confirmed", 0.98, "sources/example-grant.txt", ""),
-    ("Demo Project", "has_participant", "Example Org", "confirmed", 0.92, "sources/example-grant.txt", ""),
-    ("wirelog", "is_a", "deterministic logic engine", "candidate", 0.90, "sources/example-notes.txt", ""),
+    (
+        "Example Org",
+        "is_a",
+        "participant",
+        "needs_review",
+        0.95,
+        "sources/example-grant.txt",
+        "participant",
+    ),
+    (
+        "Example Org",
+        "established_on",
+        "2020-01-01",
+        "confirmed",
+        0.98,
+        "sources/example-grant.txt",
+        "",
+    ),
+    (
+        "Demo Project",
+        "has_participant",
+        "Example Org",
+        "confirmed",
+        0.92,
+        "sources/example-grant.txt",
+        "",
+    ),
+    (
+        "wirelog",
+        "is_a",
+        "deterministic logic engine",
+        "candidate",
+        0.90,
+        "sources/example-notes.txt",
+        "",
+    ),
 ]
 
 
@@ -45,7 +77,9 @@ def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
 def _seed(store: Store) -> None:
     for subj, rel, obj, status, conf, src, note in _DEMO_FACTS:
         sid = store.add_source(src)
-        store.add_fact(subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note)
+        store.add_fact(
+            subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note
+        )
 
 
 def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
@@ -90,12 +124,16 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         store.close()
         return 2
     if not sources:
-        print(f"no sources to sync (looked under {cfg.root / 'sources'})", file=sys.stderr)
+        print(
+            f"no sources to sync (looked under {cfg.root / 'sources'})", file=sys.stderr
+        )
         store.close()
         return 1
     try:
         client = get_client(cfg)
-        result = sync_sources(store, client, sources, provider=cfg.provider, model=cfg.model)
+        result = sync_sources(
+            store, client, sources, provider=cfg.provider, model=cfg.model
+        )
     except LLMError as e:
         print(f"extraction failed: {e}", file=sys.stderr)
         store.close()
@@ -137,23 +175,35 @@ def cmd_ui(cfg: Config, args: argparse.Namespace) -> int:
         import webbrowser
 
         threading.Timer(1.0, lambda: webbrowser.open(url)).start()
-    uvicorn.run("verinote.web.app:_default", factory=True, host=args.host, port=args.port, reload=args.reload)
+    uvicorn.run(
+        "verinote.web.app:_default",
+        factory=True,
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
     return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="verinote", description="Honest KB: LLM extracts, wirelog verifies.")
+    p = argparse.ArgumentParser(
+        prog="verinote", description="Honest KB: LLM extracts, wirelog verifies."
+    )
     p.add_argument("--version", action="version", version=f"verinote {__version__}")
     sub = p.add_subparsers(dest="command", required=True)
 
-    init = sub.add_parser("init", help="scaffold a local KB (SQLite) under VERINOTE_ROOT (./data)")
+    init = sub.add_parser(
+        "init", help="scaffold a local KB (SQLite) under VERINOTE_ROOT (./data)"
+    )
     init.add_argument("--seed", action="store_true", help="insert demo facts")
     init.set_defaults(func=cmd_init)
 
     seed = sub.add_parser("seed", help="insert demo facts into the KB")
     seed.set_defaults(func=cmd_seed)
 
-    sync = sub.add_parser("sync", help="extract candidate facts from sources via the LLM")
+    sync = sub.add_parser(
+        "sync", help="extract candidate facts from sources via the LLM"
+    )
     sync.add_argument(
         "path",
         nargs="?",
@@ -170,7 +220,9 @@ def build_parser() -> argparse.ArgumentParser:
     ui.add_argument("--reload", action="store_true", help="auto-reload (dev)")
     ui.add_argument("--no-browser", action="store_true", help="do not open a browser")
     ui.set_defaults(func=cmd_ui)
-    sub.add_parser("serve", help="alias for ui").set_defaults(func=cmd_ui, host="127.0.0.1", port=8731, reload=False, no_browser=True)
+    sub.add_parser("serve", help="alias for ui").set_defaults(
+        func=cmd_ui, host="127.0.0.1", port=8731, reload=False, no_browser=True
+    )
 
     return p
 

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -20,7 +20,7 @@ def _root() -> Path:
 class Config:
     root: Path
     db_path: Path
-    provider: str            # "anthropic" | "openai" | "ollama"
+    provider: str  # "anthropic" | "openai" | "ollama"
     model: str
     api_key: str | None
     base_url: str | None

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -14,13 +14,19 @@ class AnthropicAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def extract_facts(
+        self, *, source_text: str, schema_hint: str = ""
+    ) -> list[ExtractedFact]:
         try:
             import anthropic
         except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
+            raise LLMError(
+                "anthropic SDK not installed; `pip install verinote[anthropic]`"
+            ) from exc
 
-        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = anthropic.Anthropic(
+            api_key=self.cfg.api_key, base_url=self.cfg.base_url
+        )
         tool = {
             "name": "emit_facts",
             "description": "Return the extracted facts.",

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -32,7 +32,9 @@ class LLMClient(Protocol):
 
     name: str
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def extract_facts(
+        self, *, source_text: str, schema_hint: str = ""
+    ) -> list[ExtractedFact]:
         """Extract source-backed candidate facts from `source_text`.
 
         Adapters MUST force structured output (a JSON array of fact objects) and

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -22,14 +22,20 @@ class OllamaAdapter:
         self.cfg = cfg
         self.base_url = (cfg.base_url or "http://localhost:11434").rstrip("/")
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def extract_facts(
+        self, *, source_text: str, schema_hint: str = ""
+    ) -> list[ExtractedFact]:
         payload = {
             "model": self.cfg.model,
             "stream": False,
             # Ollama accepts a JSON schema in `format` to constrain output.
             "format": FACT_ARRAY_SCHEMA,
             "messages": [
-                {"role": "system", "content": EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else "")},
+                {
+                    "role": "system",
+                    "content": EXTRACTION_SYSTEM
+                    + ("\n" + schema_hint if schema_hint else ""),
+                },
                 {"role": "user", "content": source_text},
             ],
         }

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -14,11 +14,15 @@ class OpenAIAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def extract_facts(
+        self, *, source_text: str, schema_hint: str = ""
+    ) -> list[ExtractedFact]:
         try:
             from openai import OpenAI
         except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
+            raise LLMError(
+                "openai SDK not installed; `pip install verinote[openai]`"
+            ) from exc
 
         # base_url makes this work against any OpenAI-compatible endpoint too.
         client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
@@ -26,12 +30,20 @@ class OpenAIAdapter:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
                 messages=[
-                    {"role": "system", "content": EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else "")},
+                    {
+                        "role": "system",
+                        "content": EXTRACTION_SYSTEM
+                        + ("\n" + schema_hint if schema_hint else ""),
+                    },
                     {"role": "user", "content": source_text},
                 ],
                 response_format={
                     "type": "json_schema",
-                    "json_schema": {"name": "facts", "schema": FACT_ARRAY_SCHEMA, "strict": True},
+                    "json_schema": {
+                        "name": "facts",
+                        "schema": FACT_ARRAY_SCHEMA,
+                        "strict": True,
+                    },
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -22,7 +22,11 @@ ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
 
 
 def _load_schema() -> str:
-    return resources.files("verinote.store").joinpath("schema.sql").read_text(encoding="utf-8")
+    return (
+        resources.files("verinote.store")
+        .joinpath("schema.sql")
+        .read_text(encoding="utf-8")
+    )
 
 
 class Store:
@@ -33,7 +37,9 @@ class Store:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         # check_same_thread=False: FastAPI serves sync endpoints from a thread
         # pool. WAL allows concurrent readers; we serialise writes with _lock.
-        self._conn = sqlite3.connect(self.db_path, isolation_level=None, check_same_thread=False)
+        self._conn = sqlite3.connect(
+            self.db_path, isolation_level=None, check_same_thread=False
+        )
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON;")
         self._lock = threading.Lock()
@@ -65,7 +71,9 @@ class Store:
         return list(self._conn.execute("SELECT * FROM sources ORDER BY path"))
 
     # --- runs ------------------------------------------------------------
-    def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:
+    def add_run(
+        self, *, provider: str | None, model: str | None, summary: str = ""
+    ) -> int:
         """Open an extraction run; facts produced by it cite the returned id."""
         with self._lock:
             cur = self._conn.execute(
@@ -76,10 +84,14 @@ class Store:
 
     def set_run_summary(self, run_id: int, summary: str) -> None:
         with self._lock:
-            self._conn.execute("UPDATE runs SET summary = ? WHERE id = ?", (summary, run_id))
+            self._conn.execute(
+                "UPDATE runs SET summary = ? WHERE id = ?", (summary, run_id)
+            )
 
     def get_run(self, run_id: int) -> sqlite3.Row | None:
-        return self._conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+        return self._conn.execute(
+            "SELECT * FROM runs WHERE id = ?", (run_id,)
+        ).fetchone()
 
     # --- facts -----------------------------------------------------------
     def add_fact(
@@ -127,10 +139,14 @@ class Store:
         return self.facts(statuses=REVIEW_STATUSES)
 
     def status_counts(self) -> dict[str, int]:
-        rows = self._conn.execute("SELECT status, COUNT(*) c FROM facts GROUP BY status")
+        rows = self._conn.execute(
+            "SELECT status, COUNT(*) c FROM facts GROUP BY status"
+        )
         return {r["status"]: r["c"] for r in rows}
 
-    def set_status(self, fact_id: int, status: str, *, action: str = "set_status") -> sqlite3.Row | None:
+    def set_status(
+        self, fact_id: int, status: str, *, action: str = "set_status"
+    ) -> sqlite3.Row | None:
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
@@ -152,7 +168,13 @@ class Store:
         return self.set_status(fact_id, new_status, action="toggled")
 
     # --- audit -----------------------------------------------------------
-    def _log(self, fact_id: int, action: str, before: sqlite3.Row | None, after: sqlite3.Row | None) -> None:
+    def _log(
+        self,
+        fact_id: int,
+        action: str,
+        before: sqlite3.Row | None,
+        after: sqlite3.Row | None,
+    ) -> None:
         self._conn.execute(
             "INSERT INTO review_log(fact_id, action, before_json, after_json) VALUES(?,?,?,?)",
             (

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -40,9 +40,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
-        return templates.TemplateResponse(request, "partials/fact_row.html", {"f": fact})
+        return templates.TemplateResponse(
+            request, "partials/fact_row.html", {"f": fact}
+        )
 
-    def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
+    def _dashboard(
+        request: Request, *, error: str | None = None, status_code: int = 200
+    ):
         counts = store.status_counts()
         return templates.TemplateResponse(
             request,
@@ -74,7 +78,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         try:
             text = (await file.read()).decode("utf-8")
         except UnicodeDecodeError:
-            return _dashboard(request, error="file is not valid UTF-8 text", status_code=400)
+            return _dashboard(
+                request, error="file is not valid UTF-8 text", status_code=400
+            )
 
         sources_dir = cfg.root / "sources"
         sources_dir.mkdir(parents=True, exist_ok=True)
@@ -83,7 +89,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         try:
             client = get_client(cfg)
-            sync_sources(store, client, [(citation, text)], provider=cfg.provider, model=cfg.model)
+            sync_sources(
+                store,
+                client,
+                [(citation, text)],
+                provider=cfg.provider,
+                model=cfg.model,
+            )
         except LLMError as e:
             return _dashboard(request, error=f"extraction failed: {e}", status_code=502)
         return RedirectResponse("/review", status_code=303)
@@ -108,7 +120,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/report", response_class=HTMLResponse)
     def report(request: Request):
-        return templates.TemplateResponse(request, "report.html", {"rep": verify(store)})
+        return templates.TemplateResponse(
+            request, "report.html", {"rep": verify(store)}
+        )
 
     return app
 


### PR DESCRIPTION
Follow-up to #12. Makes formatting enforceable by first bringing the tree into
`ruff format` compliance, then adding a format gate to the lint workflow.

> **Stacked on #12** (base = `ci/ruff-lint`). GitHub will retarget this to `main`
> automatically once #12 merges. Merge #12 first.

## What
- `ruff format .` over the whole tree — **10 files reformatted**, purely
  whitespace / line-wrapping. No logic changes; the full test suite (17) still
  passes.
- `.github/workflows/lint.yml` gains a second step, `ruff format --check`, pinned
  to the same ruff 0.15.18.

## Why now
#12 deliberately shipped lint-only because the tree wasn't formatted. With this
reformat in place the format gate is green from its first run, so the two land
cleanly as a pair.