### PR TITLE
feat: DuckDB analytics page (attach SQLite read-only)

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+pytest.importorskip("duckdb")  # analytics is an optional extra
+
+from verinote.store import Store  # noqa: E402
+from verinote.store.analytics import compute  # noqa: E402
+
+
+def _seeded(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="confirmed", confidence=0.95, source_id=sid)
+    s.add_fact("C", "is_a", "D", status="candidate", confidence=0.4, source_id=sid)
+    s.add_fact("E", "born_on", "F", status="confirmed", confidence=0.8)
+    return s
+
+
+def test_compute_aggregates_against_attached_sqlite(tmp_path):
+    s = _seeded(tmp_path)
+    a = compute(tmp_path / "kb.sqlite")  # read while writer is still open (WAL)
+    s.close()
+
+    assert a.available is True
+    assert dict(a.by_status) == {"confirmed": 2, "candidate": 1}
+    assert dict(a.by_relation)["is_a"] == 2
+    assert dict(a.by_source)["sources/a.txt"] == 2
+    buckets = dict(a.by_confidence)
+    assert buckets["0.9–1.0"] == 1  # 0.95
+    assert buckets["0.7–0.9"] == 1  # 0.8
+    assert buckets["0.0–0.5"] == 1  # 0.4

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -174,3 +174,16 @@ def test_provenance_shows_source_and_audit(tmp_path):
     assert r.status_code == 200
     assert "sources/x.txt" in r.text
     assert "toggled" in r.text
+
+
+def test_analytics_page_renders(tmp_path):
+    from verinote.store.analytics import duckdb_available
+
+    c = _client(tmp_path)
+    c.app.state.store.add_fact("A", "is_a", "B", status="confirmed", confidence=0.95)
+    r = c.get("/analytics")
+    assert r.status_code == 200
+    if duckdb_available():
+        assert "By status" in r.text and "confirmed" in r.text
+    else:
+        assert "DuckDB isn't installed" in r.text

--- a/verinote/store/analytics.py
+++ b/verinote/store/analytics.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Read-only analytics over the KB via DuckDB.
+
+SQLite stays the single system-of-record; DuckDB only *reads* it by ATTACHing
+the same file read-only (the `sqlite` extension auto-loads on attach). There is
+no second source of truth and no write path here. `duckdb` is optional
+(`pip install verinote[analytics]`); callers feature-flag on `duckdb_available()`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def duckdb_available() -> bool:
+    try:
+        import duckdb  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@dataclass
+class Analytics:
+    """Aggregates for the analytics panel. `available=False` when DuckDB is absent."""
+
+    by_status: list[tuple[str, int]] = field(default_factory=list)
+    by_relation: list[tuple[str, int]] = field(default_factory=list)
+    by_source: list[tuple[str, int]] = field(default_factory=list)
+    by_confidence: list[tuple[str, int]] = field(default_factory=list)
+    available: bool = True
+
+
+# Confidence buckets, low→high; the CASE mirrors these labels.
+_CONFIDENCE_CASE = """
+    CASE
+        WHEN confidence < 0.5 THEN '0.0–0.5'
+        WHEN confidence < 0.7 THEN '0.5–0.7'
+        WHEN confidence < 0.9 THEN '0.7–0.9'
+        ELSE '0.9–1.0'
+    END
+"""
+
+
+def compute(db_path: Path) -> Analytics:
+    """ATTACH the SQLite KB read-only and return aggregate breakdowns.
+
+    Returns an empty, `available=False` `Analytics` when DuckDB isn't installed.
+    """
+    if not duckdb_available():
+        return Analytics(available=False)
+
+    import duckdb
+
+    con = duckdb.connect()
+    try:
+        con.execute(f"ATTACH '{db_path}' AS kb (TYPE sqlite, READ_ONLY);")
+        by_status = con.execute(
+            "SELECT status, COUNT(*) FROM kb.facts GROUP BY status ORDER BY COUNT(*) DESC, status"
+        ).fetchall()
+        by_relation = con.execute(
+            "SELECT relation, COUNT(*) FROM kb.facts GROUP BY relation "
+            "ORDER BY COUNT(*) DESC, relation LIMIT 20"
+        ).fetchall()
+        by_source = con.execute(
+            "SELECT COALESCE(s.path, '(none)') AS src, COUNT(*) "
+            "FROM kb.facts f LEFT JOIN kb.sources s ON s.id = f.source_id "
+            "GROUP BY src ORDER BY COUNT(*) DESC, src LIMIT 20"
+        ).fetchall()
+        by_confidence = con.execute(
+            f"SELECT {_CONFIDENCE_CASE} AS bucket, COUNT(*) "
+            "FROM kb.facts GROUP BY bucket ORDER BY bucket"
+        ).fetchall()
+    finally:
+        con.close()
+
+    return Analytics(
+        by_status=[(str(s), int(n)) for s, n in by_status],
+        by_relation=[(str(r), int(n)) for r, n in by_relation],
+        by_source=[(str(s), int(n)) for s, n in by_source],
+        by_confidence=[(str(b), int(n)) for b, n in by_confidence],
+    )

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -158,6 +158,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def report(request: Request):
         return templates.TemplateResponse(request, "report.html", {"rep": verify(store)})
 
