### PR TITLE
Define explicit fact term input boundary

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ import pytest
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline import extract_source, sync_sources
 from verinote.store import Store
+from verinote.engine.terms import StringLit
 
 
 def _store(tmp_path) -> Store:
@@ -28,6 +29,30 @@ def test_extract_source_persists_candidates_with_linkage(tmp_path, fake_client):
     assert [f["status"] for f in facts] == ["candidate", "candidate"]
     assert {f["run_id"] for f in facts} == {run_id}
     assert {f["source_path"] for f in facts} == {"sources/x.txt"}
+
+
+def test_extract_source_stores_term_syntax_as_plain_strings(tmp_path, fake_client):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client([ExtractedFact('person("Ada")', "is_a", "person", 0.9)])
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    fact = s.facts()[0]
+    assert s.get_fact_terms(fact["id"]) == (
+        StringLit('person("Ada")'),
+        StringLit("is_a"),
+        StringLit("person"),
+    )
 
 
 def test_sync_sources_opens_run_and_summarises(tmp_path, fake_client):

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 import pytest
 
-from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
+from verinote.engine.terms import (
+    Atom,
+    Compound,
+    NumberLit,
+    StringLit,
+    TermParseError,
+    Var,
+)
 from verinote.store import Store
 from verinote.store.duckdb_fact_terms import fact_terms_path
+from verinote.store.fact_input import structural_term
 
 
 def _store(tmp_path) -> Store:
@@ -53,6 +61,52 @@ def test_add_fact_accepts_structural_terms_without_parsing_strings(tmp_path):
     )
 
 
+def test_structural_term_is_an_explicit_input_boundary(tmp_path):
+    s = _store(tmp_path)
+
+    plain_id = s.add_fact('person("Ada")', "is_a", "person")
+    term_id = s.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("is_a"),
+        structural_term("1815"),
+    )
+
+    assert s.get_fact(plain_id)["subject"] == s.get_fact(term_id)["subject"]
+    assert s.get_fact_terms(plain_id) == (
+        StringLit('person("Ada")'),
+        StringLit("is_a"),
+        StringLit("person"),
+    )
+    assert s.get_fact_terms(term_id) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("is_a"),
+        NumberLit(1815),
+    )
+
+
+def test_structural_term_rejects_invalid_or_nonground_terms(tmp_path):
+    s = _store(tmp_path)
+
+    with pytest.raises(TermParseError):
+        structural_term('person("Ada"')
+    with pytest.raises(TermParseError, match="ground"):
+        structural_term("person(X)")
+
+    assert s.facts() == []
+
+
+def test_store_rejects_direct_nonground_term_inputs_without_writing(tmp_path):
+    s = _store(tmp_path)
+
+    with pytest.raises(ValueError, match="ground"):
+        s.add_fact(Var("S"), "r", "x")
+    with pytest.raises(ValueError, match="ground"):
+        s.add_fact(Compound("person", (Var("Name"),)), "r", "x")
+
+    assert s.facts() == []
+    assert s.fact_terms.get_many_fact_terms([1, 2]) == {}
+
+
 def test_fact_terms_sidecar_persists_across_store_reopen(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact(Compound("date", (NumberLit(2020), NumberLit(1), NumberLit(1))), "r", "x")
@@ -94,6 +148,24 @@ def test_amend_fact_updates_sqlite_duckdb_terms_and_audit(tmp_path):
         NumberLit(1815),
     )
     assert [e["action"] for e in s.fact_log(fid)] == ["amended"]
