### PR TITLE
[codex] Pin DuckDB query validation semantics

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import builtins
+
 import pytest
 
 import verinote.engine.wirelog as wl
@@ -117,6 +119,14 @@ def test_validate_query_accepts_relation_only():
     assert ok is True and reason == ""
 
 
+def test_validate_query_accepts_supported_ground_compound_terms():
+    ok, reason = validate_query(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(S) :- relation(S, "has_role", role(person("Ada"), "PI")).'
+    )
+    assert ok is True and reason == ""
+
+
 def test_validate_query_does_not_flag_compound_functors_as_predicates():
     ok, reason = validate_query(
         ".decl answer_q1(value: symbol)\n"
@@ -125,6 +135,44 @@ def test_validate_query_does_not_flag_compound_functors_as_predicates():
     assert ok is False
     assert "unknown predicate" not in reason
     assert "person" not in reason
+    assert "variable-bearing compound" in reason
+
+
+@pytest.mark.parametrize(
+    ("query_dl", "message"),
+    [
+        (
+            ".decl answer_q1(value: symbol)\n"
+            'answer_q1(O) :- relation(person(O), "born_in", "London").',
+            "variable-bearing compound",
+        ),
+        (
+            ".decl answer_q1(value: symbol)\n"
+            'answer_q1(S) :- relation(S, "same_as", O), O == person(S).',
+            "variable-bearing compound",
+        ),
+    ],
+)
+def test_validate_query_rejects_duckdb_unsupported_compounds(query_dl, message):
+    ok, reason = validate_query(query_dl)
+    assert ok is False
+    assert message in reason
+
+
+def test_validate_query_does_not_require_pyrewire(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pyrewire":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    ok, reason = validate_query(
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("a", "b", O).'
+    )
+    assert ok is True and reason == ""
 
 
 def test_validate_query_rejects_unknown_predicate():

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import builtins
+
 from verinote.pipeline.query import load_query
 from verinote.pipeline.repair import repair_questions
 from verinote.store import Store
@@ -22,6 +24,37 @@ def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
     assert f"answer_q{qid}" in (load_query(s) or "")
 
 
+def test_repair_accepts_duckdb_supported_compound_query(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    client = fake_client(
+        query=lambda q, i: (
+            f'answer_q{i}(S) :- relation(S, "has_role", role(person("Ada"), "PI")).'
+        )
+    )
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    assert s.questions()[0]["status"] == "translated"
+
+
+def test_repair_accepts_valid_proposal_without_pyrewire(tmp_path, monkeypatch, fake_client):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pyrewire":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    s, qid = _store_with_review_required(tmp_path)
+    client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    assert s.questions()[0]["status"] == "translated"
+
+
 def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
     # references an undeclared predicate -> engine rejects, question untouched
@@ -30,6 +63,19 @@ def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
 
     assert results[0]["accepted"] is False
     assert "bogus" in results[0]["reason"]
+    assert s.questions()[0]["status"] == "review_required"
+    assert f"answer_q{qid}" not in (load_query(s) or "")
+
+
+def test_repair_rejects_duckdb_unsupported_compound_query(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    client = fake_client(
+        query=lambda q, i: f'answer_q{i}(person(O)) :- relation("Ada", "born_in", O).'
+    )
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results[0]["accepted"] is False
+    assert "variable-bearing compound" in results[0]["reason"]
     assert s.questions()[0]["status"] == "review_required"
     assert f"answer_q{qid}" not in (load_query(s) or "")
 

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -58,13 +58,15 @@ QUERY_SCHEMA: dict[str, Any] = {
 def query_system(qid: int) -> str:
     """System prompt for translating one question to a Datalog query line."""
     return (
-        "You translate a natural-language question into ONE line of wirelog Datalog "
+        "You translate a natural-language question into ONE line of DuckDB-supported Datalog "
         "over the base relation relation(subject, rel, object), which holds the "
         "knowledge base's confirmed facts. Produce a rule whose head is exactly "
         f"answer_q{qid}(V) binding a single answer variable V, for example:\n"
         f'  answer_q{qid}(O) :- relation("Ada Lovelace", "born_in", O).\n'
-        "Use only the relation/3 predicate and string literals. If the question "
-        "cannot be expressed this way, return exactly "
+        "Use only the relation/3 predicate in rule bodies. Terms may be variables, "
+        "string literals, integer literals, atoms, or fully ground compound terms; "
+        "do not construct compound terms from variables in the answer head or body. "
+        "If the question cannot be expressed this way, return exactly "
         'review_required("<the original question>"). Emit JSON matching the schema.'
     )
 


### PR DESCRIPTION
Closes #34\n\n## Summary\n- add DuckDB-backed validation tests for supported ground compounds and unsupported variable-bearing compounds\n- prove repair gating accepts/rejects proposals through the DuckDB-supported semantics without pyrewire\n- update the query prompt contract to describe DuckDB-supported Datalog terms\n\n## Validation\n- uv run --python 3.13 --with-editable . --with '.[test,ingest]' pytest -q\n- uv run --python 3.13 --with ruff ruff check