### PR TITLE
[codex] Add Datalog subset parser and validator

### DIFF
--- a/tests/test_datalog.py
+++ b/tests/test_datalog.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+from verinote.engine import DEFAULT_POLICY
+from verinote.engine.datalog import (
+    AtomExpr,
+    Column,
+    Comparison,
+    Declaration,
+    DatalogParseError,
+    DatalogValidationError,
+    Fact,
+    Rule,
+    parse_and_validate_program,
+    parse_program,
+    validate_program,
+)
+from verinote.engine.terms import Atom, Compound, StringLit, Var
+
+
+def test_parse_and_validate_default_policy():
+    program = parse_and_validate_program(DEFAULT_POLICY)
+
+    assert [decl.name for decl in program.declarations] == [
+        "relation",
+        "functional",
+        "error_functional_conflict",
+    ]
+    assert len(program.facts) == 3
+    assert program.facts[0] == Fact(
+        AtomExpr("functional", (StringLit("established_on"),))
+    )
+    assert len(program.rules) == 1
+    rule = program.rules[0]
+    assert rule.head == AtomExpr("error_functional_conflict", (Var("S"), Var("R")))
+    assert isinstance(rule.body[-1], Comparison)
+    assert rule.body[-1].op == "!="
+
+
+def test_parse_and_validate_generated_answer_query_with_relation_decl():
+    source = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O).\n'
+    )
+
+    program = parse_and_validate_program(source)
+
+    assert program.rules == (
+        Rule(
+            AtomExpr("answer_q1", (Var("O"),)),
+            (AtomExpr("relation", (StringLit("Ada"), StringLit("born_in"), Var("O"))),),
+        ),
+    )
+
+
+def test_comments_do_not_strip_string_content():
+    source = (
+        "// full-line comment\n"
+        ".decl relation(subject: symbol, rel: symbol, object: symbol) // trailing\n"
+        'relation("Ada // not comment", "born_in", "London").\n'
+    )
+
+    program = parse_and_validate_program(source)
+
+    assert program.facts == (
+        Fact(
+            AtomExpr(
+                "relation",
+                (
+                    StringLit("Ada // not comment"),
+                    StringLit("born_in"),
+                    StringLit("London"),
+                ),
+            )
+        ),
+    )
+
+
+def test_nested_compound_terms_are_not_treated_as_predicates():
+    source = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl answer_q2(value: symbol)\n"
+        'answer_q2(person(O)) :- relation(person("Ada"), born_in, O).\n'
+    )
+
+    program = parse_and_validate_program(source)
+    rule = program.rules[0]
+
+    assert rule.head.args == (Compound("person", (Var("O"),)),)
+    assert rule.body == (
+        AtomExpr(
+            "relation",
+            (
+                Compound("person", (StringLit("Ada"),)),
+                Atom("born_in"),
+                Var("O"),
+            ),
+        ),
+    )
+
+
+def test_zero_arity_declarations_and_facts_are_supported():
+    program = parse_and_validate_program(".decl ready()\nready().")
+
+    assert program.declarations == (Declaration("ready", ()),)
+    assert program.facts == (Fact(AtomExpr("ready", ())),)
+
+
+@pytest.mark.parametrize(
+    ("source", "message"),
+    [
+        ('p("x").', "unknown predicate: p"),
+        ('.decl p(x: symbol)\np("a", "b").', "arity mismatch for p"),
+        ('.decl p(x: symbol)\n.decl q(x: symbol)\np(X) :- q(Y).', "unsafe head"),
+        (
+            '.decl p(x: symbol)\n.decl q(x: symbol)\np(X) :- q(X), Y != "blocked".',
+            "unsafe comparison",
+        ),
+        ('.decl p(x: symbol)\np(X) :- X == "Ada".', "unsafe head"),
+        (".decl p(x: string)", "unsupported type"),
+        (".decl p(x: symbol)\n.decl p(x: symbol)", "duplicate declaration"),
+        ('.decl p(x: symbol)\np(X).', "fact contains variable"),
+    ],
+)
+def test_validation_rejects_invalid_programs(source, message):
+    program = parse_program(source)
+    with pytest.raises(DatalogValidationError, match=message):
+        validate_program(program)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        ".input p",
+        ".declp(x: symbol)",
+        ".decl p(x symbol)",
+        '.decl p(x: symbol) p("a").',
+        ".decl p(x: symbol)\np(X) :- not q(X).",
+        ".decl p(x: symbol)\np(X) :- X < 3.",
+        ".decl p(x: symbol)\np(X) :- q(X),.",
+        ".decl p(x: symbol)\np(X) :- q(X)",
+        ".decl p(x: symbol)\np(X",
+        ".decl p(x: symbol)\np(X). junk",
+    ],
+)
+def test_parse_rejects_unsupported_syntax(source):
+    with pytest.raises(DatalogParseError):
+        parse_program(source)
+
+
+def test_parse_rejects_comparison_with_missing_side():
+    with pytest.raises(DatalogParseError, match="requires two terms"):
+        parse_program(".decl p(x: symbol)\np(X) :- X != .")
+
+
+def test_declarations_preserve_columns_and_types():
+    program = parse_program(".decl relation(subject: symbol, rel: symbol)")
+
+    assert program.declarations == (
+        Declaration(
+            "relation",
+            (Column("subject", "symbol"), Column("rel", "symbol")),
+        ),
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import pytest
+
 import verinote.engine.wirelog as wl
 from verinote.engine import DEFAULT_POLICY, compile_dl, run_check, validate_query
 
@@ -104,9 +106,61 @@ def test_validate_query_accepts_relation_only():
     assert ok is True and reason == ""
 
 
+def test_validate_query_does_not_flag_compound_functors_as_predicates():
+    ok, reason = validate_query(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(person(O)) :- relation(person("Ada"), born_in, O).'
+    )
+    assert ok is False
+    assert "unknown predicate" not in reason
+    assert "person" not in reason
+
+
 def test_validate_query_rejects_unknown_predicate():
     ok, reason = validate_query(".decl answer_q1(value: symbol)\nanswer_q1(O) :- bogus(O).")
     assert ok is False and "bogus" in reason
+
+
+def test_validate_query_rejects_fabricated_predicate_declarations():
+    ok, reason = validate_query(
+        ".decl answer_q1(value: symbol)\n"
+        ".decl bogus(value: symbol)\n"
+        'bogus("x").\n'
+        "answer_q1(X) :- bogus(X)."
+    )
+    assert ok is False and "only declare answer predicates" in reason
+
+
+@pytest.mark.parametrize(
+    "query_dl",
+    [
+        ".decl answer_q1(value: symbol)\n"
+        ".decl answer_query(value: symbol)\n"
+        'answer_query(O) :- relation("Ada", "born_in", O).',
+        ".decl answer_q1(value: symbol)\n"
+        ".decl answer_qevil(a: symbol, b: symbol)\n"
+        'answer_qevil(S, O) :- relation(S, "born_in", O).',
+    ],
+)
+def test_validate_query_rejects_fabricated_answer_like_predicates(query_dl):
+    ok, reason = validate_query(query_dl)
+    assert ok is False
+    assert "answer" in reason
+
+
+def test_validate_query_rejects_arity_mismatch_before_engine():
+    ok, reason = validate_query(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O, "extra").'
+    )
+    assert ok is False and "arity mismatch" in reason
+
+
+def test_validate_query_rejects_unsafe_variable_before_engine():
+    ok, reason = validate_query(
+        ".decl answer_q1(value: symbol)\n" 'answer_q1(O) :- relation("Ada", "born_in", X).'
+    )
+    assert ok is False and "unsafe head variable" in reason
 
 
 def test_validate_query_rejects_syntax_error():

