### PR TITLE
[codex] Update docs for DuckDB-backed inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![ci](https://github.com/semantic-reasoning/verinote/actions/workflows/ci.yml/badge.svg)](https://github.com/semantic-reasoning/verinote/actions/workflows/ci.yml)
 
 **Honest knowledge base.** An LLM extracts source-backed *candidate* facts from your
-documents; the deterministic **wirelog** logic engine verifies them; you keep a human
-review gate before any fact is promoted to engine input. Runs as a local web app.
+documents; a deterministic DuckDB-backed Datalog engine verifies them; you keep a
+human review gate before any fact is promoted to engine input. Runs as a local web app.
 
 > Borrows the *concept* of [factlog](https://github.com/semantic-reasoning/factlog)
-> (neurosymbolic: LLM extracts, a Datalog/wirelog engine verifies) but is a
+> (neurosymbolic: LLM extracts, a Datalog engine verifies) but is a
 > from-scratch implementation — no shared code.
 
 ## Why
@@ -17,7 +17,7 @@ sources. verinote keeps the knowledge base *honest* by pairing a neural extracto
 with a symbolic verifier:
 
 - **LLM extracts** source-backed candidate facts (provider-agnostic — see below).
-- **wirelog verifies** consistency deterministically. Because every fact is
+- **DuckDB-backed Datalog verifies** consistency deterministically. Because every fact is
   re-checked by the engine, swapping to a cheaper or local model never compromises
   correctness.
 - **You review.** Facts move `candidate → needs_review → confirmed/accepted`
@@ -27,22 +27,22 @@ with a symbolic verifier:
 
 | Concern        | Decision |
 |----------------|----------|
-| Logic engine   | **wirelog** (`pyrewire`). Confirmed rows compile to `.dl`; the engine checks them. |
+| Logic engine   | **DuckDB-backed Datalog**. Confirmed rows load into in-memory DuckDB and non-recursive policy/query rules compile to SQL. |
 | LLM            | **Hand-rolled `LLMClient` adapters** (Anthropic / OpenAI / Ollama). No vendor lock-in. |
 | Web            | **FastAPI + HTMX + Jinja** — server-rendered partials, no JS build step. |
-| Storage        | **SQLite** is the system-of-record (OLTP). **DuckDB** attaches it read-only for analytics. `.dl` is derived from confirmed rows. |
+| Storage        | **SQLite** is the system-of-record (OLTP). **DuckDB** is the inference backend and also attaches SQLite read-only for analytics. `.dl` policy/query files remain editable inputs. |
 
 ## Status
 
-Early scaffold (`v0.0.1`). Working today: SQLite store + the review-queue toggle
-loop in the web UI. Stubbed: LLM extraction, wirelog compile/check wiring.
+Early scaffold (`v0.0.1`). Working today: SQLite store, LLM adapters, review queue,
+DuckDB-backed verification, question translation/repair, and local web UI.
 
 ### v1 vertical slice
 
 1. Upload a text source → DB
 2. Auto-extract candidates via one LLM adapter
 3. **Review queue UI** (toggle / accept / reject)
-4. Compile confirmed → wirelog `.dl` → run check → show report
+4. Load confirmed facts into DuckDB → run Datalog policy/query rules → show report
 5. Dashboard
 
 Deferred: NL→Datalog query, gated self-correction (repair), coverage critic,
@@ -51,10 +51,14 @@ multi-provider expansion.
 ## Quickstart
 
 ```bash
-pip install -e ".[anthropic,analytics,test]"   # pick the providers you use
+pip install -e ".[anthropic,test]"   # pick the providers you use
 verinote init      # scaffold a local KB (SQLite) under ./data
 verinote ui        # launch the web app at http://localhost:8731
 ```
+
+DuckDB is a core dependency because it powers verification. The `analytics` extra is
+kept as a compatibility no-op; analytics uses the same DuckDB dependency. The
+`wirelog` extra installs the legacy `pyrewire` path for compatibility/debugging only.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "verinote"
 version = "0.0.1"
-description = "Honest knowledge base: an LLM extracts source-backed facts, the wirelog logic engine verifies them. Local web app."
+description = "Honest knowledge base: an LLM extracts source-backed facts, DuckDB-backed Datalog verifies them. Local web app."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MPL-2.0"
 license-files = ["LICENSE"]
 authors = [{ name = "Justin Kim" }]
-keywords = ["knowledge-base", "datalog", "wirelog", "fact-extraction", "neurosymbolic", "verification"]
+keywords = ["knowledge-base", "datalog", "duckdb", "fact-extraction", "neurosymbolic", "verification"]
 dependencies = [
   "fastapi>=0.110",
   "uvicorn[standard]>=0.29",

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import pytest
 
-pytest.importorskip("duckdb")  # analytics is an optional extra
+pytest.importorskip("duckdb")  # DuckDB is core; skip only in broken/minimal envs.
 
 from verinote.store import Store  # noqa: E402
 from verinote.store.analytics import compute  # noqa: E402

--- a/verinote/__init__.py
+++ b/verinote/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MPL-2.0
-"""verinote — honest knowledge base (LLM extracts, wirelog verifies)."""
+"""verinote — honest knowledge base (LLM extracts, DuckDB verifies)."""
 
 __version__ = "0.0.1"

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -252,7 +252,7 @@ def cmd_ui(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="verinote", description="Honest KB: LLM extracts, wirelog verifies.")
+    p = argparse.ArgumentParser(prog="verinote", description="Honest KB: LLM extracts, DuckDB verifies.")
     p.add_argument("--version", action="version", version=f"verinote {__version__}")
     sub = p.add_subparsers(dest="command", required=True)
 

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Compile confirmed facts into wirelog `.dl` and run the deterministic check.
+"""Legacy pyrewire/wirelog compatibility helpers.
 
-The database is the source of truth; the `.dl` text here is DERIVED from
-confirmed/accepted rows each time the check runs. `compile_dl` is pure and fully
-tested without the engine; `run_check` runs the compiled facts through a wirelog
-(`pyrewire`) policy program and degrades gracefully when the engine is absent.
+Production verification uses `verinote.engine.duckdb_backend.run_check_duckdb`.
+This module remains for compatibility/debug rendering of wirelog `.dl` programs:
+`compile_dl` is pure and fully tested without pyrewire, while `run_check` executes
+the legacy pyrewire path when the optional `wirelog` extra is installed.
 
 Policy contract
 ---------------
-A policy is a wirelog Datalog program over the base relation
-``relation(subject, rel, object)`` (verinote inserts the compiled facts into it).
+A policy is a Datalog program over the base relation
+``relation(subject, rel, object)``.
 Any derived relation whose name starts with ``error_`` is a blocking finding and
 ``warn_`` is a non-blocking one; verinote reads those back, so every column is a
 plain symbol it can render. See `DEFAULT_POLICY`.
@@ -150,7 +150,8 @@ def _degraded_report(dl_text: str) -> CheckReport:
         warnings=0,
         engine_available=False,
         text=(
-            "wirelog engine (pyrewire) not installed — showing compiled input only.\n"
+            "legacy wirelog compatibility engine (pyrewire) not installed — "
+            "showing compiled input only.\n"
             f"compiled facts: {n}\n\n{dl_text}"
         ),
     )
@@ -216,13 +217,14 @@ def _validate_query_contract(program: Program) -> None:
 def run_check(
     dl_text: str, *, policy_dl: str | None = None, query_dl: str | None = None
 ) -> CheckReport:
-    """Run the wirelog policy (+ optional query rules) over compiled facts.
+    """Run the legacy pyrewire policy path over compiled facts.
 
     `dl_text` is `compile_dl` output (the verbatim engine input). `policy_dl`
     defaults to `DEFAULT_POLICY`. `query_dl` holds `answer_q<id>(...)` query rules
     (see pipeline.query). Derived `error_*`/`warn_*` tuples become findings
     (`errors > 0` is the review gate); `answer_q<id>` tuples become answers. If
-    pyrewire is absent we still return a valid report flagged `engine_available=False`.
+    pyrewire is absent we still return a legacy compatibility report flagged
+    `engine_available=False`.
     """
     pyrewire = _load_engine()
     if pyrewire is None:

--- a/verinote/llm/__init__.py
+++ b/verinote/llm/__init__.py
@@ -4,7 +4,7 @@
 `LLMClient` is the single seam the rest of verinote talks to. Concrete adapters
 (Anthropic / Claude CLI / OpenAI / Ollama) normalise structured (JSON-schema)
 output in-house so no vendor API leaks upward. This is the anti-lock-in design:
-the deterministic wirelog verifier re-checks every fact, so the provider/model
+the deterministic DuckDB-backed verifier re-checks every fact, so the provider/model
 is freely swappable.
 """
 

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -15,8 +15,8 @@ class LLMError(RuntimeError):
 class ExtractedFact:
     """One candidate fact the extractor proposes from a source.
 
-    Mirrors the `facts` columns the store will persist. The wirelog verifier and
-    the human review gate decide whether it ever becomes engine input.
+    Mirrors the `facts` columns the store will persist. The DuckDB-backed
+    verifier and the human review gate decide whether it ever becomes engine input.
     """
 
     subject: str

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -2,7 +2,7 @@
 """Ollama adapter — fully local, no cloud vendor. Uses Ollama's JSON format mode.
 
 This adapter is the proof that anti-lock-in is real: with a local model the whole
-pipeline runs offline, and the wirelog verifier still guarantees correctness.
+pipeline runs offline, and the DuckDB-backed verifier still guarantees correctness.
 """
 
 from __future__ import annotations

--- a/verinote/store/analytics.py
+++ b/verinote/store/analytics.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
 """Read-only analytics over the KB via DuckDB.
 
-SQLite stays the single system-of-record; DuckDB only *reads* it by ATTACHing
-the same file read-only (the `sqlite` extension auto-loads on attach). There is
-no second source of truth and no write path here. `duckdb` is optional
-(`pip install verinote[analytics]`); callers feature-flag on `duckdb_available()`.
+SQLite stays the single system-of-record. Analytics reuse the same DuckDB
+dependency as the inference backend and ATTACH the SQLite file read-only (the
+`sqlite` extension auto-loads on attach). There is no second source of truth and
+no write path here.
 """
 
 from __future__ import annotations

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -3,8 +3,8 @@
 
 Deliberately small and synchronous: the workload is a handful of small
 transactional writes (the review toggle is a single-row UPDATE) plus reads for
-rendering. SQLite/WAL is the right fit; DuckDB is reserved for analytics and
-attaches this same file read-only (see engine/analytics, future work).
+rendering. SQLite/WAL is the right fit for writes; DuckDB reads confirmed rows
+for deterministic inference and attaches this same file read-only for analytics.
 """
 
 from __future__ import annotations

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -1,7 +1,7 @@
 -- SPDX-License-Identifier: MPL-2.0
--- verinote system-of-record (SQLite, OLTP). DuckDB attaches this file read-only
--- for analytics. The wirelog `.dl` engine input is DERIVED from confirmed rows;
--- it is never the source of truth.
+-- verinote system-of-record (SQLite, OLTP). DuckDB reads confirmed rows for
+-- inference and attaches this file read-only for analytics. Derived engine input
+-- is never the source of truth.
 
 PRAGMA journal_mode = WAL;        -- concurrent readers + a single writer
 PRAGMA foreign_keys = ON;
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS runs (
 -- A candidate/verified fact: a (subject, relation, object) triple with status.
 -- Status lifecycle:  candidate -> needs_review -> confirmed -> accepted
 --                                              \-> superseded (retired)
--- Only confirmed/accepted rows compile into the wirelog `.dl` engine input.
+-- Only confirmed/accepted rows become deterministic engine input.
 CREATE TABLE IF NOT EXISTS facts (
     id         INTEGER PRIMARY KEY,
     subject    TEXT NOT NULL,

--- a/verinote/web/templates/analytics.html
+++ b/verinote/web/templates/analytics.html
@@ -21,7 +21,7 @@
 {% if not a.available %}
 <div class="empty">
   <p>Analytics are disabled — DuckDB isn't installed.</p>
-  <p class="muted">Enable with <code>pip install verinote[analytics]</code>.</p>
+  <p class="muted">Install the core DuckDB dependency to enable analytics.</p>
 </div>
 {% else %}
 {{ breakdown("By status", a.by_status, "status") }}


### PR DESCRIPTION
Closes #35

## Summary
- update README and package metadata to describe DuckDB-backed Datalog inference
- mark pyrewire/wirelog as legacy compatibility and DuckDB as core dependency
- refresh analytics docs/UI copy to explain shared DuckDB infrastructure

## Validation
- uv run --python 3.13 --with-editable . --with '.[test]' pytest -q\n- uv run --python 3.13 --with-editable . --with '.[test]' python -c "import duckdb; print(duckdb.__version__)"\n- uv run --python 3.13 --with ruff ruff check