### PR TITLE
fix: replace real entities in demo/test data with placeholders

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+name: lint
+
+# Lint every pull request. ruff config lives in pyproject.toml ([tool.ruff]).
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: ruff check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "0.15.18"   # keep in sync with local dev
+          args: check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared test fakes — a canned `LLMClient` so the pipeline is exercised offline."""
+
+import pytest
+
+from verinote.llm.base import ExtractedFact, LLMError
+
+
+class FakeClient:
+    """An `LLMClient` that returns canned facts (or raises) — no provider needed."""
+
+    name = "fake"
+
+    def __init__(self, facts=(), *, error: LLMError | None = None):
+        self._facts = list(facts)
+        self._error = error
+        self.calls = 0
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        return list(self._facts)
+
+
+@pytest.fixture
+def fake_client():
+    return FakeClient

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+import verinote.cli as cli
+from verinote.llm.base import ExtractedFact, LLMError
+from verinote.store import Store
+
+
+def _env(monkeypatch, tmp_path):
+    """Point a fresh KB at tmp_path; `cli.main` reads these via Config.load()."""
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+
+
+def test_sync_file_inserts_candidates(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+    src = tmp_path / "note.txt"
+    src.write_text("hello", encoding="utf-8")
+
+    rc = cli.main(["sync", str(src)])
+
+    assert rc == 0
+    assert "1 candidate(s)" in capsys.readouterr().out
+    # the candidate is now queryable in the same KB
+    s = Store(tmp_path / "kb.sqlite")
+    assert [f["subject"] for f in s.review_queue()] == ["A"]
+
+
+def test_sync_missing_file_errors(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    rc = cli.main(["sync", str(tmp_path / "nope.txt")])
+    assert rc == 2
+    assert "no such file" in capsys.readouterr().err
+
+
+def test_sync_surfaces_llm_error(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(error=LLMError("provider down")),
+    )
+    src = tmp_path / "note.txt"
+    src.write_text("hello", encoding="utf-8")
+
+    rc = cli.main(["sync", str(src)])
+
+    assert rc == 1
+    assert "extraction failed: provider down" in capsys.readouterr().err

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from verinote.llm.base import ExtractedFact, LLMError
+from verinote.pipeline import extract_source, sync_sources
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_extract_source_persists_candidates_with_linkage(tmp_path, fake_client):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [ExtractedFact("A", "is_a", "B", 0.9, "n"), ExtractedFact("C", "rel", "D", 0.8)]
+    )
+
+    n = extract_source(
+        s, client, source_path="sources/x.txt", source_text="...", run_id=run_id
+    )
+
+    assert n == 2
+    facts = s.facts()
+    assert [f["status"] for f in facts] == ["candidate", "candidate"]
+    assert {f["run_id"] for f in facts} == {run_id}
+    assert {f["source_path"] for f in facts} == {"sources/x.txt"}
+
+
+def test_sync_sources_opens_run_and_summarises(tmp_path, fake_client):
+    s = _store(tmp_path)
+    client = fake_client([ExtractedFact("A", "is_a", "B", 0.9)])
+
+    result = sync_sources(
+        s,
+        client,
+        [("sources/a.txt", "ta"), ("sources/b.txt", "tb")],
+        provider="fake",
+        model="m",
+    )
+
+    assert result.total == 2
+    assert result.per_source == [("sources/a.txt", 1), ("sources/b.txt", 1)]
+    assert client.calls == 2
+
+    run = s.get_run(result.run_id)
+    assert run["provider"] == "fake" and run["model"] == "m"
+    assert run["summary"] == "2 source(s), 2 candidate(s)"
+    # every fact cites the one run that produced it
+    assert {f["run_id"] for f in s.facts()} == {result.run_id}
+
+
+def test_sync_sources_propagates_llm_error(tmp_path, fake_client):
+    s = _store(tmp_path)
+    client = fake_client(error=LLMError("no api key"))
+
+    with pytest.raises(LLMError):
+        sync_sources(s, client, [("sources/a.txt", "t")], provider="fake", model="m")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -38,10 +38,11 @@ def test_review_log_records_decision(tmp_path):
 
 def test_compile_dl_only_projects_triples(tmp_path):
     s = _store(tmp_path)
-    s.add_fact("AI프렌즈학회", "is_a", "참여기관", status="confirmed")
+    # non-ASCII placeholder keeps UTF-8 round-trip coverage (not a real entity)
+    s.add_fact("예시기관", "is_a", "참여기관", status="confirmed")
     s.add_fact("x", "y", "z", status="needs_review")  # must NOT appear
     dl = compile_dl(s.facts(statuses=ENGINE_STATUSES))
-    assert 'relation("AI프렌즈학회", "is_a", "참여기관").' in dl
+    assert 'relation("예시기관", "is_a", "참여기관").' in dl
     assert "needs_review" not in dl
     assert '"x"' not in dl
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4,7 +4,9 @@ import pytest
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import verinote.web.app as webapp  # noqa: E402
 from verinote.config import Config  # noqa: E402
+from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
 
@@ -41,3 +43,38 @@ def test_toggle_endpoint_swaps_row(tmp_path):
     assert "confirmed" in r.text
     # the only queued fact was promoted, so the review queue is now empty
     assert "Review queue is empty" in c.get("/review").text
+
+
+def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)])
+    )
+    c = _client(tmp_path)
+    r = c.post(
+        "/sources",
+        files={"file": ("note.txt", b"some text", "text/plain")},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    assert r.headers["location"] == "/review"
+    # the file was saved under the KB's sources/ dir and the candidate is queued
+    assert (tmp_path / "sources" / "note.txt").read_text() == "some text"
+    assert "is_a" in c.get("/review").text
+
+
+def test_upload_rejects_unsupported_type(tmp_path):
+    c = _client(tmp_path)
+    r = c.post("/sources", files={"file": ("note.pdf", b"x", "application/pdf")})
+    assert r.status_code == 400
+    assert "unsupported file type" in r.text
+
+
+def test_upload_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: fake_client(error=LLMError("provider down"))
+    )
+    c = _client(tmp_path)
+    r = c.post("/sources", files={"file": ("note.txt", b"x", "text/plain")})
+    # surfaced as a page, not a 500
+    assert r.status_code == 502
+    assert "extraction failed: provider down" in r.text

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -13,10 +13,13 @@ from verinote.store import Store
 
 _DEMO_FACTS = [
     # (subject, relation, object, status, confidence, source, note)
-    ("AI프렌즈학회", "is_a", "참여기관", "needs_review", 0.95, "sources/grant-0403.txt", "참여기관"),
-    ("AI프렌즈학회", "established_on", "2021.08.04", "confirmed", 0.98, "sources/grant-0403.txt", ""),
-    ("Wirelog 과제", "has_participant", "AI프렌즈학회", "confirmed", 0.92, "sources/grant-0403.txt", ""),
-    ("wirelog", "is_a", "deterministic logic engine", "candidate", 0.90, "sources/workshop.txt", ""),
+    # Obviously-fictional placeholder data: it only demonstrates the status
+    # lifecycle and the (subject, relation, object) shape. Do NOT put real
+    # organisations, people, or grant references here.
+    ("Example Org", "is_a", "participant", "needs_review", 0.95, "sources/example-grant.txt", "participant"),
+    ("Example Org", "established_on", "2020-01-01", "confirmed", 0.98, "sources/example-grant.txt", ""),
+    ("Demo Project", "has_participant", "Example Org", "confirmed", 0.92, "sources/example-grant.txt", ""),
+    ("wirelog", "is_a", "deterministic logic engine", "candidate", 0.90, "sources/example-notes.txt", ""),
 ]
 
 

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
 from verinote import __version__
 from verinote.config import Config
@@ -52,6 +53,60 @@ def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def _rel_to_root(root: Path, p: Path) -> str:
+    """Cite a source by its path relative to the KB root when it lives under it."""
+    p = p.resolve()
+    try:
+        return str(p.relative_to(root))
+    except ValueError:
+        return str(p)
+
+
+def _resolve_sources(cfg: Config, path: str | None) -> list[tuple[str, str]]:
+    """Resolve a file path (or all sources under `<root>/sources/`) to (citation, text)."""
+    if path:
+        f = Path(path)
+        if not f.is_file():
+            raise FileNotFoundError(f"no such file: {path}")
+        files = [f]
+    else:
+        sources_dir = cfg.root / "sources"
+        files = sorted(sources_dir.glob("*.txt")) + sorted(sources_dir.glob("*.md"))
+    return [(_rel_to_root(cfg.root, f), f.read_text(encoding="utf-8")) for f in files]
+
+
+def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.llm import LLMError, get_client
+    from verinote.pipeline import sync_sources
+
+    store = _store(cfg)
+    try:
+        sources = _resolve_sources(cfg, args.path)
+    except (FileNotFoundError, OSError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        store.close()
+        return 2
+    if not sources:
+        print(f"no sources to sync (looked under {cfg.root / 'sources'})", file=sys.stderr)
+        store.close()
+        return 1
+    try:
+        client = get_client(cfg)
+        result = sync_sources(store, client, sources, provider=cfg.provider, model=cfg.model)
+    except LLMError as e:
+        print(f"extraction failed: {e}", file=sys.stderr)
+        store.close()
+        return 1
+    for src, n in result.per_source:
+        print(f"  {src}: {n} candidate(s)")
+    print(
+        f"sync complete: {result.total} candidate(s) from {len(result.per_source)} "
+        f"source(s) (run #{result.run_id}) — review at `verinote ui`"
+    )
+    store.close()
+    return 0
+
+
 def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     store = _store(cfg)
     counts = store.status_counts()
@@ -94,6 +149,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     seed = sub.add_parser("seed", help="insert demo facts into the KB")
     seed.set_defaults(func=cmd_seed)
+
+    sync = sub.add_parser("sync", help="extract candidate facts from sources via the LLM")
+    sync.add_argument(
+        "path",
+        nargs="?",
+        help="a source file; omit to sync every .txt/.md under <root>/sources/",
+    )
+    sync.set_defaults(func=cmd_sync)
 
     status = sub.add_parser("status", help="summarise KB state")
     status.set_defaults(func=cmd_status)

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -5,7 +5,7 @@ The pipeline is intentionally thin glue over store/, llm/ and engine/. The human
 review gate sits between extract and compile and is driven from the web UI.
 """
 
