### PR TITLE
feat: provider/model settings UI (anti-lock-in surface)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.config import Config, read_settings, save_settings
+
+
+def _clear_env(monkeypatch):
+    for var in ("VERINOTE_PROVIDER", "VERINOTE_MODEL", "VERINOTE_BASE_URL", "VERINOTE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_save_and_read_round_trip(tmp_path):
+    save_settings(tmp_path, provider="ollama", model="llama3.1", base_url="http://x")
+    assert read_settings(tmp_path) == {
+        "provider": "ollama",
+        "model": "llama3.1",
+        "base_url": "http://x",
+    }
+
+
+def test_for_root_uses_saved_settings(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    save_settings(tmp_path, provider="openai", model="gpt-4o-mini")
+    cfg = Config.for_root(tmp_path)
+    assert (cfg.provider, cfg.model) == ("openai", "gpt-4o-mini")
+
+
+def test_env_overrides_saved_settings(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    save_settings(tmp_path, provider="openai", model="gpt-4o")
+    monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
+    assert Config.for_root(tmp_path).provider == "ollama"
+
+
+def test_default_model_when_nothing_set(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    cfg = Config.for_root(tmp_path)  # no settings file, no env
+    assert (cfg.provider, cfg.model) == ("anthropic", "claude-opus-4-8")
+
+
+def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("VERINOTE_API_KEY", "supersecret")
+    save_settings(tmp_path, provider="anthropic", model="m")
+    cfg = Config.for_root(tmp_path)
+    assert cfg.api_key == "supersecret"
+    assert "supersecret" not in (tmp_path / "config.json").read_text(encoding="utf-8")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -257,3 +257,54 @@ def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client):
     r = c.post("/questions/repair", follow_redirects=False)
     assert r.status_code == 303
     assert store.questions()[0]["status"] == "translated"
+
+
+def test_settings_page_renders(tmp_path):
+    c = _client(tmp_path)
+    r = c.get("/settings")
+    assert r.status_code == 200
+    assert "Provider" in r.text and "anthropic" in r.text
+
+
+def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
+    for var in ("VERINOTE_PROVIDER", "VERINOTE_MODEL", "VERINOTE_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    c = _client(tmp_path)
+    r = c.post(
+        "/settings",
+        data={"provider": "ollama", "model": "llama3.1", "base_url": ""},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    # the next get_client would pick the ollama adapter — no code change
+    assert c.app.state.cfg.provider == "ollama"
+    assert (tmp_path / "config.json").is_file()
+
+
+def test_settings_never_renders_api_key(tmp_path):
+    cfg = Config(
+        root=tmp_path, db_path=tmp_path / "kb.sqlite",
+        provider="anthropic", model="m", api_key="supersecret", base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+    r = client.get("/settings")
+    assert "supersecret" not in r.text
+    assert "set (from environment)" in r.text
+
+
+def test_test_connection_reports_adapter(tmp_path, monkeypatch, fake_client):
+    monkeypatch.setattr(
+        webapp, "get_client", lambda c: fake_client([ExtractedFact("A", "is_a", "B", 0.9)])
+    )
+    c = _client(tmp_path)
+    r = c.post("/settings/test")
+    assert r.status_code == 200
+    assert "fake answered with 1 fact" in r.text
+
+
+def test_test_connection_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
+    monkeypatch.setattr(webapp, "get_client", lambda c: fake_client(error=LLMError("no key")))
+    c = _client(tmp_path)
+    r = c.post("/settings/test")
+    assert r.status_code == 502
+    assert "connection failed: no key" in r.text

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -1,44 +1,94 @@
 # SPDX-License-Identifier: MPL-2.0
 """Runtime configuration: where the KB lives and which LLM provider to use.
 
-Resolved from environment variables (and CLI overrides) so nothing about the
-active provider is hard-coded — this is the anti-lock-in seam.
+Resolved so nothing about the active provider is hard-coded — this is the
+anti-lock-in seam. Precedence (highest first): environment variable, then the
+saved non-secret settings file (`<root>/config.json`, written by the Settings
+UI), then a built-in default. The API key is **only** ever read from the
+environment — it is never persisted to or read from the settings file.
 """
 
 from __future__ import annotations
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
+
+SETTINGS_FILENAME = "config.json"
+
+_MODEL_DEFAULTS = {
+    "anthropic": "claude-opus-4-8",
+    "openai": "gpt-4o",
+    "ollama": "llama3.1",
+}
+PROVIDERS = tuple(_MODEL_DEFAULTS)
 
 
 def _root() -> Path:
     return Path(os.environ.get("VERINOTE_ROOT", "./data")).expanduser().resolve()
 
 
+def _settings_path(root: Path) -> Path:
+    return root / SETTINGS_FILENAME
+
+
+def read_settings(root: Path) -> dict:
+    """Read non-secret settings (provider/model/base_url), or {} if absent/bad."""
+    path = _settings_path(root)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_settings(
+    root: Path, *, provider: str, model: str, base_url: str | None = None
+) -> None:
+    """Persist non-secret settings to `<root>/config.json` (never the API key)."""
+    root.mkdir(parents=True, exist_ok=True)
+    payload = {"provider": provider, "model": model, "base_url": base_url or None}
+    _settings_path(root).write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def _pick(env: str, saved: str | None, default: str | None) -> str | None:
+    value = os.environ.get(env)
+    if value is not None:
+        return value
+    if saved:
+        return saved
+    return default
+
+
 @dataclass(frozen=True)
 class Config:
     root: Path
     db_path: Path
-    provider: str            # "anthropic" | "openai" | "ollama"
+    provider: str  # "anthropic" | "openai" | "ollama"
     model: str
     api_key: str | None
     base_url: str | None
 
     @classmethod
-    def load(cls) -> "Config":
-        root = _root()
-        provider = os.environ.get("VERINOTE_PROVIDER", "anthropic").lower()
-        defaults = {
-            "anthropic": "claude-opus-4-8",
-            "openai": "gpt-4o",
-            "ollama": "llama3.1",
-        }
+    def for_root(cls, root: Path) -> "Config":
+        saved = read_settings(root)
+        provider = (_pick("VERINOTE_PROVIDER", saved.get("provider"), "anthropic") or "").lower()
+        model = _pick("VERINOTE_MODEL", saved.get("model"), _MODEL_DEFAULTS.get(provider, "")) or ""
+        base_url = _pick("VERINOTE_BASE_URL", saved.get("base_url"), None)
         return cls(
             root=root,
             db_path=root / "kb.sqlite",
             provider=provider,
-            model=os.environ.get("VERINOTE_MODEL", defaults.get(provider, "")),
-            api_key=os.environ.get("VERINOTE_API_KEY"),
-            base_url=os.environ.get("VERINOTE_BASE_URL"),
+            model=model,
+            api_key=os.environ.get("VERINOTE_API_KEY"),  # secrets only from env
+            base_url=base_url,
         )
+
+    @classmethod
+    def load(cls) -> "Config":
+        return cls.for_root(_root())

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -15,7 +15,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from verinote.config import Config
+from verinote.config import PROVIDERS, Config, save_settings
 from verinote.llm import LLMError, get_client
 from verinote.pipeline import (
     IngestError,
@@ -61,8 +61,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "total": sum(counts.values()),
                 "sources": store.sources(),
                 "coverage": coverage(store, root=cfg.root),
-                "provider": cfg.provider,
-                "model": cfg.model,
+                "provider": app.state.cfg.provider,
+                "model": app.state.cfg.model,
                 "error": error,
             },
             status_code=status_code,
@@ -100,8 +100,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         citation = store_source(store, cfg.root, filename, text, kind)
         try:
-            client = get_client(cfg)
-            sync_sources(store, client, [(citation, text)], provider=cfg.provider, model=cfg.model)
+            client = get_client(app.state.cfg)
+            sync_sources(
+                store,
+                client,
+                [(citation, text)],
+                provider=app.state.cfg.provider,
+                model=app.state.cfg.model,
+            )
         except LLMError as e:
             return _sources(request, error=f"extraction failed: {e}", status_code=502)
         return RedirectResponse("/review", status_code=303)
@@ -179,7 +185,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/questions/translate", response_class=HTMLResponse)
     def translate(request: Request):
         try:
-            translate_questions(store, get_client(cfg), root=cfg.root)
+            translate_questions(store, get_client(app.state.cfg), root=cfg.root)
         except LLMError as e:
             return _questions(request, error=f"translation failed: {e}", status_code=502)
         return RedirectResponse("/questions", status_code=303)
@@ -187,7 +193,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/questions/repair", response_class=HTMLResponse)
     def repair(request: Request):
         try:
-            client = get_client(cfg)
+            client = get_client(app.state.cfg)
         except LLMError as e:
             return _questions(request, error=f"repair failed: {e}", status_code=502)
         repair_questions(store, client, root=cfg.root)
@@ -202,6 +208,54 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         from verinote.store.analytics import compute
 
         return templates.TemplateResponse(request, "analytics.html", {"a": compute(cfg.db_path)})
+
+    def _settings(request: Request, *, test_result=None, error=None, status_code=200):
+        c = app.state.cfg
+        return templates.TemplateResponse(
+            request,
+            "settings.html",
+            {
+                "providers": PROVIDERS,
+                "provider": c.provider,
+                "model": c.model,
+                "base_url": c.base_url or "",
+                "has_key": bool(c.api_key),  # never render the key itself
+                "test_result": test_result,
+                "error": error,
+            },
+            status_code=status_code,
+        )
+
+    @app.get("/settings", response_class=HTMLResponse)
+    def settings_page(request: Request):
+        return _settings(request)
+
+    @app.post("/settings", response_class=HTMLResponse)
+    def save_settings_route(
+        request: Request,
+        provider: str = Form(...),
+        model: str = Form(""),
+        base_url: str = Form(""),
+    ):
+        save_settings(cfg.root, provider=provider, model=model, base_url=base_url or None)
+        # reload from the app's own root so the change takes effect on next sync
+        app.state.cfg = Config.for_root(cfg.root)
+        return RedirectResponse("/settings", status_code=303)
+
+    @app.post("/settings/test", response_class=HTMLResponse)
+    def test_connection(request: Request):
+        c = app.state.cfg
+        try:
+            client = get_client(c)
+            facts = client.extract_facts(
+                source_text="verinote connection test: Ada Lovelace is a mathematician."
+            )
+        except LLMError as e:
+            return _settings(request, error=f"connection failed: {e}", status_code=502)
+        return _settings(
+            request,
+            test_result=f"{client.name} answered with {len(facts)} fact(s) from {c.model}",
+        )
 
     return app
 

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -47,6 +47,13 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
   padding: .3rem .7rem; cursor: pointer; font-weight: 600; }
 .amend button.ghost { background: transparent; color: var(--muted); border: 1px solid var(--line); }
 tr.editing td { background: rgba(91, 157, 255, .06); }
+.settings { display: flex; flex-direction: column; gap: .8rem; max-width: 32rem; margin: 1.2rem 0; }
+.settings label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); }
+.settings select, .settings input { background: var(--bg); color: var(--fg);
+  border: 1px solid var(--line); border-radius: 6px; padding: .4rem .55rem; }
+.settings .btn { align-self: flex-start; }
+.ok-note { background: rgba(63, 185, 80, .12); border: 1px solid var(--ok); color: var(--ok);
+  border-radius: 8px; padding: .6rem .9rem; margin: 1rem 0; }
 
 .btn { display: inline-block; background: var(--accent); color: #06101f; text-decoration: none;
   padding: .5rem .9rem; border-radius: 7px; font-weight: 600; }

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -17,6 +17,7 @@
       <a href="/questions">Questions</a>
       <a href="/report">Report</a>
       <a href="/analytics">Analytics</a>
+      <a href="/settings">Settings</a>
     </nav>
   </header>
   <main>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Settings — verinote{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<p class="muted">Swap the LLM provider/model freely — the wirelog verifier
+  re-checks every fact, so correctness never depends on the model. Non-secret
+  settings are saved to <code>config.json</code>; the API key stays in the
+  environment (<code>VERINOTE_API_KEY</code>) and is never stored here.</p>
+
+{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+{% if test_result %}<p class="ok-note" role="status">✓ {{ test_result }}</p>{% endif %}
+
+<form class="settings" action="/settings" method="post">
+  <label>Provider
+    <select name="provider">
+      {% for p in providers %}
+      <option value="{{ p }}" {{ 'selected' if p == provider else '' }}>{{ p }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>Model
+    <input type="text" name="model" value="{{ model }}" placeholder="model id">
+  </label>
+  <label>Base URL <span class="muted">(optional)</span>
+    <input type="text" name="base_url" value="{{ base_url }}" placeholder="https://…">
+  </label>
+  <button class="btn" type="submit">Save</button>
+</form>
+
+<p class="muted">API key: {{ 'set (from environment)' if has_key else 'not set — export VERINOTE_API_KEY' }}</p>
+
+<p>
+  <button class="btn ghost" hx-post="/settings/test" hx-target="body" hx-swap="outerHTML">
+    Test connection
+  </button>
+</p>
+{% endblock %}


### PR DESCRIPTION
Closes #10.

Makes the anti-lock-in promise (swap Anthropic/OpenAI/Ollama freely) visible and
changeable in the app, not just via env vars.

## What
- **`config.py`** — resolution precedence is now **env > `<root>/config.json` >
  default**. `read_settings`/`save_settings` persist the non-secret
  provider/model/base_url; the **API key is only ever read from
  `VERINOTE_API_KEY`** and is never written to or rendered from the file.
  `Config.for_root(root)` loads against a specific root (`load()` =
  `for_root(_root())`).
- **Web** — a **Settings** page to view/select provider + model + base_url.
  Saving writes `config.json` and reloads `app.state.cfg`, so the next
  sync/translate/repair builds the newly chosen adapter **with no code change**
  (the LLM routes now read `app.state.cfg`). A **Test connection** action runs a
  tiny extraction and reports which adapter answered, surfacing `LLMError`
  clearly. The key is shown only as set / not-set, never rendered.

## Acceptance criteria
- [x] Switching provider/model in the UI changes which adapter `get_client`
      returns on the next sync, with no code change.
- [x] Test-connection surfaces `LLMError`s clearly.

## Tests
`test_config.py` (saved/env/default precedence, key env-only & never persisted),
`test_web.py` (settings render, save changes active provider, key never rendered,
test-connection success + LLMError) with a fake client. Full suite 88 pass; ruff
clean.