### PR TITLE
[codex] Cache DuckDB inference relation per store

### DIFF
--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -3,7 +3,8 @@ import builtins
 
 import pytest
 
-from verinote.engine.duckdb_backend import run_check_duckdb
+import verinote.engine.duckdb_backend as duckdb_backend
+from verinote.engine.duckdb_backend import DuckDBInferenceCache, run_check_duckdb
 from verinote.engine.terms import Compound, StringLit
 
 
@@ -316,3 +317,101 @@ def test_duckdb_backend_check_report_fields_are_compatible():
     assert "backend: DuckDB" in rep.text
     assert "--- policy input ---" in rep.text
     assert "--- fact input ---" in rep.text
+
+
+def test_duckdb_inference_cache_reuses_unchanged_relation(monkeypatch):
+    _duckdb()
+    loads = []
+    real_load = duckdb_backend._load_relation_facts
+
+    def counted_load(con, facts):
+        loads.append(list(facts))
+        return real_load(con, facts)
+
+    monkeypatch.setattr(duckdb_backend, "_load_relation_facts", counted_load)
+    cache = DuckDBInferenceCache()
+    try:
+        facts = [{"subject": "Org", "relation": "is_a", "object": "company"}]
+        assert cache.run_check(facts).ok is True
+        assert cache.run_check(list(facts)).ok is True
+    finally:
+        cache.close()
+
+    assert len(loads) == 1
+
+
+def test_duckdb_inference_cache_reloads_changed_relation(monkeypatch):
+    _duckdb()
+    loads = []
+    real_load = duckdb_backend._load_relation_facts
+
+    def counted_load(con, facts):
+        loads.append(list(facts))
+        return real_load(con, facts)
+
+    monkeypatch.setattr(duckdb_backend, "_load_relation_facts", counted_load)
+    cache = DuckDBInferenceCache()
+    try:
+        assert cache.run_check(
+            [{"subject": "Org", "relation": "established_on", "object": "2020"}]
+        ).ok is True
+        assert cache.run_check(
+            [
+                {"subject": "Org", "relation": "established_on", "object": "2020"},
+                {"subject": "Org", "relation": "established_on", "object": "2021"},
+            ]
+        ).ok is False
+    finally:
+        cache.close()
+
+    assert len(loads) == 2
+
+
+def test_duckdb_inference_cache_does_not_leak_query_answers():
+    _duckdb()
+    cache = DuckDBInferenceCache()
+    try:
+        facts = [{"subject": "Ada", "relation": "born_in", "object": "London"}]
+        query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n'
+
+        first = cache.run_check(facts, query_dl=query)
+        second = cache.run_check(facts)
+    finally:
+        cache.close()
+
+    assert first.answers == ["q1: London"]
+    assert second.answers == []
+    assert "--- answers ---" not in second.text
+
+
+def test_duckdb_inference_cache_does_not_leak_policy_findings():
+    _duckdb()
+    warning_policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_has_isa(subject: symbol)\n"
+        'warn_has_isa(S) :- relation(S, "is_a", O).\n'
+    )
+    quiet_policy = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+    cache = DuckDBInferenceCache()
+    try:
+        facts = [{"subject": "Ada", "relation": "is_a", "object": "person"}]
+        first = cache.run_check(facts, policy_dl=warning_policy)
+        second = cache.run_check(facts, policy_dl=quiet_policy)
+    finally:
+        cache.close()
+
+    assert first.findings == ["WARN has_isa: Ada"]
+    assert second.findings == []
+
+
+def test_duckdb_backend_rejects_policy_relation_facts():
+    _duckdb()
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        'relation("Ghost", "is_a", "phantom").\n'
+    )
+
+    rep = run_check_duckdb([], policy_dl=policy)
+
+    assert rep.ok is False
+    assert "relation facts must come from SQLite engine input" in rep.text

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
 
+import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import policy_path, verify
 from verinote.store import Store
