### PR TITLE
[codex] Switch verification pipeline to DuckDB backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "uvicorn[standard]>=0.29",
   "jinja2>=3.1",
   "python-multipart>=0.0.9",
-  "pyrewire>=1.0.1,<2.0",
+  "duckdb>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -25,7 +25,8 @@ dependencies = [
 # (anti-lock-in: pick whichever you have a key for, or run Ollama locally).
 anthropic = ["anthropic>=0.40"]
 openai = ["openai>=1.40"]
-analytics = ["duckdb>=1.0"]
+analytics = []
+wirelog = ["pyrewire>=1.0.1,<2.0"]
 # Binary source ingestion (docx/pdf -> text). Optional so the core stays light.
 ingest = ["python-docx>=1.1", "pypdf>=4.0"]
 test = ["pytest>=7", "httpx>=0.27", "python-docx>=1.1"]

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -44,6 +44,9 @@ def test_duckdb_backend_default_policy_flags_functional_conflict():
     assert rep.errors == 1
     assert rep.warnings == 0
     assert rep.findings == ["ERROR functional_conflict: Org established_on"]
+    assert "backend: DuckDB" in rep.text
+    assert "--- policy input ---" in rep.text
+    assert "--- fact input ---" in rep.text
 
 
 def test_duckdb_backend_consistent_kb_is_ok():
@@ -310,3 +313,6 @@ def test_duckdb_backend_check_report_fields_are_compatible():
     assert isinstance(rep.answers, list)
     assert rep.engine_available is True
     assert "facts: 0" in rep.text
+    assert "backend: DuckDB" in rep.text
+    assert "--- policy input ---" in rep.text
+    assert "--- fact input ---" in rep.text

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -20,12 +20,17 @@ _CONSISTENT = compile_dl(
 )
 
 
+def _require_pyrewire():
+    return pytest.importorskip("pyrewire")
+
+
 def test_parse_relation_facts_roundtrips_escaping():
     dl = compile_dl([{"subject": 'a"b', "relation": "r", "object": "c"}])
     assert wl._parse_relation_facts(dl) == [('a"b', "r", "c")]
 
 
 def test_run_check_flags_functional_conflict():
+    _require_pyrewire()
     rep = run_check(_CONFLICT)
     assert rep.engine_available is True
     assert rep.errors > 0
@@ -37,6 +42,7 @@ def test_run_check_flags_functional_conflict():
 
 
 def test_run_check_consistent_is_ok():
+    _require_pyrewire()
     rep = run_check(_CONSISTENT)
     assert rep.errors == 0
     assert rep.ok is True
@@ -44,11 +50,13 @@ def test_run_check_consistent_is_ok():
 
 
 def test_run_check_empty_kb_is_ok():
+    _require_pyrewire()
     rep = run_check("")
     assert rep.ok is True and rep.errors == 0
 
 
 def test_run_check_uses_custom_policy():
