### PR TITLE
feat: fact amend/edit + provenance view in the review UI

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -52,3 +52,29 @@ def test_compile_dl_escapes_quotes(tmp_path):
     s.add_fact('a"b', "r", "c", status="confirmed")
     dl = compile_dl(s.facts(statuses=ENGINE_STATUSES))
     assert r'relation("a\"b", "r", "c").' in dl
+
+
+def test_amend_fact_persists_and_audits(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "is_a", "B", status="needs_review", note="orig")
+    after = s.amend_fact(fid, subject="A2", relation="became", obj="C", note="fixed")
+    assert (after["subject"], after["relation"], after["object"], after["note"]) == (
+        "A2",
+        "became",
+        "C",
+        "fixed",
+    )
+    assert [e["action"] for e in s.fact_log(fid)] == ["amended"]
+
+
+def test_amend_missing_fact_returns_none(tmp_path):
+    s = _store(tmp_path)
+    assert s.amend_fact(999, subject="x", relation="y", obj="z") is None
+
+
+def test_fact_log_orders_decisions(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "r", "B", status="needs_review")
+    s.toggle_review(fid)
+    s.amend_fact(fid, subject="A", relation="r", obj="B2")
+    assert [e["action"] for e in s.fact_log(fid)] == ["toggled", "amended"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -141,3 +141,36 @@ def test_report_gates_on_contradiction(tmp_path):
     assert r.status_code == 200
     assert "ERRORS" in r.text
     assert "functional_conflict" in r.text
+
+
+def test_edit_form_renders(tmp_path):
+    c = _client(tmp_path)
+    r = c.get(f"/facts/{c.fact_id}/edit")
+    assert r.status_code == 200
+    assert 'name="subject"' in r.text
+    assert "/amend" in r.text
+
+
+def test_amend_endpoint_updates_and_audits(tmp_path):
+    c = _client(tmp_path)
+    r = c.post(
+        f"/facts/{c.fact_id}/amend",
+        data={"subject": "NewSubj", "relation": "became", "object": "NewObj", "note": "n"},
+    )
+    assert r.status_code == 200
+    assert "NewSubj" in r.text and "NewObj" in r.text
+    store = c.app.state.store
+    assert store.get_fact(c.fact_id)["subject"] == "NewSubj"
+    assert any(e["action"] == "amended" for e in store.fact_log(c.fact_id))
+
+
+def test_provenance_shows_source_and_audit(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/x.txt", kind="text")
+    fid = store.add_fact("S", "r", "O", status="needs_review", source_id=sid)
+    store.toggle_review(fid)  # leaves an audit entry
+    r = c.get(f"/facts/{fid}/provenance")
+    assert r.status_code == 200
+    assert "sources/x.txt" in r.text
+    assert "toggled" in r.text

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -165,7 +165,39 @@ class Store:
         new_status = "needs_review" if row["status"] in ENGINE_STATUSES else "confirmed"
         return self.set_status(fact_id, new_status, action="toggled")
 
+    def amend_fact(
+        self,
+        fact_id: int,
+        *,
+        subject: str,
+        relation: str,
+        obj: str,
+        note: str = "",
+    ) -> sqlite3.Row | None:
+        """Correct a fact's (subject, relation, object, note); audit as `amended`."""
+        with self._lock:
+            before = self.get_fact(fact_id)
+            if before is None:
+                return None
+            self._conn.execute(
+                "UPDATE facts SET subject = ?, relation = ?, object = ?, note = ?, "
+                "updated_at = datetime('now') WHERE id = ?",
+                (subject, relation, obj, note, fact_id),
+            )
+            after = self.get_fact(fact_id)
+            self._log(fact_id, "amended", before, after)
+            return after
+
     # --- audit -----------------------------------------------------------
+    def fact_log(self, fact_id: int) -> list[sqlite3.Row]:
+        """Audit trail (oldest first) for one fact — drives the provenance view."""
+        return list(
+            self._conn.execute(
+                "SELECT id, action, at FROM review_log WHERE fact_id = ? ORDER BY id",
+                (fact_id,),
+            )
+        )
+
     def _log(self, fact_id: int, action: str, before: sqlite3.Row | None, after: sqlite3.Row | None) -> None:
         self._conn.execute(
             "INSERT INTO review_log(fact_id, action, before_json, after_json) VALUES(?,?,?,?)",

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 
-from fastapi import FastAPI, File, Request, UploadFile
+from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -118,6 +118,41 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/facts/{fact_id}/reject", response_class=HTMLResponse)
     def reject(request: Request, fact_id: int):
         return _row(request, store.set_status(fact_id, "superseded", action="rejected"))
+
+    @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
+    def edit_fact(request: Request, fact_id: int):
+        return templates.TemplateResponse(
+            request, "partials/fact_edit.html", {"f": store.get_fact(fact_id)}
+        )
+
+    @app.get("/facts/{fact_id}/row", response_class=HTMLResponse)
+    def fact_row(request: Request, fact_id: int):
+        # Re-render the read-only row (used to cancel an inline edit).
+        return _row(request, store.get_fact(fact_id))
+
+    @app.post("/facts/{fact_id}/amend", response_class=HTMLResponse)
+    def amend_fact(
+        request: Request,
+        fact_id: int,
+        subject: str = Form(...),
+        relation: str = Form(...),
+        object: str = Form(...),
+        note: str = Form(""),
+    ):
+        amended = store.amend_fact(
+            fact_id, subject=subject, relation=relation, obj=object, note=note
+        )
+        return _row(request, amended)
+
+    @app.get("/facts/{fact_id}/provenance", response_class=HTMLResponse)
+    def provenance(request: Request, fact_id: int):
+        fact = store.get_fact(fact_id)
+        run = store.get_run(fact["run_id"]) if fact and fact["run_id"] else None
+        return templates.TemplateResponse(
+            request,
+            "provenance.html",
+            {"f": fact, "run": run, "log": store.fact_log(fact_id) if fact else []},
+        )
 
     @app.get("/report", response_class=HTMLResponse)
     def report(request: Request):

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -38,6 +38,15 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
   border-radius: 6px; padding: .25rem .5rem; margin-right: .3rem; cursor: pointer; font-size: .82rem; }
 .actions button:hover { border-color: var(--accent); }
 .actions button.danger:hover { border-color: var(--danger); color: var(--danger); }
+.actions .srclink { color: var(--muted); text-decoration: none; font-size: .82rem; margin-left: .3rem; }
+.actions .srclink:hover { color: var(--accent); }
+.amend { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
+.amend input { background: var(--bg); color: var(--fg); border: 1px solid var(--line);
+  border-radius: 6px; padding: .3rem .5rem; }
+.amend button { background: var(--accent); color: #06101f; border: 0; border-radius: 6px;
+  padding: .3rem .7rem; cursor: pointer; font-weight: 600; }
+.amend button.ghost { background: transparent; color: var(--muted); border: 1px solid var(--line); }
+tr.editing td { background: rgba(91, 157, 255, .06); }
 
 .btn { display: inline-block; background: var(--accent); color: #06101f; text-decoration: none;
   padding: .5rem .9rem; border-radius: 7px; font-weight: 600; }

--- a/verinote/web/templates/partials/fact_edit.html
+++ b/verinote/web/templates/partials/fact_edit.html
@@ -1,0 +1,17 @@
+{# Inline edit form for one fact. Swapped in by HTMX from the row's ✎ edit;
+   save POSTs /amend (re-renders the row), cancel GETs /row (reverts). #}
+<tr id="fact-{{ f['id'] }}" class="fact editing">
+  <td colspan="5">
+    <form class="amend" hx-post="/facts/{{ f['id'] }}/amend"
+          hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">
+      <input name="subject" value="{{ f['subject'] }}" aria-label="subject" required>
+      <input name="relation" value="{{ f['relation'] }}" aria-label="relation" required>
+      <input name="object" value="{{ f['object'] }}" aria-label="object" required>
+      <input name="note" value="{{ f['note'] }}" aria-label="note" placeholder="note">
+      <button type="submit">save</button>
+      <button type="button" class="ghost"
+              hx-get="/facts/{{ f['id'] }}/row"
+              hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">cancel</button>
+    </form>
+  </td>
+</tr>

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -17,5 +17,8 @@
     <button hx-post="/facts/{{ f['id'] }}/reject"
             hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML"
             class="danger">✗ reject</button>
+    <button hx-get="/facts/{{ f['id'] }}/edit"
+            hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">✎ edit</button>
+    <a class="srclink" href="/facts/{{ f['id'] }}/provenance" title="source &amp; audit trail">ⓘ source</a>
   </td>
 </tr>

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block title %}Provenance — verinote{% endblock %}
+{% block content %}
+{% if not f %}
+<div class="empty"><p>No such fact.</p></div>
+{% else %}
+<h1>Provenance — fact #{{ f["id"] }}</h1>
+<p class="triple">
+  <span class="subj">{{ f["subject"] }}</span>
+  <span class="rel">{{ f["relation"] }}</span>
+  <span class="obj">{{ f["object"] }}</span>
+  <span class="badge badge-{{ f['status'] }}">{{ f["status"] }}</span>
+</p>
+
+<table class="counts">
+  <tbody>
+    <tr><td>source</td><td><code>{{ f["source_path"] or "—" }}</code></td></tr>
+    <tr><td>confidence</td><td class="conf">{{ '%.2f'|format(f["confidence"]) }}</td></tr>
+    <tr><td>note</td><td>{{ f["note"] or "—" }}</td></tr>
+    <tr><td>run</td><td>
+      {% if run %}#{{ run["id"] }} · {{ run["provider"] or "—" }}/{{ run["model"] or "—" }}
+        {% if run["summary"] %}<span class="muted">({{ run["summary"] }})</span>{% endif %}
+      {% else %}— (seeded or hand-entered){% endif %}
+    </td></tr>
+    <tr><td>created</td><td class="src">{{ f["created_at"] }}</td></tr>
+    <tr><td>updated</td><td class="src">{{ f["updated_at"] }}</td></tr>
+  </tbody>
+</table>
+
+<h2>Audit trail</h2>
+{% if log %}
+<table class="counts">
+  <thead><tr><th>when</th><th>action</th></tr></thead>
+  <tbody>
+    {% for e in log %}
+    <tr><td class="src">{{ e["at"] }}</td><td><span class="badge">{{ e["action"] }}</span></td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="muted">No review decisions recorded yet.</p>
+{% endif %}
+
+<p><a class="btn ghost" href="/review">← back to review</a></p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Closes #8.

Reviewers can now **correct** a fact's structure and **inspect provenance**.

## What
- **`Store.amend_fact(...)`** — updates subject/relation/object/note and writes
  an `amended` entry to `review_log`, mirroring `set_status`'s audit pattern.
  **`Store.fact_log(id)`** returns a fact's audit trail (oldest first).
- **Web**
  - `GET /facts/{id}/edit` swaps the row into an inline HTMX edit form.
  - `POST /facts/{id}/amend` persists the edit and re-renders the row.
  - `GET /facts/{id}/row` cancels back to the read-only row.
  - `GET /facts/{id}/provenance` renders a page with source path, run
    (provider/model/summary), confidence, note, timestamps, and the audit trail.
  - The fact row gains **✎ edit** and **ⓘ source** affordances.

## Acceptance criteria
- [x] Editing a fact persists and re-renders the row; an `amended` row appears
      in `review_log`.
- [x] Provenance view shows source + audit history.
- [x] Tests cover amend persistence + audit logging.

## Tests
`test_store.py` (amend persists + audits, missing-fact None, log ordering),
`test_web.py` (edit form renders, amend updates + audits, provenance shows
source + audit). Full suite 50 pass; `ruff check` clean.