### PR TITLE
[codex] Add DuckDB Datalog backend

### DIFF
--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: MPL-2.0
+import builtins
+
+import pytest
+
+from verinote.engine.duckdb_backend import run_check_duckdb
+from verinote.engine.terms import Compound, StringLit
+
+
+def _duckdb():
+    return pytest.importorskip("duckdb")
+
+
+def test_duckdb_backend_missing_duckdb_is_blocking(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "duckdb":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    rep = run_check_duckdb([])
+
+    assert rep.ok is False
+    assert rep.engine_available is False
+    assert rep.errors == 1
+    assert "DuckDB is not installed" in rep.text
+
+
+def test_duckdb_backend_default_policy_flags_functional_conflict():
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": "Org", "relation": "established_on", "object": "2020"},
+            {"subject": "Org", "relation": "established_on", "object": "2021"},
+            {"subject": "Org", "relation": "is_a", "object": "company"},
+        ]
+    )
+
+    assert rep.engine_available is True
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert rep.warnings == 0
+    assert rep.findings == ["ERROR functional_conflict: Org established_on"]
+
+
+def test_duckdb_backend_consistent_kb_is_ok():
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": "Org", "relation": "established_on", "object": "2020"},
+            {"subject": "Org", "relation": "is_a", "object": "company"},
+        ]
+    )
+
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings == 0
+    assert rep.findings == []
+    assert "no findings" in rep.text
+
+
+def test_duckdb_backend_warn_is_non_blocking():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_has_isa(subject: symbol)\n"
+        'warn_has_isa(S) :- relation(S, "is_a", O).\n'
+    )
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "is_a", "object": "person"}],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings == 1
+    assert rep.findings == ["WARN has_isa: Ada"]
+
+
+def test_duckdb_backend_answer_query_format_matches_check_report():
+    _duckdb()
+    query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n'
+    rep = run_check_duckdb(
+        [
+            {"subject": "Ada", "relation": "born_in", "object": "London"},
+            {"subject": "Ada", "relation": "is_a", "object": "mathematician"},
+        ],
+        query_dl=query,
+    )
+
+    assert rep.ok is True
+    assert rep.answers == ["q1: London"]
+    assert "q1: London" in rep.text
+
+
+def test_duckdb_backend_supports_joins_projection_and_duplicates_are_set_semantics():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_grandparent(subject: symbol, object: symbol)\n"
+        'warn_grandparent(A, C) :- relation(A, "parent", B), relation(B, "parent", C).\n'
+    )
+    rep = run_check_duckdb(
+        [
+            {"subject": "Ada", "relation": "parent", "object": "Bea"},
+            {"subject": "Bea", "relation": "parent", "object": "Cal"},
+            {"subject": "Bea", "relation": "parent", "object": "Cal"},
+        ],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is True
+    assert rep.warnings == 1
+    assert rep.findings == ["WARN grandparent: Ada Cal"]
+
+
+def test_duckdb_backend_supports_repeated_variables_and_inequality():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_same(subject: symbol)\n"
+        ".decl error_diff(subject: symbol, object: symbol)\n"
+        'warn_same(X) :- relation(X, "same_as", X).\n'
+        'error_diff(A, B) :- relation(A, "related_to", B), A != B.\n'
+    )
+    rep = run_check_duckdb(
+        [
+            {"subject": "Ada", "relation": "same_as", "object": "Ada"},
+            {"subject": "Ada", "relation": "related_to", "object": "Bea"},
+            {"subject": "Cal", "relation": "related_to", "object": "Cal"},
+        ],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is False
+    assert rep.findings == [
+        "ERROR diff: Ada Bea",
+        "WARN same: Ada",
+    ]
+
+
+def test_duckdb_backend_supports_constants_in_all_atom_positions():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_exact(subject: symbol)\n"
+        'warn_exact("hit") :- relation("Ada", "born_in", "London").\n'
+    )
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "born_in", "object": "London"}],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is True
+    assert rep.findings == ["WARN exact: hit"]
+
+
+def test_duckdb_backend_supports_zero_arity_predicates():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl ready()\n"
+        ".decl warn_ready()\n"
+        "ready().\n"
+        "warn_ready() :- ready().\n"
+    )
+    rep = run_check_duckdb([], policy_dl=policy)
+
+    assert rep.ok is True
+    assert rep.warnings == 1
+    assert rep.findings == ["WARN ready: "]
+
+
+def test_duckdb_backend_supports_ground_compound_and_nested_terms():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl source(value: symbol)\n"
+        '.decl answer_q1(value: symbol)\n'
+        'source(role(person("Ada"), "PI")).\n'
+        'answer_q1(X) :- source(X), X != role(person("Ada"), "CoPI").\n'
+    )
+    rep = run_check_duckdb([], policy_dl=policy)
+
+    assert rep.ok is True
+    assert rep.answers == ['q1: role(person("Ada"), "PI")']
+
+
+def test_duckdb_backend_supports_compound_terms_in_base_relation():
+    _duckdb()
+    query = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(S) :- relation(S, "has_role", role(person("Ada"), "PI")).\n'
+    )
+    rep = run_check_duckdb(
+        [
+            {
+                "subject": Compound("person", (StringLit("Ada"),)),
+                "relation": "has_role",
+                "object": Compound(
+                    "role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))
+                ),
+            }
+        ],
+        query_dl=query,
+    )
+
+    assert rep.ok is True
+    assert rep.answers == ['q1: person("Ada")']
+
+
+def test_duckdb_backend_supports_equality_comparison():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_self(value: symbol)\n"
+        'warn_self(X) :- relation(X, "same_as", Y), X == Y.\n'
+    )
+    rep = run_check_duckdb(
+        [
+            {"subject": "Ada", "relation": "same_as", "object": "Ada"},
+            {"subject": "Bea", "relation": "same_as", "object": "Cal"},
+        ],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is True
+    assert rep.findings == ["WARN self: Ada"]
+
+
+def test_duckdb_backend_rejects_variable_bearing_compound_terms():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(person(O)) :- relation("Ada", "born_in", O).\n'
+    )
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "born_in", "object": "London"}],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is False
+    assert "variable-bearing compound" in rep.text
+
+
+def test_duckdb_backend_invalid_policy_returns_blocking_error():
+    _duckdb()
+    rep = run_check_duckdb([], policy_dl="this is not datalog")
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert any("engine error" in finding for finding in rep.findings)
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        (
+            ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+            ".decl loop(value: symbol)\n"
+            "loop(X) :- loop(X).\n"
+        ),
+        (
+            ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+            ".decl a(value: symbol)\n"
+            ".decl b(value: symbol)\n"
+            "a(X) :- b(X).\n"
+            "b(X) :- a(X).\n"
+        ),
+    ],
+)
+def test_duckdb_backend_rejects_recursive_rules(policy):
+    _duckdb()
+    rep = run_check_duckdb([], policy_dl=policy)
+
+    assert rep.ok is False
+    assert "recursive rules are not supported" in rep.text
+
+
+def test_duckdb_backend_string_values_are_parameterized():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_injection(value: symbol)\n"
+        'warn_injection(O) :- relation("Ada", "says", O).\n'
+    )
+    payload = 'x"); DROP TABLE "relation"; --'
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "says", "object": payload}],
+        policy_dl=policy,
+    )
+
+    assert rep.ok is True
+    assert rep.findings == [f"WARN injection: {payload}"]
+
+
+def test_duckdb_backend_check_report_fields_are_compatible():
+    _duckdb()
+    rep = run_check_duckdb([])
+
+    assert isinstance(rep.ok, bool)
+    assert isinstance(rep.errors, int)
+    assert isinstance(rep.warnings, int)
+    assert isinstance(rep.text, str)
+    assert isinstance(rep.findings, list)
+    assert isinstance(rep.answers, list)
+    assert rep.engine_available is True
+    assert "facts: 0" in rep.text

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Experimental DuckDB inference backend for the supported Datalog subset."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from verinote.engine.datalog import (
+    AtomExpr,
+    Comparison,
+    DatalogParseError,
+    DatalogValidationError,
+    Declaration,
+    Fact,
+    Program,
+    Rule,
+    parse_and_validate_program,
+)
+from verinote.engine.duckdb_terms import (
+    create_decl_table_sql,
+    duckdb_value_to_term,
+    term_to_duckdb_value,
+)
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Term, Var, render_term
+from verinote.engine.wirelog import CheckReport, DEFAULT_POLICY
+
+_ERROR_PREFIX = "error_"
+_WARN_PREFIX = "warn_"
+_ANSWER_PREFIX = "answer_q"
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+_ZERO_ARITY_COLUMN = "__present"
+
+
+class DuckDBBackendError(ValueError):
+    """Raised when the DuckDB backend cannot compile or execute a program."""
+
+
+@dataclass(frozen=True)
+class _RuleSql:
+    sql: str
+    params: tuple[str, ...]
+
+
+def run_check_duckdb(
+    facts: Iterable[Mapping[str, object]],
+    *,
+    policy_dl: str | None = None,
+    query_dl: str | None = None,
+) -> CheckReport:
+    """Run supported non-recursive Datalog rules through an in-memory DuckDB DB."""
+    try:
+        import duckdb
+    except ImportError:
+        return _engine_error("DuckDB is not installed", engine_available=False)
+
+    policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
+    source = policy + ("\n" + query_dl if query_dl else "")
+    try:
+        program = parse_and_validate_program(source)
+        _validate_relation_decl(program)
+        ordered_rules = _topological_rules(program)
+    except (DatalogParseError, DatalogValidationError, DuckDBBackendError) as exc:
+        return _engine_error(str(exc))
+
+    try:
+        con = duckdb.connect()
+        fact_rows = list(facts)
+        declarations = {decl.name: decl for decl in program.declarations}
+        for decl in program.declarations:
+            con.execute(_create_decl_table_sql(decl))
+        _load_relation_facts(con, fact_rows)
+        _load_extensional_facts(con, program.facts, declarations)
+        for rule in ordered_rules:
+            compiled = _compile_rule(rule, declarations)
+            con.execute(compiled.sql, list(compiled.params))
+        return _collect_report(con, declarations, len(fact_rows))
+    except Exception as exc:
+        return _engine_error(str(exc))
+
+
+def _engine_error(message: str, *, engine_available: bool = True) -> CheckReport:
+    return CheckReport(
+        ok=False,
+        errors=1,
+        warnings=0,
+        text=f"policy/engine error: {message}",
+        findings=[f"ERROR engine error: {message}"],
+        engine_available=engine_available,
+    )
+
+
+def _validate_relation_decl(program: Program) -> None:
+    relation = next((decl for decl in program.declarations if decl.name == "relation"), None)
+    if relation is None:
+        raise DuckDBBackendError("program must declare relation/3")
+    columns = tuple(column.name for column in relation.columns)
+    if columns != ("subject", "rel", "object"):
+        raise DuckDBBackendError("relation declaration must be relation(subject, rel, object)")
+
+
+def _load_relation_facts(con, facts: Iterable[Mapping[str, object]]) -> None:
+    rows = {
+        (
+            term_to_duckdb_value(_coerce_fact_term(row["subject"])),
+            term_to_duckdb_value(_coerce_fact_term(row["relation"])),
+            term_to_duckdb_value(_coerce_fact_term(row["object"])),
+        )
+        for row in facts
+    }
+    if rows:
+        con.executemany(
+            'INSERT INTO "relation" ("subject", "rel", "object") VALUES (?, ?, ?)',
+            sorted(rows),
+        )
+
+
+def _load_extensional_facts(
+    con, facts: tuple[Fact, ...], declarations: dict[str, Declaration]
+) -> None:
+    for fact in facts:
+        decl = declarations[fact.atom.predicate]
+        columns = _insert_columns(decl)
+        placeholders = ", ".join("?" for _ in _insert_values(fact.atom.args))
+        params = [term_to_duckdb_value(arg) for arg in fact.atom.args]
+        con.execute(
+            f"INSERT INTO {_quote_ident(fact.atom.predicate)} ({columns}) VALUES ({placeholders})",
+            _insert_values(params),
+        )
+
+
+def _coerce_fact_term(value: object) -> Term:
+    if isinstance(value, (Atom, Compound, NumberLit, StringLit, Var)):
+        return value
+    return StringLit(str(value))
+
+
+def _topological_rules(program: Program) -> list[Rule]:
+    derived = {rule.head.predicate for rule in program.rules}
+    deps: dict[str, set[str]] = {name: set() for name in derived}
+    rules_by_head: dict[str, list[Rule]] = {name: [] for name in derived}
+    for rule in program.rules:
+        rules_by_head[rule.head.predicate].append(rule)
+        for item in rule.body:
+            if isinstance(item, AtomExpr) and item.predicate in derived:
+                deps[rule.head.predicate].add(item.predicate)
+
+    _reject_cycles(deps)
+
+    ordered_heads: list[str] = []
+    remaining = {name: set(values) for name, values in deps.items()}
+    while remaining:
+        ready = sorted(name for name, values in remaining.items() if not values)
+        if not ready:
+            raise DuckDBBackendError("recursive rules are not supported")
+        for name in ready:
+            ordered_heads.append(name)
+            del remaining[name]
+        for values in remaining.values():
+            values.difference_update(ready)
+
+    return [rule for head in ordered_heads for rule in rules_by_head[head]]
+
+
+def _reject_cycles(deps: dict[str, set[str]]) -> None:
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(name: str, path: tuple[str, ...]) -> None:
+        if name in visiting:
+            cycle = " -> ".join(path + (name,))
+            raise DuckDBBackendError(f"recursive rules are not supported: {cycle}")
+        if name in visited:
+            return
+        visiting.add(name)
+        for dep in deps.get(name, set()):
+            visit(dep, path + (name,))
+        visiting.remove(name)
+        visited.add(name)
+
+    for name in sorted(deps):
+        visit(name, ())
+
+
+def _compile_rule(rule: Rule, declarations: dict[str, Declaration]) -> _RuleSql:
+    aliases: list[tuple[AtomExpr, str, Declaration]] = []
+    where_sql: list[str] = []
+    where_params: list[str] = []
+    bindings: dict[str, str] = {}
+
+    for atom_index, item in enumerate(item for item in rule.body if isinstance(item, AtomExpr)):
+        alias = f"a{atom_index}"
+        decl = declarations[item.predicate]
+        aliases.append((item, alias, decl))
+        for column, term in zip(decl.columns, item.args, strict=True):
+            expr = f"{alias}.{_quote_ident(column.name)}"
+            if isinstance(term, Var):
+                prior = bindings.get(term.name)
+                if prior is None:
+                    bindings[term.name] = expr
+                else:
+                    where_sql.append(f"{expr} = {prior}")
+            elif _has_vars(term):
+                raise DuckDBBackendError(
+                    f"variable-bearing compound terms are not supported in body atom {item.predicate}"
+                )
+            else:
+                where_sql.append(f"{expr} = ?")
+                where_params.append(term_to_duckdb_value(term))
+
+    for item in rule.body:
+        if isinstance(item, Comparison):
+            sql, params = _compile_comparison(item, bindings)
+            where_sql.append(sql)
+            where_params.extend(params)
+
+    select_sql: list[str] = []
+    select_params: list[str] = []
+    for term in rule.head.args:
+        if isinstance(term, Var):
+            try:
+                select_sql.append(bindings[term.name])
+            except KeyError as exc:
+                raise DuckDBBackendError(f"unbound head variable: {term.name}") from exc
+        elif _has_vars(term):
+            raise DuckDBBackendError(
+                "variable-bearing compound terms are not supported in rule heads"
+            )
+        else:
+            select_sql.append("?")
+            select_params.append(term_to_duckdb_value(term))
+    if not select_sql:
+        select_sql.append("TRUE")
+
+    from_sql = ", ".join(
+        f"{_quote_ident(atom.predicate)} AS {alias}" for atom, alias, _decl in aliases
+    )
+    where_clause = " WHERE " + " AND ".join(where_sql) if where_sql else ""
+    if from_sql:
+        query = f"SELECT DISTINCT {', '.join(select_sql)} FROM {from_sql}{where_clause}"
+    else:
+        query = f"SELECT DISTINCT {', '.join(select_sql)}{where_clause}"
+    head_decl = declarations[rule.head.predicate]
+    head_columns = _insert_columns(head_decl)
+    sql = f"INSERT INTO {_quote_ident(rule.head.predicate)} ({head_columns}) {query}"
+    return _RuleSql(sql, tuple(select_params + where_params))
+
+
+def _compile_comparison(
+    comparison: Comparison, bindings: dict[str, str]
+) -> tuple[str, list[str]]:
+    left_sql, left_params = _term_sql(comparison.left, bindings)
+    right_sql, right_params = _term_sql(comparison.right, bindings)
+    op = "=" if comparison.op == "==" else "!="
+    return f"{left_sql} {op} {right_sql}", left_params + right_params
+
+
+def _term_sql(term: Term, bindings: dict[str, str]) -> tuple[str, list[str]]:
+    if isinstance(term, Var):
+        try:
+            return bindings[term.name], []
+        except KeyError as exc:
+            raise DuckDBBackendError(f"unbound comparison variable: {term.name}") from exc
+    if _has_vars(term):
+        raise DuckDBBackendError("variable-bearing compound comparisons are not supported")
+    return "?", [term_to_duckdb_value(term)]
+
+
+def _collect_report(con, declarations: dict[str, Declaration], fact_count: int) -> CheckReport:
+    errors: list[str] = []
+    warnings: list[str] = []
+    answers_by_q: dict[str, list[str]] = {}
+    for name in sorted(declarations):
+        if not (
+            name.startswith(_ERROR_PREFIX)
+            or name.startswith(_WARN_PREFIX)
+            or name.startswith(_ANSWER_PREFIX)
+        ):
+            continue
+        rows = con.execute(f"SELECT DISTINCT * FROM {_quote_ident(name)}").fetchall()
+        if not declarations[name].columns:
+            rows = [() for _row in rows]
+        rendered_rows = [_render_row(row) for row in rows]
+        if name.startswith(_ERROR_PREFIX):
+            errors.extend(
+                f"{name[len(_ERROR_PREFIX) :]}: {row}" for row in rendered_rows
+            )
+        elif name.startswith(_WARN_PREFIX):
+            warnings.extend(
+                f"{name[len(_WARN_PREFIX) :]}: {row}" for row in rendered_rows
+            )
+        elif name.startswith(_ANSWER_PREFIX):
+            qid = name[len(_ANSWER_PREFIX) :]
+            answers_by_q.setdefault(qid, []).extend(rendered_rows)
+
+    errors = sorted(set(errors))
+    warnings = sorted(set(warnings))
+    answers = [
+        f"q{qid}: {', '.join(sorted(set(vals)))}"
+        for qid, vals in sorted(answers_by_q.items())
+    ]
+    findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
+    summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {fact_count}"
+    body = (
+        "\n".join(findings)
+        if findings
+        else "no findings — knowledge base is consistent."
+    )
+    if answers:
+        body += "\n\n--- answers ---\n" + "\n".join(answers)
+    return CheckReport(
+        ok=not errors,
+        errors=len(errors),
+        warnings=len(warnings),
+        answers=answers,
+        text=f"{summary}\n\n{body}",
+        findings=findings,
+    )
+
+
+def _render_row(row: tuple[object, ...]) -> str:
+    return " ".join(_render_output_term(duckdb_value_to_term(value)) for value in row)
+
+
+def _render_output_term(term: Term) -> str:
+    if isinstance(term, StringLit):
+        return term.value
+    return render_term(term)
+
+
+def _has_vars(term: Term) -> bool:
+    if isinstance(term, Var):
+        return True
+    if isinstance(term, Compound):
+        return any(_has_vars(arg) for arg in term.args)
+    return False
+
+
+def _quote_ident(identifier: str) -> str:
+    if not _IDENT_RE.fullmatch(identifier):
+        raise DuckDBBackendError(f"invalid SQL identifier: {identifier!r}")
+    return f'"{identifier}"'
+
+
+def _create_decl_table_sql(decl: Declaration) -> str:
+    if decl.columns:
+        return create_decl_table_sql(decl)
+    return (
+        f"CREATE TABLE {_quote_ident(decl.name)} "
+        f"({_quote_ident(_ZERO_ARITY_COLUMN)} BOOLEAN NOT NULL)"
+    )
+
+
+def _insert_columns(decl: Declaration) -> str:
+    if decl.columns:
+        return ", ".join(_quote_ident(column.name) for column in decl.columns)
+    return _quote_ident(_ZERO_ARITY_COLUMN)
+
+
+def _insert_values(values: list[str] | tuple[Term, ...]) -> list[str] | list[bool]:
+    if values:
+        return list(values)
+    return [True]


### PR DESCRIPTION
Closes #32\n\n## Summary\n- add experimental run_check_duckdb backend behind a focused API\n- compile and execute non-recursive supported Datalog rules in in-memory DuckDB\n- support joins, repeated variables, constants, ground compound terms, comparisons, zero-arity predicates, warnings/errors/answers, and CheckReport-compatible output\n\n## Validation\n- uv run --python 3.13 --with-editable . --with '.[test,analytics,ingest]' pytest -q\n- uv run --python 3.13 --with ruff ruff check