### PR TITLE
feat: source ingestion — binary→text conversion + Sources page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
 anthropic = ["anthropic>=0.40"]
 openai = ["openai>=1.40"]
 analytics = ["duckdb>=1.0"]
-test = ["pytest>=7", "httpx>=0.27"]
+# Binary source ingestion (docx/pdf -> text). Optional so the core stays light.
+ingest = ["python-docx>=1.1", "pypdf>=4.0"]
+test = ["pytest>=7", "httpx>=0.27", "python-docx>=1.1"]
 
 [project.scripts]
 verinote = "verinote.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,30 @@ def test_sync_missing_file_errors(tmp_path, monkeypatch, capsys):
     assert "no such file" in capsys.readouterr().err
 
 
+def test_ingest_registers_text_source(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "doc.txt"
+    src.write_text("body", encoding="utf-8")
+
+    rc = cli.main(["ingest", str(src)])
+
+    assert rc == 0
+    assert "text" in capsys.readouterr().out
+    s = Store(tmp_path / "kb.sqlite")
+    assert [(r["path"], r["kind"]) for r in s.sources_with_counts()] == [
+        ("sources/doc.txt", "text")
+    ]
+
+
+def test_ingest_unsupported_type_errors(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "blob.bin"
+    src.write_bytes(b"\x00\x01")
+    rc = cli.main(["ingest", str(src)])
+    assert rc == 1
+    assert "unsupported source type" in capsys.readouterr().err
+
+
 def test_sync_surfaces_llm_error(tmp_path, monkeypatch, capsys, fake_client):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MPL-2.0
+import io
+
+import pytest
+
+from verinote.pipeline import ingest_bytes, ingest_file, supported_suffixes
+from verinote.pipeline.ingest import IngestError
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _docx_bytes(text: str) -> bytes:
+    import docx
+
+    d = docx.Document()
+    for line in text.splitlines() or [""]:
+        d.add_paragraph(line)
+    buf = io.BytesIO()
+    d.save(buf)
+    return buf.getvalue()
+
+
+def test_text_passthrough():
+    assert ingest_bytes(b"hello", "notes.txt") == ("hello", "text")
+    assert ingest_bytes(b"# title", "notes.md") == ("# title", "text")
+
+
+def test_unsupported_suffix_raises():
+    with pytest.raises(IngestError, match="unsupported source type"):
+        ingest_bytes(b"\x00\x01", "archive.bin")
+
+
+def test_non_utf8_text_raises():
+    with pytest.raises(IngestError, match="UTF-8"):
+        ingest_bytes(b"\xff\xfe\x00", "notes.txt")
+
+
+def test_docx_converts_to_text():
+    text, kind = ingest_bytes(_docx_bytes("hello world"), "report.docx")
+    assert kind == "conversion"
+    assert "hello world" in text
+
+
+def test_supported_suffixes_includes_binaries():
+    assert {".txt", ".md", ".docx", ".pdf"} <= supported_suffixes()
+
+
+def test_ingest_file_registers_text_source(tmp_path):
+    s = _store(tmp_path)
+    src = tmp_path / "doc.txt"
+    src.write_text("body", encoding="utf-8")
+    result = ingest_file(s, src, root=tmp_path)
+    assert result["kind"] == "text"
+    assert result["citation"] == "sources/doc.txt"
+    assert (tmp_path / "sources" / "doc.txt").read_text() == "body"
+    rows = s.sources_with_counts()
+    assert [(r["path"], r["kind"], r["fact_count"]) for r in rows] == [
+        ("sources/doc.txt", "text", 0)
+    ]
+
+
+def test_ingest_file_converts_binary_source(tmp_path):
+    s = _store(tmp_path)
+    src = tmp_path / "report.docx"
+    src.write_bytes(_docx_bytes("converted body"))
+    result = ingest_file(s, src, root=tmp_path)
+    assert result["kind"] == "conversion"
+    # the produced text file lives under sources/ as .txt
+    assert result["citation"] == "sources/report.txt"
+    assert "converted body" in (tmp_path / "sources" / "report.txt").read_text()
+    assert s.sources_with_counts()[0]["kind"] == "conversion"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -64,9 +64,52 @@ def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
 
 def test_upload_rejects_unsupported_type(tmp_path):
     c = _client(tmp_path)
-    r = c.post("/sources", files={"file": ("note.pdf", b"x", "application/pdf")})
+    r = c.post("/sources", files={"file": ("blob.bin", b"\x00\x01", "application/octet-stream")})
     assert r.status_code == 400
-    assert "unsupported file type" in r.text
+    assert "unsupported source type" in r.text
+
+
+def test_sources_page_lists_sources(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/a.txt", kind="text")
+    store.add_fact("A", "is_a", "B", status="candidate", source_id=sid)
+    r = c.get("/sources")
+    assert r.status_code == 200
+    assert "sources/a.txt" in r.text
+    assert "text" in r.text
+
+
+def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
+    import io
+
+    import docx
+
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)])
+    )
+    d = docx.Document()
+    d.add_paragraph("converted text")
+    buf = io.BytesIO()
+    d.save(buf)
+
+    c = _client(tmp_path)
+    r = c.post(
+        "/sources",
+        files={
+            "file": (
+                "report.docx",
+                buf.getvalue(),
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    # the binary was converted to a text file and registered as a conversion
+    assert (tmp_path / "sources" / "report.txt").read_text().strip() == "converted text"
+    kinds = {s["kind"] for s in c.app.state.store.sources_with_counts()}
+    assert "conversion" in kinds
 
 
 def test_upload_surfaces_llm_error(tmp_path, monkeypatch, fake_client):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -126,6 +126,23 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_ingest(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.pipeline import IngestError, ingest_file
+
+    cfg.root.mkdir(parents=True, exist_ok=True)
+    store = _store(cfg)
+    try:
+        result = ingest_file(store, Path(args.path), root=cfg.root)
+    except IngestError as e:
+        print(f"ingest failed: {e}", file=sys.stderr)
+        store.close()
+        return 1
+    store.close()
+    print(f"ingested {args.path} -> {result['citation']} ({result['kind']})")
+    print("run `verinote sync` to extract candidate facts from it")
+    return 0
+
+
 def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     store = _store(cfg)
     counts = store.status_counts()
@@ -176,6 +193,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="a source file; omit to sync every .txt/.md under <root>/sources/",
     )
     sync.set_defaults(func=cmd_sync)
+
+    ingest = sub.add_parser("ingest", help="register a source file (converting docx/pdf to text)")
+    ingest.add_argument("path", help="a .txt/.md file, or a .docx/.pdf to convert")
+    ingest.set_defaults(func=cmd_ingest)
 
     status = sub.add_parser("status", help="summarise KB state")
     status.set_defaults(func=cmd_status)

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -6,6 +6,23 @@ review gate sits between extract and compile and is driven from the web UI.
 """
 
 from verinote.pipeline.extract import SyncResult, extract_source, sync_sources
+from verinote.pipeline.ingest import (
+    IngestError,
+    ingest_bytes,
+    ingest_file,
+    store_source,
+    supported_suffixes,
+)
 from verinote.pipeline.verify import verify
 
-__all__ = ["extract_source", "sync_sources", "SyncResult", "verify"]
+__all__ = [
+    "extract_source",
+    "sync_sources",
+    "SyncResult",
+    "verify",
+    "ingest_bytes",
+    "ingest_file",
+    "store_source",
+    "supported_suffixes",
+    "IngestError",
+]

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Source ingestion: register text sources, convert binaries (docx/pdf) to text.
+
+Extraction reads text, but real sources are often docx/pdf. This turns a file
+into a text source under the KB so the extractor — and the coverage view — can
+use it. Text files are stored as-is (`kind='text'`); a binary is run through a
+per-extension converter and stored as a `.txt` alongside, with the registered
+source marked `kind='conversion'`.
+
+The converter table is open: `register_converter('.ext', fn)` adds a format.
+The built-in docx/pdf converters import their (optional) library lazily and
+raise a helpful `IngestError` when it is missing — install with
+`pip install verinote[ingest]`.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import Callable
+
+from verinote.store import Store
+
+# Stored as-is, no conversion.
+TEXT_SUFFIXES = {".txt", ".md"}
+
+
+class IngestError(RuntimeError):
+    """Unsupported source type, a missing converter dependency, or a parse failure."""
+
+
+Converter = Callable[[bytes], str]
+_CONVERTERS: dict[str, Converter] = {}
+
+
+def register_converter(suffix: str, fn: Converter) -> None:
+    """Register a binary→text converter for a file extension (e.g. ``.rtf``)."""
+    _CONVERTERS[suffix.lower()] = fn
+
+
+def supported_suffixes() -> set[str]:
+    """Every suffix the uploader/ingester accepts (text + registered binaries)."""
+    return TEXT_SUFFIXES | set(_CONVERTERS)
+
+
+def _convert_docx(raw: bytes) -> str:
+    try:
+        import docx  # python-docx
+    except ImportError as e:
+        raise IngestError("docx ingestion needs `pip install verinote[ingest]`") from e
+    try:
+        document = docx.Document(BytesIO(raw))
+    except Exception as e:  # python-docx raises various errors on bad input
+        raise IngestError(f"could not read docx: {e}") from e
+    return "\n".join(p.text for p in document.paragraphs)
+
+
+def _convert_pdf(raw: bytes) -> str:
+    try:
+        from pypdf import PdfReader
+    except ImportError as e:
+        raise IngestError("pdf ingestion needs `pip install verinote[ingest]`") from e
+    try:
+        reader = PdfReader(BytesIO(raw))
+        return "\n".join((page.extract_text() or "") for page in reader.pages)
+    except Exception as e:
+        raise IngestError(f"could not read pdf: {e}") from e
+
+
+register_converter(".docx", _convert_docx)
+register_converter(".pdf", _convert_pdf)
+
+
+def ingest_bytes(raw: bytes, filename: str) -> tuple[str, str]:
+    """Resolve raw upload bytes to ``(text, kind)``; kind is ``text``/``conversion``.
+
+    Raises `IngestError` for unsupported suffixes or conversion failures.
+    """
+    suffix = Path(filename).suffix.lower()
+    if suffix in TEXT_SUFFIXES:
+        try:
+            return raw.decode("utf-8"), "text"
+        except UnicodeDecodeError as e:
+            raise IngestError("file is not valid UTF-8 text") from e
+    if suffix in _CONVERTERS:
+        return _CONVERTERS[suffix](raw), "conversion"
+    raise IngestError(f"unsupported source type: {suffix or filename!r}")
+
+
+def store_source(store: Store, root: Path, filename: str, text: str, kind: str) -> str:
+    """Write `text` under `<root>/sources/` and register it. Returns the citation."""
+    sources_dir = root / "sources"
+    sources_dir.mkdir(parents=True, exist_ok=True)
+    name = Path(filename).name
+    out_name = name if kind == "text" else f"{Path(name).stem}.txt"
+    (sources_dir / out_name).write_text(text, encoding="utf-8")
+    citation = f"sources/{out_name}"
+    store.add_source(citation, kind=kind)
+    return citation
+
+
+def ingest_file(store: Store, src: Path, *, root: Path) -> dict:
+    """Convert/register a file on disk. Returns {citation, text, kind}."""
+    src = Path(src)
+    if not src.is_file():
+        raise IngestError(f"no such file: {src}")
+    text, kind = ingest_bytes(src.read_bytes(), src.name)
+    citation = store_source(store, root, src.name, text, kind)
+    return {"citation": citation, "text": text, "kind": kind}

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -53,16 +53,30 @@ class Store:
 
     # --- sources ---------------------------------------------------------
     def add_source(self, path: str, kind: str = "text") -> int:
+        # kind is set at first registration (e.g. ingest marks 'conversion') and
+        # preserved on re-registration — the no-op SET keeps the existing kind
+        # while still letting RETURNING hand back the id on conflict, so a later
+        # extraction pass over the same path doesn't downgrade it to 'text'.
         with self._lock:
             cur = self._conn.execute(
                 "INSERT INTO sources(path, kind) VALUES(?, ?) "
-                "ON CONFLICT(path) DO UPDATE SET kind=excluded.kind RETURNING id",
+                "ON CONFLICT(path) DO UPDATE SET path=excluded.path RETURNING id",
                 (path, kind),
             )
             return int(cur.fetchone()[0])
 
     def sources(self) -> list[sqlite3.Row]:
         return list(self._conn.execute("SELECT * FROM sources ORDER BY path"))
+
+    def sources_with_counts(self) -> list[sqlite3.Row]:
+        """Sources plus how many facts cite each — for the Sources listing."""
+        return list(
+            self._conn.execute(
+                "SELECT s.id, s.path, s.kind, s.added_at, COUNT(f.id) AS fact_count "
+                "FROM sources s LEFT JOIN facts f ON f.source_id = s.id "
+                "GROUP BY s.id ORDER BY s.path"
+            )
+        )
 
     # --- runs ------------------------------------------------------------
     def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -17,10 +17,15 @@ from fastapi.templating import Jinja2Templates
 
 from verinote.config import Config
 from verinote.llm import LLMError, get_client
-from verinote.pipeline import sync_sources, verify
+from verinote.pipeline import (
+    IngestError,
+    ingest_bytes,
+    store_source,
+    supported_suffixes,
+    sync_sources,
+    verify,
+)
 from verinote.store import Store
-
-_UPLOAD_SUFFIXES = {".txt", ".md"}
 
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
 _STATIC = resources.files("verinote.web").joinpath("static")
@@ -58,34 +63,42 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             status_code=status_code,
         )
 
+    def _sources(request: Request, *, error: str | None = None, status_code: int = 200):
+        return templates.TemplateResponse(
+            request,
+            "sources.html",
+            {
+                "sources": store.sources_with_counts(),
+                "suffixes": ", ".join(sorted(supported_suffixes())),
+                "accept": ",".join(sorted(supported_suffixes())),
+                "error": error,
+            },
+            status_code=status_code,
+        )
+
     @app.get("/", response_class=HTMLResponse)
     def dashboard(request: Request):
         return _dashboard(request)
 
+    @app.get("/sources", response_class=HTMLResponse)
+    def sources_page(request: Request):
+        return _sources(request)
+
     @app.post("/sources", response_class=HTMLResponse)
     async def upload_source(request: Request, file: UploadFile = File(...)):
         filename = Path(file.filename or "").name
-        if Path(filename).suffix.lower() not in _UPLOAD_SUFFIXES:
-            return _dashboard(
-                request,
-                error=f"unsupported file type: {filename or '(none)'!r} (upload a .txt or .md file)",
-                status_code=400,
-            )
+        raw = await file.read()
         try:
-            text = (await file.read()).decode("utf-8")
-        except UnicodeDecodeError:
-            return _dashboard(request, error="file is not valid UTF-8 text", status_code=400)
+            text, kind = ingest_bytes(raw, filename)
+        except IngestError as e:
+            return _sources(request, error=str(e), status_code=400)
 
-        sources_dir = cfg.root / "sources"
-        sources_dir.mkdir(parents=True, exist_ok=True)
-        (sources_dir / filename).write_text(text, encoding="utf-8")
-        citation = f"sources/{filename}"
-
+        citation = store_source(store, cfg.root, filename, text, kind)
         try:
             client = get_client(cfg)
             sync_sources(store, client, [(citation, text)], provider=cfg.provider, model=cfg.model)
         except LLMError as e:
-            return _dashboard(request, error=f"extraction failed: {e}", status_code=502)
+            return _sources(request, error=f"extraction failed: {e}", status_code=502)
         return RedirectResponse("/review", status_code=303)
 
     @app.get("/review", response_class=HTMLResponse)

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -41,6 +41,7 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 
 .btn { display: inline-block; background: var(--accent); color: #06101f; text-decoration: none;
   padding: .5rem .9rem; border-radius: 7px; font-weight: 600; }
+.btn.ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); }
 .empty { background: var(--panel); border: 1px dashed var(--line); border-radius: 10px; padding: 2rem; text-align: center; color: var(--muted); }
 .warn { color: var(--warn); }
 .error { background: rgba(240, 82, 109, .12); border: 1px solid var(--danger);

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -12,6 +12,7 @@
     <a class="brand" href="/">verinote</a>
     <nav>
       <a href="/">Dashboard</a>
+      <a href="/sources">Sources</a>
       <a href="/review">Review</a>
       <a href="/report">Report</a>
     </nav>

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -4,15 +4,6 @@
 <h1>Knowledge base</h1>
 <p class="muted">Provider <strong>{{ provider }}</strong> · model <code>{{ model }}</code></p>
 
-{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
-
-<form class="upload" action="/sources" method="post" enctype="multipart/form-data">
-  <label>Add a source
-    <input type="file" name="file" accept=".txt,.md" required>
-  </label>
-  <button class="btn" type="submit">Upload &amp; extract</button>
-</form>
-
 <section class="cards">
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>
   <div class="card"><div class="num">{{ total }}</div><div class="lbl">facts</div></div>
@@ -29,5 +20,6 @@
   </tbody>
 </table>
 
-<p><a class="btn" href="/review">Go to review queue →</a></p>
+<p><a class="btn" href="/review">Go to review queue →</a>
+   <a class="btn ghost" href="/sources">Manage sources →</a></p>
 {% endblock %}

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}Sources — verinote{% endblock %}
+{% block content %}
+<h1>Sources</h1>
+<p class="muted">Files facts are extracted from and cited against. Text is stored
+  as-is; binaries ({{ suffixes }}) are converted to text on upload.</p>
+
+{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+
+<form class="upload" action="/sources" method="post" enctype="multipart/form-data">
+  <label>Add a source
+    <input type="file" name="file" accept="{{ accept }}" required>
+  </label>
+  <button class="btn" type="submit">Upload &amp; extract</button>
+</form>
+
+{% if sources %}
+<table class="sources">
+  <thead>
+    <tr><th>Path</th><th>Kind</th><th>Facts</th><th>Added</th></tr>
+  </thead>
+  <tbody>
+    {% for s in sources %}
+    <tr>
+      <td><code>{{ s["path"] }}</code></td>
+      <td><span class="badge">{{ s["kind"] }}</span></td>
+      <td class="conf">{{ s["fact_count"] }}</td>
+      <td class="src">{{ s["added_at"] }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty"><p>No sources yet — upload a file above to get started.</p></div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Closes #7.

Extraction reads text, but real sources are often docx/pdf. This adds an
ingestion step that converts binaries to text under the KB and a page to manage
sources.

## What
- **`verinote/pipeline/ingest.py`** — an open converter registry
  (`register_converter('.ext', fn)`). `ingest_bytes(raw, name) -> (text, kind)`:
  `.txt`/`.md` are stored as-is (`kind='text'`); `.docx`/`.pdf` are converted to
  a `.txt` under `sources/` (`kind='conversion'`). The docx/pdf converters import
  their optional library lazily and raise a helpful `IngestError` when missing.
- **CLI** — `verinote ingest <file>` converts/registers a source (no LLM needed,
  so it's offline-testable).
- **Web** — `GET /sources` lists every source (path, kind, fact count) with an
  upload form; `POST /sources` routes binaries through ingest, then extracts.
  Nav gains a Sources link; the dashboard links to it.
- **Store** — `sources_with_counts()` for the listing. `add_source` no longer
  downgrades a source's `kind` on re-registration, so a later extraction pass
  can't clobber `conversion` back to `text`.
- **pyproject** — optional `[ingest]` extra (`python-docx`, `pypdf`);
  `python-docx` added to `[test]` so the docx path runs in CI.

## Acceptance criteria
- [x] Uploading `.txt`/`.md` registers a text source; a supported binary (docx)
      produces a text conversion + `conversion` linkage.
- [x] Tests cover text registration and the source listing.

## Tests
`test_ingest.py` (text passthrough, unsupported suffix, non-UTF-8, real docx
conversion, registry, file→source), `test_cli.py` (`ingest` text + unsupported),
`test_web.py` (Sources listing, docx upload → conversion, unsupported reject).
Full suite 44 pass locally; `ruff check` clean.