### PR TITLE
Use DuckDB fact terms for verification

### DIFF
--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2,9 +2,11 @@
 import builtins
 
 import verinote.engine.duckdb_backend as duckdb_backend
+from verinote.engine.terms import Compound, StringLit
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import policy_path, verify
 from verinote.store import Store
+from verinote.store.fact_input import structural_term
 
 
 def _store(tmp_path) -> Store:
@@ -73,6 +75,68 @@ def test_verify_loads_query_file(tmp_path):
     assert "--- query input ---" in rep.text
 
 
+def test_verify_uses_duckdb_fact_terms_for_structural_compounds(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="confirmed",
+    )
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation(person("Ada"), has_role, O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.answers == ['q1: role(person("Ada"), "PI")']
+
+
+def test_verify_ignores_candidate_structural_terms(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="candidate",
+    )
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(S) :- relation(S, has_role, role(person("Ada"), "PI")).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert "--- fact input ---\n(none)" in rep.text
+
+
+def test_verify_keeps_plain_term_syntax_as_stringlit(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact('person("Ada")', "has_role", 'role(person("Ada"), "PI")', status="confirmed")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation(person("Ada"), "has_role", O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert 'relation("person(\\"Ada\\")", "has_role", "role(person(\\"Ada\\"), \\"PI\\")")' in rep.text
+    assert 'relation(person("Ada"), "has_role", role(person("Ada"), "PI"))' not in rep.text
+
+
 def test_verify_debug_fact_input_is_quoted_and_escaped(tmp_path):
     s = _store(tmp_path)
     s.add_fact('a"b', "r", "line\nnext", status="confirmed")
@@ -80,6 +144,46 @@ def test_verify_debug_fact_input_is_quoted_and_escaped(tmp_path):
     rep = verify(s)
 
     assert 'relation("a\\"b", "r", "line\\nnext")' in rep.text
+
+
+def test_verify_backfills_missing_duckdb_terms_for_legacy_engine_rows(tmp_path):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ("Ada", "born_in", "London", "confirmed"),
+    )
+    fid = int(cur.fetchone()[0])
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.answers == ["q1: London"]
+    assert s.get_fact_terms(fid) == (
+        StringLit("Ada"),
+        StringLit("born_in"),
+        StringLit("London"),
+    )
+
+
+def test_verify_fails_closed_when_engine_fact_terms_remain_missing(tmp_path, monkeypatch):
+    s = _store(tmp_path)
+    s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?)",
+        ("Ada", "born_in", "London", "confirmed"),
+    )
+    monkeypatch.setattr(s, "backfill_fact_terms", lambda: 0)
+
+    rep = verify(s)
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert "missing DuckDB fact terms" in rep.text
 
 
 def test_verify_reports_missing_duckdb_as_blocking(tmp_path, monkeypatch):
@@ -182,6 +286,49 @@ def test_verify_cache_refreshes_after_engine_fact_amendment(tmp_path):
     )
 
     assert verify(s).ok is True
+
+
+def test_verify_cache_refreshes_after_duckdb_term_payload_change(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("Ada", "born_in", "London", status="confirmed")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    assert verify(s).answers == ["q1: London"]
+    s.fact_terms.put_fact_terms(fid, "Ada", "born_in", "Paris")
+
+    assert verify(s).answers == ["q1: Paris"]
+
+
+def test_verify_cache_does_not_reload_for_candidate_term_payload_change(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    s.add_fact("Ada", "born_in", "London", status="confirmed")
+    candidate = s.add_fact(
+        Compound("person", (StringLit("Ada"),)),
+        "has_role",
+        "PI",
+        status="candidate",
+    )
+    loads = []
+    real_load = duckdb_backend._load_relation_facts
+
+    def counted_load(con, facts):
+        loads.append(list(facts))
+        return real_load(con, facts)
+
+    monkeypatch.setattr(duckdb_backend, "_load_relation_facts", counted_load)
+
+    assert verify(s).ok is True
+    s.fact_terms.put_fact_terms(candidate, Compound("person", (StringLit("Grace"),)), "has_role", "PI")
+    assert verify(s).ok is True
+
+    assert len(loads) == 1
 
 
 def test_verify_cached_engine_does_not_leak_removed_query_answers(tmp_path):

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from verinote.engine import CheckReport
-from verinote.store import ENGINE_STATUSES, Store
+from verinote.store import Store
 
 # Per-KB policy location, relative to the KB root (the db file's directory).
 POLICY_RELPATH = Path("policy") / "logic-policy.dl"
@@ -25,10 +25,20 @@ def load_policy(store: Store) -> str | None:
 
 
 def verify(store: Store) -> CheckReport:
-    """Run confirmed/accepted rows through the deterministic DuckDB check."""
+    """Run confirmed/accepted facts through the deterministic DuckDB check."""
     from verinote.pipeline.query import load_query
+    from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
 
-    rows = store.facts(statuses=ENGINE_STATUSES)
+    try:
+        rows = store.engine_fact_terms()
+    except DuckDBFactTermStoreError as exc:
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"backend: DuckDB\n\npolicy/engine error: {exc}",
+            findings=[f"ERROR engine error: {exc}"],
+        )
     return store.inference_cache.run_check(
         rows, policy_dl=load_policy(store), query_dl=load_query(store)
     )

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -179,6 +179,37 @@ class Store:
         """Return structural DuckDB terms for a fact metadata row."""
         return self.fact_terms.get_fact_terms(fact_id)
 
+    def engine_fact_terms(self) -> list[dict[str, object]]:
+        """Return confirmed/accepted facts using DuckDB terms as logical values."""
+        rows = self.facts(statuses=ENGINE_STATUSES)
+        ids = [int(row["id"]) for row in rows]
+        if not ids:
+            return []
+
+        terms = self.fact_terms.get_many_fact_terms(ids)
+        missing = [fact_id for fact_id in ids if fact_id not in terms]
+        if missing:
+            self.backfill_fact_terms()
+            terms = self.fact_terms.get_many_fact_terms(ids)
+            missing = [fact_id for fact_id in ids if fact_id not in terms]
+        if missing:
+            from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+
+            raise DuckDBFactTermStoreError(
+                "missing DuckDB fact terms for engine fact id(s): "
+                + ", ".join(str(fact_id) for fact_id in missing)
+            )
+
+        return [
+            {
+                "id": fact_id,
+                "subject": terms[fact_id][0],
+                "relation": terms[fact_id][1],
+                "object": terms[fact_id][2],
+            }
+            for fact_id in ids
+        ]
+
     def backfill_fact_terms(self) -> int:
         """Backfill missing DuckDB term rows from SQLite text mirrors as StringLit."""
         with self._lock:


### PR DESCRIPTION
Closes #50

## Summary
- add `Store.engine_fact_terms()` to select SQLite confirmed/accepted ids, then load their DuckDB structural term payloads
- make `verify(store)` feed DuckDB terms into the existing inference cache instead of SQLite display text
- backfill missing legacy term rows once, then fail closed with a blocking report if selected engine facts still lack DuckDB terms
- cover structural compound answers, candidate exclusion, plain StringLit preservation, missing-row handling, and cache refresh on sidecar payload changes

## Verification
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q tests/test_verify.py tests/test_store_fact_terms.py tests/test_duckdb_fact_terms.py tests/test_duckdb_backend.py`
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q`
- `uv run --python 3.13 --with-editable . ruff check .`
- reviewer subagent: no blocking findings