### PR TITLE
[codex] Add DuckDB term representation

### DIFF
--- a/tests/test_duckdb_terms.py
+++ b/tests/test_duckdb_terms.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: MPL-2.0
+import json
+
+import pytest
+
+from verinote.engine.datalog import Column, Declaration
+from verinote.engine.duckdb_terms import (
+    DUCKDB_TERM_SQL_TYPE,
+    DuckDBTermError,
+    create_decl_table_sql,
+    create_relation_table_sql,
+    create_term_table_sql,
+    duckdb_value_to_term,
+    term_eq_sql,
+    term_to_duckdb_value,
+)
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var, render_term
+
+
+@pytest.mark.parametrize(
+    "term",
+    [
+        Atom("a"),
+        Var("A"),
+        StringLit("a"),
+        NumberLit(1),
+        NumberLit(-1),
+        Compound("unit", ()),
+        Compound("f", (StringLit(","), StringLit(")"), Atom("a"))),
+        Compound(
+            "role",
+            (Compound("person", (StringLit("Ada"),)), StringLit("PI")),
+        ),
+        StringLit('a"b\\c\n'),
+    ],
+)
+def test_term_values_round_trip(term):
+    value = term_to_duckdb_value(term)
+
+    assert duckdb_value_to_term(value) == term
+    assert render_term(duckdb_value_to_term(value)) == render_term(term)
+    assert value == json.dumps(json.loads(value), sort_keys=True, separators=(",", ":"))
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (Atom("a"), StringLit("a")),
+        (Var("A"), StringLit("A")),
+        (Var("A"), Atom("a")),
+        (NumberLit(1), StringLit("1")),
+        (Compound("f", (StringLit("A"),)), StringLit("f(A)")),
+        (Compound("f", (Var("A"),)), Compound("f", (StringLit("A"),))),
+    ],
+)
+def test_term_values_distinguish_term_types(left, right):
+    assert term_to_duckdb_value(left) != term_to_duckdb_value(right)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        '{"t":"atom","v":"a","extra":true}',
+        '{"t":"atom","v":1}',
+        '{"t":"number","v":true}',
+        '{"t":"number","v":1.5}',
+        '{"t":"compound","f":"f","a":{}}',
+        '{"t":"atom","v":"Bad"}',
+        '{"t":"var","v":"bad"}',
+        '{"t":"compound","f":"Bad","a":[]}',
+        '{"t":"unknown","v":"a"}',
+        '{"v":"a","t":"atom"}',
+        "not json",
+    ],
+)
+def test_malformed_or_noncanonical_values_are_rejected(value):
+    with pytest.raises(DuckDBTermError):
+        duckdb_value_to_term(value)
+
+
+def test_create_relation_table_sql_uses_varchar_term_columns():
+    assert create_relation_table_sql() == (
+        'CREATE TABLE "relation" ('
+        f'"subject" {DUCKDB_TERM_SQL_TYPE} NOT NULL, '
+        f'"rel" {DUCKDB_TERM_SQL_TYPE} NOT NULL, '
+        f'"object" {DUCKDB_TERM_SQL_TYPE} NOT NULL)'
+    )
+
+
+def test_create_decl_table_sql_uses_declared_columns():
+    decl = Declaration("answer_q1", (Column("value", "symbol"),))
+    assert create_decl_table_sql(decl) == (
+        f'CREATE TABLE "answer_q1" ("value" {DUCKDB_TERM_SQL_TYPE} NOT NULL)'
+    )
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: create_term_table_sql("bad-name", ("value",)),
+        lambda: create_term_table_sql("answer", ("bad-name",)),
+        lambda: create_term_table_sql("answer", ()),
+        lambda: create_term_table_sql("answer", ("value", "value")),
+    ],
+)
+def test_create_term_table_sql_rejects_invalid_shapes(call):
+    with pytest.raises(ValueError):
+        call()
+
+
+def _duckdb():
+    return pytest.importorskip("duckdb")
+
+
+def test_duckdb_round_trips_stored_terms():
+    duckdb = _duckdb()
+    con = duckdb.connect()
+    con.execute(create_relation_table_sql())
+    term = Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI")))
+
+    con.execute(
+        "INSERT INTO relation VALUES (?, ?, ?)",
+        [
+            term_to_duckdb_value(term),
+            term_to_duckdb_value(Atom("rel")),
+            term_to_duckdb_value(term),
+        ],
+    )
+
+    row = con.execute("SELECT subject, object FROM relation").fetchone()
+    assert duckdb_value_to_term(row[0]) == term
+    assert duckdb_value_to_term(row[1]) == term
+
+
+def test_duckdb_structurally_equal_nested_terms_compare_equal():
+    duckdb = _duckdb()
+    con = duckdb.connect()
+    con.execute("CREATE TABLE terms (left_value VARCHAR NOT NULL, right_value VARCHAR NOT NULL)")
+    left = Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI")))
+    right = Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI")))
+
+    con.execute(
+        "INSERT INTO terms VALUES (?, ?)",
+        [term_to_duckdb_value(left), term_to_duckdb_value(right)],
+    )
+
+    assert con.execute(
+        f"SELECT {term_eq_sql('left_value', 'right_value')} FROM terms"
+    ).fetchone() == (True,)
+
+
+def test_duckdb_structurally_different_nested_terms_compare_unequal():
+    duckdb = _duckdb()
+    con = duckdb.connect()
+    con.execute("CREATE TABLE terms (left_value VARCHAR NOT NULL, right_value VARCHAR NOT NULL)")
+    left = Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI")))
+    right = Compound("role", (Compound("person", (StringLit("Ada"),)), Atom("pi")))
+
+    con.execute(
+        "INSERT INTO terms VALUES (?, ?)",
+        [term_to_duckdb_value(left), term_to_duckdb_value(right)],
+    )
+
+    assert con.execute(
+        f"SELECT {term_eq_sql('left_value', 'right_value')} FROM terms"
+    ).fetchone() == (False,)
+
+
+def test_duckdb_acceptance_collisions_compare_unequal():
+    duckdb = _duckdb()
+    con = duckdb.connect()
+    con.execute("CREATE TABLE terms (left_value VARCHAR NOT NULL, right_value VARCHAR NOT NULL)")
+    pairs = [
+        (Compound("f", (StringLit("A"),)), StringLit("f(A)")),
+        (Compound("f", (Var("A"),)), Compound("f", (StringLit("A"),))),
+    ]
+    con.executemany(
+        "INSERT INTO terms VALUES (?, ?)",
+        [(term_to_duckdb_value(left), term_to_duckdb_value(right)) for left, right in pairs],
+    )
+
+    assert con.execute(
+        f"SELECT bool_or({term_eq_sql('left_value', 'right_value')}) FROM terms"
+    ).fetchone() == (False,)