-from verinote.pipeline.extract import extract_source
+from verinote.pipeline.extract import SyncResult, extract_source, sync_sources
 from verinote.pipeline.verify import verify
 
-__all__ = ["extract_source", "verify"]
+__all__ = ["extract_source", "sync_sources", "SyncResult", "verify"]

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Extract candidate facts from a source and persist them as `candidate` rows."""
+"""Extract candidate facts from sources and persist them as `candidate` rows.
+
+`extract_source` handles one source; `sync_sources` wraps a batch in a single
+`runs` row so the whole pass can later be inspected or retired as a unit.
+"""
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
 
 from verinote.llm.base import LLMClient
 from verinote.store import Store
@@ -14,11 +21,13 @@ def extract_source(
     source_path: str,
     source_text: str,
     schema_hint: str = "",
+    run_id: int | None = None,
 ) -> int:
     """Run extraction for one source; insert candidates. Returns count inserted.
 
     Newly extracted facts land as `candidate` — they only become engine input
-    after passing the human review gate (see the web review queue).
+    after passing the human review gate (see the web review queue). Each fact
+    cites its `source` and (when given) the `run` that produced it.
     """
     source_id = store.add_source(source_path)
     facts = client.extract_facts(source_text=source_text, schema_hint=schema_hint)
@@ -30,6 +39,53 @@ def extract_source(
             status="candidate",
             confidence=f.confidence,
             source_id=source_id,
+            run_id=run_id,
             note=f.note,
         )
     return len(facts)
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Outcome of one `sync_sources` pass over a batch of sources."""
+
+    run_id: int
+    per_source: list[tuple[str, int]] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return sum(n for _, n in self.per_source)
+
+
+def sync_sources(
+    store: Store,
+    client: LLMClient,
+    sources: Iterable[tuple[str, str]],
+    *,
+    provider: str | None,
+    model: str | None,
+    schema_hint: str = "",
+) -> SyncResult:
+    """Extract a batch of `(source_path, source_text)` pairs under one run.
+
+    Opens a `runs` row (recording provider/model), links every produced fact to
+    it, then writes a one-line summary. Any `LLMError` raised by the client
+    propagates to the caller — the partial run row is left for inspection.
+    """
+    run_id = store.add_run(provider=provider, model=model)
+    per_source: list[tuple[str, int]] = []
+    for source_path, source_text in sources:
+        n = extract_source(
+            store,
+            client,
+            source_path=source_path,
+            source_text=source_text,
+            schema_hint=schema_hint,
+            run_id=run_id,
+        )
+        per_source.append((source_path, n))
+    result = SyncResult(run_id=run_id, per_source=per_source)
+    store.set_run_summary(
+        run_id, f"{len(per_source)} source(s), {result.total} candidate(s)"
+    )
+    return result

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -64,6 +64,23 @@ class Store:
     def sources(self) -> list[sqlite3.Row]:
         return list(self._conn.execute("SELECT * FROM sources ORDER BY path"))
 
