### PR TITLE
Render structural fact terms in the web UI

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+from html import unescape
 
 import pytest
 
@@ -51,6 +52,29 @@ def test_review_shows_queue(tmp_path):
     r = c.get("/review")
     assert r.status_code == 200
     assert "is_a" in r.text
+
+
+def test_review_renders_structural_terms_from_duckdb_and_distinguishes_strings(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact(
+        'person("Ada")',
+        "has_role",
+        'role(person("Ada"), "PI")',
+        status="candidate",
+    )
+    store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="candidate",
+    )
+
+    body = unescape(c.get("/review").text)
+
+    assert 'class="subj term-string" title="string">"person(\\"Ada\\")"' in body
+    assert 'class="subj term-term" title="term">person("Ada")' in body
+    assert 'class="obj term-term" title="term">role(person("Ada"), "PI")' in body
 
 
 def test_toggle_endpoint_swaps_row(tmp_path):
@@ -238,6 +262,111 @@ def test_edit_form_preserves_structural_fact_input_kinds(tmp_path):
     assert '<option value="string" selected>string</option>' in r.text
 
 
+def test_edit_form_uses_duckdb_term_values_not_stale_sqlite_mirrors(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="needs_review",
+    )
+    store._conn.execute(
+        "UPDATE facts SET subject = ?, relation = ?, object = ? WHERE id = ?",
+        ("stale_subject", "stale_relation", "stale_object", fid),
+    )
+
+    body = unescape(c.get(f"/facts/{fid}/edit").text)
+
+    assert 'value="person("Ada")"' in body
+    assert 'value="has_role"' in body
+    assert 'value="role(person("Ada"), "PI")"' in body
+    assert "stale_subject" not in body
+
+
+def test_edit_form_uses_raw_values_for_stringlit_inputs(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        'person("Ada")',
+        "has_role",
+        'role(person("Ada"), "PI")',
+        status="needs_review",
+    )
+
+    body = unescape(c.get(f"/facts/{fid}/edit").text)
+
+    assert 'value="person("Ada")"' in body
+    assert 'value="role(person("Ada"), "PI")"' in body
+    assert 'value=""person(' not in body
+
+
+def test_edit_save_preserves_duckdb_terms_when_sqlite_mirror_is_stale(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="needs_review",
+    )
+    store._conn.execute(
+        "UPDATE facts SET subject = ?, relation = ?, object = ? WHERE id = ?",
+        ("stale_subject", "stale_relation", "stale_object", fid),
+    )
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": 'person("Ada")',
+            "subject_kind": "term",
+            "relation": "has_role",
+            "relation_kind": "term",
+            "object": 'role(person("Ada"), "PI")',
+            "object_kind": "term",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 200
+    assert store.get_fact_terms(fid) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("has_role"),
+        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+    )
+
+
+def test_edit_save_preserves_unchanged_stringlit_without_adding_display_quotes(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        'person("Ada")',
+        "has_role",
+        'role(person("Ada"), "PI")',
+        status="needs_review",
+    )
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": 'person("Ada")',
+            "subject_kind": "string",
+            "relation": "has_role",
+            "relation_kind": "string",
+            "object": 'role(person("Ada"), "PI")',
+            "object_kind": "string",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 200
+    assert store.get_fact_terms(fid) == (
+        StringLit('person("Ada")'),
+        StringLit("has_role"),
+        StringLit('role(person("Ada"), "PI")'),
+    )
+
+
 def test_amend_endpoint_can_save_explicit_structural_terms(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store
@@ -262,6 +391,33 @@ def test_amend_endpoint_can_save_explicit_structural_terms(tmp_path):
         Atom("born_in"),
         StringLit("London"),
     )
