### PR TITLE
feat: gated self-correction (repair) of review_required queries

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,3 +113,31 @@ def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
     rc = cli.main(["query"])
     assert rc == 1
     assert "no pending questions" in capsys.readouterr().err
+
+
+def test_repair_validates_and_translates(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(
+            query=lambda question, qid: f'answer_q{qid}(O) :- relation("Ada", "born_in", O).'
+        ),
+    )
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    qid = s.add_question("Where was Ada born?")
+    s.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
+    s.close()
+
+    rc = cli.main(["repair"])
+
+    assert rc == 0
+    assert "repaired 1/1" in capsys.readouterr().out
+    assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "translated"
+
+
+def test_repair_no_review_required_errors(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    rc = cli.main(["repair"])
+    assert rc == 1
+    assert "no review_required questions" in capsys.readouterr().err

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import verinote.engine.wirelog as wl
-from verinote.engine import DEFAULT_POLICY, compile_dl, run_check
+from verinote.engine import DEFAULT_POLICY, compile_dl, run_check, validate_query
 
 # A subject with two distinct objects for a functional relation is a conflict.
 _CONFLICT = compile_dl(
@@ -95,3 +95,20 @@ def test_run_check_evaluates_query():
 def test_run_check_without_query_has_no_answers():
     dl = compile_dl([{"subject": "Ada", "relation": "is_a", "object": "x"}])
     assert run_check(dl).answers == []
+
+
+def test_validate_query_accepts_relation_only():
+    ok, reason = validate_query(
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("a", "b", O).'
+    )
+    assert ok is True and reason == ""
+
+
+def test_validate_query_rejects_unknown_predicate():
+    ok, reason = validate_query(".decl answer_q1(value: symbol)\nanswer_q1(O) :- bogus(O).")
+    assert ok is False and "bogus" in reason
+
+
+def test_validate_query_rejects_syntax_error():
+    ok, reason = validate_query("this is not datalog")
+    assert ok is False and reason

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.pipeline.query import load_query
+from verinote.pipeline.repair import repair_questions
+from verinote.store import Store
+
+
+def _store_with_review_required(tmp_path):
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    qid = s.add_question("Where was Ada born?")
+    s.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
+    return s, qid
+
+
+def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    assert s.questions()[0]["status"] == "translated"
+    assert f"answer_q{qid}" in (load_query(s) or "")
+
+
+def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    # references an undeclared predicate -> engine rejects, question untouched
+    client = fake_client(query=lambda q, i: f"answer_q{i}(O) :- bogus(O).")
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results[0]["accepted"] is False
+    assert "bogus" in results[0]["reason"]
+    assert s.questions()[0]["status"] == "review_required"
+    assert f"answer_q{qid}" not in (load_query(s) or "")
+
+
+def test_repair_rejects_still_unanswerable(tmp_path, fake_client):
+    s, _qid = _store_with_review_required(tmp_path)
+    client = fake_client(query=lambda q, i: 'review_required("still nope")')
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results[0]["accepted"] is False
+    assert "cannot express" in results[0]["reason"]
+    assert s.questions()[0]["status"] == "review_required"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -227,3 +227,21 @@ def test_translate_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
     r = c.post("/questions/translate")
     assert r.status_code == 502
     assert "translation failed: provider down" in r.text
+
+
+def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client):
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(
+            query=lambda question, qid: f'answer_q{qid}(O) :- relation("Ada", "born_in", O).'
+        ),
+    )
+    c = _client(tmp_path)
+    store = c.app.state.store
+    qid = store.add_question("Where was Ada born?")
+    store.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
+
+    r = c.post("/questions/repair", follow_redirects=False)
+    assert r.status_code == 303
+    assert store.questions()[0]["status"] == "translated"

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -170,6 +170,32 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.llm import LLMError, get_client
+    from verinote.pipeline import repair_questions
+
+    store = _store(cfg)
+    pending = [q for q in store.questions() if q["status"] == "review_required"]
+    if not pending:
+        print("no review_required questions to repair", file=sys.stderr)
+        store.close()
+        return 1
+    try:
+        client = get_client(cfg)
+    except LLMError as e:
+        print(f"repair failed: {e}", file=sys.stderr)
+        store.close()
+        return 1
+    results = repair_questions(store, client, root=cfg.root)
+    repaired = sum(1 for r in results if r["accepted"])
+    for r in results:
+        mark = "repaired" if r["accepted"] else f"kept review_required ({r['reason']})"
+        print(f"  q{r['id']}: {mark}")
+    print(f"repaired {repaired}/{len(results)} question(s) (engine-validated)")
+    store.close()
+    return 0
+
+
 def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     store = _store(cfg)
     counts = store.status_counts()