+    # --- runs ------------------------------------------------------------
+    def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:
+        """Open an extraction run; facts produced by it cite the returned id."""
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO runs(provider, model, summary) VALUES(?,?,?) RETURNING id",
+                (provider, model, summary),
+            )
+            return int(cur.fetchone()[0])
+
+    def set_run_summary(self, run_id: int, summary: str) -> None:
+        with self._lock:
+            self._conn.execute("UPDATE runs SET summary = ? WHERE id = ?", (summary, run_id))
+
+    def get_run(self, run_id: int) -> sqlite3.Row | None:
+        return self._conn.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+
     # --- facts -----------------------------------------------------------
     def add_fact(
         self,

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, File, Request, UploadFile
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from verinote.config import Config
-from verinote.pipeline import verify
+from verinote.llm import LLMError, get_client
+from verinote.pipeline import sync_sources, verify
 from verinote.store import Store
+
+_UPLOAD_SUFFIXES = {".txt", ".md"}
 
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
 _STATIC = resources.files("verinote.web").joinpath("static")
@@ -39,8 +42,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # Starlette's current API is TemplateResponse(request, name, context).
         return templates.TemplateResponse(request, "partials/fact_row.html", {"f": fact})
 
-    @app.get("/", response_class=HTMLResponse)
-    def dashboard(request: Request):
+    def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
         counts = store.status_counts()
         return templates.TemplateResponse(
             request,
@@ -51,8 +53,40 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "sources": store.sources(),
                 "provider": cfg.provider,
                 "model": cfg.model,
+                "error": error,
             },
+            status_code=status_code,
         )