--- a/verinote/engine/datalog.py
+++ b/verinote/engine/datalog.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Parser and validator for verinote's supported wirelog/Datalog subset.
+
+This module defines the source-language boundary future DuckDB-backed inference
+will compile. It is intentionally independent from pyrewire, DuckDB, SQLite, and
+the verification runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from verinote.engine.terms import Compound, Term, TermParseError, Var, parse_term
+
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class DatalogParseError(ValueError):
+    """Raised when Datalog source is outside the supported concrete syntax."""
+
+
+class DatalogValidationError(ValueError):
+    """Raised when parsed Datalog source fails semantic validation."""
+
+
+@dataclass(frozen=True)
+class Column:
+    name: str
+    type: str
+
+    def __post_init__(self) -> None:
+        if not _IDENT_RE.fullmatch(self.name):
+            raise ValueError(f"invalid column name: {self.name!r}")
+        if not _IDENT_RE.fullmatch(self.type):
+            raise ValueError(f"invalid column type: {self.type!r}")
+
+
+@dataclass(frozen=True)
+class Declaration:
+    name: str
+    columns: tuple[Column, ...]
+
+    def __post_init__(self) -> None:
+        if not _IDENT_RE.fullmatch(self.name):
+            raise ValueError(f"invalid predicate name: {self.name!r}")
+
+
+@dataclass(frozen=True)
+class AtomExpr:
+    predicate: str
+    args: tuple[Term, ...]
+
+    def __post_init__(self) -> None:
+        if not _IDENT_RE.fullmatch(self.predicate):
+            raise ValueError(f"invalid predicate name: {self.predicate!r}")
+
+
+@dataclass(frozen=True)
+class Comparison:
+    left: Term
+    op: Literal["==", "!="]
+    right: Term
+
+
+BodyItem: TypeAlias = AtomExpr | Comparison
+
+
+@dataclass(frozen=True)
+class Fact:
+    atom: AtomExpr
+
+
+@dataclass(frozen=True)
+class Rule:
+    head: AtomExpr
+    body: tuple[BodyItem, ...]
+
+
+@dataclass(frozen=True)
+class Program:
+    declarations: tuple[Declaration, ...]
+    facts: tuple[Fact, ...]
+    rules: tuple[Rule, ...]
+
+
+def parse_program(source: str) -> Program:
+    """Parse supported Datalog source into a structural AST."""
+    return _Parser(_strip_comments(source)).parse_program()
+
+
+def validate_program(program: Program) -> None:
+    """Validate declarations, arity, vocabulary, and rule variable safety."""
+    arities: dict[str, int] = {}
+    for decl in program.declarations:
+        if decl.name in arities:
+            raise DatalogValidationError(f"duplicate declaration: {decl.name}")
+        for column in decl.columns:
+            if column.type != "symbol":
+                raise DatalogValidationError(
+                    f"unsupported type for {decl.name}.{column.name}: {column.type}"
+                )
+        arities[decl.name] = len(decl.columns)
+
+    for fact in program.facts:
+        _validate_atom(fact.atom, arities)
+        vars_in_fact = _vars_in_atom(fact.atom)
+        if vars_in_fact:
+            joined = ", ".join(sorted(vars_in_fact))
+            raise DatalogValidationError(f"fact contains variable(s): {joined}")
+
+    for rule in program.rules:
+        _validate_atom(rule.head, arities)
+        positive_vars: set[str] = set()
+        for item in rule.body:
+            if isinstance(item, AtomExpr):
+                _validate_atom(item, arities)
+                positive_vars.update(_vars_in_atom(item))
+            elif item.op not in {"==", "!="}:
+                raise DatalogValidationError(f"unsupported comparison operator: {item.op}")
+
+        head_vars = _vars_in_atom(rule.head)
+        unsafe_head = head_vars - positive_vars
+        if unsafe_head:
+            joined = ", ".join(sorted(unsafe_head))
+            raise DatalogValidationError(f"unsafe head variable(s): {joined}")
+
+        for item in rule.body:
+            if isinstance(item, Comparison):
+                comparison_vars = _vars_in_term(item.left) | _vars_in_term(item.right)
+                unsafe_comparison = comparison_vars - positive_vars
+                if unsafe_comparison:
+                    joined = ", ".join(sorted(unsafe_comparison))
+                    raise DatalogValidationError(
+                        f"unsafe comparison variable(s): {joined}"
+                    )
+
+
+def parse_and_validate_program(source: str) -> Program:
+    """Parse source and raise on unsupported syntax or invalid semantics."""
+    program = parse_program(source)
+    validate_program(program)
+    return program
+
+
+def _validate_atom(atom: AtomExpr, arities: dict[str, int]) -> None:
+    if atom.predicate not in arities:
+        raise DatalogValidationError(f"unknown predicate: {atom.predicate}")
+    expected = arities[atom.predicate]
+    actual = len(atom.args)
+    if actual != expected:
+        raise DatalogValidationError(
+            f"arity mismatch for {atom.predicate}: expected {expected}, got {actual}"
+        )
+
+
+def _vars_in_atom(atom: AtomExpr) -> set[str]:
+    vars_: set[str] = set()
+    for arg in atom.args:
+        vars_.update(_vars_in_term(arg))
+    return vars_
+
+
+def _vars_in_term(term: Term) -> set[str]:
+    if isinstance(term, Var):
+        return {term.name}
+    if isinstance(term, Compound):
+        vars_: set[str] = set()
+        for arg in term.args:
+            vars_.update(_vars_in_term(arg))
+        return vars_
+    return set()
+
+
+def _strip_comments(source: str) -> str:
+    out: list[str] = []
+    i = 0
+    in_string = False
+    while i < len(source):
+        ch = source[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < len(source):
+                out.append(source[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < len(source) and source[i + 1] == "/":
+            while i < len(source) and source[i] != "\n":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+class _Parser:
+    def __init__(self, source: str) -> None:
+        self.source = source
+        self.pos = 0
+
+    @property
+    def done(self) -> bool:
+        return self.pos >= len(self.source)
+
+    def parse_program(self) -> Program:
+        declarations: list[Declaration] = []
+        facts: list[Fact] = []
+        rules: list[Rule] = []
+
+        while True:
+            self.skip_ws()
+            if self.done:
+                return Program(tuple(declarations), tuple(facts), tuple(rules))
+            if self.peek(".decl"):
+                declarations.append(self.parse_declaration())
+                self.require_line_end_or_eof()
+                continue
+            statement = self.read_statement()
+            if not statement.strip():
+                raise self.error("empty statement")
+            fact_or_rule = _parse_fact_or_rule(statement)
+            if isinstance(fact_or_rule, Fact):
+                facts.append(fact_or_rule)
+            else:
+                rules.append(fact_or_rule)
+
+    def parse_declaration(self) -> Declaration:
+        self.expect(".decl")
+        self.require_separator_after_directive()
+        self.skip_ws()
+        name = self.parse_identifier()
+        self.skip_ws()
+        self.expect("(")
+        columns: list[Column] = []
+        self.skip_ws()
+        if self.peek(")"):
+            self.pos += 1
+            return Declaration(name, ())
+
+        while True:
+            self.skip_ws()
+            column_name = self.parse_identifier()
+            self.skip_ws()
+            self.expect(":")
+            self.skip_ws()
+            column_type = self.parse_identifier()
+            columns.append(Column(column_name, column_type))
+            self.skip_ws()
+            if self.peek(")"):
+                self.pos += 1
+                return Declaration(name, tuple(columns))
+            self.expect(",")
+
+    def read_statement(self) -> str:
+        start = self.pos
+        depth = 0
+        in_string = False
+        while not self.done:
+            ch = self.source[self.pos]
+            if in_string:
+                if ch == "\\" and self.pos + 1 < len(self.source):
+                    self.pos += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+                self.pos += 1
+                continue
+            if ch == '"':
+                in_string = True
+                self.pos += 1
+                continue
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth < 0:
+                    raise self.error("unexpected ')'")
+            elif ch == "." and depth == 0:
+                statement = self.source[start : self.pos]
+                self.pos += 1
+                return statement
+            self.pos += 1
+        raise self.error("expected statement terminator '.'")
+
+    def parse_identifier(self) -> str:
+        start = self.pos
+        if self.done or not _is_ident_start(self.source[self.pos]):
+            raise self.error("expected identifier")
+        self.pos += 1
+        while not self.done and _is_ident_tail(self.source[self.pos]):
+            self.pos += 1
+        return self.source[start:self.pos]
+
+    def skip_ws(self) -> None:
+        while not self.done and self.source[self.pos].isspace():
+            self.pos += 1
+
+    def peek(self, text: str) -> bool:
+        return self.source.startswith(text, self.pos)
+
+    def expect(self, text: str) -> None:
+        if not self.peek(text):
+            raise self.error(f"expected {text!r}")
+        self.pos += len(text)
+
+    def require_separator_after_directive(self) -> None:
+        if not self.done and not self.source[self.pos].isspace():
+            raise self.error("expected whitespace after .decl")
+
+    def require_line_end_or_eof(self) -> None:
+        while not self.done and self.source[self.pos] in " \t\r":
+            self.pos += 1
+        if not self.done and self.source[self.pos] != "\n":
+            raise self.error("expected newline after declaration")
+        while not self.done and self.source[self.pos] == "\n":
+            self.pos += 1
+
+    def error(self, message: str) -> DatalogParseError:
+        return DatalogParseError(f"{message} at position {self.pos}")
+
+
+class _FragmentParser:
+    def __init__(self, source: str) -> None:
+        self.source = source
+        self.pos = 0
+
+    @property
+    def done(self) -> bool:
+        return self.pos >= len(self.source)
+
+    def parse_atom_expr(self) -> AtomExpr:
+        self.skip_ws()
+        predicate = self.parse_identifier()
+        self.skip_ws()
+        self.expect("(")
+        args: list[Term] = []
+        self.skip_ws()
+        if self.peek(")"):
+            self.pos += 1
+            return AtomExpr(predicate, ())
+
+        while True:
+            arg_text = self.read_until_top_level({",", ")"})
+            if not arg_text.strip():
+                raise self.error("expected term")
+            args.append(_parse_term_fragment(arg_text))
+            self.skip_ws()
+            if self.peek(")"):
+                self.pos += 1
+                return AtomExpr(predicate, tuple(args))
+            self.expect(",")
+
+    def read_until_top_level(self, delimiters: set[str]) -> str:
+        start = self.pos
+        depth = 0
+        in_string = False
+        while not self.done:
+            ch = self.source[self.pos]
+            if in_string:
+                if ch == "\\" and self.pos + 1 < len(self.source):
+                    self.pos += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+                self.pos += 1
+                continue
+            if ch == '"':
+                in_string = True
+                self.pos += 1
+                continue
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                if depth == 0 and ")" in delimiters:
+                    break
+                depth -= 1
+                if depth < 0:
+                    raise self.error("unexpected ')'")
+            elif depth == 0 and ch in delimiters:
+                break
+            self.pos += 1
+        if in_string:
+            raise self.error("unterminated string")
+        if depth != 0:
+            raise self.error("unbalanced parentheses")
+        return self.source[start:self.pos]
+
+    def parse_identifier(self) -> str:
+        start = self.pos
+        if self.done or not _is_ident_start(self.source[self.pos]):
+            raise self.error("expected identifier")
+        self.pos += 1
+        while not self.done and _is_ident_tail(self.source[self.pos]):
+            self.pos += 1
+        return self.source[start:self.pos]
+
+    def skip_ws(self) -> None:
+        while not self.done and self.source[self.pos].isspace():
+            self.pos += 1
+
+    def peek(self, text: str) -> bool:
+        return self.source.startswith(text, self.pos)
+
+    def expect(self, text: str) -> None:
+        if not self.peek(text):
+            raise self.error(f"expected {text!r}")
+        self.pos += len(text)
+
+    def require_done(self) -> None:
+        self.skip_ws()
+        if not self.done:
+            raise self.error("unexpected trailing input")
+
+    def error(self, message: str) -> DatalogParseError:
+        return DatalogParseError(f"{message} at fragment position {self.pos}")
+
+
+def _parse_fact_or_rule(statement: str) -> Fact | Rule:
+    head_text, sep, body_text = _partition_top_level(statement, ":-")
+    head = _parse_atom_fragment(head_text)
+    if not sep:
+        return Fact(head)
+    body_items = tuple(_parse_body_item(part) for part in _split_top_level(body_text, ","))
+    if not body_items:
+        raise DatalogParseError("rule body must not be empty")
+    return Rule(head, body_items)
+
+
+def _parse_body_item(source: str) -> BodyItem:
+    left, op, right = _partition_top_level_comparison(source)
+    if op:
+        if not left.strip() or not right.strip():
+            raise DatalogParseError(f"comparison {op} requires two terms")
+        return Comparison(_parse_term_fragment(left), op, _parse_term_fragment(right))
+    if _contains_unsupported_operator(source):
+        raise DatalogParseError("unsupported operator in rule body")
+    return _parse_atom_fragment(source)
+
+
+def _parse_atom_fragment(source: str) -> AtomExpr:
+    parser = _FragmentParser(source)
+    atom = parser.parse_atom_expr()
+    parser.require_done()
+    return atom
+
+
+def _parse_term_fragment(source: str) -> Term:
+    try:
+        return parse_term(source)
+    except TermParseError as exc:
+        raise DatalogParseError(str(exc)) from exc
+
+
+def _partition_top_level(source: str, token: str) -> tuple[str, str, str]:
+    idx = _find_top_level_token(source, token)
+    if idx < 0:
+        return source, "", ""
+    return source[:idx], token, source[idx + len(token) :]
+
+
+def _partition_top_level_comparison(
+    source: str,
+) -> tuple[str, Literal["==", "!="] | str, str]:
+    hits = [
+        (idx, op)
+        for op in ("==", "!=")
+        if (idx := _find_top_level_token(source, op)) >= 0
+    ]
+    if not hits:
+        return source, "", ""
+    hits.sort()
+    if len(hits) > 1:
+        raise DatalogParseError("body item contains multiple comparisons")
+    idx, op = hits[0]
+    return source[:idx], op, source[idx + len(op) :]
+
+
+def _split_top_level(source: str, delimiter: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    in_string = False
+    i = 0
+    while i < len(source):
+        ch = source[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                raise DatalogParseError("unexpected ')' in rule body")
+        elif ch == delimiter and depth == 0:
+            part = source[start:i]
+            if not part.strip():
+                raise DatalogParseError("empty rule body item")
+            parts.append(part)
+            start = i + 1
+        i += 1
+    if in_string:
+        raise DatalogParseError("unterminated string in rule body")
+    if depth != 0:
+        raise DatalogParseError("unbalanced parentheses in rule body")
+    tail = source[start:]
+    if not tail.strip():
+        raise DatalogParseError("empty rule body item")
+    parts.append(tail)
+    return parts
+
+
+def _find_top_level_token(source: str, token: str) -> int:
+    depth = 0
+    in_string = False
+    i = 0
+    while i < len(source):
+        ch = source[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                raise DatalogParseError("unexpected ')' in source fragment")
+        elif depth == 0 and source.startswith(token, i):
+            return i
+        i += 1
+    return -1
+
+
+def _contains_unsupported_operator(source: str) -> bool:
+    for op in ("<=", ">=", "<", ">", "=", "+", "-", "*", "/", ";", "|"):
+        if _find_top_level_token(source, op) >= 0:
+            return True
+    return False
+
+
+def _is_ident_start(ch: str) -> bool:
+    return ch == "_" or ("A" <= ch <= "Z") or ("a" <= ch <= "z")
+
+
+def _is_ident_tail(ch: str) -> bool:
+    return _is_ident_start(ch) or ("0" <= ch <= "9")

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -21,6 +21,14 @@ import re
 from dataclasses import dataclass, field
 from typing import Iterable, Mapping
 
+from verinote.engine.datalog import (
+    AtomExpr,
+    DatalogParseError,
+    DatalogValidationError,
+    Program,
+    parse_and_validate_program,
+)
+
 # Datalog string literals: escape embedded quotes/backslashes.
 _ESCAPE = re.compile(r'(["\\])')
 
@@ -149,8 +157,7 @@ def _degraded_report(dl_text: str) -> CheckReport:
 
 
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
-_PREDICATE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
-_STRING_LIT = re.compile(r'"(?:[^"\\]|\\.)*"')
+_ANSWER_DECL = re.compile(r"answer_q[0-9]+\Z")
 
 
 def validate_query(query_dl: str) -> tuple[bool, str]:
@@ -160,17 +167,15 @@ def validate_query(query_dl: str) -> tuple[bool, str]:
     vocabulary (plus its own declared `answer_*` head) and parses+runs in
     pyrewire, else ``(False, reason)``. Used to gate LLM-proposed repairs.
     """
-    # 1. vocabulary: every predicate must be `relation` or a relation declared in
-    #    the snippet itself (the answer head). Strip string literals first so a
-    #    `word(` inside a literal isn't mistaken for a predicate call.
-    stripped = _STRING_LIT.sub('""', query_dl)
-    declared = {m.group(1) for m in re.finditer(r"\.decl\s+([A-Za-z_][A-Za-z0-9_]*)", stripped)}
-    allowed = {"relation"} | declared
-    unknown = sorted(set(_PREDICATE.findall(stripped)) - allowed)
-    if unknown:
-        return False, f"references unknown predicate(s): {', '.join(unknown)}"
+    # 1. structural parse/validation: this catches arity, unsupported syntax, and
+    #    unsafe variables before the engine is involved.
+    try:
+        program = parse_and_validate_program(_RELATION_DECL + query_dl)
+        _validate_query_contract(program)
+    except (DatalogParseError, DatalogValidationError) as exc:
+        return False, str(exc)
 
-    # 2. parse/run check (catches syntax errors the vocabulary scan can't).
+    # 2. parse/run check (catches pyrewire compatibility errors).
     pyrewire = _load_engine()
     if pyrewire is None:
         return False, "wirelog engine (pyrewire) not installed"
@@ -181,6 +186,35 @@ def validate_query(query_dl: str) -> tuple[bool, str]:
     except Exception as exc:  # parse/exec error -> not a valid query
         return False, str(exc)
     return True, ""
+
+
+def _validate_query_contract(program: Program) -> None:
+    """Ensure LLM-generated query snippets only answer from `relation/3`."""
+    answer_decls: set[str] = set()
+    for decl in program.declarations:
+        if decl.name == "relation":
+            continue
+        if not _ANSWER_DECL.fullmatch(decl.name):
+            raise DatalogValidationError(
+                f"query may only declare answer predicates, got: {decl.name}"
+            )
+        if len(decl.columns) != 1:
+            raise DatalogValidationError(
+                f"query answer predicate must have arity 1: {decl.name}"
+            )
+        answer_decls.add(decl.name)
+    if program.facts:
+        raise DatalogValidationError("query snippets must not contain facts")
+    for rule in program.rules:
+        if rule.head.predicate not in answer_decls:
+            raise DatalogValidationError(
+                f"query rule head must be an answer predicate: {rule.head.predicate}"
+            )
+        for item in rule.body:
+            if isinstance(item, AtomExpr) and item.predicate != "relation":
+                raise DatalogValidationError(
+                    f"query may only reference relation/3, got: {item.predicate}"
+                )
 
 
 def run_check(


### PR DESCRIPTION
Closes #30\n\n## Summary\n- add an engine-independent AST/parser/validator for the supported wirelog/Datalog subset\n- validate declarations, arity, unknown predicates, facts, and unsafe rule variables\n- route validate_query through the structural validator while preserving the relation/3 + answer_qN query contract\n\n## Validation\n- uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q\n- uv run --python 3.13 --with ruff ruff check