+    _require_pyrewire()
     # A policy that flags *any* is_a edge as an error.
     policy = (
         ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
@@ -61,6 +69,7 @@ def test_run_check_uses_custom_policy():
 
 
 def test_run_check_surfaces_policy_error():
+    _require_pyrewire()
     rep = run_check(_CONSISTENT, policy_dl="this is not valid datalog !!!")
     assert rep.ok is False
     assert rep.errors == 1
@@ -81,6 +90,7 @@ def test_default_policy_declares_finding_relations():
 
 
 def test_run_check_evaluates_query():
+    _require_pyrewire()
     dl = compile_dl(
         [
             {"subject": "Ada", "relation": "born_in", "object": "London"},
@@ -95,6 +105,7 @@ def test_run_check_evaluates_query():
 
 
 def test_run_check_without_query_has_no_answers():
+    _require_pyrewire()
     dl = compile_dl([{"subject": "Ada", "relation": "is_a", "object": "x"}])
     assert run_check(dl).answers == []
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
+import builtins
+
+from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import policy_path, verify
 from verinote.store import Store
 
@@ -16,6 +19,7 @@ def test_verify_gates_on_contradiction_with_default_policy(tmp_path):
     s.add_fact("Org", "established_on", "2021", status="confirmed")
     rep = verify(s)
     assert rep.errors > 0 and rep.ok is False
+    assert "backend: DuckDB" in rep.text
 
 
 def test_verify_consistent_kb_passes(tmp_path):
@@ -49,3 +53,49 @@ def test_verify_loads_kb_policy_file(tmp_path):
     rep = verify(s)
     assert rep.errors == 1
     assert "has_isa: Org company" in "\n".join(rep.findings)
+
+
+def test_verify_loads_query_file(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Ada", "born_in", "London", status="confirmed")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.answers == ["q1: London"]
+    assert "--- query input ---" in rep.text
+
+
+def test_verify_debug_fact_input_is_quoted_and_escaped(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact('a"b', "r", "line\nnext", status="confirmed")
+
+    rep = verify(s)
+
+    assert 'relation("a\\"b", "r", "line\\nnext")' in rep.text
+
+
+def test_verify_reports_missing_duckdb_as_blocking(tmp_path, monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "duckdb":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    s = _store(tmp_path)
+
+    rep = verify(s)
+
+    assert rep.engine_available is False
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert "backend: DuckDB" in rep.text
+    assert "DuckDB is not installed" in rep.text

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import builtins
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -7,6 +9,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 import verinote.web.app as webapp  # noqa: E402
 from verinote.config import Config  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
+from verinote.pipeline.query import query_path  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
 
@@ -142,6 +145,7 @@ def test_report_ok_for_consistent_kb(tmp_path):
     r = c.get("/report")
     assert r.status_code == 200
     assert "errors: 0" in r.text
+    assert "backend: DuckDB" in r.text
 
 
 def test_report_gates_on_contradiction(tmp_path):
@@ -153,6 +157,34 @@ def test_report_gates_on_contradiction(tmp_path):
     assert r.status_code == 200
     assert "ERRORS" in r.text
     assert "functional_conflict" in r.text
+
+
+def test_report_shows_missing_duckdb_message(tmp_path, monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "duckdb":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    c = _client(tmp_path)
+    r = c.get("/report")
+    assert r.status_code == 200
+    assert "DuckDB verification backend is not available" in r.text
+    assert "DuckDB is not installed" in r.text
+
+
+def test_report_surfaces_invalid_query_file(tmp_path):
+    c = _client(tmp_path)
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(".decl answer_q1(value: symbol)\nanswer_q1(O) :- bogus(O).\n", encoding="utf-8")
+
+    r = c.get("/report")
+    assert r.status_code == 200
+    assert "ERRORS" in r.text
+    assert "bogus" in r.text
 
 
 def test_edit_form_renders(tmp_path):

--- a/verinote/engine/__init__.py
+++ b/verinote/engine/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-"""wirelog engine integration: compile confirmed facts to `.dl`, run the check."""
+"""Engine integrations and deterministic KB checks."""
 
 from verinote.engine.coverage import Coverage, SourceCoverage, coverage
+from verinote.engine.duckdb_backend import run_check_duckdb
 from verinote.engine.wirelog import (
     DEFAULT_POLICY,
     CheckReport,
@@ -13,6 +14,7 @@ from verinote.engine.wirelog import (
 __all__ = [
     "compile_dl",
     "run_check",
+    "run_check_duckdb",
     "validate_query",
     "CheckReport",
     "DEFAULT_POLICY",

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -75,7 +75,13 @@ def run_check_duckdb(
         for rule in ordered_rules:
             compiled = _compile_rule(rule, declarations)
             con.execute(compiled.sql, list(compiled.params))
-        return _collect_report(con, declarations, len(fact_rows))
+        return _collect_report(
+            con,
+            declarations,
+            fact_rows,
+            policy_dl=policy,
+            query_dl=query_dl,
+        )
     except Exception as exc:
         return _engine_error(str(exc))
 
@@ -85,7 +91,7 @@ def _engine_error(message: str, *, engine_available: bool = True) -> CheckReport
         ok=False,
         errors=1,
         warnings=0,
-        text=f"policy/engine error: {message}",
+        text=f"backend: DuckDB\n\npolicy/engine error: {message}",
         findings=[f"ERROR engine error: {message}"],
         engine_available=engine_available,
     )
@@ -267,7 +273,14 @@ def _term_sql(term: Term, bindings: dict[str, str]) -> tuple[str, list[str]]:
     return "?", [term_to_duckdb_value(term)]
 
 
-def _collect_report(con, declarations: dict[str, Declaration], fact_count: int) -> CheckReport:
+def _collect_report(
+    con,
+    declarations: dict[str, Declaration],
+    facts: list[Mapping[str, object]],
+    *,
+    policy_dl: str,
+    query_dl: str | None,
+) -> CheckReport:
     errors: list[str] = []
     warnings: list[str] = []
     answers_by_q: dict[str, list[str]] = {}
@@ -301,7 +314,7 @@ def _collect_report(con, declarations: dict[str, Declaration], fact_count: int) 
         for qid, vals in sorted(answers_by_q.items())
     ]
     findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
-    summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {fact_count}"
+    summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {len(facts)}"
     body = (
         "\n".join(findings)
         if findings
@@ -309,14 +322,37 @@ def _collect_report(con, declarations: dict[str, Declaration], fact_count: int) 
     )
     if answers:
         body += "\n\n--- answers ---\n" + "\n".join(answers)
+    debug = (
+        "\n\n--- policy input ---\n"
+        + policy_dl
+        + ("\n--- query input ---\n" + query_dl if query_dl else "")
+        + "\n--- fact input ---\n"
+        + _render_fact_input(facts)
+    )
     return CheckReport(
         ok=not errors,
         errors=len(errors),
         warnings=len(warnings),
         answers=answers,
-        text=f"{summary}\n\n{body}",
+        text=f"backend: DuckDB\n{summary}\n\n{body}{debug}",
         findings=findings,
     )
+
+
+def _render_fact_input(facts: list[Mapping[str, object]]) -> str:
+    if not facts:
+        return "(none)"
+    lines = []
+    for row in facts:
+        lines.append(
+            "relation("
+            + ", ".join(
+                render_term(_coerce_fact_term(row[key]))
+                for key in ("subject", "relation", "object")
+            )
+            + ")"
+        )
+    return "\n".join(sorted(set(lines)))
 
 
 def _render_row(row: tuple[object, ...]) -> str:

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -161,11 +161,11 @@ _ANSWER_DECL = re.compile(r"answer_q[0-9]+\Z")
 
 
 def validate_query(query_dl: str) -> tuple[bool, str]:
-    """Deterministically check a proposed query line — the engine has final say.
+    """Deterministically check a proposed query line — the DuckDB engine has final say.
 
     Returns ``(True, "")`` when the line only references the ``relation/3``
     vocabulary (plus its own declared `answer_*` head) and parses+runs in
-    pyrewire, else ``(False, reason)``. Used to gate LLM-proposed repairs.
+    DuckDB, else ``(False, reason)``. Used to gate LLM-proposed repairs.
     """
     # 1. structural parse/validation: this catches arity, unsupported syntax, and
     #    unsafe variables before the engine is involved.
@@ -175,16 +175,12 @@ def validate_query(query_dl: str) -> tuple[bool, str]:
     except (DatalogParseError, DatalogValidationError) as exc:
         return False, str(exc)
 
-    # 2. parse/run check (catches pyrewire compatibility errors).
-    pyrewire = _load_engine()
-    if pyrewire is None:
-        return False, "wirelog engine (pyrewire) not installed"
-    try:
-        with pyrewire.EasySession(_RELATION_DECL + query_dl) as session:
-            session.insert_sym("relation", "_probe_s", "_probe_r", "_probe_o")
-            session.step()
-    except Exception as exc:  # parse/exec error -> not a valid query
-        return False, str(exc)
+    # 2. compile/run check (catches DuckDB-backend subset limitations).
+    from verinote.engine.duckdb_backend import run_check_duckdb
+
+    rep = run_check_duckdb([], policy_dl=_RELATION_DECL, query_dl=query_dl)
+    if not rep.ok:
+        return False, rep.findings[0] if rep.findings else rep.text
     return True, ""
 
 

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -4,8 +4,9 @@
 Each pending question is translated by the `LLMClient` into either an
 `answer_q<id>` rule (status `translated`) or a `review_required(...)` line
 (status `review_required`). The translated rules are written to
-`<root>/facts/query.dl`, which `verify()` feeds to pyrewire so `/report` shows
-each query's evaluation. `review_required` questions are tracked in the DB only.
+`<root>/facts/query.dl`, which `verify()` feeds to the DuckDB backend so
+`/report` shows each query's evaluation. `review_required` questions are tracked
+in the DB only.
 """
 
 from __future__ import annotations

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Compile confirmed facts and run the wirelog check against the KB policy."""
+"""Run the DuckDB-backed logic check against the KB policy."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from verinote.engine import CheckReport, compile_dl, run_check
+from verinote.engine import CheckReport, run_check_duckdb
 from verinote.store import ENGINE_STATUSES, Store
 
 # Per-KB policy location, relative to the KB root (the db file's directory).
@@ -25,9 +25,8 @@ def load_policy(store: Store) -> str | None:
 
 
 def verify(store: Store) -> CheckReport:
-    """Project confirmed/accepted rows to `.dl` and run the deterministic check."""
+    """Run confirmed/accepted rows through the deterministic DuckDB check."""
     from verinote.pipeline.query import load_query
 
     rows = store.facts(statuses=ENGINE_STATUSES)
-    dl_text = compile_dl(rows)
-    return run_check(dl_text, policy_dl=load_policy(store), query_dl=load_query(store))
+    return run_check_duckdb(rows, policy_dl=load_policy(store), query_dl=load_query(store))

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Logic check report</h1>
 {% if not rep.engine_available %}
-<p class="warn">wirelog engine (pyrewire) not installed — showing compiled engine input only.</p>
+<p class="warn">DuckDB verification backend is not available.</p>
 {% endif %}
 <p>
   <span class="badge {{ 'badge-confirmed' if rep.ok and rep.errors == 0 else 'badge-superseded' }}">


### PR DESCRIPTION
Closes #33\n\n## Summary\n- switch production verify(store) path to run_check_duckdb with direct fact rows\n- make DuckDB a runtime dependency and move pyrewire to a compatibility extra\n- replace query validation's pyrewire execution check with DuckDB backend validation\n- update report backend messaging and add DuckDB debug input sections\n\n## Validation\n- uv run --python 3.13 --with-editable . --with '.[test,ingest]' pytest -q\n- uv run --python 3.13 --with ruff ruff check