+
+    @app.get("/", response_class=HTMLResponse)
+    def dashboard(request: Request):
+        return _dashboard(request)
+
+    @app.post("/sources", response_class=HTMLResponse)
+    async def upload_source(request: Request, file: UploadFile = File(...)):
+        filename = Path(file.filename or "").name
+        if Path(filename).suffix.lower() not in _UPLOAD_SUFFIXES:
+            return _dashboard(
+                request,
+                error=f"unsupported file type: {filename or '(none)'!r} (upload a .txt or .md file)",
+                status_code=400,
+            )
+        try:
+            text = (await file.read()).decode("utf-8")
+        except UnicodeDecodeError:
+            return _dashboard(request, error="file is not valid UTF-8 text", status_code=400)
+
+        sources_dir = cfg.root / "sources"
+        sources_dir.mkdir(parents=True, exist_ok=True)
+        (sources_dir / filename).write_text(text, encoding="utf-8")
+        citation = f"sources/{filename}"
+
+        try:
+            client = get_client(cfg)
+            sync_sources(store, client, [(citation, text)], provider=cfg.provider, model=cfg.model)
+        except LLMError as e:
+            return _dashboard(request, error=f"extraction failed: {e}", status_code=502)
+        return RedirectResponse("/review", status_code=303)
 
     @app.get("/review", response_class=HTMLResponse)
     def review(request: Request):

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -43,4 +43,11 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
   padding: .5rem .9rem; border-radius: 7px; font-weight: 600; }
 .empty { background: var(--panel); border: 1px dashed var(--line); border-radius: 10px; padding: 2rem; text-align: center; color: var(--muted); }
 .warn { color: var(--warn); }
+.error { background: rgba(240, 82, 109, .12); border: 1px solid var(--danger);
+  color: var(--danger); border-radius: 8px; padding: .6rem .9rem; margin: 1rem 0; }
+.upload { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px;
+  padding: 1rem; margin: 1.2rem 0; }
+.upload label { display: flex; align-items: center; gap: .6rem; color: var(--muted); }
+.upload button { border: 0; cursor: pointer; }
 .report { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 1rem; overflow-x: auto; white-space: pre-wrap; }

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -4,6 +4,15 @@
 <h1>Knowledge base</h1>
 <p class="muted">Provider <strong>{{ provider }}</strong> · model <code>{{ model }}</code></p>
 
+{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+
+<form class="upload" action="/sources" method="post" enctype="multipart/form-data">
+  <label>Add a source
+    <input type="file" name="file" accept=".txt,.md" required>
+  </label>
+  <button class="btn" type="submit">Upload &amp; extract</button>
+</form>
+
 <section class="cards">
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>
   <div class="card"><div class="num">{{ total }}</div><div class="lbl">facts</div></div>


### PR DESCRIPTION
The seed demo facts (`cli.py::_DEMO_FACTS`) and one store test hard-coded
**real-world entities** — `AI프렌즈학회` (a real academic society), `Wirelog 과제`,
and a `sources/grant-0403.txt` source that reads like a real grant number.
Demo/fixture data shouldn't reference real organisations, people, or grants.

## Changes
- `_DEMO_FACTS` → obviously-fictional placeholders: `Example Org` /
  `Demo Project` / `sources/example-grant.txt` / `sources/example-notes.txt`,
  plus a comment telling future contributors not to add real entities here.
  The self-referential `wirelog is_a deterministic logic engine` fact stays —
  it's this repo's own engine, not a third-party entity.
- `tests/test_store.py` — the UTF-8 `.dl` round-trip test swaps the real org
  for a generic non-ASCII placeholder (`예시기관`), so coverage is unchanged.

Lint clean, full suite (17) passes.