### PR TITLE
[codex] Add web KB switcher and Claude CLI provider

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -264,6 +264,7 @@ def test_settings_page_renders(tmp_path):
     r = c.get("/settings")
     assert r.status_code == 200
     assert "Provider" in r.text and "anthropic" in r.text
+    assert str(tmp_path) in r.text
 
 
 def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
@@ -279,6 +280,30 @@ def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
     # the next get_client would pick the ollama adapter — no code change
     assert c.app.state.cfg.provider == "ollama"
     assert (tmp_path / "config.json").is_file()
+
+
+def test_settings_switches_active_kb_root(tmp_path):
+    c = _client(tmp_path)
+    other = tmp_path / "other-kb"
+
+    r = c.post("/settings/root", data={"root": str(other)}, follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/"
+    assert c.app.state.cfg.root == other.resolve()
+    assert c.app.state.store.db_path == other.resolve() / "kb.sqlite"
+    assert (other / "kb.sqlite").is_file()
+    assert "Review queue is empty" in c.get("/review").text
+    assert str(other.resolve()) in c.get("/").text
+
+
+def test_settings_rejects_empty_kb_root(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post("/settings/root", data={"root": "   "})
+
+    assert r.status_code == 400
+    assert "KB directory is required" in r.text
 
 
 def test_settings_never_renders_api_key(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -45,6 +45,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     templates = Jinja2Templates(directory=str(_TEMPLATES))
     app.mount("/static", StaticFiles(directory=str(_STATIC)), name="static")
 
+    def _switch_root(root: Path) -> None:
+        """Point this running app at a different KB root."""
+        nonlocal cfg, store
+        next_cfg = Config.for_root(root.expanduser().resolve())
+        next_store = Store(next_cfg.db_path)
+        next_store.init_schema()
+        old_store = store
+        cfg = next_cfg
+        store = next_store
+        app.state.cfg = next_cfg
+        app.state.store = next_store
+        old_store.close()
+
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
         return templates.TemplateResponse(request, "partials/fact_row.html", {"f": fact})
@@ -63,6 +76,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "coverage": coverage(store, root=cfg.root),
                 "provider": app.state.cfg.provider,
                 "model": app.state.cfg.model,
+                "root": app.state.cfg.root,
                 "error": error,
             },
             status_code=status_code,
@@ -219,6 +233,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "provider": c.provider,
                 "model": c.model,
                 "base_url": c.base_url or "",
+                "root": c.root,
                 "has_key": bool(c.api_key),  # never render the key itself
                 "test_result": test_result,
                 "error": error,
@@ -241,6 +256,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)
         return RedirectResponse("/settings", status_code=303)
+
+    @app.post("/settings/root", response_class=HTMLResponse)
+    def switch_root(request: Request, root: str = Form(...)):
+        path = root.strip()
+        if not path:
+            return _settings(request, error="KB directory is required", status_code=400)
+        try:
+            _switch_root(Path(path))
+        except OSError as e:
+            return _settings(request, error=f"could not open KB directory: {e}", status_code=400)
+        return RedirectResponse("/", status_code=303)
 
     @app.post("/settings/test", response_class=HTMLResponse)
     def test_connection(request: Request):

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -2,7 +2,7 @@
 {% block title %}verinote{% endblock %}
 {% block content %}
 <h1>Knowledge base</h1>
-<p class="muted">Provider <strong>{{ provider }}</strong> · model <code>{{ model }}</code></p>
+<p class="muted">KB <code>{{ root }}</code> · provider <strong>{{ provider }}</strong> · model <code>{{ model }}</code></p>
 
 <section class="cards">
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -2,14 +2,22 @@
 {% block title %}Settings — verinote{% endblock %}
 {% block content %}
 <h1>Settings</h1>
-<p class="muted">Swap the LLM provider/model freely — the wirelog verifier
-  re-checks every fact, so correctness never depends on the model. Non-secret
-  settings are saved to <code>config.json</code>; the API key stays in the
-  environment (<code>VERINOTE_API_KEY</code>) and is never stored here.</p>
+<p class="muted">Choose the local KB directory and swap the LLM provider/model
+  freely. Non-secret model settings are saved to that KB's <code>config.json</code>;
+  the API key stays in the environment (<code>VERINOTE_API_KEY</code>).</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 {% if test_result %}<p class="ok-note" role="status">✓ {{ test_result }}</p>{% endif %}
 
+<h2>Knowledge base</h2>
+<form class="settings" action="/settings/root" method="post">
+  <label>Directory
+    <input type="text" name="root" value="{{ root }}" placeholder="/path/to/kb">
+  </label>
+  <button class="btn" type="submit">Open KB</button>
+</form>
+
+<h2>LLM provider</h2>
 <form class="settings" action="/settings" method="post">
   <label>Provider
     <select name="provider">


### PR DESCRIPTION
## Summary

Adds a web Settings flow for switching the active local KB directory at runtime, plus a `claude -p` based LLM provider.

## What changed

- Adds a Knowledge base directory form to Settings.
- Reopens the app against the selected root by replacing the active Config and Store.
- Initializes the selected KB schema and closes the previous SQLite store.
- Shows the active KB path on the dashboard.
- Adds provider `claude`, backed by the local `claude -p` CLI.
- Parses Claude CLI stdout through the existing JSON schema parsers.
- Covers root switching, empty-root validation, provider registration, and Claude CLI subprocess behavior in tests.

## Impact

Users can open another local KB from the web UI without restarting with `VERINOTE_ROOT`. Users with Claude Code installed can select provider `claude` and use the local CLI path without installing the Anthropic SDK. Provider/model settings remain per selected KB via `config.json` under that root.

## Validation

- `uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q`\n- `uv run --python 3.13 --with-editable . --with ruff ruff check`\n\nNote: the local `claude` binary is not installed in this environment, so the adapter is validated with subprocess-level tests rather than a live CLI call.