### PR TITLE
[codex] Add Claude CLI provider

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MPL-2.0
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from verinote.config import Config
+from verinote.llm.base import LLMError
+from verinote.llm.claude_cli_adapter import ClaudeCliAdapter
+from verinote.llm.factory import get_client
+
+
+def _cfg(tmp_path, *, model: str = "") -> Config:
+    return Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="claude",
+        model=model,
+        api_key=None,
+        base_url=None,
+    )
+
+
+def test_factory_selects_claude_cli_adapter(tmp_path):
+    assert isinstance(get_client(_cfg(tmp_path)), ClaudeCliAdapter)
+
+
+def test_claude_cli_extracts_facts_from_stdout(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                '{"facts":[{"subject":"Ada","relation":"is_a",'
+                '"object":"mathematician","confidence":0.9}]}'
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    facts = ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada is a mathematician.")
+
+    assert facts[0].subject == "Ada"
+    assert calls[0][0][0:2] == ["claude", "-p"]
+    assert calls[0][1]["capture_output"] is True
+
+
+def test_claude_cli_uses_model_when_configured(tmp_path, monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"datalog":"answer_q7(V) :- relation(V, \\"is_a\\", \\"person\\")."}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    line = ClaudeCliAdapter(_cfg(tmp_path, model="sonnet")).translate_query(question="Who?", qid=7)
+
+    assert commands[0][0:3] == ["claude", "--model", "sonnet"]
+    assert line.startswith("answer_q7")
+
+
+def test_claude_cli_missing_binary_is_llm_error(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(LLMError, match="claude CLI not found"):
+        ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="x")
+
+
+def test_claude_cli_nonzero_is_llm_error(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=2, stdout="", stderr="not logged in")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(LLMError, match="not logged in"):
+        ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="x")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-from verinote.config import Config, read_settings, save_settings
+from verinote.config import PROVIDERS, Config, read_settings, save_settings
 
 
 def _clear_env(monkeypatch):
@@ -34,6 +34,10 @@ def test_default_model_when_nothing_set(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     cfg = Config.for_root(tmp_path)  # no settings file, no env
     assert (cfg.provider, cfg.model) == ("anthropic", "claude-opus-4-8")
+
+
+def test_claude_cli_provider_is_available():
+    assert "claude" in PROVIDERS
 
 
 def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -19,6 +19,7 @@ SETTINGS_FILENAME = "config.json"
 
 _MODEL_DEFAULTS = {
     "anthropic": "claude-opus-4-8",
+    "claude": "",
     "openai": "gpt-4o",
     "ollama": "llama3.1",
 }
@@ -69,7 +70,7 @@ def _pick(env: str, saved: str | None, default: str | None) -> str | None:
 class Config:
     root: Path
     db_path: Path
-    provider: str  # "anthropic" | "openai" | "ollama"
+    provider: str  # "anthropic" | "claude" | "openai" | "ollama"
     model: str
     api_key: str | None
     base_url: str | None

--- a/verinote/llm/__init__.py
+++ b/verinote/llm/__init__.py
@@ -2,9 +2,10 @@
 """Provider-agnostic LLM layer.
 
 `LLMClient` is the single seam the rest of verinote talks to. Concrete adapters
-(Anthropic / OpenAI / Ollama) normalise structured (JSON-schema) output in-house
-so no vendor API leaks upward. This is the anti-lock-in design: the deterministic
-wirelog verifier re-checks every fact, so the provider/model is freely swappable.
+(Anthropic / Claude CLI / OpenAI / Ollama) normalise structured (JSON-schema)
+output in-house so no vendor API leaks upward. This is the anti-lock-in design:
+the deterministic wirelog verifier re-checks every fact, so the provider/model
+is freely swappable.
 """
 
 from verinote.llm.base import ExtractedFact, LLMClient, LLMError

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Claude Code CLI adapter. Uses `claude -p` and parses JSON from stdout."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+from verinote.config import Config
+from verinote.llm.base import ExtractedFact, LLMError
+from verinote.llm.schema import (
+    EXTRACTION_SYSTEM,
+    FACT_ARRAY_SCHEMA,
+    QUERY_SCHEMA,
+    parse_facts,
+    parse_query,
+    query_system,
+)
+
+
+class ClaudeCliAdapter:
+    name = "claude"
+
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        prompt = _json_prompt(
+            system=EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else ""),
+            schema=FACT_ARRAY_SCHEMA,
+            user=source_text,
+        )
+        return parse_facts(self._run(prompt))
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        prompt = _json_prompt(
+            system=query_system(qid) + ("\n" + schema_hint if schema_hint else ""),
+            schema=QUERY_SCHEMA,
+            user=question,
+        )
+        return parse_query(self._run(prompt))
+
+    def _run(self, prompt: str) -> str:
+        cmd = ["claude", "-p", prompt]
+        if self.cfg.model:
+            cmd = ["claude", "--model", self.cfg.model, "-p", prompt]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=180,
+            )
+        except FileNotFoundError as exc:
+            raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise LLMError("claude CLI request timed out") from exc
+        except OSError as exc:
+            raise LLMError(f"claude CLI request failed: {exc}") from exc
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            raise LLMError(f"claude CLI exited with {proc.returncode}: {detail}")
+        return proc.stdout.strip()
+
+
+def _json_prompt(*, system: str, schema: dict[str, Any], user: str) -> str:
+    schema_json = json.dumps(schema, ensure_ascii=False, indent=2)
+    return (
+        f"{system}\n\n"
+        "Return only a single JSON object. Do not wrap it in Markdown fences. "
+        "The JSON object must match this schema:\n"
+        f"{schema_json}\n\n"
+        "Input:\n"
+        f"{user}"
+    )

--- a/verinote/llm/factory.py
+++ b/verinote/llm/factory.py
@@ -13,6 +13,10 @@ def get_client(cfg: Config) -> LLMClient:
         from verinote.llm.anthropic_adapter import AnthropicAdapter
 
         return AnthropicAdapter(cfg)
+    if provider == "claude":
+        from verinote.llm.claude_cli_adapter import ClaudeCliAdapter
+
+        return ClaudeCliAdapter(cfg)
     if provider == "openai":
         from verinote.llm.openai_adapter import OpenAIAdapter
 
@@ -22,5 +26,5 @@ def get_client(cfg: Config) -> LLMClient:
 
         return OllamaAdapter(cfg)
     raise LLMError(
-        f"unknown VERINOTE_PROVIDER={provider!r}; expected anthropic|openai|ollama"
+        f"unknown VERINOTE_PROVIDER={provider!r}; expected anthropic|claude|openai|ollama"
     )


### PR DESCRIPTION
## Summary

Adds a `claude -p` based LLM provider for users who have the local Claude Code CLI installed.

## What changed

- Adds provider `claude` to the provider list used by config and Settings.
- Adds `ClaudeCliAdapter`, which invokes `claude -p` and parses stdout through the existing JSON schema parsers.
- Supports an optional configured model by passing `--model <model>` to the CLI.
- Normalizes missing binary, timeout, OS, and non-zero exit failures into `LLMError`.
- Adds subprocess-level tests for extraction, query translation, missing binary, non-zero exit, and factory registration.

## Impact

Users can select provider `claude` and use the local Claude CLI path without installing the Anthropic SDK. Existing provider behavior is unchanged.

## Validation

- `uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q`\n- `uv run --python 3.13 --with-editable . --with ruff ruff check`\n\nNote: the local `claude` binary is not installed in this environment, so this validates the adapter with subprocess-level tests rather than a live CLI call.