### PR TITLE
Document DuckDB fact term ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ with a symbolic verifier:
 | Logic engine   | **DuckDB-backed Datalog**. Confirmed rows load into in-memory DuckDB and non-recursive policy/query rules compile to SQL. |
 | LLM            | **Hand-rolled `LLMClient` adapters** (Anthropic / OpenAI / Ollama). No vendor lock-in. |
 | Web            | **FastAPI + HTMX + Jinja** — server-rendered partials, no JS build step. |
-| Storage        | **SQLite** is the system-of-record (OLTP). **DuckDB** is the inference backend and also attaches SQLite read-only for analytics. `.dl` policy/query files remain editable inputs. |
+| Storage        | **SQLite** owns KB metadata, source/run provenance, review lifecycle, audit log, and text display mirrors. **DuckDB** owns logical fact terms in `facts.duckdb`, runs verification, and attaches SQLite read-only for metadata analytics. `.dl` policy/query files remain editable inputs. |
 
 ## Status
 
@@ -59,6 +59,26 @@ verinote ui        # launch the web app at http://localhost:8731
 DuckDB is a core dependency because it powers verification. The `analytics` extra is
 kept as a compatibility no-op; analytics uses the same DuckDB dependency. The
 `wirelog` extra installs the legacy `pyrewire` path for compatibility/debugging only.
+
+## Fact Storage Boundary
+
+Each KB stores two coordinated files under the KB root:
+
+- `kb.sqlite`: sources, extraction runs, review status, audit history, questions,
+  and the `facts.subject/relation/object` text columns used as display mirrors
+  and legacy backfill data.
+- `facts.duckdb`: canonical logical fact terms keyed by SQLite `facts.id`.
+
+Verification and report fact input read confirmed/accepted fact ids from SQLite,
+then load their logical terms from `facts.duckdb`. Source coverage, status counts,
+and analytics use SQLite metadata; relation analytics intentionally summarize the
+SQLite display mirror rather than acting as logical inference input.
+
+Plain extractor output remains `StringLit` by default, so text such as
+`person("Ada")` is not reinterpreted as a compound term. Structural facts must be
+entered through explicit term mode or `structural_term(...)`. Legacy SQLite rows
+without DuckDB term rows are backfilled as `StringLit` values the first time they
+are selected for verification.
 
 ## License
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -5,6 +5,7 @@ pytest.importorskip("duckdb")  # DuckDB is core; skip only in broken/minimal env
 
 from verinote.store import Store  # noqa: E402
 from verinote.store.analytics import compute  # noqa: E402
+from verinote.store.fact_input import structural_term  # noqa: E402
 
 
 def _seeded(tmp_path) -> Store:
@@ -30,3 +31,19 @@ def test_compute_aggregates_against_attached_sqlite(tmp_path):
     assert buckets["0.9–1.0"] == 1  # 0.95
     assert buckets["0.7–0.9"] == 1  # 0.8
     assert buckets["0.0–0.5"] == 1  # 0.4
+
+
+def test_compute_relation_aggregates_use_sqlite_display_mirror(tmp_path):
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    s.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="confirmed",
+    )
+
+    a = compute(tmp_path / "kb.sqlite")
+    s.close()
+
+    assert dict(a.by_relation)["has_role"] == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import verinote.cli as cli
 from verinote.engine import DEFAULT_POLICY
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.store import Store
+from verinote.store.fact_input import structural_term
 
 
 def _env(monkeypatch, tmp_path):
@@ -154,3 +155,23 @@ def test_coverage_strict_gates_on_gap(tmp_path, monkeypatch, capsys):
     assert cli.main(["coverage"]) == 0  # non-strict always succeeds
     assert cli.main(["coverage", "--strict"]) == 1  # a gap exists
     assert "GAP" in capsys.readouterr().out