+    @app.get("/analytics", response_class=HTMLResponse)
+    def analytics(request: Request):
+        from verinote.store.analytics import compute
+
+        return templates.TemplateResponse(request, "analytics.html", {"a": compute(cfg.db_path)})
+
     return app
 
 

--- a/verinote/web/templates/analytics.html
+++ b/verinote/web/templates/analytics.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Analytics — verinote{% endblock %}
+{% macro breakdown(title, rows, label) %}
+<h2>{{ title }}</h2>
+{% if rows %}
+<table class="counts">
+  <thead><tr><th>{{ label }}</th><th>facts</th></tr></thead>
+  <tbody>
+    {% for name, n in rows %}
+    <tr><td><code>{{ name }}</code></td><td class="conf">{{ n }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}<p class="muted">No data yet.</p>{% endif %}
+{% endmacro %}
+{% block content %}
+<h1>Analytics</h1>
+<p class="muted">Read-only aggregates computed by DuckDB, which attaches the
+  SQLite system-of-record read-only — no second source of truth.</p>
+
+{% if not a.available %}
+<div class="empty">
+  <p>Analytics are disabled — DuckDB isn't installed.</p>
+  <p class="muted">Enable with <code>pip install verinote[analytics]</code>.</p>
+</div>
+{% else %}
+{{ breakdown("By status", a.by_status, "status") }}
+{{ breakdown("By relation", a.by_relation, "relation") }}
+{{ breakdown("By source", a.by_source, "source") }}
+{{ breakdown("Confidence distribution", a.by_confidence, "bucket") }}
+{% endif %}
+{% endblock %}

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -15,6 +15,7 @@
       <a href="/sources">Sources</a>
       <a href="/review">Review</a>
       <a href="/report">Report</a>
+      <a href="/analytics">Analytics</a>
     </nav>
   </header>
   <main>


### PR DESCRIPTION
Closes #6.

SQLite stays the single system-of-record; DuckDB only **reads** it by ATTACHing
the same file **read-only** (the `sqlite` extension auto-loads — no network, no
second source of truth). Verified DuckDB sees committed WAL data with the writer
connection still open, so it works against the live app DB.

## What
- **`verinote/store/analytics.py`** — `duckdb_available()` + `compute(db_path)`
  returning an `Analytics` dataclass: breakdowns by status, relation, source, and
  confidence bucket. Returns `available=False` when duckdb isn't installed.
- **Web** — `GET /analytics` renders the aggregates, or a disabled panel pointing
  at `pip install verinote[analytics]`. Nav gains an **Analytics** link.

## Acceptance criteria
- [x] Analytics page renders aggregates with DuckDB installed; shows a disabled
      panel without.
- [x] A test (skipped if duckdb absent) asserts the attach+query path returns
      expected counts against a seeded SQLite file.

## Tests
`test_analytics.py` (`importorskip("duckdb")`) checks status/relation/source/
confidence aggregates. `test_web.py::test_analytics_page_renders` asserts the
aggregates when duckdb is present and the disabled panel when absent — so it
passes both locally and in CI (where duckdb, an `[analytics]`-only dep, is absent
and the analytics test skips). Full suite 52 pass locally; `ruff check` clean.