@@ -99,3 +100,124 @@ def test_verify_reports_missing_duckdb_as_blocking(tmp_path, monkeypatch):
     assert rep.errors == 1
     assert "backend: DuckDB" in rep.text
     assert "DuckDB is not installed" in rep.text
+
+
+def test_verify_reuses_store_inference_cache(tmp_path, monkeypatch):
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    loads = []
+    real_load = duckdb_backend._load_relation_facts
+
+    def counted_load(con, facts):
+        loads.append(list(facts))
+        return real_load(con, facts)
+
+    monkeypatch.setattr(duckdb_backend, "_load_relation_facts", counted_load)
+
+    assert verify(s).ok is True
+    assert verify(s).ok is True
+
+    assert len(loads) == 1
+
+
+def test_store_close_clears_inference_cache(tmp_path):
+    s = _store(tmp_path)
+    _ = s.inference_cache
+
+    assert s._inference_cache is not None
+    s.close()
+
+    assert s._inference_cache is None
+
+
+def test_verify_candidate_change_does_not_enter_or_reload_cached_relation(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    loads = []
+    real_load = duckdb_backend._load_relation_facts
+
+    def counted_load(con, facts):
+        loads.append(list(facts))
+        return real_load(con, facts)
+
+    monkeypatch.setattr(duckdb_backend, "_load_relation_facts", counted_load)
+
+    assert verify(s).ok is True
+    s.add_fact("Org", "established_on", "2021", status="candidate")
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert "2021" not in rep.text
+    assert len(loads) == 1
+
+
+def test_verify_cache_refreshes_after_status_promotion_and_demotion(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    conflict = s.add_fact("Org", "established_on", "2021", status="needs_review")
+
+    assert verify(s).ok is True
+    s.set_status(conflict, "confirmed")
+    rep = verify(s)
+    assert rep.ok is False
+    assert "functional_conflict" in "\n".join(rep.findings)
+
+    s.set_status(conflict, "superseded")
+    assert verify(s).ok is True
+
+
+def test_verify_cache_refreshes_after_engine_fact_amendment(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    conflict = s.add_fact("Org", "established_on", "2021", status="confirmed")
+
+    assert verify(s).ok is False
+    s.amend_fact(
+        conflict,
+        subject="Org",
+        relation="established_on",
+        obj="2020",
+    )
+
+    assert verify(s).ok is True
+
+
+def test_verify_cached_engine_does_not_leak_removed_query_answers(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Ada", "born_in", "London", status="confirmed")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    assert verify(s).answers == ["q1: London"]
+    path.unlink()
+
+    rep = verify(s)
+    assert rep.answers == []
+    assert "--- answers ---" not in rep.text
+
+
+def test_verify_cached_engine_does_not_leak_changed_policy_findings(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Ada", "is_a", "person", status="confirmed")
+    path = policy_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_has_isa(subject: symbol)\n"
+        'warn_has_isa(S) :- relation(S, "is_a", O).\n',
+        encoding="utf-8",
+    )
+
+    assert verify(s).findings == ["WARN has_isa: Ada"]
+    path.write_text(
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n",
+        encoding="utf-8",
+    )
+
+    assert verify(s).findings == []

--- a/verinote/engine/__init__.py
+++ b/verinote/engine/__init__.py
@@ -2,7 +2,7 @@
 """Engine integrations and deterministic KB checks."""
 
 from verinote.engine.coverage import Coverage, SourceCoverage, coverage
-from verinote.engine.duckdb_backend import run_check_duckdb
+from verinote.engine.duckdb_backend import DuckDBInferenceCache, run_check_duckdb
 from verinote.engine.wirelog import (
     DEFAULT_POLICY,
     CheckReport,
@@ -15,6 +15,7 @@ __all__ = [
     "compile_dl",
     "run_check",
     "run_check_duckdb",
+    "DuckDBInferenceCache",
     "validate_query",
     "CheckReport",
     "DEFAULT_POLICY",

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import threading
 from dataclasses import dataclass
 from typing import Iterable, Mapping
 
@@ -19,6 +20,7 @@ from verinote.engine.datalog import (
     parse_and_validate_program,
 )
 from verinote.engine.duckdb_terms import (
+    create_relation_table_sql,
     create_decl_table_sql,
     duckdb_value_to_term,
     term_to_duckdb_value,
@@ -50,40 +52,110 @@ def run_check_duckdb(
     query_dl: str | None = None,
 ) -> CheckReport:
     """Run supported non-recursive Datalog rules through an in-memory DuckDB DB."""
+    cache = DuckDBInferenceCache()
     try:
-        import duckdb
-    except ImportError:
-        return _engine_error("DuckDB is not installed", engine_available=False)
+        return cache.run_check(facts, policy_dl=policy_dl, query_dl=query_dl)
+    finally:
+        cache.close()
 
-    policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
-    source = policy + ("\n" + query_dl if query_dl else "")
-    try:
-        program = parse_and_validate_program(source)
-        _validate_relation_decl(program)
-        ordered_rules = _topological_rules(program)
-    except (DatalogParseError, DatalogValidationError, DuckDBBackendError) as exc:
-        return _engine_error(str(exc))
 
-    try:
-        con = duckdb.connect()
-        fact_rows = list(facts)
-        declarations = {decl.name: decl for decl in program.declarations}
-        for decl in program.declarations:
-            con.execute(_create_decl_table_sql(decl))
-        _load_relation_facts(con, fact_rows)
-        _load_extensional_facts(con, program.facts, declarations)
-        for rule in ordered_rules:
-            compiled = _compile_rule(rule, declarations)
-            con.execute(compiled.sql, list(compiled.params))
-        return _collect_report(
-            con,
-            declarations,
-            fact_rows,
-            policy_dl=policy,
-            query_dl=query_dl,
+class DuckDBInferenceCache:
+    """Reusable DuckDB inference session with cached engine-input facts.
+
+    SQLite remains the source-of-truth. This cache only keeps the derived
+    `relation(subject, rel, object)` table in an in-memory DuckDB connection and
+    refreshes it when the engine-input facts change. Policy/query derived tables
+    are recreated on every run so rule output cannot leak across checks.
+    """
+
+    def __init__(self) -> None:
+        self._con = None
+        self._relation_fingerprint: tuple[tuple[object, ...], ...] | None = None
+        self._decl_tables: set[str] = set()
+        self._lock = threading.Lock()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._con is not None:
+                self._con.close()
+                self._con = None
+            self._relation_fingerprint = None
+            self._decl_tables.clear()
+
+    def run_check(
+        self,
+        facts: Iterable[Mapping[str, object]],
+        *,
+        policy_dl: str | None = None,
+        query_dl: str | None = None,
+    ) -> CheckReport:
+        """Run a check while reusing the cached DuckDB base relation."""
+        try:
+            import duckdb
+        except ImportError:
+            return _engine_error("DuckDB is not installed", engine_available=False)
+
+        policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
+        source = policy + ("\n" + query_dl if query_dl else "")
+        try:
+            program = parse_and_validate_program(source)
+            _validate_relation_decl(program)
+            ordered_rules = _topological_rules(program)
+        except (DatalogParseError, DatalogValidationError, DuckDBBackendError) as exc:
+            return _engine_error(str(exc))
+
+        try:
+            fact_rows = list(facts)
+            with self._lock:
+                if self._con is None:
+                    self._con = duckdb.connect()
+                    self._con.execute(create_relation_table_sql())
+                con = self._con
+                self._reset_derived_tables()
+                fingerprint = _relation_fingerprint(fact_rows)
+                if fingerprint != self._relation_fingerprint:
+                    con.execute('DELETE FROM "relation"')
+                    _load_relation_facts(con, fact_rows)
+                    self._relation_fingerprint = fingerprint
+
+                declarations = {decl.name: decl for decl in program.declarations}
+                for decl in program.declarations:
+                    if decl.name == "relation":
+                        continue
+                    con.execute(_create_decl_table_sql(decl))
+                    self._decl_tables.add(decl.name)
+                _load_extensional_facts(con, program.facts, declarations)
+                for rule in ordered_rules:
+                    compiled = _compile_rule(rule, declarations)
+                    con.execute(compiled.sql, list(compiled.params))
+                return _collect_report(
+                    con,
+                    declarations,
+                    fact_rows,
+                    policy_dl=policy,
+                    query_dl=query_dl,
+                )
+        except Exception as exc:
+            return _engine_error(str(exc))
+
+    def _reset_derived_tables(self) -> None:
+        assert self._con is not None
+        for name in sorted(self._decl_tables):
+            self._con.execute(f"DROP TABLE IF EXISTS {_quote_ident(name)}")
+        self._decl_tables.clear()
+
+
+def _relation_fingerprint(facts: list[Mapping[str, object]]) -> tuple[tuple[object, ...], ...]:
+    """Stable fingerprint for the facts materialized into DuckDB."""
+    rows: list[tuple[object, ...]] = []
+    for row in facts:
+        rows.append(
+            tuple(
+                term_to_duckdb_value(_coerce_fact_term(row[key]))
+                for key in ("subject", "relation", "object")
+            )
         )
-    except Exception as exc:
-        return _engine_error(str(exc))
+    return tuple(sorted(set(rows)))
 
 
 def _engine_error(message: str, *, engine_available: bool = True) -> CheckReport:
@@ -126,6 +198,8 @@ def _load_extensional_facts(
     con, facts: tuple[Fact, ...], declarations: dict[str, Declaration]
 ) -> None:
     for fact in facts:
+        if fact.atom.predicate == "relation":
+            raise DuckDBBackendError("relation facts must come from SQLite engine input")
         decl = declarations[fact.atom.predicate]
         columns = _insert_columns(decl)
         placeholders = ", ".join("?" for _ in _insert_values(fact.atom.args))

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from verinote.engine import CheckReport, run_check_duckdb
+from verinote.engine import CheckReport
 from verinote.store import ENGINE_STATUSES, Store
 
 # Per-KB policy location, relative to the KB root (the db file's directory).
@@ -29,4 +29,6 @@ def verify(store: Store) -> CheckReport:
     from verinote.pipeline.query import load_query
 
     rows = store.facts(statuses=ENGINE_STATUSES)
-    return run_check_duckdb(rows, policy_dl=load_policy(store), query_dl=load_query(store))
+    return store.inference_cache.run_check(
+        rows, policy_dl=load_policy(store), query_dl=load_query(store)
+    )

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -37,13 +37,26 @@ class Store:
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON;")
         self._lock = threading.Lock()
+        self._inference_cache: Any = None
 
     # --- lifecycle -------------------------------------------------------
     def init_schema(self) -> None:
         self._conn.executescript(_load_schema())
 
     def close(self) -> None:
+        if self._inference_cache is not None:
+            self._inference_cache.close()
+            self._inference_cache = None
         self._conn.close()
+
+    @property
+    def inference_cache(self):
+        """Per-store reusable DuckDB inference cache."""
+        if self._inference_cache is None:
+            from verinote.engine import DuckDBInferenceCache
+
+            self._inference_cache = DuckDBInferenceCache()
+        return self._inference_cache
 
     def __enter__(self) -> "Store":
         return self


### PR DESCRIPTION
Closes #44

## Summary
- add a reusable in-memory DuckDB inference cache for engine-input facts
- bind the cache to Store lifecycle and route verify(store) through it
- reset derived policy/query tables per run and reject policy/query relation facts
- cover cache reuse, invalidation, candidate exclusion, leakage, and close lifecycle

## Validation
- uv run --python 3.13 --with-editable . --with '.[test]' pytest -q tests/test_duckdb_backend.py tests/test_verify.py\n- uv run --python 3.13 --with-editable . --with '.[test]' pytest -q\n- uv run --python 3.13 --with ruff ruff check