+
+
+def test_coverage_counts_structural_engine_fact_metadata(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    sid = s.add_source("sources/a.txt")
+    s.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="confirmed",
+        source_id=sid,
+    )
+    s.close()
+
+    assert cli.main(["coverage", "--strict"]) == 0
+    out = capsys.readouterr().out
+    assert "sources/a.txt: 1/1 engine facts" in out
+    assert "gap(s)" in out

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 from verinote.engine import coverage
 from verinote.store import Store
+from verinote.store.fact_input import structural_term
 
 
 def _store(tmp_path) -> Store:
@@ -21,6 +22,24 @@ def test_confirmed_source_is_covered(tmp_path):
     s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
     sc = coverage(s, root=tmp_path).sources[0]
     assert sc.engine_facts == 1 and not sc.is_gap and not sc.is_orphan
+
+
+def test_structural_confirmed_fact_uses_sqlite_metadata_for_coverage(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source(_with_file(tmp_path, "a.txt"))
+    s.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="confirmed",
+        source_id=sid,
+    )
+
+    sc = coverage(s, root=tmp_path).sources[0]
+
+    assert sc.engine_facts == 1
+    assert sc.total_facts == 1
+    assert not sc.is_gap
 
 
 def test_needs_review_only_is_a_gap(tmp_path):

--- a/tests/test_fact_term_e2e.py
+++ b/tests/test_fact_term_e2e.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MPL-2.0
+from html import unescape
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import verinote.web.app as webapp  # noqa: E402
+from verinote.config import Config  # noqa: E402
+from verinote.llm.base import ExtractedFact  # noqa: E402
+from verinote.pipeline.query import query_path  # noqa: E402
+from verinote.store.fact_input import structural_term  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+
+def test_plain_extraction_and_structural_fact_report_end_to_end(
+    tmp_path, monkeypatch, fake_client
+):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(
+            [ExtractedFact('person("Ada")', "has_role", 'role(person("Ada"), "PI")', 0.9)]
+        ),
+    )
+    client = TestClient(create_app(cfg))
+
+    upload = client.post(
+        "/sources",
+        files={"file": ("note.txt", b"Ada has a role.", "text/plain")},
+        follow_redirects=False,
+    )
+    assert upload.status_code == 303
+    store = client.app.state.store
+    extracted = store.review_queue()[0]
+
+    review_body = unescape(client.get("/review").text)
+    assert 'class="subj term-string" title="string">"person(\\"Ada\\")"' in review_body
+    assert client.post(f"/facts/{extracted['id']}/accept").status_code == 200
+
+    structural = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="needs_review",
+    )
+    structural_review = unescape(client.get("/review").text)
+    assert 'class="subj term-term" title="term">person("Ada")' in structural_review
+    assert client.post(f"/facts/{structural}/accept").status_code == 200
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation(person("Ada"), has_role, O).\n',
+        encoding="utf-8",
+    )
+
+    report = unescape(client.get("/report").text)
+    assert 'q1: role(person("Ada"), "PI")' in report
+    assert 'relation("person(\\"Ada\\")", "has_role", "role(person(\\"Ada\\"), \\"PI\\")")' in report
+    assert 'relation(person("Ada"), has_role, role(person("Ada"), "PI"))' in report

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
 """Legacy pyrewire/wirelog compatibility helpers.
 
-Production verification uses `verinote.engine.duckdb_backend.run_check_duckdb`.
-This module remains for compatibility/debug rendering of wirelog `.dl` programs:
+Production verification loads canonical fact terms from the DuckDB sidecar and
+uses `verinote.engine.duckdb_backend.run_check_duckdb`. This module remains for
+compatibility/debug rendering of string-only wirelog `.dl` programs:
 `compile_dl` is pure and fully tested without pyrewire, while `run_check` executes
 the legacy pyrewire path when the optional `wirelog` extra is installed.
 
@@ -67,10 +68,11 @@ def _lit(value: str) -> str:
 
 
 def compile_dl(facts: Iterable[Mapping[str, object]]) -> str:
-    """Render confirmed facts as `relation("s", "r", "o").` lines (sorted, unique).
+    """Render string-display facts as `relation("s", "r", "o").` lines.
 
     Accepts any row-like mapping with subject/relation/object keys (sqlite3.Row
-    included). Only this projection becomes engine input.
+    included). This is a legacy compatibility/debug helper; production
+    verification reads structural terms from the DuckDB fact-term store.
     """
     lines = set()
     for f in facts:

--- a/verinote/store/analytics.py
+++ b/verinote/store/analytics.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Read-only analytics over the KB via DuckDB.
+"""Read-only metadata analytics over the KB via DuckDB.
 
-SQLite stays the single system-of-record. Analytics reuse the same DuckDB
-dependency as the inference backend and ATTACH the SQLite file read-only (the
-`sqlite` extension auto-loads on attach). There is no second source of truth and
-no write path here.
+SQLite stays the system-of-record for metadata, review lifecycle, and text
+display mirrors. Logical fact terms live in the DuckDB fact-term sidecar and are
+used by verification, not by these aggregate counts. Analytics reuse the same
+DuckDB dependency as the inference backend and ATTACH the SQLite file read-only
+(the `sqlite` extension auto-loads on attach). There is no write path here.
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ class Analytics:
     """Aggregates for the analytics panel. `available=False` when DuckDB is absent."""
 
     by_status: list[tuple[str, int]] = field(default_factory=list)
-    by_relation: list[tuple[str, int]] = field(default_factory=list)
+    by_relation: list[tuple[str, int]] = field(default_factory=list)  # display mirror
     by_source: list[tuple[str, int]] = field(default_factory=list)
     by_confidence: list[tuple[str, int]] = field(default_factory=list)
     available: bool = True

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -1,7 +1,8 @@
 -- SPDX-License-Identifier: MPL-2.0
--- verinote system-of-record (SQLite, OLTP). DuckDB reads confirmed rows for
--- inference and attaches this file read-only for analytics. Derived engine input
--- is never the source of truth.
+-- verinote metadata system-of-record (SQLite, OLTP). DuckDB owns canonical
+-- logical fact terms in <kb>/facts.duckdb, while verification selects
+-- confirmed/accepted fact ids from this file. Analytics attach this file
+-- read-only for metadata aggregates.
 
 PRAGMA journal_mode = WAL;        -- concurrent readers + a single writer
 PRAGMA foreign_keys = ON;
@@ -24,10 +25,12 @@ CREATE TABLE IF NOT EXISTS runs (
     summary    TEXT
 );
 
--- A candidate/verified fact: a (subject, relation, object) triple with status.
+-- A candidate/verified fact with review metadata. The subject/relation/object
+-- columns are text display mirrors and legacy backfill inputs; the authoritative
+-- logical terms live in DuckDB fact_terms keyed by this row id.
 -- Status lifecycle:  candidate -> needs_review -> confirmed -> accepted
 --                                              \-> superseded (retired)
--- Only confirmed/accepted rows become deterministic engine input.
+-- Only confirmed/accepted ids are eligible for deterministic engine input.
 CREATE TABLE IF NOT EXISTS facts (
     id         INTEGER PRIMARY KEY,
     subject    TEXT NOT NULL,


### PR DESCRIPTION
Closes #52

## Summary
- document the final SQLite metadata/display mirror vs DuckDB logical term ownership boundary in README/schema/comments
- mark legacy wirelog `compile_dl` as string-display compatibility/debug output, not production verification input
- clarify analytics as SQLite metadata/display-mirror aggregates
- add metadata coverage for structural facts through coverage, CLI coverage, and analytics
- add an E2E regression covering plain extracted StringLit facts and structural compound facts through review promotion, verify, and report/query output

## Verification
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q tests/test_fact_term_e2e.py tests/test_coverage.py tests/test_cli.py tests/test_analytics.py`
- `uv run --python 3.13 --with-editable . --with '.[test]' pytest -q`
- `uv run --python 3.13 --with-editable . ruff check .`
- reviewer subagent re-review: no blocking findings