@@ -228,6 +254,9 @@ def build_parser() -> argparse.ArgumentParser:
     query = sub.add_parser("query", help="translate pending NL questions to Datalog queries")
     query.add_argument("question", nargs="?", help="a question to add before translating")
     query.set_defaults(func=cmd_query)
+
+    repair = sub.add_parser("repair", help="re-translate review_required questions (engine-gated)")
+    repair.set_defaults(func=cmd_repair)
 
     status = sub.add_parser("status", help="summarise KB state")
     status.set_defaults(func=cmd_status)

--- a/verinote/engine/__init__.py
+++ b/verinote/engine/__init__.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 """wirelog engine integration: compile confirmed facts to `.dl`, run the check."""
 
-from verinote.engine.wirelog import DEFAULT_POLICY, CheckReport, compile_dl, run_check
+from verinote.engine.wirelog import (
+    DEFAULT_POLICY,
+    CheckReport,
+    compile_dl,
+    run_check,
+    validate_query,
+)
 
-__all__ = ["compile_dl", "run_check", "CheckReport", "DEFAULT_POLICY"]
+__all__ = ["compile_dl", "run_check", "validate_query", "CheckReport", "DEFAULT_POLICY"]

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -148,6 +148,41 @@ def _degraded_report(dl_text: str) -> CheckReport:
     )
 
 
+_RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+_PREDICATE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+_STRING_LIT = re.compile(r'"(?:[^"\\]|\\.)*"')
+
+
+def validate_query(query_dl: str) -> tuple[bool, str]:
+    """Deterministically check a proposed query line — the engine has final say.
+
+    Returns ``(True, "")`` when the line only references the ``relation/3``
+    vocabulary (plus its own declared `answer_*` head) and parses+runs in
+    pyrewire, else ``(False, reason)``. Used to gate LLM-proposed repairs.
+    """
+    # 1. vocabulary: every predicate must be `relation` or a relation declared in
+    #    the snippet itself (the answer head). Strip string literals first so a
+    #    `word(` inside a literal isn't mistaken for a predicate call.
+    stripped = _STRING_LIT.sub('""', query_dl)
+    declared = {m.group(1) for m in re.finditer(r"\.decl\s+([A-Za-z_][A-Za-z0-9_]*)", stripped)}
+    allowed = {"relation"} | declared
+    unknown = sorted(set(_PREDICATE.findall(stripped)) - allowed)
+    if unknown:
+        return False, f"references unknown predicate(s): {', '.join(unknown)}"
+
+    # 2. parse/run check (catches syntax errors the vocabulary scan can't).
+    pyrewire = _load_engine()
+    if pyrewire is None:
+        return False, "wirelog engine (pyrewire) not installed"
+    try:
+        with pyrewire.EasySession(_RELATION_DECL + query_dl) as session:
+            session.insert_sym("relation", "_probe_s", "_probe_r", "_probe_o")
+            session.step()
+    except Exception as exc:  # parse/exec error -> not a valid query
+        return False, str(exc)
+    return True, ""
+
+
 def run_check(
     dl_text: str, *, policy_dl: str | None = None, query_dl: str | None = None
 ) -> CheckReport:

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -14,6 +14,7 @@ from verinote.pipeline.ingest import (
     supported_suffixes,
 )
 from verinote.pipeline.query import translate_questions, write_query_file
+from verinote.pipeline.repair import repair_questions
 from verinote.pipeline.verify import verify
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "IngestError",
     "translate_questions",
     "write_query_file",
