### PR TITLE
[codex] Add wirelog term model and parser

### DIFF
--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+from verinote.engine.terms import (
+    Atom,
+    Compound,
+    NumberLit,
+    StringLit,
+    TermParseError,
+    Var,
+    canonical_term_key,
+    parse_term,
+    render_term,
+)
+
+
+def test_parse_variables_and_atoms():
+    assert parse_term("S") == Var("S")
+    assert parse_term("Answer") == Var("Answer")
+    assert parse_term("wirelog") == Atom("wirelog")
+    assert parse_term("participant_1") == Atom("participant_1")
+    assert parse_term("_anonymous") == Atom("_anonymous")
+
+
+@pytest.mark.parametrize("text", ["_", "_1", "a1", "a_b2", "A1", "Camel"])
+def test_identifier_edges_are_explicit(text):
+    term = parse_term(text)
+    if text[0].isupper():
+        assert isinstance(term, Var)
+    else:
+        assert isinstance(term, Atom)
+
+
+def test_uppercase_functor_is_rejected():
+    with pytest.raises(TermParseError, match="compound functor"):
+        parse_term("F(A)")
+
+
+def test_parse_and_render_strings():
+    assert parse_term('"Ada"') == StringLit("Ada")
+    assert parse_term('"a\\"b"') == StringLit('a"b')
+    assert parse_term('"a\\\\b"') == StringLit("a\\b")
+    assert parse_term('"a\\nb\\tc"') == StringLit("a\nb\tc")
+    assert render_term(StringLit('a"\\b\n')) == '"a\\"\\\\b\\n"'
+
+
+def test_parse_integer_numbers():
+    assert parse_term("2020") == NumberLit(2020)
+    assert parse_term("-1") == NumberLit(-1)
+    assert render_term(NumberLit(-42)) == "-42"
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["1.5", "1.0", "1e3", "+1", "01", "--1", "1abc", "١", "²", "a١"],
+)
+def test_float_and_malformed_numbers_are_rejected(text):
+    with pytest.raises(TermParseError):
+        parse_term(text)
+
+
+def test_parse_compound_terms():
+    assert parse_term('person("Ada")') == Compound("person", (StringLit("Ada"),))
+    assert parse_term("date(2020, 1, 1)") == Compound(
+        "date", (NumberLit(2020), NumberLit(1), NumberLit(1))
+    )
+    assert parse_term('grant("NSF", "123")') == Compound(
+        "grant", (StringLit("NSF"), StringLit("123"))
+    )
+    assert parse_term('role(person("Ada"), "PI")') == Compound(
+        "role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))
+    )
+    assert parse_term("outer(inner(A), B)") == Compound(
+        "outer", (Compound("inner", (Var("A"),)), Var("B"))
+    )
+
+
+def test_zero_arity_compound_is_supported():
+    assert parse_term("unit()") == Compound("unit", ())
+    assert render_term(parse_term("unit()")) == "unit()"
+
+
+def test_render_canonicalizes_whitespace():
+    assert render_term(parse_term(' f( A , "x" , inner( B ) ) ')) == 'f(A, "x", inner(B))'
+
+
+@pytest.mark.parametrize(
+    "term",
+    [
+        Var("Answer"),
+        Atom("participant"),
+        StringLit('a"b\\c'),
+        NumberLit(2020),
+        Compound("person", (StringLit("Ada"),)),
+        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+        Compound("unit", ()),
+    ],
+)
+def test_render_round_trips(term):
+    assert parse_term(render_term(term)) == term
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ('f("A")', "f(A)"),
+        ("f(A)", "g(A)"),
+        ("f(A, B)", "f(B, A)"),
+        ('"f(A)"', "f(A)"),
+        ("a", "A"),
+        ('"a"', "a"),
+        ('"1"', "1"),
+    ],
+)
+def test_structural_inequality(left, right):
+    a = parse_term(left)
+    b = parse_term(right)
+    assert a != b
+    assert canonical_term_key(a) != canonical_term_key(b)
+
+
+def test_canonical_key_is_stable_and_type_tagged():
+    a = parse_term('role(person("Ada"), "PI")')
+    b = parse_term(' role( person( "Ada" ) , "PI" ) ')
+    assert canonical_term_key(a) == canonical_term_key(b)
+    assert canonical_term_key(a) == canonical_term_key(parse_term(render_term(a)))
+    assert canonical_term_key(Var("A")).startswith("V:")
+    assert canonical_term_key(Atom("a")).startswith("A:")
+    assert canonical_term_key(StringLit("a")).startswith("S:")
+    assert canonical_term_key(NumberLit(1)).startswith("N:")
+    assert canonical_term_key(Compound("f", (Var("A"),))).startswith("C:f(")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "f(",
+        "f(A",
+        "f(A))",
+        "f(A,,B)",
+        "f(,A)",
+        "f(A,)",
+        'f("unterminated)',
+        '"unterminated',
+        '"bad\\q"',
+        "f(A)junk",
+        "a b",
+        ".decl relation(subject: symbol)",
+    ],
+)
+def test_malformed_terms_are_rejected(text):
+    with pytest.raises(TermParseError):
+        parse_term(text)
+
+
+def test_current_flat_relation_fields_can_be_parsed_independently():
+    fields = {"subject": 'person("Ada")', "relation": "born_in", "object": '"London"'}
+    assert parse_term(fields["subject"]) == Compound("person", (StringLit("Ada"),))
+    assert parse_term(fields["relation"]) == Atom("born_in")
+    assert parse_term(fields["object"]) == StringLit("London")

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Logical term model and parser for the supported wirelog/Datalog subset.
+
+This module is deliberately independent from pyrewire, DuckDB, SQLite, and the
+verification pipeline. It defines the term semantics future DuckDB-backed
+inference must preserve:
+
+- uppercase identifiers are variables: ``A``, ``Subject``
+- lowercase/underscore identifiers are atoms: ``wirelog``, ``born_on``
+- compound functors use atom identifiers: ``person("Ada")``
+- strings, integers, and nested compounds are first-class terms
+
+Floating point and exponent notation are intentionally rejected for now. That
+keeps numeric equality unambiguous until a later issue defines float semantics.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TypeAlias
+
+_VAR_RE = re.compile(r"[A-Z][A-Za-z0-9_]*\Z")
+_ATOM_RE = re.compile(r"[a-z_][A-Za-z0-9_]*\Z")
+
+
+class TermParseError(ValueError):
+    """Raised when term text cannot be parsed completely."""
+
+
+@dataclass(frozen=True)
+class Var:
+    name: str
+
+    def __post_init__(self) -> None:
+        if not _VAR_RE.fullmatch(self.name):
+            raise ValueError(f"invalid variable name: {self.name!r}")
+
+
+@dataclass(frozen=True)
+class Atom:
+    name: str
+
+    def __post_init__(self) -> None:
+        if not _ATOM_RE.fullmatch(self.name):
+            raise ValueError(f"invalid atom name: {self.name!r}")
+
+
+@dataclass(frozen=True)
+class StringLit:
+    value: str
+
+
+@dataclass(frozen=True)
+class NumberLit:
+    value: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, bool) or not isinstance(self.value, int):
+            raise ValueError(f"invalid integer literal: {self.value!r}")
+
+
+@dataclass(frozen=True)
+class Compound:
+    functor: str
+    args: tuple["Term", ...]
+
+    def __post_init__(self) -> None:
+        if not _ATOM_RE.fullmatch(self.functor):
+            raise ValueError(f"invalid compound functor: {self.functor!r}")
+        if not isinstance(self.args, tuple):
+            raise ValueError("compound args must be a tuple")
+        for arg in self.args:
+            if not isinstance(arg, (Var, Atom, StringLit, NumberLit, Compound)):
+                raise ValueError(f"invalid compound arg: {arg!r}")
+
+
+Term: TypeAlias = Var | Atom | StringLit | NumberLit | Compound
+
+
+def parse_term(text: str) -> Term:
+    """Parse one complete logical term."""
+    parser = _Parser(text)
+    term = parser.parse_term()
+    parser.skip_ws()
+    if not parser.done:
+        raise parser.error("unexpected trailing input")
+    return term
+
+
+def render_term(term: Term) -> str:
+    """Render a term in canonical concrete syntax."""
+    if isinstance(term, Var):
+        return term.name
+    if isinstance(term, Atom):
+        return term.name
+    if isinstance(term, StringLit):
+        return _render_string(term.value)
+    if isinstance(term, NumberLit):
+        return str(term.value)
+    if isinstance(term, Compound):
+        return f"{term.functor}(" + ", ".join(render_term(arg) for arg in term.args) + ")"
+    raise TypeError(f"not a term: {term!r}")
+
+
+def canonical_term_key(term: Term) -> str:
+    """Return a stable, type-tagged structural key for equality/storage work."""
+    if isinstance(term, Var):
+        return f"V:{term.name}"
+    if isinstance(term, Atom):
+        return f"A:{term.name}"
+    if isinstance(term, StringLit):
+        return "S:" + _render_string(term.value)
+    if isinstance(term, NumberLit):
+        return f"N:{term.value}"
+    if isinstance(term, Compound):
+        return (
+            f"C:{term.functor}("
+            + ",".join(canonical_term_key(arg) for arg in term.args)
+            + ")"
+        )
+    raise TypeError(f"not a term: {term!r}")
+
+
+def _render_string(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+class _Parser:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.pos = 0
+
+    @property
+    def done(self) -> bool:
+        return self.pos >= len(self.text)
+
+    def error(self, message: str) -> TermParseError:
+        return TermParseError(f"{message} at position {self.pos}")
+
+    def skip_ws(self) -> None:
+        while not self.done and self.text[self.pos].isspace():
+            self.pos += 1
+
+    def parse_term(self) -> Term:
+        self.skip_ws()
+        if self.done:
+            raise self.error("expected term")
+
+        ch = self.text[self.pos]
+        if ch == '"':
+            return self.parse_string()
+        if ch == "-" or _is_ascii_digit(ch):
+            return self.parse_number()
+        if _is_ident_start(ch):
+            ident = self.parse_identifier()
+            self.skip_ws()
+            if not self.done and self.text[self.pos] == "(":
+                if not _ATOM_RE.fullmatch(ident):
+                    raise self.error("compound functor must be an atom identifier")
+                return self.parse_compound(ident)
+            if _VAR_RE.fullmatch(ident):
+                return Var(ident)
+            if _ATOM_RE.fullmatch(ident):
+                return Atom(ident)
+            raise self.error("invalid identifier")
+        raise self.error("expected term")
+
+    def parse_identifier(self) -> str:
+        start = self.pos
+        self.pos += 1
+        while not self.done and _is_ident_tail(self.text[self.pos]):
+            self.pos += 1
+        return self.text[start:self.pos]
+
+    def parse_string(self) -> StringLit:
+        self.pos += 1  # opening quote
+        chars: list[str] = []
+        while not self.done:
+            ch = self.text[self.pos]
+            self.pos += 1
+            if ch == '"':
+                return StringLit("".join(chars))
+            if ch == "\\":
+                if self.done:
+                    raise self.error("unterminated escape")
+                esc = self.text[self.pos]
+                self.pos += 1
+                if esc == '"':
+                    chars.append('"')
+                elif esc == "\\":
+                    chars.append("\\")
+                elif esc == "n":
+                    chars.append("\n")
+                elif esc == "r":
+                    chars.append("\r")
+                elif esc == "t":
+                    chars.append("\t")
+                else:
+                    raise self.error(f"unsupported escape \\{esc}")
+            else:
+                chars.append(ch)
+        raise self.error("unterminated string")
+
+    def parse_number(self) -> NumberLit:
+        start = self.pos
+        if self.text[self.pos] == "-":
+            self.pos += 1
+            if self.done or not _is_ascii_digit(self.text[self.pos]):
+                raise self.error("expected digit after '-'")
+
+        digit_start = self.pos
+        if self.text[self.pos] == "0":
+            self.pos += 1
+            if not self.done and _is_ascii_digit(self.text[self.pos]):
+                raise self.error("leading zero is not supported")
+        else:
+            while not self.done and _is_ascii_digit(self.text[self.pos]):
+                self.pos += 1
+
+        if digit_start == self.pos:
+            raise self.error("expected digit")
+        if not self.done and self.text[self.pos] in ".eE":
+            raise self.error("only integer numeric terms are supported")
+        if not self.done and _is_ident_start(self.text[self.pos]):
+            raise self.error("unexpected identifier after number")
+        return NumberLit(int(self.text[start:self.pos]))
+
+    def parse_compound(self, functor: str) -> Compound:
+        self.pos += 1  # opening paren
+        args: list[Term] = []
+        self.skip_ws()
+        if not self.done and self.text[self.pos] == ")":
+            self.pos += 1
+            return Compound(functor, ())
+
+        while True:
+            args.append(self.parse_term())
+            self.skip_ws()
+            if self.done:
+                raise self.error("expected ',' or ')'")
+            ch = self.text[self.pos]
+            if ch == ")":
+                self.pos += 1
+                return Compound(functor, tuple(args))
+            if ch != ",":
+                raise self.error("expected ',' or ')'")
+            self.pos += 1
+            self.skip_ws()
+            if not self.done and self.text[self.pos] == ")":
+                raise self.error("expected term after ','")
+
+
+def _is_ident_start(ch: str) -> bool:
+    return ch == "_" or ("A" <= ch <= "Z") or ("a" <= ch <= "z")
+
+
+def _is_ident_tail(ch: str) -> bool:
+    return _is_ident_start(ch) or _is_ascii_digit(ch)
+
+
+def _is_ascii_digit(ch: str) -> bool:
+    return "0" <= ch <= "9"


### PR DESCRIPTION
## Summary

Closes #29. Adds a standalone logical term model and recursive parser for the supported wirelog/Datalog term subset. This is the first atomic step toward #28 and intentionally does not change verification behavior.

## What changed

- Adds `verinote.engine.terms` with `Var`, `Atom`, `StringLit`, `NumberLit`, and `Compound` term types.
- Adds `parse_term`, `render_term`, and `canonical_term_key`.
- Defines conservative identifier semantics: uppercase identifiers are variables, lowercase/underscore identifiers are atoms, and compound functors must be atom identifiers.
- Supports quoted strings with deterministic escaping, integer numeric terms, zero-arity compounds, arbitrary-arity compounds, and nested compounds.
- Explicitly rejects floats, exponent notation, Unicode digits, partial parses, malformed compounds, and invalid escapes.
- Adds focused tests for parsing, rendering, round-trip canonicalization, structural inequality, canonical keys, malformed input, and current flat relation field parsing.

## Deliberate non-changes

- Does not switch `verify()` or `run_check()` to DuckDB.
- Does not alter SQLite schema.
- Does not change `compile_dl()` or pyrewire behavior.

## Validation

- `uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q tests/test_terms.py tests/test_engine.py tests/test_verify.py` -> `69 passed`\n- `uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q` -> `152 passed`\n- `uv run --python 3.13 --with-editable . --with ruff ruff check`