### PR TITLE
feat: NL→Datalog query translation (verinote query)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,11 @@ class FakeClient:
 
     name = "fake"
 
-    def __init__(self, facts=(), *, error: LLMError | None = None):
+    def __init__(self, facts=(), *, error: LLMError | None = None, query=None):
         self._facts = list(facts)
         self._error = error
+        # query: callable(question, qid) -> Datalog line; default answers an is_a.
+        self._query = query
         self.calls = 0
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
@@ -21,6 +23,14 @@ class FakeClient:
         if self._error is not None:
             raise self._error
         return list(self._facts)
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        if self._query is not None:
+            return self._query(question, qid)
+        return f'answer_q{qid}(O) :- relation("{question}", "is_a", O).'
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,3 +92,24 @@ def test_sync_surfaces_llm_error(tmp_path, monkeypatch, capsys, fake_client):
 
     assert rc == 1
     assert "extraction failed: provider down" in capsys.readouterr().err
+
+
+def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: fake_client())
+
+    rc = cli.main(["query", "What is Ada?"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "translated 1 question(s)" in out
+    s = Store(tmp_path / "kb.sqlite")
+    assert s.questions()[0]["status"] == "translated"
+    assert (tmp_path / "facts" / "query.dl").is_file()
+
+
+def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    rc = cli.main(["query"])
+    assert rc == 1
+    assert "no pending questions" in capsys.readouterr().err

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -76,3 +76,22 @@ def test_run_check_degrades_without_engine(monkeypatch):
 def test_default_policy_declares_finding_relations():
     assert "error_functional_conflict" in DEFAULT_POLICY
     assert ".decl relation(" in DEFAULT_POLICY
+
+
+def test_run_check_evaluates_query():
+    dl = compile_dl(
+        [
+            {"subject": "Ada", "relation": "born_in", "object": "London"},
+            {"subject": "Ada", "relation": "is_a", "object": "mathematician"},
+        ]
+    )
+    query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n'
+    rep = run_check(dl, query_dl=query)
+    assert rep.ok is True
+    assert rep.answers == ["q1: London"]
+    assert "q1: London" in rep.text
+
+
+def test_run_check_without_query_has_no_answers():
+    dl = compile_dl([{"subject": "Ada", "relation": "is_a", "object": "x"}])
+    assert run_check(dl).answers == []

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.pipeline.query import load_query, query_path, translate_questions
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
+    s = _store(tmp_path)
+    qid = s.add_question("What is Ada?")
+    results = translate_questions(s, fake_client(), root=tmp_path)
+
+    assert results[0]["id"] == qid
+    assert results[0]["status"] == "translated"
+    # the question row now carries a generated answer rule + its .decl
+    q = s.questions()[0]
+    assert q["status"] == "translated"
+    assert f".decl answer_q{qid}" in q["query_dl"]
+    assert "answer_q%d(O) :- relation(" % qid in q["query_dl"]
+    # and the engine draft file was written
+    draft = query_path(tmp_path)
+    assert draft.is_file()
+    assert load_query(s) == draft.read_text(encoding="utf-8")
+    assert f"answer_q{qid}" in load_query(s)
+
+
+def test_review_required_question_is_flagged_not_in_draft(tmp_path, fake_client):
+    s = _store(tmp_path)
+    qid = s.add_question("What is the meaning of life?")
+    client = fake_client(query=lambda question, qid: f'review_required("{question}")')
+    translate_questions(s, client, root=tmp_path)
+
+    q = s.questions()[0]
+    assert q["status"] == "review_required"
+    assert q["query_dl"].startswith("review_required(")
+    # review_required lines are tracked in the DB, not fed to the engine
+    assert f"answer_q{qid}" not in (load_query(s) or "")
+    assert "review_required" not in (load_query(s) or "")
+
+
+def test_translate_only_touches_pending(tmp_path, fake_client):
+    s = _store(tmp_path)
+    s.add_question("q1")
+    translate_questions(s, fake_client(), root=tmp_path)
+    # second run with no new pending questions returns nothing
+    again = translate_questions(s, fake_client(), root=tmp_path)
+    assert again == []

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -78,3 +78,14 @@ def test_fact_log_orders_decisions(tmp_path):
     s.toggle_review(fid)
     s.amend_fact(fid, subject="A", relation="r", obj="B2")
     assert [e["action"] for e in s.fact_log(fid)] == ["toggled", "amended"]
+
+
+def test_questions_add_list_and_translate(tmp_path):
+    s = _store(tmp_path)
+    qid = s.add_question("Where was Ada born?")
+    assert [(q["id"], q["status"]) for q in s.questions()] == [(qid, "pending")]
+    assert [q["id"] for q in s.questions(pending_only=True)] == [qid]
+
+    s.set_question_query(qid, ".decl answer_q1(value: symbol)", "translated")
+    assert s.questions(pending_only=True) == []
+    assert s.questions()[0]["status"] == "translated"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -187,3 +187,43 @@ def test_analytics_page_renders(tmp_path):
         assert "By status" in r.text and "confirmed" in r.text
     else:
         assert "DuckDB isn't installed" in r.text
+
+
+def test_add_question_persists(tmp_path):
+    c = _client(tmp_path)
+    r = c.post("/questions", data={"text": "Where was Ada born?"}, follow_redirects=False)
+    assert r.status_code == 303
+    assert [q["text"] for q in c.app.state.store.questions()] == ["Where was Ada born?"]
+
+
+def test_translate_and_report_answers(tmp_path, monkeypatch, fake_client):
+    # canned translator: answer_q<id>(O) :- relation("Ada","born_in",O)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(
+            query=lambda question, qid: f'answer_q{qid}(O) :- relation("Ada", "born_in", O).'
+        ),
+    )
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact("Ada", "born_in", "London", status="confirmed")
+    store.add_question("Where was Ada born?")
+
+    r = c.post("/questions/translate", follow_redirects=False)
+    assert r.status_code == 303
+    assert store.questions()[0]["status"] == "translated"
+    # the report and questions page now surface the engine-evaluated answer
+    assert "London" in c.get("/report").text
+    assert "London" in c.get("/questions").text
+
+
+def test_translate_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: fake_client(error=LLMError("provider down"))
+    )
+    c = _client(tmp_path)
+    c.app.state.store.add_question("q?")
+    r = c.post("/questions/translate")
+    assert r.status_code == 502
+    assert "translation failed: provider down" in r.text

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -143,6 +143,33 @@ def cmd_ingest(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.llm import LLMError, get_client
+    from verinote.pipeline import translate_questions
+
+    store = _store(cfg)
+    if args.question:
+        store.add_question(args.question)
+    pending = store.questions(pending_only=True)
+    if not pending:
+        print("no pending questions (add one: `verinote query \"...\"`)", file=sys.stderr)
+        store.close()
+        return 1
+    try:
+        client = get_client(cfg)
+        results = translate_questions(store, client, root=cfg.root)
+    except LLMError as e:
+        print(f"translation failed: {e}", file=sys.stderr)
+        store.close()
+        return 1
+    for r in results:
+        print(f"  q{r['id']}: {r['status']}")
+    print(f"translated {len(results)} question(s) -> {cfg.root / 'facts' / 'query.dl'}")
+    print("run the check to see answers (`verinote ui` → Report)")
+    store.close()
+    return 0
+
+
 def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     store = _store(cfg)
     counts = store.status_counts()
@@ -197,6 +224,10 @@ def build_parser() -> argparse.ArgumentParser:
     ingest = sub.add_parser("ingest", help="register a source file (converting docx/pdf to text)")
     ingest.add_argument("path", help="a .txt/.md file, or a .docx/.pdf to convert")
     ingest.set_defaults(func=cmd_ingest)
+
+    query = sub.add_parser("query", help="translate pending NL questions to Datalog queries")
+    query.add_argument("question", nargs="?", help="a question to add before translating")
+    query.set_defaults(func=cmd_query)
 
     status = sub.add_parser("status", help="summarise KB state")
     status.set_defaults(func=cmd_status)

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -108,6 +108,9 @@ def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
     return facts
 
 
+_ANSWER_PREFIX = "answer_q"
+
+
 @dataclass
 class CheckReport:
     ok: bool
@@ -115,6 +118,7 @@ class CheckReport:
     warnings: int
     text: str
     findings: list[str] = field(default_factory=list)
+    answers: list[str] = field(default_factory=list)
     engine_available: bool = True
 
 
@@ -144,23 +148,27 @@ def _degraded_report(dl_text: str) -> CheckReport:
     )
 
 