--- a/verinote/engine/duckdb_terms.py
+++ b/verinote/engine/duckdb_terms.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MPL-2.0
+"""DuckDB storage representation for logical terms.
+
+DuckDB has no recursive `TERM` type, so verinote stores terms as canonical JSON
+text in `VARCHAR` columns. Equality in DuckDB is then ordinary text equality,
+but the text is a typed tree encoding rather than user-facing Datalog syntax:
+atoms, strings, variables, numbers, and compounds cannot collide.
+
+This module deliberately does not import DuckDB; callers can use these helpers
+with any in-memory connection that has `VARCHAR` columns.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from verinote.engine.datalog import Declaration
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Term, Var
+
+DUCKDB_TERM_SQL_TYPE = "VARCHAR"
+
+_TABLE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+class DuckDBTermError(ValueError):
+    """Raised when a DuckDB term value is malformed or non-canonical."""
+
+
+def term_to_duckdb_value(term: Term) -> str:
+    """Return the canonical DuckDB `VARCHAR` value for a logical term."""
+    return json.dumps(
+        _term_to_payload(term),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def duckdb_value_to_term(value: object) -> Term:
+    """Decode a canonical DuckDB term value back into a logical term."""
+    if not isinstance(value, str):
+        raise DuckDBTermError(f"DuckDB term value must be a string, got {type(value)!r}")
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise DuckDBTermError(f"invalid DuckDB term JSON: {exc}") from exc
+    term = _payload_to_term(payload)
+    if term_to_duckdb_value(term) != value:
+        raise DuckDBTermError("DuckDB term value is not canonical")
+    return term
+
+
+def term_eq_sql(left_expr: str, right_expr: str) -> str:
+    """Return SQL comparing two physical DuckDB term expressions."""
+    return f"{left_expr} = {right_expr}"
+
+
+def create_term_table_sql(table_name: str, columns: tuple[str, ...]) -> str:
+    """Return SQL for a table whose columns are logical terms stored as VARCHAR."""
+    _validate_sql_identifier(table_name, "table")
+    if not columns:
+        raise ValueError("term table must have at least one column")
+    column_sql: list[str] = []
+    seen: set[str] = set()
+    for column in columns:
+        _validate_sql_identifier(column, "column")
+        if column in seen:
+            raise ValueError(f"duplicate column: {column}")
+        seen.add(column)
+        column_sql.append(
+            f"{_quote_sql_identifier(column)} {DUCKDB_TERM_SQL_TYPE} NOT NULL"
+        )
+    return f"CREATE TABLE {_quote_sql_identifier(table_name)} (" + ", ".join(column_sql) + ")"
+
+
+def create_relation_table_sql(table_name: str = "relation") -> str:
+    """Return SQL for the base relation(subject, rel, object) term table."""
+    return create_term_table_sql(table_name, ("subject", "rel", "object"))
+
+
+def create_decl_table_sql(declaration: Declaration) -> str:
+    """Return SQL for a declared Datalog predicate table."""
+    return create_term_table_sql(
+        declaration.name, tuple(column.name for column in declaration.columns)
+    )
+
+
+def _term_to_payload(term: Term) -> dict[str, Any]:
+    if isinstance(term, Atom):
+        return {"t": "atom", "v": term.name}
+    if isinstance(term, Var):
+        return {"t": "var", "v": term.name}
+    if isinstance(term, StringLit):
+        return {"t": "string", "v": term.value}
+    if isinstance(term, NumberLit):
+        return {"t": "number", "v": term.value}
+    if isinstance(term, Compound):
+        return {
+            "a": [_term_to_payload(arg) for arg in term.args],
+            "f": term.functor,
+            "t": "compound",
+        }
+    raise TypeError(f"not a term: {term!r}")
+
+
+def _payload_to_term(payload: Any) -> Term:
+    if not isinstance(payload, dict):
+        raise DuckDBTermError("DuckDB term payload must be an object")
+    tag = payload.get("t")
+    if tag == "atom":
+        _require_keys(payload, {"t", "v"})
+        if not isinstance(payload["v"], str):
+            raise DuckDBTermError("atom payload value must be a string")
+        try:
+            return Atom(payload["v"])
+        except ValueError as exc:
+            raise DuckDBTermError(str(exc)) from exc
+    if tag == "var":
+        _require_keys(payload, {"t", "v"})
+        if not isinstance(payload["v"], str):
+            raise DuckDBTermError("var payload value must be a string")
+        try:
+            return Var(payload["v"])
+        except ValueError as exc:
+            raise DuckDBTermError(str(exc)) from exc
+    if tag == "string":
+        _require_keys(payload, {"t", "v"})
+        if not isinstance(payload["v"], str):
+            raise DuckDBTermError("string payload value must be a string")
+        return StringLit(payload["v"])
+    if tag == "number":
+        _require_keys(payload, {"t", "v"})
+        if isinstance(payload["v"], bool) or not isinstance(payload["v"], int):
+            raise DuckDBTermError("number payload value must be an integer")
+        return NumberLit(payload["v"])
+    if tag == "compound":
+        _require_keys(payload, {"a", "f", "t"})
+        if not isinstance(payload["f"], str):
+            raise DuckDBTermError("compound functor must be a string")
+        if not isinstance(payload["a"], list):
+            raise DuckDBTermError("compound args must be a list")
+        args = tuple(_payload_to_term(arg) for arg in payload["a"])
+        try:
+            return Compound(payload["f"], args)
+        except ValueError as exc:
+            raise DuckDBTermError(str(exc)) from exc
+    raise DuckDBTermError(f"unsupported DuckDB term tag: {tag!r}")
+
+
+def _require_keys(payload: dict[str, Any], keys: set[str]) -> None:
+    actual = set(payload)
+    if actual != keys:
+        raise DuckDBTermError(
+            "DuckDB term payload has unexpected keys: "
+            + ", ".join(sorted(actual.symmetric_difference(keys)))
+        )
+
+
+def _validate_sql_identifier(identifier: str, kind: str) -> None:
+    if not _TABLE_RE.fullmatch(identifier):
+        raise ValueError(f"invalid {kind} identifier: {identifier!r}")
+
+
+def _quote_sql_identifier(identifier: str) -> str:
+    _validate_sql_identifier(identifier, "SQL")
+    return f'"{identifier}"'


### PR DESCRIPTION
Closes #31\n\n## Summary\n- add canonical JSON VARCHAR encoding for logical terms in DuckDB\n- add decoding, term equality SQL, and term table DDL helpers\n- cover round-trip, collision, nested equality, optional DuckDB behavior, and DDL safety\n\n## Validation\n- uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q\n- uv run --python 3.13 --with-editable . --with '.[test,ingest]' pytest -q tests/test_duckdb_terms.py\n- uv run --python 3.13 --with ruff ruff check