### PR TITLE
[codex] Write fact terms to DuckDB sidecar

### DIFF
--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
+from verinote.store import Store
+from verinote.store.duckdb_fact_terms import fact_terms_path
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_add_fact_writes_sqlite_metadata_and_stringlit_terms(tmp_path):
+    s = _store(tmp_path)
+
+    fid = s.add_fact('person("Ada")', "is_a", "person", status="candidate", confidence=0.7)
+
+    row = s.get_fact(fid)
+    assert (row["subject"], row["relation"], row["object"], row["status"]) == (
+        'person("Ada")',
+        "is_a",
+        "person",
+        "candidate",
+    )
+    assert s.get_fact_terms(fid) == (
+        StringLit('person("Ada")'),
+        StringLit("is_a"),
+        StringLit("person"),
+    )
+
+
+def test_add_fact_accepts_structural_terms_without_parsing_strings(tmp_path):
+    s = _store(tmp_path)
+
+    fid = s.add_fact(
+        Compound("person", (StringLit("Ada"),)),
+        Atom("has_role"),
+        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+    )
+
+    row = s.get_fact(fid)
+    assert (row["subject"], row["relation"], row["object"]) == (
+        'person("Ada")',
+        "has_role",
+        'role(person("Ada"), "PI")',
+    )
+    assert s.get_fact_terms(fid) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("has_role"),
+        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+    )
+
+
+def test_fact_terms_sidecar_persists_across_store_reopen(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact(Compound("date", (NumberLit(2020), NumberLit(1), NumberLit(1))), "r", "x")
+    s.close()
+
+    reopened = Store(tmp_path / "kb.sqlite")
+    try:
+        assert fact_terms_path(tmp_path).is_file()
+        assert reopened.get_fact_terms(fid) == (
+            Compound("date", (NumberLit(2020), NumberLit(1), NumberLit(1))),
+            StringLit("r"),
+            StringLit("x"),
+        )
+    finally:
+        reopened.close()
+
+
+def test_amend_fact_updates_sqlite_duckdb_terms_and_audit(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "r", "B", status="needs_review")
+
+    after = s.amend_fact(
+        fid,
+        subject=Compound("person", (StringLit("Ada"),)),
+        relation=Atom("born_year"),
+        obj=NumberLit(1815),
+        note="fixed",
+    )
+
+    assert (after["subject"], after["relation"], after["object"], after["note"]) == (
+        'person("Ada")',
+        "born_year",
+        "1815",
+        "fixed",
+    )
+    assert s.get_fact_terms(fid) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("born_year"),
+        NumberLit(1815),
+    )
+    assert [e["action"] for e in s.fact_log(fid)] == ["amended"]
+
+
+def test_backfill_fact_terms_migrates_legacy_sqlite_text_as_stringlit(tmp_path):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ('person("Ada")', "is_a", "person", "confirmed"),
+    )
+    fid = int(cur.fetchone()[0])
+
+    assert s.backfill_fact_terms() == 1
+    assert s.get_fact_terms(fid) == (
+        StringLit('person("Ada")'),
+        StringLit("is_a"),
+        StringLit("person"),
+    )
+    assert s.backfill_fact_terms() == 0
+
+
+def test_backfill_fact_terms_does_not_overwrite_structural_terms(tmp_path):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ('person("Ada")', "is_a", "person", "confirmed"),
+    )
+    fid = int(cur.fetchone()[0])
+    s.fact_terms.put_fact_terms(
+        fid,
+        Compound("person", (StringLit("Ada"),)),
+        Atom("is_a"),
+        StringLit("person"),
+    )
+
+    assert s.backfill_fact_terms() == 0
+    assert s.get_fact_terms(fid) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("is_a"),
+        StringLit("person"),
+    )
+
+
+def test_status_changes_do_not_mutate_duckdb_terms(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact(Compound("person", (StringLit("Ada"),)), "r", "x", status="needs_review")
+    before = s.get_fact_terms(fid)
+
+    s.toggle_review(fid)
+    s.set_status(fid, "superseded")
+
+    assert s.get_fact_terms(fid) == before
+
+
+def test_add_fact_duckdb_failure_rolls_back_sqlite_insert(tmp_path, monkeypatch):
+    s = _store(tmp_path)
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("sidecar down")
+
+    monkeypatch.setattr(s.fact_terms, "put_fact_terms", fail)
+
+    with pytest.raises(RuntimeError, match="sidecar down"):
+        s.add_fact("A", "r", "B")
+
+    assert s.facts() == []
+
+
+def test_amend_fact_duckdb_failure_leaves_sqlite_and_audit_unchanged(tmp_path, monkeypatch):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "r", "B", status="needs_review", note="orig")
+    before_terms = s.get_fact_terms(fid)
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("sidecar down")
+
+    monkeypatch.setattr(s.fact_terms, "put_fact_terms", fail)
+
+    with pytest.raises(RuntimeError, match="sidecar down"):
+        s.amend_fact(fid, subject="A2", relation="r2", obj="B2", note="changed")
+
+    row = s.get_fact(fid)
+    assert (row["subject"], row["relation"], row["object"], row["note"]) == (
+        "A",
+        "r",
+        "B",
+        "orig",
+    )
+    assert s.fact_log(fid) == []
+    assert s.get_fact_terms(fid) == before_terms
+
+
+def test_amend_fact_audit_failure_rolls_back_sqlite_and_restores_terms(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "r", "B", status="needs_review", note="orig")
+    before_terms = s.get_fact_terms(fid)
+
+    def fail_log(*args, **kwargs):
+        raise RuntimeError("audit down")
+
+    monkeypatch.setattr(s, "_log", fail_log)
+
+    with pytest.raises(RuntimeError, match="audit down"):
+        s.amend_fact(
+            fid,
+            subject=Compound("person", (StringLit("Ada"),)),
+            relation=Atom("born_year"),
+            obj=NumberLit(1815),
+            note="changed",
+        )
+
+    row = s.get_fact(fid)
+    assert (row["subject"], row["relation"], row["object"], row["note"]) == (
+        "A",
+        "r",
+        "B",
+        "orig",
+    )
+    assert s.fact_log(fid) == []
+    assert s.get_fact_terms(fid) == before_terms
+
+
+def test_store_close_closes_fact_term_store(tmp_path):
+    s = _store(tmp_path)
+    _ = s.fact_terms
+
+    assert s._fact_terms is not None
+    s.close()
+
+    assert s._fact_terms is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -168,7 +168,15 @@ def test_report_shows_missing_duckdb_message(tmp_path, monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    c = _client(tmp_path)
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    c = TestClient(create_app(cfg))
     r = c.get("/report")
     assert r.status_code == 200
     assert "DuckDB verification backend is not available" in r.text

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -38,6 +38,7 @@ class Store:
         self._conn.execute("PRAGMA foreign_keys = ON;")
         self._lock = threading.Lock()
         self._inference_cache: Any = None
+        self._fact_terms: Any = None
 
     # --- lifecycle -------------------------------------------------------
     def init_schema(self) -> None:
@@ -47,6 +48,9 @@ class Store:
         if self._inference_cache is not None:
             self._inference_cache.close()
             self._inference_cache = None
+        if self._fact_terms is not None:
+            self._fact_terms.close()
+            self._fact_terms = None
         self._conn.close()
 
     @property
@@ -57,6 +61,15 @@ class Store:
 
             self._inference_cache = DuckDBInferenceCache()
         return self._inference_cache
+
+    @property
+    def fact_terms(self):
+        """Per-KB DuckDB sidecar for structural fact terms."""
+        if self._fact_terms is None:
+            from verinote.store.duckdb_fact_terms import DuckDBFactTermStore
+
+            self._fact_terms = DuckDBFactTermStore.for_root(self.db_path.parent)
+        return self._fact_terms
 
     def __enter__(self) -> "Store":
         return self
@@ -124,9 +137,9 @@ class Store:
     # --- facts -----------------------------------------------------------
     def add_fact(
         self,
-        subject: str,
-        relation: str,
-        obj: str,
+        subject: object,
+        relation: object,
+        obj: object,
         *,
         status: str = "candidate",
         confidence: float = 0.0,
@@ -135,12 +148,56 @@ class Store:
         note: str = "",
     ) -> int:
         with self._lock:
-            cur = self._conn.execute(
-                "INSERT INTO facts(subject, relation, object, status, confidence, source_id, run_id, note) "
-                "VALUES(?,?,?,?,?,?,?,?) RETURNING id",
-                (subject, relation, obj, status, confidence, source_id, run_id, note),
+            fact_id: int | None = None
+            self._conn.execute("BEGIN")
+            try:
+                cur = self._conn.execute(
+                    "INSERT INTO facts(subject, relation, object, status, confidence, source_id, run_id, note) "
+                    "VALUES(?,?,?,?,?,?,?,?) RETURNING id",
+                    (
+                        _display_fact_value(subject),
+                        _display_fact_value(relation),
+                        _display_fact_value(obj),
+                        status,
+                        confidence,
+                        source_id,
+                        run_id,
+                        note,
+                    ),
+                )
+                fact_id = int(cur.fetchone()[0])
+                self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
+                self._conn.execute("COMMIT")
+                return fact_id
+            except Exception:
+                self._rollback_quietly()
+                if fact_id is not None:
+                    self._delete_fact_terms_quietly(fact_id)
+                raise
+
+    def get_fact_terms(self, fact_id: int):
+        """Return structural DuckDB terms for a fact metadata row."""
+        return self.fact_terms.get_fact_terms(fact_id)
+
+    def backfill_fact_terms(self) -> int:
+        """Backfill missing DuckDB term rows from SQLite text mirrors as StringLit."""
+        with self._lock:
+            rows = list(
+                self._conn.execute(
+                    "SELECT id, subject, relation, object FROM facts ORDER BY id"
+                )
             )
-            return int(cur.fetchone()[0])
+            existing = self.fact_terms.get_many_fact_terms(row["id"] for row in rows)
+            written = 0
+            for row in rows:
+                fact_id = int(row["id"])
+                if fact_id in existing:
+                    continue
+                self.fact_terms.put_fact_terms(
+                    fact_id, row["subject"], row["relation"], row["object"]
+                )
+                written += 1
+            return written
 
     def get_fact(self, fact_id: int) -> sqlite3.Row | None:
         return self._conn.execute(
@@ -195,9 +252,9 @@ class Store:
         self,
         fact_id: int,
         *,
-        subject: str,
-        relation: str,
-        obj: str,
+        subject: object,
+        relation: object,
+        obj: object,
         note: str = "",
     ) -> sqlite3.Row | None:
         """Correct a fact's (subject, relation, object, note); audit as `amended`."""
@@ -205,14 +262,32 @@ class Store:
             before = self.get_fact(fact_id)
             if before is None:
                 return None
-            self._conn.execute(
-                "UPDATE facts SET subject = ?, relation = ?, object = ?, note = ?, "
-                "updated_at = datetime('now') WHERE id = ?",
-                (subject, relation, obj, note, fact_id),
-            )
-            after = self.get_fact(fact_id)
-            self._log(fact_id, "amended", before, after)
-            return after
+            previous_terms = self.fact_terms.get_fact_terms(fact_id)
+            terms_written = False
+            self._conn.execute("BEGIN")
+            try:
+                self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
+                terms_written = True
+                self._conn.execute(
+                    "UPDATE facts SET subject = ?, relation = ?, object = ?, note = ?, "
+                    "updated_at = datetime('now') WHERE id = ?",
+                    (
+                        _display_fact_value(subject),
+                        _display_fact_value(relation),
+                        _display_fact_value(obj),
+                        note,
+                        fact_id,
+                    ),
+                )
+                after = self.get_fact(fact_id)
+                self._log(fact_id, "amended", before, after)
+                self._conn.execute("COMMIT")
+                return after
+            except Exception:
+                self._rollback_quietly()
+                if terms_written:
+                    self._restore_fact_terms_quietly(fact_id, previous_terms)
+                raise
 
     # --- questions -------------------------------------------------------
     def add_question(self, text: str) -> int:
@@ -255,3 +330,34 @@ class Store:
                 json.dumps(dict(after), ensure_ascii=False) if after else None,
             ),
         )