-def run_check(dl_text: str, *, policy_dl: str | None = None) -> CheckReport:
-    """Run the wirelog policy over compiled facts and parse the report.
+def run_check(
+    dl_text: str, *, policy_dl: str | None = None, query_dl: str | None = None
+) -> CheckReport:
+    """Run the wirelog policy (+ optional query rules) over compiled facts.
 
     `dl_text` is `compile_dl` output (the verbatim engine input). `policy_dl`
-    defaults to `DEFAULT_POLICY`. Derived `error_*`/`warn_*` tuples become the
-    report's findings; `errors > 0` is the review gate. If pyrewire is absent we
-    still return a valid report flagged `engine_available=False`.
+    defaults to `DEFAULT_POLICY`. `query_dl` holds `answer_q<id>(...)` query rules
+    (see pipeline.query). Derived `error_*`/`warn_*` tuples become findings
+    (`errors > 0` is the review gate); `answer_q<id>` tuples become answers. If
+    pyrewire is absent we still return a valid report flagged `engine_available=False`.
     """
     pyrewire = _load_engine()
     if pyrewire is None:
         return _degraded_report(dl_text)
 
     policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
+    program = policy + ("\n" + query_dl if query_dl else "")
     facts = _parse_relation_facts(dl_text)
 
     try:
-        with pyrewire.EasySession(policy) as session:
+        with pyrewire.EasySession(program) as session:
             for subject, rel, obj in facts:
                 session.insert_sym("relation", subject, rel, obj)
             deltas = session.step()
@@ -175,6 +183,7 @@ def run_check(dl_text: str, *, policy_dl: str | None = None) -> CheckReport:
 
     errors: list[str] = []
     warnings: list[str] = []
+    answers_by_q: dict[str, list[str]] = {}
     for name, row, mult in deltas:
         if mult <= 0:
             continue
@@ -182,9 +191,15 @@ def run_check(dl_text: str, *, policy_dl: str | None = None) -> CheckReport:
             errors.append(f"{name[len(_ERROR_PREFIX) :]}: {' '.join(map(str, row))}")
         elif name.startswith(_WARN_PREFIX):
             warnings.append(f"{name[len(_WARN_PREFIX) :]}: {' '.join(map(str, row))}")
+        elif name.startswith(_ANSWER_PREFIX):
+            qid = name[len(_ANSWER_PREFIX) :]
+            answers_by_q.setdefault(qid, []).append(" ".join(map(str, row)))
 
     errors.sort()
     warnings.sort()
+    answers = [
+        f"q{qid}: {', '.join(sorted(vals))}" for qid, vals in sorted(answers_by_q.items())
+    ]
     findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
     summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {len(facts)}"
     body = (
@@ -192,10 +207,13 @@ def run_check(dl_text: str, *, policy_dl: str | None = None) -> CheckReport:
         if findings
         else "no findings — knowledge base is consistent."
     )
+    if answers:
+        body += "\n\n--- answers ---\n" + "\n".join(answers)
     return CheckReport(
         ok=not errors,
         errors=len(errors),
         warnings=len(warnings),
+        answers=answers,
         text=f"{summary}\n\n{body}\n\n--- engine input ---\n{dl_text}",
         findings=findings,
     )

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 from verinote.config import Config
 from verinote.llm.base import ExtractedFact, LLMError
-from verinote.llm.schema import EXTRACTION_SYSTEM, FACT_ARRAY_SCHEMA, parse_facts
+from verinote.llm.schema import (
+    EXTRACTION_SYSTEM,
+    FACT_ARRAY_SCHEMA,
+    QUERY_SCHEMA,
+    parse_facts,
+    parse_query,
+    query_system,
+)
 
 
 class AnthropicAdapter:
@@ -41,4 +48,33 @@ class AnthropicAdapter:
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
                 return parse_facts(block.input)
+        raise LLMError("anthropic response contained no tool_use block")
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        try:
+            import anthropic
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
+
+        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        tool = {
+            "name": "emit_query",
+            "description": "Return the Datalog query line.",
+            "input_schema": QUERY_SCHEMA,
+        }
+        try:
+            msg = client.messages.create(
+                model=self.cfg.model,
+                max_tokens=1024,
+                system=query_system(qid) + ("\n" + schema_hint if schema_hint else ""),
+                tools=[tool],
+                tool_choice={"type": "tool", "name": "emit_query"},
+                messages=[{"role": "user", "content": question}],
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise provider errors
+            raise LLMError(f"anthropic request failed: {exc}") from exc
+
+        for block in msg.content:
+            if getattr(block, "type", None) == "tool_use":
+                return parse_query(block.input)
         raise LLMError("anthropic response contained no tool_use block")

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -40,3 +40,12 @@ class LLMClient(Protocol):
         or schema violation so the caller can retry deterministically.
         """
         ...
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        """Translate an NL `question` into a single Datalog query line.
+
+        Return a rule whose head is ``answer_q<qid>(V)`` binding one answer
+        variable over ``relation/3``, or ``review_required("<question>")`` when
+        the question can't be expressed. Raise `LLMError` on provider/parse error.
+        """
+        ...

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -12,7 +12,14 @@ import urllib.request
 
 from verinote.config import Config
 from verinote.llm.base import ExtractedFact, LLMError