+    "repair_questions",
 ]

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Gated self-correction: re-translate `review_required` questions, engine-gated.
+
+The LLM proposes a corrected query line for each `review_required` question, but
+the proposal is only accepted if the deterministic engine validates it — the
+engine, not the model, has the final say. Rejected proposals leave the question
+untouched and the reason is logged.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from verinote.engine import validate_query
+from verinote.llm.base import LLMClient, LLMError
+from verinote.pipeline.query import write_query_file
+from verinote.store import Store
+
+_log = logging.getLogger("verinote.repair")
+
+
+def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
+    """Attempt to repair every `review_required` question. Returns per-question
+    results: {id, accepted, reason}. Only engine-validated proposals are applied.
+    """
+    results: list[dict] = []
+    for q in store.questions():
+        if q["status"] != "review_required":
+            continue
+        qid = q["id"]
+        try:
+            line = client.translate_query(question=q["text"], qid=qid)
+        except LLMError as exc:
+            results.append({"id": qid, "accepted": False, "reason": f"llm error: {exc}"})
+            _log.warning("repair q%d: llm error: %s", qid, exc)
+            continue
+
+        if line.lstrip().startswith("review_required"):
+            results.append({"id": qid, "accepted": False, "reason": "model still cannot express it"})
+            _log.warning("repair q%d: still review_required", qid)
+            continue
+
+        proposal = f".decl answer_q{qid}(value: symbol)\n{line}"
+        ok, reason = validate_query(proposal)
+        if ok:
+            store.set_question_query(qid, proposal, "translated")
+            results.append({"id": qid, "accepted": True, "reason": ""})
+        else:
+            results.append({"id": qid, "accepted": False, "reason": reason})
+            _log.warning("repair q%d rejected by engine: %s", qid, reason)
+
+    write_query_file(store, root)
+    return results

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -22,6 +22,7 @@ from verinote.pipeline import (
     ingest_bytes,
     store_source,
     supported_suffixes,
+    repair_questions,
     sync_sources,
     translate_questions,
     verify,
@@ -178,6 +179,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             translate_questions(store, get_client(cfg), root=cfg.root)
         except LLMError as e:
             return _questions(request, error=f"translation failed: {e}", status_code=502)
+        return RedirectResponse("/questions", status_code=303)
+
+    @app.post("/questions/repair", response_class=HTMLResponse)
+    def repair(request: Request):
+        try:
+            client = get_client(cfg)
+        except LLMError as e:
+            return _questions(request, error=f"repair failed: {e}", status_code=502)
+        repair_questions(store, client, root=cfg.root)
         return RedirectResponse("/questions", status_code=303)
 
     @app.get("/report", response_class=HTMLResponse)

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -18,6 +18,10 @@
   <button class="btn" hx-post="/questions/translate" hx-target="body" hx-swap="outerHTML">
     Translate &amp; run
   </button>
+  <button class="btn ghost" hx-post="/questions/repair" hx-target="body" hx-swap="outerHTML"
+          title="re-translate review_required questions; the engine re-validates each fix">
+    Repair review_required
+  </button>
 </p>
 
 {% if questions %}


### PR DESCRIPTION
Closes #4. (Depended on #3, now merged.)

`repair` re-translates `review_required` questions via the LLM, but each proposed
fix is **re-validated deterministically** before it's accepted — the engine, not
the model, has the final say.

## What
- **`engine.validate_query(query_dl)`** — a vocabulary check (the rule may only
  reference `relation/3` plus its own declared `answer_*` head; string literals
  are stripped first so a `word(` inside a literal isn't mistaken for a predicate)
  followed by a pyrewire parse/run check. Returns `(ok, reason)`.
- **`pipeline/repair.py`** — `repair_questions` re-translates each
  `review_required` question and accepts the proposal **only if**
  `validate_query` passes (status → `translated`, `query.dl` rewritten); otherwise
  the question is left untouched and the reason is logged.
- **CLI** — `verinote repair`. **Web** — a *Repair review_required* action on the
  Questions page.

## Acceptance criteria
- [x] A repairable question gets a valid `query.dl` line; an unrepairable one is
      left untouched with a logged reason.
- [x] Test with a fake client covers both accept and reject paths.

## Tests
`test_repair.py` (accept valid `relation/3` rule, reject unknown predicate +
untouched, reject still-review_required), `test_engine.py` (`validate_query`
accept/unknown-predicate/syntax-error), `test_web.py` (repair action), `test_cli.py`
(`repair` validates + translates, no-review_required error). Full suite 72 pass;
ruff clean.