+
+    def _rollback_quietly(self) -> None:
+        try:
+            self._conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+
+    def _delete_fact_terms_quietly(self, fact_id: int) -> None:
+        try:
+            self.fact_terms.delete_fact_terms(fact_id)
+        except Exception:
+            pass
+
+    def _restore_fact_terms_quietly(
+        self, fact_id: int, terms: tuple[object, object, object] | None
+    ) -> None:
+        try:
+            if terms is None:
+                self.fact_terms.delete_fact_terms(fact_id)
+            else:
+                self.fact_terms.put_fact_terms(fact_id, *terms)
+        except Exception:
+            pass
+
+
+def _display_fact_value(value: object) -> str:
+    from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var, render_term
+
+    if isinstance(value, (Atom, Compound, NumberLit, StringLit, Var)):
+        return render_term(value)
+    return str(value)


### PR DESCRIPTION
Closes #48

## Summary
- attach a per-KB DuckDB fact-term sidecar to Store lifecycle
- write new and amended facts to SQLite metadata mirrors plus DuckDB structural term rows
- add explicit safe backfill for legacy SQLite-only facts as StringLit terms
- test rollback/restore behavior, structural term preservation, status-only changes, and missing-DuckDB report behavior

## Validation
- uv run --python 3.13 --with-editable . --with '.[test]' pytest -q tests/test_store_fact_terms.py tests/test_store.py tests/test_duckdb_fact_terms.py tests/test_verify.py tests/test_web.py\n- uv run --python 3.13 --with-editable . --with '.[test]' pytest -q\n- uv run --python 3.13 --with ruff ruff check