-from verinote.llm.schema import EXTRACTION_SYSTEM, FACT_ARRAY_SCHEMA, parse_facts
+from verinote.llm.schema import (
+    EXTRACTION_SYSTEM,
+    FACT_ARRAY_SCHEMA,
+    QUERY_SCHEMA,
+    parse_facts,
+    parse_query,
+    query_system,
+)
 
 
 class OllamaAdapter:
@@ -45,3 +52,26 @@ class OllamaAdapter:
             raise LLMError(f"ollama request failed: {exc}") from exc
 
         return parse_facts(body.get("message", {}).get("content", ""))
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        payload = {
+            "model": self.cfg.model,
+            "stream": False,
+            "format": QUERY_SCHEMA,
+            "messages": [
+                {"role": "system", "content": query_system(qid) + ("\n" + schema_hint if schema_hint else "")},
+                {"role": "user", "content": question},
+            ],
+        }
+        req = urllib.request.Request(
+            f"{self.base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 - local trusted endpoint
+                body = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+            raise LLMError(f"ollama request failed: {exc}") from exc
+
+        return parse_query(body.get("message", {}).get("content", ""))

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 from verinote.config import Config
 from verinote.llm.base import ExtractedFact, LLMError
-from verinote.llm.schema import EXTRACTION_SYSTEM, FACT_ARRAY_SCHEMA, parse_facts
+from verinote.llm.schema import (
+    EXTRACTION_SYSTEM,
+    FACT_ARRAY_SCHEMA,
+    QUERY_SCHEMA,
+    parse_facts,
+    parse_query,
+    query_system,
+)
 
 
 class OpenAIAdapter:
@@ -38,3 +45,27 @@ class OpenAIAdapter:
             raise LLMError(f"openai request failed: {exc}") from exc
 
         return parse_facts(resp.choices[0].message.content or "")
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
+
+        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        try:
+            resp = client.chat.completions.create(
+                model=self.cfg.model,
+                messages=[
+                    {"role": "system", "content": query_system(qid) + ("\n" + schema_hint if schema_hint else "")},
+                    {"role": "user", "content": question},
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"name": "query", "schema": QUERY_SCHEMA, "strict": True},
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise provider errors
+            raise LLMError(f"openai request failed: {exc}") from exc
+
+        return parse_query(resp.choices[0].message.content or "")

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -44,6 +44,43 @@ EXTRACTION_SYSTEM = (
 )
 
 
+# --- query translation (#3) ------------------------------------------------
+# A single Datalog query line: a rule deriving the question's answer relation,
+# or a review_required(...) fallback when the question can't be expressed.
+QUERY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["datalog"],
+    "additionalProperties": False,
+    "properties": {"datalog": {"type": "string", "minLength": 1}},
+}
+
+
+def query_system(qid: int) -> str:
+    """System prompt for translating one question to a Datalog query line."""
+    return (
+        "You translate a natural-language question into ONE line of wirelog Datalog "
+        "over the base relation relation(subject, rel, object), which holds the "
+        "knowledge base's confirmed facts. Produce a rule whose head is exactly "
+        f"answer_q{qid}(V) binding a single answer variable V, for example:\n"
+        f'  answer_q{qid}(O) :- relation("Ada Lovelace", "born_in", O).\n'
+        "Use only the relation/3 predicate and string literals. If the question "
+        "cannot be expressed this way, return exactly "
+        'review_required("<the original question>"). Emit JSON matching the schema.'
+    )
+
+
+def parse_query(raw: str | dict[str, Any]) -> str:
+    """Parse provider output into a single trimmed Datalog query line."""
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+        line = str(data["datalog"]).strip()
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise LLMError(f"query translation did not match schema: {exc}") from exc
+    if not line:
+        raise LLMError("query translation was empty")
+    return line
+
+
 def parse_facts(raw: str | dict[str, Any]) -> list[ExtractedFact]:
     """Parse provider output (a JSON string or already-decoded dict) into facts."""
     try:

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -13,6 +13,7 @@ from verinote.pipeline.ingest import (
     store_source,
     supported_suffixes,
 )
+from verinote.pipeline.query import translate_questions, write_query_file
 from verinote.pipeline.verify import verify
 
 __all__ = [
@@ -25,4 +26,6 @@ __all__ = [
     "store_source",
     "supported_suffixes",
     "IngestError",
+    "translate_questions",
+    "write_query_file",
 ]

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Translate NL questions to Datalog query drafts and persist them for the engine.
+
+Each pending question is translated by the `LLMClient` into either an
+`answer_q<id>` rule (status `translated`) or a `review_required(...)` line
+(status `review_required`). The translated rules are written to
+`<root>/facts/query.dl`, which `verify()` feeds to pyrewire so `/report` shows
+each query's evaluation. `review_required` questions are tracked in the DB only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from verinote.llm.base import LLMClient
+from verinote.store import Store
+
+# Query draft, relative to the KB root (the db file's directory).
+QUERY_RELPATH = Path("facts") / "query.dl"
+
+
+def query_path(root: Path) -> Path:
+    return root / QUERY_RELPATH
+
+
+def _is_review_required(line: str) -> bool:
+    return line.lstrip().startswith("review_required")
+
+
+def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
+    """Translate every pending question, persist drafts, rewrite `query.dl`.
+
+    Returns one dict per translated question: {id, status, query_dl}.
+    """
+    results: list[dict] = []
+    for q in store.questions(pending_only=True):
+        line = client.translate_query(question=q["text"], qid=q["id"])
+        if _is_review_required(line):
+            status, query_dl = "review_required", line
+        else:
+            status = "translated"
+            query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
+        store.set_question_query(q["id"], query_dl, status)
+        results.append({"id": q["id"], "status": status, "query_dl": query_dl})
+    write_query_file(store, root)
+    return results
+
+
+def write_query_file(store: Store, root: Path) -> Path:
+    """Write the engine query draft (translated rules only) to `<root>/facts/query.dl`."""
+    lines = [
+        q["query_dl"]
+        for q in store.questions()
+        if q["status"] == "translated" and q["query_dl"]
+    ]
+    path = query_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def load_query(store: Store) -> str | None:
+    """Read the KB's query draft, or None when none has been generated."""
+    path = store.db_path.parent / QUERY_RELPATH
+    if path.is_file():
+        return path.read_text(encoding="utf-8")
+    return None

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -26,6 +26,8 @@ def load_policy(store: Store) -> str | None:
 
 def verify(store: Store) -> CheckReport:
     """Project confirmed/accepted rows to `.dl` and run the deterministic check."""
+    from verinote.pipeline.query import load_query
+
     rows = store.facts(statuses=ENGINE_STATUSES)
     dl_text = compile_dl(rows)
-    return run_check(dl_text, policy_dl=load_policy(store))
+    return run_check(dl_text, policy_dl=load_policy(store), query_dl=load_query(store))

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -188,6 +188,27 @@ class Store:
             self._log(fact_id, "amended", before, after)
             return after
 
+    # --- questions -------------------------------------------------------
+    def add_question(self, text: str) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO questions(text) VALUES(?) RETURNING id", (text,)
+            )
+            return int(cur.fetchone()[0])
+
+    def questions(self, *, pending_only: bool = False) -> list[sqlite3.Row]:
+        sql = "SELECT * FROM questions"
+        if pending_only:
+            sql += " WHERE status = 'pending'"
+        return list(self._conn.execute(sql + " ORDER BY id"))
+
+    def set_question_query(self, question_id: int, query_dl: str, status: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE questions SET query_dl = ?, status = ? WHERE id = ?",
+                (query_dl, status, question_id),
+            )
+
     # --- audit -----------------------------------------------------------
     def fact_log(self, fact_id: int) -> list[sqlite3.Row]:
         """Audit trail (oldest first) for one fact — drives the provenance view."""

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -46,6 +46,17 @@ CREATE TABLE IF NOT EXISTS facts (
 CREATE INDEX IF NOT EXISTS idx_facts_status ON facts(status);
 CREATE INDEX IF NOT EXISTS idx_facts_triple ON facts(subject, relation, object);
 
+-- Natural-language questions translated to a Datalog query draft (#3). status:
+-- pending -> translated (an `answer_q<id>` rule) | review_required (untranslatable).
+CREATE TABLE IF NOT EXISTS questions (
+    id         INTEGER PRIMARY KEY,
+    text       TEXT NOT NULL,
+    query_dl   TEXT,
+    status     TEXT NOT NULL DEFAULT 'pending'
+                 CHECK (status IN ('pending','translated','review_required')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- Append-only audit of human review decisions (toggle/accept/reject/amend),
 -- mirroring the "decisions are preserved" property of the borrowed concept.
 CREATE TABLE IF NOT EXISTS review_log (

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -23,6 +23,7 @@ from verinote.pipeline import (
     store_source,
     supported_suffixes,
     sync_sources,
+    translate_questions,
     verify,
 )
 from verinote.store import Store
@@ -153,6 +154,31 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             "provenance.html",
             {"f": fact, "run": run, "log": store.fact_log(fact_id) if fact else []},
         )
+
+    def _questions(request: Request, *, error: str | None = None, status_code: int = 200):
+        return templates.TemplateResponse(
+            request,
+            "questions.html",
+            {"questions": store.questions(), "answers": verify(store).answers, "error": error},
+            status_code=status_code,
+        )
+
+    @app.get("/questions", response_class=HTMLResponse)
+    def questions_page(request: Request):
+        return _questions(request)
+
+    @app.post("/questions", response_class=HTMLResponse)
+    def add_question(request: Request, text: str = Form(...)):
+        store.add_question(text)
+        return RedirectResponse("/questions", status_code=303)
+
+    @app.post("/questions/translate", response_class=HTMLResponse)
+    def translate(request: Request):
+        try:
+            translate_questions(store, get_client(cfg), root=cfg.root)
+        except LLMError as e:
+            return _questions(request, error=f"translation failed: {e}", status_code=502)
+        return RedirectResponse("/questions", status_code=303)
 
     @app.get("/report", response_class=HTMLResponse)
     def report(request: Request):

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -14,6 +14,7 @@
       <a href="/">Dashboard</a>
       <a href="/sources">Sources</a>
       <a href="/review">Review</a>
+      <a href="/questions">Questions</a>
       <a href="/report">Report</a>
       <a href="/analytics">Analytics</a>
     </nav>

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}Questions — verinote{% endblock %}
+{% block content %}
+<h1>Questions</h1>
+<p class="muted">Natural-language questions are translated to a Datalog query the
+  engine evaluates over confirmed facts. Untranslatable ones are flagged
+  <code>review_required</code>.</p>
+
+{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+
+<form class="upload" action="/questions" method="post">
+  <label>Ask a question
+    <input type="text" name="text" size="48" placeholder="Where was Ada Lovelace born?" required>
+  </label>
+  <button class="btn" type="submit">Add</button>
+</form>
+<p>
+  <button class="btn" hx-post="/questions/translate" hx-target="body" hx-swap="outerHTML">
+    Translate &amp; run
+  </button>
+</p>
+
+{% if questions %}
+<table class="counts">
+  <thead><tr><th>#</th><th>Question</th><th>Status</th><th>Query</th></tr></thead>
+  <tbody>
+    {% for q in questions %}
+    <tr>
+      <td>{{ q["id"] }}</td>
+      <td>{{ q["text"] }}</td>
+      <td><span class="badge">{{ q["status"] }}</span></td>
+      <td><pre class="report">{{ q["query_dl"] or "—" }}</pre></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty"><p>No questions yet — ask one above.</p></div>
+{% endif %}
+
+<h2>Answers</h2>
+{% if answers %}
+<ul class="findings">{% for a in answers %}<li>{{ a }}</li>{% endfor %}</ul>
+{% else %}
+<p class="muted">No answers yet — add a question, translate, and confirm the facts it needs.</p>
+{% endif %}
+{% endblock %}

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -22,5 +22,11 @@
   {% for f in rep.findings %}<li>{{ f }}</li>{% endfor %}
 </ul>
 {% endif %}
+{% if rep.answers %}
+<h2>Query answers</h2>
+<ul class="findings">
+  {% for a in rep.answers %}<li>{{ a }}</li>{% endfor %}
+</ul>
+{% endif %}
 <pre class="report">{{ rep.text }}</pre>
 {% endblock %}


### PR DESCRIPTION
Closes #3. (Depended on #2, now merged.)

Completes the borrowed pipeline's **sync → query → check** loop: natural-language
questions are translated to Datalog the engine evaluates over confirmed facts.

## What
- **Storage** — a `questions` table (text, query_dl, status
  pending/translated/review_required) + `Store.add_question/questions/
  set_question_query`.
- **LLM** — `LLMClient.translate_query(question, qid)` added to the Protocol and
  all three adapters (shared `QUERY_SCHEMA` / `query_system` / `parse_query`).
  Returns an `answer_q<id>` rule, or `review_required("...")` when unanswerable.
- **`pipeline/query.py`** — `translate_questions` persists drafts and writes the
  engine draft to `<root>/facts/query.dl` (translated rules only; review_required
  stays in the DB). `verify()` loads it and passes `query_dl` to `run_check`.
- **Engine** — `run_check` gains `query_dl`; collects `answer_q<id>` deltas into
  `CheckReport.answers` (readable — head names carry the id, values are inserted
  symbols). `/report` shows a **Query answers** section.
- **CLI** — `verinote query ["question"]` adds + translates pending questions.
- **Web** — a **Questions** page to add questions, translate (HTMX), and see the
  generated queries + answers. Nav link added.

## Acceptance criteria
- [x] Adding a question + running query produces a `query.dl` line (or a
      `review_required` line) and the report shows its evaluation.
- [x] Unit test with a fake client asserts the translate→persist path.

## Tests
`test_query.py` (translate→persist→write, review_required flagged + excluded from
draft, only-pending), `test_engine.py` (query evaluation + no-query), `test_store.py`
(questions CRUD), `test_web.py` (add/translate/report answers/LLMError),
`test_cli.py` (`query` adds+translates, no-pending). Full suite 63 pass; ruff clean.