+
+
+def test_amend_endpoint_saves_term_looking_text_as_stringlit_in_string_mode(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact("A", "r", "B", status="needs_review")
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": 'person("Ada")',
+            "subject_kind": "string",
+            "relation": "has_role",
+            "relation_kind": "string",
+            "object": 'role(person("Ada"), "PI")',
+            "object_kind": "string",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 200
+    assert store.get_fact_terms(fid) == (
+        StringLit('person("Ada")'),
+        StringLit("has_role"),
+        StringLit('role(person("Ada"), "PI")'),
+    )
+    assert 'class="subj term-string" title="string">"person(\\"Ada\\")"' in unescape(r.text)
 
 
 def test_amend_endpoint_rejects_invalid_structural_terms_without_writing(tmp_path):
@@ -333,6 +489,49 @@ def test_provenance_shows_source_and_audit(tmp_path):
     assert r.status_code == 200
     assert "sources/x.txt" in r.text
     assert "toggled" in r.text
+
+
+def test_provenance_renders_structural_terms_from_duckdb(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/x.txt", kind="text")
+    fid = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="needs_review",
+        source_id=sid,
+    )
+
+    body = unescape(c.get(f"/facts/{fid}/provenance").text)
+
+    assert 'class="subj term-term" title="term">person("Ada")' in body
+    assert 'class="rel term-term" title="term">has_role' in body
+    assert 'class="obj term-term" title="term">role(person("Ada"), "PI")' in body
+    assert "sources/x.txt" in body
+
+
+def test_report_renders_compound_fact_input_and_answer(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="confirmed",
+    )
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation(person("Ada"), has_role, O).\n',
+        encoding="utf-8",
+    )
+
+    body = unescape(c.get("/report").text)
+
+    assert 'q1: role(person("Ada"), "PI")' in body
+    assert 'relation(person("Ada"), has_role, role(person("Ada"), "PI"))' in body
 
 
 def test_analytics_page_renders(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -33,6 +33,7 @@ from verinote.pipeline import (
     translate_questions,
     verify,
 )
+from verinote.engine.terms import StringLit, render_term
 from verinote.store import Store
 from verinote.store.fact_input import structural_term, term_input_kind
 
@@ -65,9 +66,29 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         app.state.store = next_store
         old_store.close()
 
+    def _fact_view(fact):
+        if fact is None:
+            return None
+        view = dict(fact)
+        try:
+            terms = store.get_fact_terms(fact["id"])
+        except ValueError:
+            terms = None
+        if terms is None:
+            for field in ("subject", "relation", "object"):
+                view[f"{field}_display"] = fact[field]
+                view[f"{field}_edit"] = fact[field]
+                view[f"{field}_kind"] = "string"
+            return view
+        for field, term in zip(("subject", "relation", "object"), terms, strict=True):
+            view[f"{field}_display"] = render_term(term)
+            view[f"{field}_edit"] = term.value if isinstance(term, StringLit) else render_term(term)
+            view[f"{field}_kind"] = term_input_kind(term)
+        return view
+
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
-        return templates.TemplateResponse(request, "partials/fact_row.html", {"f": fact})
+        return templates.TemplateResponse(request, "partials/fact_row.html", {"f": _fact_view(fact)})
 
     def _fact_edit_context(fact, *, error: str | None = None):
         kinds = {"subject": "string", "relation": "string", "object": "string"}
@@ -79,7 +100,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     "relation": term_input_kind(terms[1]),
                     "object": term_input_kind(terms[2]),
                 }
-        return {"f": fact, "kinds": kinds, "error": error}
+        return {"f": _fact_view(fact), "kinds": kinds, "error": error}
 
     def _fact_input(value: str, kind: str):
         if kind == "string":
@@ -158,7 +179,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.get("/review", response_class=HTMLResponse)
     def review(request: Request):
         return templates.TemplateResponse(
-            request, "review.html", {"queue": store.review_queue()}
+            request, "review.html", {"queue": [_fact_view(f) for f in store.review_queue()]}
         )
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)
@@ -223,7 +244,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return templates.TemplateResponse(
             request,
             "provenance.html",
-            {"f": fact, "run": run, "log": store.fact_log(fact_id) if fact else []},
+            {"f": _fact_view(fact), "run": run, "log": store.fact_log(fact_id) if fact else []},
         )
 
     def _questions(request: Request, *, error: str | None = None, status_code: int = 200):

