### PR TITLE
Wire run_check into pyrewire (policy load, report parsing, errors>0 gate)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import verinote.cli as cli
+from verinote.engine import DEFAULT_POLICY
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.store import Store
 
@@ -8,6 +9,25 @@ def _env(monkeypatch, tmp_path):
     """Point a fresh KB at tmp_path; `cli.main` reads these via Config.load()."""
     monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
     monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+
+
+def test_init_scaffolds_policy(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    rc = cli.main(["init"])
+    assert rc == 0
+    policy = tmp_path / "policy" / "logic-policy.dl"
+    assert policy.is_file()
+    assert policy.read_text(encoding="utf-8") == DEFAULT_POLICY
+    assert "policy:" in capsys.readouterr().out
+
+
+def test_init_does_not_overwrite_existing_policy(tmp_path, monkeypatch):
+    _env(monkeypatch, tmp_path)
+    policy = tmp_path / "policy" / "logic-policy.dl"
+    policy.parent.mkdir(parents=True)
+    policy.write_text("// my custom policy\n", encoding="utf-8")
+    cli.main(["init"])
+    assert policy.read_text(encoding="utf-8") == "// my custom policy\n"
 
 
 def test_sync_file_inserts_candidates(tmp_path, monkeypatch, capsys, fake_client):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+import verinote.engine.wirelog as wl
+from verinote.engine import DEFAULT_POLICY, compile_dl, run_check
+
+# A subject with two distinct objects for a functional relation is a conflict.
+_CONFLICT = compile_dl(
+    [
+        {"subject": "Org", "relation": "established_on", "object": "2020"},
+        {"subject": "Org", "relation": "established_on", "object": "2021"},
+        {"subject": "Org", "relation": "is_a", "object": "company"},
+    ]
+)
+_CONSISTENT = compile_dl(
+    [
+        {"subject": "Org", "relation": "established_on", "object": "2020"},
+        {"subject": "Org", "relation": "is_a", "object": "company"},
+    ]
+)
+
+
+def test_parse_relation_facts_roundtrips_escaping():
+    dl = compile_dl([{"subject": 'a"b', "relation": "r", "object": "c"}])
+    assert wl._parse_relation_facts(dl) == [('a"b', "r", "c")]
+
+
+def test_run_check_flags_functional_conflict():
+    rep = run_check(_CONFLICT)
+    assert rep.engine_available is True
+    assert rep.errors > 0
+    assert rep.ok is False
+    # finding is human-readable: names the subject and the conflicting relation
+    joined = "\n".join(rep.findings)
+    assert "functional_conflict" in joined
+    assert "Org" in joined and "established_on" in joined
+
+
+def test_run_check_consistent_is_ok():
+    rep = run_check(_CONSISTENT)
+    assert rep.errors == 0
+    assert rep.ok is True
+    assert rep.findings == []
+
+
+def test_run_check_empty_kb_is_ok():
+    rep = run_check("")
+    assert rep.ok is True and rep.errors == 0
+
+
+def test_run_check_uses_custom_policy():
+    # A policy that flags *any* is_a edge as an error.
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_has_isa(subject: symbol, object: symbol)\n"
+        'error_has_isa(S, O) :- relation(S, "is_a", O).\n'
+    )
+    rep = run_check(_CONSISTENT, policy_dl=policy)
+    assert rep.errors == 1
+    assert "has_isa: Org company" in "\n".join(rep.findings)
+
+
+def test_run_check_surfaces_policy_error():
+    rep = run_check(_CONSISTENT, policy_dl="this is not valid datalog !!!")
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert any("engine error" in f for f in rep.findings)
+
+
+def test_run_check_degrades_without_engine(monkeypatch):
+    monkeypatch.setattr(wl, "_load_engine", lambda: None)
+    rep = run_check(_CONFLICT)
+    assert rep.engine_available is False
+    assert rep.ok is True and rep.errors == 0  # cannot gate without the engine
+    assert "not installed" in rep.text
+
+
+def test_default_policy_declares_finding_relations():
+    assert "error_functional_conflict" in DEFAULT_POLICY
+    assert ".decl relation(" in DEFAULT_POLICY

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+from verinote.pipeline.verify import policy_path, verify
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_verify_gates_on_contradiction_with_default_policy(tmp_path):
+    s = _store(tmp_path)
+    # two distinct established_on values for one subject = functional conflict
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    s.add_fact("Org", "established_on", "2021", status="confirmed")
+    rep = verify(s)
+    assert rep.errors > 0 and rep.ok is False
+
+
+def test_verify_consistent_kb_passes(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    s.add_fact("Org", "is_a", "company", status="accepted")
+    rep = verify(s)
+    assert rep.errors == 0 and rep.ok is True
+
+
+def test_verify_only_considers_engine_statuses(tmp_path):
+    s = _store(tmp_path)
+    # a contradicting pair that is NOT yet confirmed must not gate
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    s.add_fact("Org", "established_on", "2021", status="needs_review")
+    rep = verify(s)
+    assert rep.errors == 0 and rep.ok is True
+
+
+def test_verify_loads_kb_policy_file(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    p = policy_path(s)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_has_isa(subject: symbol, object: symbol)\n"
+        'error_has_isa(S, O) :- relation(S, "is_a", O).\n',
+        encoding="utf-8",
+    )
+    rep = verify(s)
+    assert rep.errors == 1
+    assert "has_isa: Org company" in "\n".join(rep.findings)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -78,3 +78,23 @@ def test_upload_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
     # surfaced as a page, not a 500
     assert r.status_code == 502
     assert "extraction failed: provider down" in r.text
+
+
+def test_report_ok_for_consistent_kb(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    r = c.get("/report")
+    assert r.status_code == 200
+    assert "errors: 0" in r.text
+
+
+def test_report_gates_on_contradiction(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Org", "established_on", "2021", status="confirmed")
+    r = c.get("/report")
+    assert r.status_code == 200
+    assert "ERRORS" in r.text
+    assert "functional_conflict" in r.text

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -29,14 +29,30 @@ def _store(cfg: Config) -> Store:
     return store
 
 
+def _scaffold_policy(cfg: Config) -> Path | None:
+    """Write the default logic policy if the KB doesn't have one yet."""
+    from verinote.engine import DEFAULT_POLICY
+    from verinote.pipeline.verify import POLICY_RELPATH
+
+    path = cfg.root / POLICY_RELPATH
+    if path.exists():
+        return None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(DEFAULT_POLICY, encoding="utf-8")
+    return path
+
+
 def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
     cfg.root.mkdir(parents=True, exist_ok=True)
     store = _store(cfg)
     if args.seed:
         _seed(store)
     store.close()
+    policy = _scaffold_policy(cfg)
     print(f"initialised KB at {cfg.root}")
     print(f"  db: {cfg.db_path}")
+    if policy is not None:
+        print(f"  policy: {policy}")
     if args.seed:
         print("  seeded demo facts (run `verinote status`)")
     return 0

--- a/verinote/engine/__init__.py
+++ b/verinote/engine/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """wirelog engine integration: compile confirmed facts to `.dl`, run the check."""
 
-from verinote.engine.wirelog import CheckReport, compile_dl, run_check
+from verinote.engine.wirelog import DEFAULT_POLICY, CheckReport, compile_dl, run_check
 
-__all__ = ["compile_dl", "run_check", "CheckReport"]
+__all__ = ["compile_dl", "run_check", "CheckReport", "DEFAULT_POLICY"]

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -3,8 +3,16 @@
 
 The database is the source of truth; the `.dl` text here is DERIVED from
 confirmed/accepted rows each time the check runs. `compile_dl` is pure and fully
-tested without the engine; `run_check` shells into the wirelog/pyrewire engine
-and degrades gracefully when it is not installed (so the scaffold runs today).
+tested without the engine; `run_check` runs the compiled facts through a wirelog
+(`pyrewire`) policy program and degrades gracefully when the engine is absent.
+
+Policy contract
+---------------
+A policy is a wirelog Datalog program over the base relation
+``relation(subject, rel, object)`` (verinote inserts the compiled facts into it).
+Any derived relation whose name starts with ``error_`` is a blocking finding and
+``warn_`` is a non-blocking one; verinote reads those back, so every column is a
+plain symbol it can render. See `DEFAULT_POLICY`.
 """
 
 from __future__ import annotations
@@ -15,6 +23,35 @@ from typing import Iterable, Mapping
 
 # Datalog string literals: escape embedded quotes/backslashes.
 _ESCAPE = re.compile(r'(["\\])')
+
+# Prefixes that mark a derived relation as a verinote finding.
+_ERROR_PREFIX = "error_"
+_WARN_PREFIX = "warn_"
+
+# Shipped default policy. `verinote init` scaffolds a copy to
+# `<root>/policy/logic-policy.dl`; edit that copy per-KB.
+DEFAULT_POLICY = """\
+// verinote logic policy (wirelog Datalog).
+//
+// verinote compiles confirmed/accepted facts to
+//   relation(subject, rel, object)
+// and runs this policy over them. A derived `error_*` relation FAILS the review
+// gate; a `warn_*` relation is a non-blocking note. Edit freely — the engine
+// re-checks every fact, so the policy is the one place review rules live.
+
+.decl relation(subject: symbol, rel: symbol, object: symbol)
+
+// Relations that may hold at most one object per subject. Add your own.
+.decl functional(rel: symbol)
+functional("established_on").
+functional("born_on").
+functional("died_on").
+
+// A functional relation must not carry two distinct objects for one subject.
+.decl error_functional_conflict(subject: symbol, rel: symbol)
+error_functional_conflict(S, R) :-
+    relation(S, R, A), relation(S, R, B), functional(R), A != B.
+"""
 
 
 def _lit(value: str) -> str:
@@ -34,6 +71,43 @@ def compile_dl(facts: Iterable[Mapping[str, object]]) -> str:
     return "\n".join(sorted(lines)) + ("\n" if lines else "")
 
 
+def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
+    """Recover (subject, rel, object) triples from `compile_dl` output.
+
+    Mirrors `_lit`'s escaping (``\\"`` -> ``"``, ``\\\\`` -> ``\\``) so the round
+    trip is exact, including embedded quotes.
+    """
+    facts: list[tuple[str, str, str]] = []
+    for line in dl_text.splitlines():
+        line = line.strip()
+        if not line.startswith("relation("):
+            continue
+        out: list[str] = []
+        i, n = 0, len(line)
+        while i < n and len(out) < 3:
+            while i < n and line[i] != '"':
+                i += 1
+            if i >= n:
+                break
+            i += 1
+            buf: list[str] = []
+            while i < n:
+                c = line[i]
+                if c == "\\" and i + 1 < n:
+                    buf.append(line[i + 1])
+                    i += 2
+                    continue
+                if c == '"':
+                    i += 1
+                    break
+                buf.append(c)
+                i += 1
+            out.append("".join(buf))
+        if len(out) == 3:
+            facts.append((out[0], out[1], out[2]))
+    return facts
+
+
 @dataclass
 class CheckReport:
     ok: bool
@@ -44,32 +118,84 @@ class CheckReport:
     engine_available: bool = True
 
 
-def run_check(dl_text: str) -> CheckReport:
-    """Run the wirelog engine over compiled facts (+ policy/query, future work).
+def _load_engine():
+    """Return the pyrewire module, or None when it is not installed.
 
-    Returns a structured report. If pyrewire is absent we still return a valid
-    report flagged `engine_available=False` so the UI renders during scaffolding.
+    Factored out so tests can exercise the graceful-degradation path.
     """
     try:
-        import pyrewire  # noqa: F401
+        import pyrewire
     except ImportError:
-        n = dl_text.count("relation(")
-        return CheckReport(
-            ok=True,
-            errors=0,
-            warnings=0,
-            engine_available=False,
-            text=(
-                "wirelog engine (pyrewire) not installed — showing compiled input only.\n"
-                f"compiled facts: {n}\n\n{dl_text}"
-            ),
-        )
+        return None
+    return pyrewire
 
-    # TODO(v1): feed dl_text + policy/*.dl + query.dl to pyrewire and parse its
-    # report into errors/warnings/findings. Wiring tracked in the v1 slice.
+
+def _degraded_report(dl_text: str) -> CheckReport:
+    n = dl_text.count("relation(")
     return CheckReport(
         ok=True,
         errors=0,
         warnings=0,
-        text="engine wiring pending (see TODO in engine/wirelog.py)",
+        engine_available=False,
+        text=(
+            "wirelog engine (pyrewire) not installed — showing compiled input only.\n"
+            f"compiled facts: {n}\n\n{dl_text}"
+        ),
+    )
+
+
+def run_check(dl_text: str, *, policy_dl: str | None = None) -> CheckReport:
+    """Run the wirelog policy over compiled facts and parse the report.
+
+    `dl_text` is `compile_dl` output (the verbatim engine input). `policy_dl`
+    defaults to `DEFAULT_POLICY`. Derived `error_*`/`warn_*` tuples become the
+    report's findings; `errors > 0` is the review gate. If pyrewire is absent we
+    still return a valid report flagged `engine_available=False`.
+    """
+    pyrewire = _load_engine()
+    if pyrewire is None:
+        return _degraded_report(dl_text)
+
+    policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
+    facts = _parse_relation_facts(dl_text)
+
+    try:
+        with pyrewire.EasySession(policy) as session:
+            for subject, rel, obj in facts:
+                session.insert_sym("relation", subject, rel, obj)
+            deltas = session.step()
+    except Exception as exc:  # pyrewire parse/exec errors -> blocking, surfaced
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"policy/engine error: {exc}\n\n{dl_text}",
+            findings=[f"engine error: {exc}"],
+        )
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    for name, row, mult in deltas:
+        if mult <= 0:
+            continue
+        if name.startswith(_ERROR_PREFIX):
+            errors.append(f"{name[len(_ERROR_PREFIX) :]}: {' '.join(map(str, row))}")
+        elif name.startswith(_WARN_PREFIX):
+            warnings.append(f"{name[len(_WARN_PREFIX) :]}: {' '.join(map(str, row))}")
+
+    errors.sort()
+    warnings.sort()
+    findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
+    summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {len(facts)}"
+    body = (
+        "\n".join(findings)
+        if findings
+        else "no findings — knowledge base is consistent."
+    )
+    return CheckReport(
+        ok=not errors,
+        errors=len(errors),
+        warnings=len(warnings),
+        text=f"{summary}\n\n{body}\n\n--- engine input ---\n{dl_text}",
+        findings=findings,
     )

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -1,14 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Compile confirmed facts and run the wirelog check."""
+"""Compile confirmed facts and run the wirelog check against the KB policy."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from verinote.engine import CheckReport, compile_dl, run_check
 from verinote.store import ENGINE_STATUSES, Store
+
+# Per-KB policy location, relative to the KB root (the db file's directory).
+POLICY_RELPATH = Path("policy") / "logic-policy.dl"
+
+
+def policy_path(store: Store) -> Path:
+    return store.db_path.parent / POLICY_RELPATH
+
+
+def load_policy(store: Store) -> str | None:
+    """Read the KB's policy file, or None to fall back to the shipped default."""
+    path = policy_path(store)
+    if path.is_file():
+        return path.read_text(encoding="utf-8")
+    return None
 
 
 def verify(store: Store) -> CheckReport:
     """Project confirmed/accepted rows to `.dl` and run the deterministic check."""
     rows = store.facts(statuses=ENGINE_STATUSES)
     dl_text = compile_dl(rows)
-    return run_check(dl_text)
+    return run_check(dl_text, policy_dl=load_policy(store))

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -51,3 +51,5 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .upload label { display: flex; align-items: center; gap: .6rem; color: var(--muted); }
 .upload button { border: 0; cursor: pointer; }
 .report { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 1rem; overflow-x: auto; white-space: pre-wrap; }
+.findings { margin: 1rem 0; padding-left: 1.2rem; }
+.findings li { font-family: ui-monospace, monospace; font-size: .9rem; margin: .2rem 0; }

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -6,10 +6,21 @@
 <p class="warn">wirelog engine (pyrewire) not installed — showing compiled engine input only.</p>
 {% endif %}
 <p>
-  <span class="badge {{ 'badge-confirmed' if rep.errors == 0 else 'badge-superseded' }}">
+  <span class="badge {{ 'badge-confirmed' if rep.ok and rep.errors == 0 else 'badge-superseded' }}">
     {{ 'OK' if rep.ok and rep.errors == 0 else 'ERRORS' }}
   </span>
   errors: {{ rep.errors }} · warnings: {{ rep.warnings }}
 </p>
+{% if rep.errors > 0 %}
+<p class="error" role="alert">
+  The knowledge base is inconsistent — promotion/query stay gated until the
+  errors below are resolved.
+</p>
+{% endif %}
+{% if rep.findings %}
+<ul class="findings">
+  {% for f in rep.findings %}<li>{{ f }}</li>{% endfor %}
+</ul>
+{% endif %}
 <pre class="report">{{ rep.text }}</pre>
 {% endblock %}


### PR DESCRIPTION
Closes #2.

`run_check` was a stub (`"engine wiring pending"`), so the verifier loop never
actually verified anything. This runs compiled facts through the wirelog
(pyrewire) engine against a policy and parses the result.

## Approach
- **Policy contract.** A policy is a wirelog Datalog program over the base
  relation `relation(subject, rel, object)`. Any derived relation named `error_*`
  is a blocking finding, `warn_*` a non-blocking one. verinote reads those back,
  so every column stays a plain symbol it can render (no intern-id resolution).
- **`run_check(dl_text, *, policy_dl=None)`** parses the `relation(...)` triples
  back out of `compile_dl`'s output (exact round-trip, escaped quotes included),
  inserts them into an `EasySession` built from the policy, `step()`s, and
  buckets the derived `error_*`/`warn_*` deltas into `CheckReport`
  (errors / warnings / findings / verbatim text). `errors > 0` is the gate.
- **Policy lives per-KB** at `<root>/policy/logic-policy.dl`: `verinote init`
  scaffolds the shipped `DEFAULT_POLICY` (a functional-relation conflict rule),
  and `verify()` loads it, falling back to the default when absent.
- **UI gate.** `/report` shows an error state + findings list when `errors > 0`.
  pyrewire parse/exec errors are caught and surfaced as a blocking finding, not
  a 500. The no-pyrewire degraded path (`engine_available=False`) is preserved.

## Acceptance criteria
- [x] A KB with a contradictory pair of confirmed facts reports `errors > 0`;
      a consistent KB reports `errors == 0`. (`test_verify.py`)
- [x] `/report` shows the verbatim engine text plus parsed counts/findings.
- [x] Tests cover report parsing and the gate flag.

## Tests (all 33 pass; `ruff check` clean)
`test_engine.py` — conflict gates / consistent passes / empty KB / custom policy /
surfaced policy error / degraded-without-engine / escaped-quote round-trip.
`test_verify.py` — default + KB-file policy, and that only engine-status rows gate.
`test_cli.py` — `init` scaffolds the policy (and doesn't clobber an existing one).
`test_web.py` — `/report` OK vs ERRORS render.

Verified end to end: `verinote init --seed` scaffolds the policy and the seeded
KB reports OK; injecting a second `established_on` flips it to
`ERROR functional_conflict: Example Org established_on`.

> Note: lint-only CI on `main` today. This branch leaves the pre-existing
> formatting debt to the open format PR (#13); only the new `engine/wirelog.py`
> is ruff-formatted here.