### PR TITLE
[codex] Fix ClaudeCLI provider behavior

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -14,7 +14,7 @@ def _cfg(tmp_path, *, model: str = "") -> Config:
     return Config(
         root=tmp_path,
         db_path=tmp_path / "kb.sqlite",
-        provider="claude",
+        provider="claudecli",
         model=model,
         api_key=None,
         base_url=None,
@@ -44,7 +44,10 @@ def test_claude_cli_extracts_facts_from_stdout(tmp_path, monkeypatch):
     facts = ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada is a mathematician.")
 
     assert facts[0].subject == "Ada"
-    assert calls[0][0][0:2] == ["claude", "-p"]
+    assert calls[0][0][0] == "claude"
+    assert "--json-schema" in calls[0][0]
+    assert "--system-prompt" in calls[0][0]
+    assert "-p" in calls[0][0]
     assert calls[0][1]["capture_output"] is True
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-from verinote.config import PROVIDERS, Config, read_settings, save_settings
+from verinote.config import PROVIDERS, TESTABLE_PROVIDERS, Config, read_settings, save_settings
 
 
 def _clear_env(monkeypatch):
@@ -37,7 +37,16 @@ def test_default_model_when_nothing_set(tmp_path, monkeypatch):
 
 
 def test_claude_cli_provider_is_available():
-    assert "claude" in PROVIDERS
+    assert "claudecli" in PROVIDERS
+    assert "claudecli" not in TESTABLE_PROVIDERS
+    assert "ollama" in TESTABLE_PROVIDERS
+
+
+def test_legacy_claude_provider_normalizes_to_claudecli(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    save_settings(tmp_path, provider="claude", model="")
+    assert read_settings(tmp_path)["provider"] == "claudecli"
+    assert Config.for_root(tmp_path).provider == "claudecli"
 
 
 def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -263,7 +263,8 @@ def test_settings_page_renders(tmp_path):
     c = _client(tmp_path)
     r = c.get("/settings")
     assert r.status_code == 200
-    assert "Provider" in r.text and "anthropic" in r.text
+    assert "Provider" in r.text and "Anthropic" in r.text
+    assert "ClaudeCLI" in r.text
     assert str(tmp_path) in r.text
 
 
@@ -280,6 +281,60 @@ def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
     # the next get_client would pick the ollama adapter — no code change
     assert c.app.state.cfg.provider == "ollama"
     assert (tmp_path / "config.json").is_file()
+
+
+def test_settings_disables_connection_test_for_non_api_provider(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="claudecli",
+        model="",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+
+    r = client.get("/settings")
+
+    assert "ClaudeCLI" in r.text
+    assert "Test connection" in r.text
+    assert 'aria-disabled="true"' in r.text
+    assert "Connection test is not available for this provider." not in r.text
+
+
+def test_test_connection_rejects_non_api_provider(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="claudecli",
+        model="",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+
+    r = client.post("/settings/test")
+
+    assert r.status_code == 400
+    assert "Connection test is not available for this provider." in r.text
+
+
+def test_settings_enables_connection_test_for_ollama(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="ollama",
+        model="llama3.1",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+
+    r = client.get("/settings")
+
+    assert "Ollama" in r.text
+    assert "Test connection" in r.text
+    assert 'aria-disabled="true"' not in r.text
 
 
 def test_settings_switches_active_kb_root(tmp_path):

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -19,11 +19,26 @@ SETTINGS_FILENAME = "config.json"
 
 _MODEL_DEFAULTS = {
     "anthropic": "claude-opus-4-8",
-    "claude": "",
+    "claudecli": "",
     "openai": "gpt-4o",
     "ollama": "llama3.1",
 }
 PROVIDERS = tuple(_MODEL_DEFAULTS)
+PROVIDER_LABELS = {
+    "anthropic": "Anthropic",
+    "claudecli": "ClaudeCLI",
+    "openai": "OpenAI",
+    "ollama": "Ollama",
+}
+TESTABLE_PROVIDERS = frozenset({"anthropic", "openai", "ollama"})
+
+
+def normalize_provider(provider: str | None) -> str:
+    """Canonical provider id used in config and dispatch."""
+    key = (provider or "").replace("-", "").replace("_", "").lower()
+    if key == "claude":
+        return "claudecli"
+    return key
 
 
 def _root() -> Path:
@@ -51,7 +66,11 @@ def save_settings(
 ) -> None:
     """Persist non-secret settings to `<root>/config.json` (never the API key)."""
     root.mkdir(parents=True, exist_ok=True)
-    payload = {"provider": provider, "model": model, "base_url": base_url or None}
+    payload = {
+        "provider": normalize_provider(provider),
+        "model": model,
+        "base_url": base_url or None,
+    }
     _settings_path(root).write_text(
         json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
@@ -70,7 +89,7 @@ def _pick(env: str, saved: str | None, default: str | None) -> str | None:
 class Config:
     root: Path
     db_path: Path
-    provider: str  # "anthropic" | "claude" | "openai" | "ollama"
+    provider: str  # "anthropic" | "claudecli" | "openai" | "ollama"
     model: str
     api_key: str | None
     base_url: str | None
@@ -78,7 +97,9 @@ class Config:
     @classmethod
     def for_root(cls, root: Path) -> "Config":
         saved = read_settings(root)
-        provider = (_pick("VERINOTE_PROVIDER", saved.get("provider"), "anthropic") or "").lower()
+        provider = normalize_provider(
+            _pick("VERINOTE_PROVIDER", saved.get("provider"), "anthropic")
+        )
         model = _pick("VERINOTE_MODEL", saved.get("model"), _MODEL_DEFAULTS.get(provider, "")) or ""
         base_url = _pick("VERINOTE_BASE_URL", saved.get("base_url"), None)
         return cls(

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Claude Code CLI adapter. Uses `claude -p` and parses JSON from stdout."""
+"""Claude Code CLI adapter. Uses `claude -p --json-schema` and parses stdout."""
 
 from __future__ import annotations
 
@@ -20,31 +20,40 @@ from verinote.llm.schema import (
 
 
 class ClaudeCliAdapter:
-    name = "claude"
+    name = "ClaudeCLI"
 
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
-        prompt = _json_prompt(
+        prompt = _prompt(
             system=EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else ""),
             schema=FACT_ARRAY_SCHEMA,
             user=source_text,
         )
-        return parse_facts(self._run(prompt))
+        return parse_facts(self._run(prompt, schema=FACT_ARRAY_SCHEMA))
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
-        prompt = _json_prompt(
+        prompt = _prompt(
             system=query_system(qid) + ("\n" + schema_hint if schema_hint else ""),
             schema=QUERY_SCHEMA,
             user=question,
         )
-        return parse_query(self._run(prompt))
+        return parse_query(self._run(prompt, schema=QUERY_SCHEMA))
 
-    def _run(self, prompt: str) -> str:
-        cmd = ["claude", "-p", prompt]
+    def _run(self, prompt: "_Prompt", *, schema: dict[str, Any]) -> str:
+        schema_json = json.dumps(schema, ensure_ascii=False)
+        cmd = [
+            "claude",
+            "--system-prompt",
+            prompt.system,
+            "--json-schema",
+            schema_json,
+            "-p",
+            prompt.user,
+        ]
         if self.cfg.model:
-            cmd = ["claude", "--model", self.cfg.model, "-p", prompt]
+            cmd = ["claude", "--model", self.cfg.model, *cmd[1:]]
         try:
             proc = subprocess.run(
                 cmd,
@@ -65,13 +74,23 @@ class ClaudeCliAdapter:
         return proc.stdout.strip()
 
 
-def _json_prompt(*, system: str, schema: dict[str, Any], user: str) -> str:
+class _Prompt:
+    def __init__(self, *, system: str, user: str) -> None:
+        self.system = system
+        self.user = user
+
+
+def _prompt(*, system: str, schema: dict[str, Any], user: str) -> _Prompt:
     schema_json = json.dumps(schema, ensure_ascii=False, indent=2)
-    return (
-        f"{system}\n\n"
-        "Return only a single JSON object. Do not wrap it in Markdown fences. "
-        "The JSON object must match this schema:\n"
-        f"{schema_json}\n\n"
-        "Input:\n"
-        f"{user}"
+    return _Prompt(
+        system=(
+            f"{system}\n\n"
+            "Return only a single JSON object. Do not wrap it in Markdown fences. "
+            "The JSON object must match this schema:\n"
+            f"{schema_json}"
+        ),
+        user=(
+            "Input:\n"
+            f"{user}"
+        ),
     )

--- a/verinote/llm/factory.py
+++ b/verinote/llm/factory.py
@@ -13,7 +13,7 @@ def get_client(cfg: Config) -> LLMClient:
         from verinote.llm.anthropic_adapter import AnthropicAdapter
 
         return AnthropicAdapter(cfg)
-    if provider == "claude":
+    if provider == "claudecli":
         from verinote.llm.claude_cli_adapter import ClaudeCliAdapter
 
         return ClaudeCliAdapter(cfg)
@@ -26,5 +26,5 @@ def get_client(cfg: Config) -> LLMClient:
 
         return OllamaAdapter(cfg)
     raise LLMError(
-        f"unknown VERINOTE_PROVIDER={provider!r}; expected anthropic|claude|openai|ollama"
+        f"unknown VERINOTE_PROVIDER={provider!r}; expected anthropic|claudecli|openai|ollama"
     )

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -15,7 +15,13 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from verinote.config import PROVIDERS, Config, save_settings
+from verinote.config import (
+    PROVIDER_LABELS,
+    PROVIDERS,
+    TESTABLE_PROVIDERS,
+    Config,
+    save_settings,
+)
 from verinote.llm import LLMError, get_client
 from verinote.pipeline import (
     IngestError,
@@ -75,6 +81,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "sources": store.sources(),
                 "coverage": coverage(store, root=cfg.root),
                 "provider": app.state.cfg.provider,
+                "provider_label": PROVIDER_LABELS.get(
+                    app.state.cfg.provider, app.state.cfg.provider
+                ),
                 "model": app.state.cfg.model,
                 "root": app.state.cfg.root,
                 "error": error,
@@ -230,11 +239,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             "settings.html",
             {
                 "providers": PROVIDERS,
+                "provider_labels": PROVIDER_LABELS,
                 "provider": c.provider,
+                "provider_label": PROVIDER_LABELS.get(c.provider, c.provider),
                 "model": c.model,
                 "base_url": c.base_url or "",
                 "root": c.root,
                 "has_key": bool(c.api_key),  # never render the key itself
+                "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
                 "test_result": test_result,
                 "error": error,
             },
@@ -271,6 +283,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/settings/test", response_class=HTMLResponse)
     def test_connection(request: Request):
         c = app.state.cfg
+        if c.provider not in TESTABLE_PROVIDERS:
+            return _settings(
+                request,
+                error="Connection test is not available for this provider.",
+                status_code=400,
+            )
         try:
             client = get_client(c)
             facts = client.extract_facts(

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -58,6 +58,7 @@ tr.editing td { background: rgba(91, 157, 255, .06); }
 .btn { display: inline-block; background: var(--accent); color: #06101f; text-decoration: none;
   padding: .5rem .9rem; border-radius: 7px; font-weight: 600; }
 .btn.ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); }
+.btn:disabled, .btn[aria-disabled="true"] { color: var(--muted); opacity: .55; }
 .empty { background: var(--panel); border: 1px dashed var(--line); border-radius: 10px; padding: 2rem; text-align: center; color: var(--muted); }
 .warn { color: var(--warn); }
 .error { background: rgba(240, 82, 109, .12); border: 1px solid var(--danger);

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -2,7 +2,7 @@
 {% block title %}verinote{% endblock %}
 {% block content %}
 <h1>Knowledge base</h1>
-<p class="muted">KB <code>{{ root }}</code> · provider <strong>{{ provider }}</strong> · model <code>{{ model }}</code></p>
+<p class="muted">KB <code>{{ root }}</code> · provider <strong>{{ provider_label }}</strong> · model <code>{{ model }}</code></p>
 
 <section class="cards">
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -22,7 +22,9 @@
   <label>Provider
     <select name="provider">
       {% for p in providers %}
-      <option value="{{ p }}" {{ 'selected' if p == provider else '' }}>{{ p }}</option>
+      <option value="{{ p }}" {{ 'selected' if p == provider else '' }}>
+        {{ provider_labels.get(p, p) }}
+      </option>
       {% endfor %}
     </select>
   </label>
@@ -38,7 +40,8 @@
 <p class="muted">API key: {{ 'set (from environment)' if has_key else 'not set — export VERINOTE_API_KEY' }}</p>
 
 <p>
-  <button class="btn ghost" hx-post="/settings/test" hx-target="body" hx-swap="outerHTML">
+  <button class="btn ghost" hx-post="/settings/test" hx-target="body" hx-swap="outerHTML"
+          {% if not connection_test_enabled %}aria-disabled="true"{% endif %}>
     Test connection
   </button>
 </p>


### PR DESCRIPTION
## Summary

Fixes the ClaudeCLI provider path and Settings behavior. The provider is presented as `ClaudeCLI`, uses Claude Code's native JSON schema output, and connection testing is available only for providers that actually support it.

## What changed

- Renames the provider id from `claude` to canonical `claudecli`, with UI label `ClaudeCLI`.
- Normalizes legacy saved/env values like `claude` to `claudecli`.
- Calls `claude --system-prompt ... --json-schema ... -p ...` for structured output.
- Keeps optional `--model <model>` support.
- Adds provider display labels for Settings and Dashboard.
- Enables `Test connection` for `Anthropic`, `OpenAI`, and `Ollama`.
- Marks `Test connection` unavailable for `ClaudeCLI`; saving the provider shows no warning.
- Clicking `Test connection` for a non-testable provider returns `Connection test is not available for this provider.`
- Updates tests for provider normalization, Ollama test availability, ClaudeCLI click-time messaging, and CLI flags.

## Validation

- `claude --version` -> `2.1.193 (Claude Code)`
- `claude -p 'Return only this exact JSON object and no markdown: {"ok":true}'` -> `{"ok":true}`
- Live `ClaudeCliAdapter.extract_facts(...)` returned an `ExtractedFact`
- Live `ClaudeCliAdapter.translate_query(...)` returned an `answer_q42(...)` rule
- `uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q` -> `100 passed`\n- `uv run --python 3.13 --with-editable . --with ruff ruff check`