### PR TITLE
feat: coverage critic — silent-omission guard

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,3 +141,16 @@ def test_repair_no_review_required_errors(tmp_path, monkeypatch, capsys):
     rc = cli.main(["repair"])
     assert rc == 1
     assert "no review_required questions" in capsys.readouterr().err
+
+
+def test_coverage_strict_gates_on_gap(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="needs_review", source_id=sid)  # not engine input
+    s.close()
+
+    assert cli.main(["coverage"]) == 0  # non-strict always succeeds
+    assert cli.main(["coverage", "--strict"]) == 1  # a gap exists
+    assert "GAP" in capsys.readouterr().out

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.engine import coverage
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _with_file(tmp_path, name: str) -> str:
+    (tmp_path / "sources").mkdir(exist_ok=True)
+    (tmp_path / "sources" / name).write_text("body", encoding="utf-8")
+    return f"sources/{name}"
+
+
+def test_confirmed_source_is_covered(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source(_with_file(tmp_path, "a.txt"))
+    s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+    sc = coverage(s, root=tmp_path).sources[0]
+    assert sc.engine_facts == 1 and not sc.is_gap and not sc.is_orphan
+
+
+def test_needs_review_only_is_a_gap(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source(_with_file(tmp_path, "a.txt"))
+    s.add_fact("A", "is_a", "B", status="needs_review", source_id=sid)
+    cov = coverage(s, root=tmp_path)
+    sc = cov.sources[0]
+    assert sc.engine_facts == 0 and sc.total_facts == 1 and sc.is_gap
+    assert cov.covered == []
+
+
+def test_zero_fact_source_is_a_gap(tmp_path):
+    s = _store(tmp_path)
+    s.add_source(_with_file(tmp_path, "a.txt"))
+    sc = coverage(s, root=tmp_path).sources[0]
+    assert sc.total_facts == 0 and sc.is_gap
+
+
+def test_orphan_when_backing_file_missing(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/missing.txt")  # no file written
+    s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+    cov = coverage(s, root=tmp_path)
+    sc = cov.sources[0]
+    assert sc.is_orphan is True
+    assert sc in cov.orphans

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -29,6 +29,18 @@ def test_dashboard_renders(tmp_path):
     assert "verinote" in r.text
 
 
+def test_dashboard_shows_coverage_gap(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/a.txt")  # no file on disk
+    store.add_fact("X", "is_a", "Y", status="needs_review", source_id=sid)
+    r = c.get("/")
+    assert r.status_code == 200
+    assert "Coverage" in r.text
+    assert "sources/a.txt" in r.text
+    assert "gap" in r.text
+
+
 def test_review_shows_queue(tmp_path):
     c = _client(tmp_path)
     r = c.get("/review")

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -196,6 +196,30 @@ def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.engine import coverage
+
+    store = _store(cfg)
+    cov = coverage(store, root=cfg.root)
+    store.close()
+    for s in cov.sources:
+        flags = []
+        if s.is_gap:
+            flags.append("GAP")
+        if s.is_orphan:
+            flags.append("ORPHAN")
+        tag = ("  " + " ".join(flags)) if flags else ""
+        print(f"  {s.path}: {s.engine_facts}/{s.total_facts} engine facts{tag}")
+    print(
+        f"coverage: {len(cov.covered)} covered, {len(cov.gaps)} gap(s), "
+        f"{len(cov.orphans)} orphan(s)"
+    )
+    if args.strict and cov.gaps:
+        print("strict: uncovered text source(s) present", file=sys.stderr)
+        return 1
+    return 0
+
+
 def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     store = _store(cfg)
     counts = store.status_counts()
@@ -257,6 +281,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     repair = sub.add_parser("repair", help="re-translate review_required questions (engine-gated)")
     repair.set_defaults(func=cmd_repair)
+
+    coverage = sub.add_parser("coverage", help="report per-source engine-fact coverage")
+    coverage.add_argument(
+        "--strict", action="store_true", help="exit non-zero if any text source has no engine facts"
+    )
+    coverage.set_defaults(func=cmd_coverage)
 
     status = sub.add_parser("status", help="summarise KB state")
     status.set_defaults(func=cmd_status)

--- a/verinote/engine/__init__.py
+++ b/verinote/engine/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 """wirelog engine integration: compile confirmed facts to `.dl`, run the check."""
 
+from verinote.engine.coverage import Coverage, SourceCoverage, coverage
 from verinote.engine.wirelog import (
     DEFAULT_POLICY,
     CheckReport,
@@ -9,4 +10,13 @@ from verinote.engine.wirelog import (
     validate_query,
 )
 
-__all__ = ["compile_dl", "run_check", "validate_query", "CheckReport", "DEFAULT_POLICY"]
+__all__ = [
+    "compile_dl",
+    "run_check",
+    "validate_query",
+    "CheckReport",
+    "DEFAULT_POLICY",
+    "coverage",
+    "Coverage",
+    "SourceCoverage",
+]

--- a/verinote/engine/coverage.py
+++ b/verinote/engine/coverage.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Coverage critic — the deterministic guard against silent omission.
+
+A free-text source can't tell you what the extractor *failed* to capture, but the
+store can tell you which sources contributed nothing to engine input. For each
+source we report how many confirmed/accepted facts cite it and flag:
+
+- **gap**: a source with zero engine-input facts (its text was never turned into
+  a confirmed fact — only `candidate`/`needs_review` ones, or none at all).
+- **orphan**: a source whose backing file is missing under the KB root.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from verinote.store import Store
+
+
+@dataclass(frozen=True)
+class SourceCoverage:
+    path: str
+    kind: str
+    engine_facts: int  # confirmed/accepted facts citing this source
+    total_facts: int
+    is_gap: bool  # zero engine-input facts
+    is_orphan: bool  # backing file missing under the KB root
+
+
+@dataclass(frozen=True)
+class Coverage:
+    sources: list[SourceCoverage]
+
+    @property
+    def gaps(self) -> list[SourceCoverage]:
+        return [s for s in self.sources if s.is_gap]
+
+    @property
+    def orphans(self) -> list[SourceCoverage]:
+        return [s for s in self.sources if s.is_orphan]
+
+    @property
+    def covered(self) -> list[SourceCoverage]:
+        return [s for s in self.sources if not s.is_gap]
+
+
+def coverage(store: Store, *, root: Path | None = None) -> Coverage:
+    """Compute per-source engine-input coverage; flag gaps and orphan files."""
+    kb_root = root if root is not None else store.db_path.parent
+    rows = []
+    for r in store.source_fact_counts():
+        engine = int(r["engine"])
+        path = r["path"]
+        rows.append(
+            SourceCoverage(
+                path=path,
+                kind=r["kind"],
+                engine_facts=engine,
+                total_facts=int(r["total"]),
+                is_gap=engine == 0,
+                is_orphan=not (kb_root / path).exists(),
+            )
+        )
+    return Coverage(sources=rows)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -78,6 +78,19 @@ class Store:
             )
         )
 
+    def source_fact_counts(self) -> list[sqlite3.Row]:
+        """Per-source total vs engine-input (confirmed/accepted) fact counts."""
+        return list(
+            self._conn.execute(
+                "SELECT s.id, s.path, s.kind, "
+                "COUNT(f.id) AS total, "
+                "COALESCE(SUM(CASE WHEN f.status IN ('confirmed','accepted') "
+                "THEN 1 ELSE 0 END), 0) AS engine "
+                "FROM sources s LEFT JOIN facts f ON f.source_id = s.id "
+                "GROUP BY s.id ORDER BY s.path"
+            )
+        )
+
     # --- runs ------------------------------------------------------------
     def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:
         """Open an extraction run; facts produced by it cite the returned id."""

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -50,6 +50,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return templates.TemplateResponse(request, "partials/fact_row.html", {"f": fact})
 
     def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
+        from verinote.engine import coverage
+
         counts = store.status_counts()
         return templates.TemplateResponse(
             request,
@@ -58,6 +60,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "counts": counts,
                 "total": sum(counts.values()),
                 "sources": store.sources(),
+                "coverage": coverage(store, root=cfg.root),
                 "provider": cfg.provider,
                 "model": cfg.model,
                 "error": error,

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -20,6 +20,30 @@
   </tbody>
 </table>
 
+<h2>Coverage <span class="muted">— engine-input facts per source</span></h2>
+{% if coverage.sources %}
+<table class="counts">
+  <thead><tr><th>Source</th><th>Engine facts</th><th></th></tr></thead>
+  <tbody>
+    {% for s in coverage.sources %}
+    <tr>
+      <td><code>{{ s.path }}</code></td>
+      <td class="conf">{{ s.engine_facts }} / {{ s.total_facts }}</td>
+      <td>
+        {% if s.is_gap %}<span class="badge badge-needs_review">gap</span>{% endif %}
+        {% if s.is_orphan %}<span class="badge badge-superseded">orphan</span>{% endif %}
+        {% if not s.is_gap and not s.is_orphan %}<span class="badge badge-confirmed">covered</span>{% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p class="muted">{{ coverage.covered|length }} covered · {{ coverage.gaps|length }} gap(s)
+  · {{ coverage.orphans|length }} orphan(s) (file missing under the KB root).</p>
+{% else %}
+<p class="muted">No sources yet.</p>
+{% endif %}
+
 <p><a class="btn" href="/review">Go to review queue →</a>
    <a class="btn ghost" href="/sources">Manage sources →</a></p>
 {% endblock %}


### PR DESCRIPTION
Closes #5.

A free-text source can't tell you what the extractor *failed* to capture, but the
store can flag sources that contributed nothing to engine input.

## What
- **`store.source_fact_counts()`** — per-source total vs engine-input
  (confirmed/accepted) fact counts.
- **`engine/coverage.py`** — `coverage(store)` returns per-source
  `SourceCoverage` with:
  - **`is_gap`** — zero engine-input facts, so a source with only
    `needs_review`/`candidate` facts is a gap, *not* "covered".
  - **`is_orphan`** — backing file missing under the KB root.
- **CLI** — `verinote coverage` (exit 0 always; `--strict` exits non-zero on any
  gap).
- **Web** — a coverage panel on the dashboard (gap / orphan / covered per source).

## Acceptance criteria
- [x] A source with only `needs_review` facts is reported as a gap (not "covered").
- [x] Tests cover zero-fact gap, orphan citation, and a covered source.

## Tests
`test_coverage.py` (covered, needs_review-only gap, zero-fact gap, orphan),
`test_cli.py` (`--strict` gates on a gap), `test_web.py` (dashboard coverage
panel shows the gap). Full suite 78 pass; ruff clean.