+
+
+def test_amend_fact_keeps_term_syntax_strings_as_stringlit(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact(Compound("person", (StringLit("Ada"),)), Atom("born_in"), "London")
+
+    s.amend_fact(
+        fid,
+        subject='person("Ada")',
+        relation="born_in",
+        obj='city("London")',
+    )
+
+    assert s.get_fact_terms(fid) == (
+        StringLit('person("Ada")'),
+        StringLit("born_in"),
+        StringLit('city("London")'),
+    )
 
 
 def test_backfill_fact_terms_migrates_legacy_sqlite_text_as_stringlit(tmp_path):
@@ -182,6 +254,26 @@ def test_amend_fact_duckdb_failure_leaves_sqlite_and_audit_unchanged(tmp_path, m
     )
     assert s.fact_log(fid) == []
     assert s.get_fact_terms(fid) == before_terms
+
+
+def test_amend_fact_rejects_direct_nonground_terms_and_restores_state(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "r", "B", status="needs_review", note="orig")
+    before = dict(s.get_fact(fid))
+    before_terms = s.get_fact_terms(fid)
+
+    with pytest.raises(ValueError, match="ground"):
+        s.amend_fact(
+            fid,
+            subject=Compound("person", (Var("Name"),)),
+            relation="r",
+            obj="B2",
+            note="bad",
+        )
+
+    assert dict(s.get_fact(fid)) == before
+    assert s.get_fact_terms(fid) == before_terms
+    assert s.fact_log(fid) == []
 
 
 def test_amend_fact_audit_failure_rolls_back_sqlite_and_restores_terms(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -8,8 +8,10 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 import verinote.web.app as webapp  # noqa: E402
 from verinote.config import Config  # noqa: E402
+from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
 from verinote.pipeline.query import query_path  # noqa: E402
+from verinote.store.fact_input import structural_term  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
 
@@ -200,6 +202,7 @@ def test_edit_form_renders(tmp_path):
     r = c.get(f"/facts/{c.fact_id}/edit")
     assert r.status_code == 200
     assert 'name="subject"' in r.text
+    assert 'name="subject_kind"' in r.text
     assert "/amend" in r.text
 
 
@@ -214,6 +217,110 @@ def test_amend_endpoint_updates_and_audits(tmp_path):
     store = c.app.state.store
     assert store.get_fact(c.fact_id)["subject"] == "NewSubj"
     assert any(e["action"] == "amended" for e in store.fact_log(c.fact_id))
+
+
+def test_edit_form_preserves_structural_fact_input_kinds(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("born_in"),
+        "London",
+        status="needs_review",
+    )
+
+    r = c.get(f"/facts/{fid}/edit")
+
+    assert r.status_code == 200
+    assert 'name="subject_kind"' in r.text
+    assert '<option value="term" selected>term</option>' in r.text
+    assert 'name="object_kind"' in r.text
+    assert '<option value="string" selected>string</option>' in r.text
+
+
+def test_amend_endpoint_can_save_explicit_structural_terms(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact("A", "r", "B", status="needs_review")
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": 'person("Ada")',
+            "subject_kind": "term",
+            "relation": "born_in",
+            "relation_kind": "term",
+            "object": "London",
+            "object_kind": "string",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 200
+    assert store.get_fact_terms(fid) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("born_in"),
+        StringLit("London"),
+    )
+
+
+def test_amend_endpoint_rejects_invalid_structural_terms_without_writing(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("born_in"),
+        "London",
+        status="needs_review",
+    )
+    before_row = dict(store.get_fact(fid))
+    before_terms = store.get_fact_terms(fid)
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": 'person("Ada"',
+            "subject_kind": "term",
+            "relation": "born_in",
+            "relation_kind": "term",
+            "object": "London",
+            "object_kind": "string",
+            "note": "bad",
+        },
+    )
+
+    assert r.status_code == 400
+    assert "expected" in r.text
+    assert dict(store.get_fact(fid)) == before_row
+    assert store.get_fact_terms(fid) == before_terms
+    assert store.fact_log(fid) == []
+
+
+def test_amend_endpoint_rejects_nonground_structural_terms_without_writing(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact("A", "r", "B", status="needs_review")
+    before_row = dict(store.get_fact(fid))
+    before_terms = store.get_fact_terms(fid)
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": "person(X)",
+            "subject_kind": "term",
+            "relation": "r",
+            "relation_kind": "string",
+            "object": "B",
+            "object_kind": "string",
+            "note": "bad",
+        },
+    )
+
+    assert r.status_code == 400
+    assert "ground" in r.text
+    assert dict(store.get_fact(fid)) == before_row
+    assert store.get_fact_terms(fid) == before_terms
+    assert store.fact_log(fid) == []
 
 
 def test_provenance_shows_source_and_audit(tmp_path):

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -156,7 +156,15 @@ def _validate_fact_id(fact_id: int) -> int:
 
 
 def _coerce_term(value: object) -> Term:
-    if isinstance(value, (Atom, Compound, NumberLit, StringLit, Var)):
+    if isinstance(value, Var):
+        raise DuckDBFactTermStoreError("fact terms must be ground")
+    if isinstance(value, Compound):
+        from verinote.store.fact_input import is_ground_term
+
+        if not is_ground_term(value):
+            raise DuckDBFactTermStoreError("fact terms must be ground")
+        return value
+    if isinstance(value, (Atom, NumberLit, StringLit)):
         return value
     return StringLit(str(value))
 