--- a/verinote/web/templates/partials/fact_edit.html
+++ b/verinote/web/templates/partials/fact_edit.html
@@ -11,17 +11,17 @@
         <option value="string" {% if kinds.subject == 'string' %}selected{% endif %}>string</option>
         <option value="term" {% if kinds.subject == 'term' %}selected{% endif %}>term</option>
       </select>
-      <input name="subject" value="{{ f['subject'] }}" aria-label="subject" required>
+      <input name="subject" value="{{ f['subject_edit'] }}" aria-label="subject" required>
       <select name="relation_kind" aria-label="relation kind">
         <option value="string" {% if kinds.relation == 'string' %}selected{% endif %}>string</option>
         <option value="term" {% if kinds.relation == 'term' %}selected{% endif %}>term</option>
       </select>
-      <input name="relation" value="{{ f['relation'] }}" aria-label="relation" required>
+      <input name="relation" value="{{ f['relation_edit'] }}" aria-label="relation" required>
       <select name="object_kind" aria-label="object kind">
         <option value="string" {% if kinds.object == 'string' %}selected{% endif %}>string</option>
         <option value="term" {% if kinds.object == 'term' %}selected{% endif %}>term</option>
       </select>
-      <input name="object" value="{{ f['object'] }}" aria-label="object" required>
+      <input name="object" value="{{ f['object_edit'] }}" aria-label="object" required>
       <input name="note" value="{{ f['note'] }}" aria-label="note" placeholder="note">
       <button type="submit">save</button>
       <button type="button" class="ghost"

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -1,9 +1,9 @@
 {# A single fact row. Re-rendered and swapped in place by HTMX after a decision. #}
 <tr id="fact-{{ f['id'] }}" class="fact status-{{ f['status'] }}">
   <td class="triple">
-    <span class="subj">{{ f['subject'] }}</span>
-    <span class="rel">{{ f['relation'] }}</span>
-    <span class="obj">{{ f['object'] }}</span>
+    <span class="subj term-{{ f['subject_kind'] }}" title="{{ f['subject_kind'] }}">{{ f['subject_display'] }}</span>
+    <span class="rel term-{{ f['relation_kind'] }}" title="{{ f['relation_kind'] }}">{{ f['relation_display'] }}</span>
+    <span class="obj term-{{ f['object_kind'] }}" title="{{ f['object_kind'] }}">{{ f['object_display'] }}</span>
   </td>
   <td><span class="badge badge-{{ f['status'] }}">{{ f['status'] }}</span></td>
   <td class="conf">{{ '%.2f'|format(f['confidence']) }}</td>

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -6,9 +6,9 @@
 {% else %}
 <h1>Provenance — fact #{{ f["id"] }}</h1>
 <p class="triple">
-  <span class="subj">{{ f["subject"] }}</span>
-  <span class="rel">{{ f["relation"] }}</span>
-  <span class="obj">{{ f["object"] }}</span>
+  <span class="subj term-{{ f['subject_kind'] }}" title="{{ f['subject_kind'] }}">{{ f["subject_display"] }}</span>
+  <span class="rel term-{{ f['relation_kind'] }}" title="{{ f['relation_kind'] }}">{{ f["relation_display"] }}</span>
+  <span class="obj term-{{ f['object_kind'] }}" title="{{ f['object_kind'] }}">{{ f["object_display"] }}</span>
   <span class="badge badge-{{ f['status'] }}">{{ f["status"] }}</span>
 </p>
 


### PR DESCRIPTION
Closes #51

## Summary
- render review/provenance rows from DuckDB structural fact terms instead of SQLite display mirrors
- distinguish StringLit from structural terms with quoted display and term kind classes/titles
- split display values from edit input values so string mode edits use raw StringLit values while term mode uses canonical syntax
- cover stale SQLite mirror edit safety, string-mode save preservation, structural save behavior, provenance, and compound report output

## Verification
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q tests/test_web.py`
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q`
- `uv run --python 3.13 --with-editable . ruff check .`
- reviewer subagent re-review: no blocking findings