--- a/verinote/store/fact_input.py
+++ b/verinote/store/fact_input.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Explicit fact input boundary helpers.
+
+Plain Python strings passed to `Store.add_fact` / `Store.amend_fact` are stored
+as `StringLit` terms. Call `structural_term(...)` only when the caller
+intentionally wants Datalog term syntax parsed as a logical term.
+"""
+
+from __future__ import annotations
+
+from verinote.engine.terms import Compound, Term, TermParseError, Var, parse_term
+
+
+def structural_term(text: str) -> Term:
+    """Parse explicit structural fact-term syntax.
+
+    Invalid syntax raises `TermParseError`. Variables are rejected because base
+    fact rows are data, not Datalog rule patterns.
+    """
+    term = parse_term(text)
+    if not is_ground_term(term):
+        raise TermParseError("structural fact terms must be ground")
+    return term
+
+
+def is_ground_term(term: Term) -> bool:
+    """Return True when a term contains no variables."""
+    return not _has_var(term)
+
+
+def term_input_kind(term: Term) -> str:
+    """Return the edit/input kind for a stored term."""
+    from verinote.engine.terms import StringLit
+
+    return "string" if isinstance(term, StringLit) else "term"
+
+
+def _has_var(term: Term) -> bool:
+    if isinstance(term, Var):
+        return True
+    if isinstance(term, Compound):
+        return any(_has_var(arg) for arg in term.args)
+    return False

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -34,6 +34,7 @@ from verinote.pipeline import (
     verify,
 )
 from verinote.store import Store
+from verinote.store.fact_input import structural_term, term_input_kind
 
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
 _STATIC = resources.files("verinote.web").joinpath("static")
@@ -67,6 +68,25 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
         return templates.TemplateResponse(request, "partials/fact_row.html", {"f": fact})
+
+    def _fact_edit_context(fact, *, error: str | None = None):
+        kinds = {"subject": "string", "relation": "string", "object": "string"}
+        if fact is not None:
+            terms = store.get_fact_terms(fact["id"])
+            if terms is not None:
+                kinds = {
+                    "subject": term_input_kind(terms[0]),
+                    "relation": term_input_kind(terms[1]),
+                    "object": term_input_kind(terms[2]),
+                }
+        return {"f": fact, "kinds": kinds, "error": error}
+
+    def _fact_input(value: str, kind: str):
+        if kind == "string":
+            return value
+        if kind == "term":
+            return structural_term(value)
+        raise ValueError(f"unknown fact input kind: {kind}")
 
     def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
         from verinote.engine import coverage
@@ -156,7 +176,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):
         return templates.TemplateResponse(
-            request, "partials/fact_edit.html", {"f": store.get_fact(fact_id)}
+            request, "partials/fact_edit.html", _fact_edit_context(store.get_fact(fact_id))
         )
 
     @app.get("/facts/{fact_id}/row", response_class=HTMLResponse)
@@ -171,10 +191,28 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         subject: str = Form(...),
         relation: str = Form(...),
         object: str = Form(...),
+        subject_kind: str = Form("string"),
+        relation_kind: str = Form("string"),
+        object_kind: str = Form("string"),
         note: str = Form(""),
     ):
+        try:
+            subject_value = _fact_input(subject, subject_kind)
+            relation_value = _fact_input(relation, relation_kind)
+            object_value = _fact_input(object, object_kind)
+        except ValueError as e:
+            return templates.TemplateResponse(
+                request,
+                "partials/fact_edit.html",
+                _fact_edit_context(store.get_fact(fact_id), error=str(e)),
+                status_code=400,
+            )
         amended = store.amend_fact(
-            fact_id, subject=subject, relation=relation, obj=object, note=note
+            fact_id,
+            subject=subject_value,
+            relation=relation_value,
+            obj=object_value,
+            note=note,
         )
         return _row(request, amended)
 

--- a/verinote/web/templates/partials/fact_edit.html
+++ b/verinote/web/templates/partials/fact_edit.html
@@ -2,10 +2,25 @@
    save POSTs /amend (re-renders the row), cancel GETs /row (reverts). #}
 <tr id="fact-{{ f['id'] }}" class="fact editing">
   <td colspan="5">
+    {% if error %}
+    <p class="error">{{ error }}</p>
+    {% endif %}
     <form class="amend" hx-post="/facts/{{ f['id'] }}/amend"
           hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">
+      <select name="subject_kind" aria-label="subject kind">
+        <option value="string" {% if kinds.subject == 'string' %}selected{% endif %}>string</option>
+        <option value="term" {% if kinds.subject == 'term' %}selected{% endif %}>term</option>
+      </select>
       <input name="subject" value="{{ f['subject'] }}" aria-label="subject" required>
+      <select name="relation_kind" aria-label="relation kind">
+        <option value="string" {% if kinds.relation == 'string' %}selected{% endif %}>string</option>
+        <option value="term" {% if kinds.relation == 'term' %}selected{% endif %}>term</option>
+      </select>
       <input name="relation" value="{{ f['relation'] }}" aria-label="relation" required>
+      <select name="object_kind" aria-label="object kind">
+        <option value="string" {% if kinds.object == 'string' %}selected{% endif %}>string</option>
+        <option value="term" {% if kinds.object == 'term' %}selected{% endif %}>term</option>
+      </select>
       <input name="object" value="{{ f['object'] }}" aria-label="object" required>
       <input name="note" value="{{ f['note'] }}" aria-label="note" placeholder="note">
       <button type="submit">save</button>


### PR DESCRIPTION
Closes #49

## Summary
- add an explicit `structural_term(...)` helper for deliberate structural fact input
- keep extraction and plain Store string inputs as `StringLit` by default
- preserve/edit structural term kinds in the web amend form and reject invalid/nonground term input without writing
- reject direct nonground `Term` values at the DuckDB fact-term sidecar boundary

## Verification
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q`
- `uv run --python 3.13 --with-editable . ruff check .`
- reviewer subagent re-review: no remaining blocking findings