### PR TITLE
[codex] Add KB selection startup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,34 @@ DuckDB-backed verification, question translation/repair, and local web UI.
 4. Load confirmed facts into DuckDB → run Datalog policy/query rules → show report
 5. Dashboard
 
-Deferred: NL→Datalog query, gated self-correction (repair), coverage critic,
-multi-provider expansion.
-
 ## Quickstart
 
 ```bash
 pip install -e ".[anthropic,test]"   # pick the providers you use
-verinote init      # scaffold a local KB (SQLite) under ./data
 verinote ui        # launch the web app at http://localhost:8731
+```
+
+On first launch, if verinote cannot find an active KB, the web app opens a KB
+selection screen. Choose a KB folder there; if the folder has no `kb.sqlite`,
+verinote creates one. On later launches, the app opens that KB directly.
+
+The active KB path is saved in a platform-native app config file:
+
+- Windows: `%APPDATA%\verinote\app.json`
+- macOS: `~/Library/Application Support/verinote/app.json`
+- Linux/Unix: `${XDG_CONFIG_HOME:-~/.config}/verinote/app.json`
+
+`VERINOTE_ROOT` overrides the saved active KB and is still useful for scripts,
+tests, and one-off launches.
+
+```bash
+VERINOTE_ROOT=/path/to/kb verinote ui
+```
+
+You can also scaffold a KB explicitly:
+
+```bash
+verinote init      # uses VERINOTE_ROOT, the saved active KB, or ./data
 ```
 
 DuckDB is a core dependency because it powers verification. The `analytics` extra is

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,27 @@
 # SPDX-License-Identifier: MPL-2.0
-from verinote.config import PROVIDERS, TESTABLE_PROVIDERS, Config, read_settings, save_settings
+import sys
+
+from verinote.config import (
+    Config,
+    PROVIDERS,
+    TESTABLE_PROVIDERS,
+    active_root,
+    app_config_path,
+    read_settings,
+    save_active_root,
+    save_settings,
+)
 
 
 def _clear_env(monkeypatch):
-    for var in ("VERINOTE_PROVIDER", "VERINOTE_MODEL", "VERINOTE_BASE_URL", "VERINOTE_API_KEY"):
+    for var in (
+        "VERINOTE_PROVIDER",
+        "VERINOTE_MODEL",
+        "VERINOTE_BASE_URL",
+        "VERINOTE_API_KEY",
+        "VERINOTE_ROOT",
+        "XDG_CONFIG_HOME",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -56,3 +74,47 @@ def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):
     cfg = Config.for_root(tmp_path)
     assert cfg.api_key == "supersecret"
     assert "supersecret" not in (tmp_path / "config.json").read_text(encoding="utf-8")
+
+
+def test_active_root_uses_env_first(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    assert active_root() == tmp_path.resolve()
+
+
+def test_active_root_uses_app_config_when_kb_exists(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    (kb / "kb.sqlite").write_text("", encoding="utf-8")
+
+    save_active_root(kb)
+
+    if sys.platform == "darwin":
+        expected = (
+            tmp_path
+            / "home"
+            / "Library"
+            / "Application Support"
+            / "verinote"
+            / "app.json"
+        )
+    elif sys.platform == "win32":
+        expected = tmp_path / "appdata" / "verinote" / "app.json"
+    else:
+        expected = tmp_path / "xdg" / "verinote" / "app.json"
+    assert app_config_path() == expected
+    assert active_root() == kb.resolve()
+
+
+def test_ui_config_is_none_without_selected_kb(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.chdir(tmp_path)
+
+    assert Config.load_for_ui() is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -35,6 +35,38 @@ def test_dashboard_renders(tmp_path):
     assert "verinote" in r.text
 
 
+def test_no_active_kb_shows_selector(tmp_path, monkeypatch):
+    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.chdir(tmp_path)
+
+    c = TestClient(create_app())
+    r = c.get("/")
+
+    assert r.status_code == 200
+    assert "Select a knowledge base" in r.text
+
+
+def test_select_kb_activates_app(tmp_path, monkeypatch):
+    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.chdir(tmp_path)
+    kb = tmp_path / "chosen"
+
+    c = TestClient(create_app())
+    r = c.post("/kb/select", data={"root": str(kb)}, follow_redirects=False)
+
+    assert r.status_code == 303
+    assert (kb / "kb.sqlite").is_file()
+    assert (kb / "policy" / "logic-policy.dl").is_file()
+    assert c.app.state.cfg.root == kb.resolve()
+    assert "Knowledge base" in c.get("/").text
+
+
 def test_dashboard_shows_coverage_gap(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -232,16 +232,17 @@ def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_ui(cfg: Config, args: argparse.Namespace) -> int:
+def cmd_ui(cfg: Config | None, args: argparse.Namespace) -> int:
     try:
         import uvicorn
     except ImportError:  # pragma: no cover
         print("uvicorn not installed; `pip install verinote`", file=sys.stderr)
         return 1
-    # Ensure the KB exists before serving.
-    _store(cfg).close()
     url = f"http://{args.host}:{args.port}"
-    print(f"verinote ui → {url}  (KB: {cfg.root})")
+    if cfg is None:
+        print(f"verinote ui → {url}  (select a KB in the browser)")
+    else:
+        print(f"verinote ui → {url}  (KB: {cfg.root})")
     if not args.no_browser:
         import threading
         import webbrowser
@@ -304,7 +305,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    cfg = Config.load()
+    cfg = Config.load_for_ui() if args.command in {"ui", "serve"} else Config.load()
     return args.func(cfg, args)
 
 

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -6,16 +6,24 @@ anti-lock-in seam. Precedence (highest first): environment variable, then the
 saved non-secret settings file (`<root>/config.json`, written by the Settings
 UI), then a built-in default. The API key is **only** ever read from the
 environment — it is never persisted to or read from the settings file.
+
+The active KB root is stored in a platform-native app config file when the web
+UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
+Support`, and Unix uses `${XDG_CONFIG_HOME:-~/.config}`. `VERINOTE_ROOT` still
+overrides this for scripts and tests.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 SETTINGS_FILENAME = "config.json"
+APP_CONFIG_FILENAME = "app.json"
+APP_NAME = "verinote"
 
 _MODEL_DEFAULTS = {
     "anthropic": "claude-opus-4-8",
@@ -41,8 +49,69 @@ def normalize_provider(provider: str | None) -> str:
     return key
 
 
+def _default_root() -> Path:
+    return Path("./data").expanduser().resolve()
+
+
 def _root() -> Path:
-    return Path(os.environ.get("VERINOTE_ROOT", "./data")).expanduser().resolve()
+    root = active_root()
+    return root if root is not None else _default_root()
+
+
+def app_config_dir() -> Path:
+    """Return the platform-native directory for verinote's app-level config."""
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA") or os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base).expanduser() / APP_NAME
+        return Path.home() / "AppData" / "Roaming" / APP_NAME
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_NAME
+    base = os.environ.get("XDG_CONFIG_HOME")
+    return (Path(base).expanduser() if base else Path.home() / ".config") / APP_NAME
+
+
+def app_config_path() -> Path:
+    return app_config_dir() / APP_CONFIG_FILENAME
+
+
+def read_app_config() -> dict:
+    path = app_config_path()
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_active_root(root: Path) -> None:
+    """Persist the active KB root outside any individual KB."""
+    path = app_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"active_root": str(Path(root).expanduser().resolve())}
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def active_root() -> Path | None:
+    """Return the selected KB root, or None when the web UI should ask."""
+    env_root = os.environ.get("VERINOTE_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+
+    saved = read_app_config().get("active_root")
+    if saved:
+        root = Path(str(saved)).expanduser().resolve()
+        if (root / "kb.sqlite").is_file():
+            return root
+
+    default = _default_root()
+    if (default / "kb.sqlite").is_file():
+        return default
+    return None
 
 
 def _settings_path(root: Path) -> Path:
@@ -114,3 +183,8 @@ class Config:
     @classmethod
     def load(cls) -> "Config":
         return cls.for_root(_root())
+
+    @classmethod
+    def load_for_ui(cls) -> "Config | None":
+        root = active_root()
+        return cls.for_root(root) if root is not None else None

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -20,6 +20,8 @@ from verinote.config import (
     PROVIDERS,
     TESTABLE_PROVIDERS,
     Config,
+    app_config_path,
+    save_active_root,
     save_settings,
 )
 from verinote.llm import LLMError, get_client
@@ -42,33 +44,66 @@ _STATIC = resources.files("verinote.web").joinpath("static")
 
 
 def create_app(cfg: Config | None = None) -> FastAPI:
-    cfg = cfg or Config.load()
-    store = Store(cfg.db_path)
-    store.init_schema()
+    cfg = cfg if cfg is not None else Config.load_for_ui()
 
     app = FastAPI(title="verinote")
-    app.state.store = store
     app.state.cfg = cfg
+    app.state.store = None
+    if cfg is not None:
+        store = Store(cfg.db_path)
+        store.init_schema()
+        app.state.store = store
 
     templates = Jinja2Templates(directory=str(_TEMPLATES))
     app.mount("/static", StaticFiles(directory=str(_STATIC)), name="static")
 
-    def _switch_root(root: Path) -> None:
-        """Point this running app at a different KB root."""
-        nonlocal cfg, store
-        next_cfg = Config.for_root(root.expanduser().resolve())
+    def _active_store() -> Store:
+        store = app.state.store
+        if store is None:
+            raise RuntimeError("no active KB")
+        return store
+
+    def _active_cfg() -> Config:
+        cfg = app.state.cfg
+        if cfg is None:
+            raise RuntimeError("no active KB")
+        return cfg
+
+    def _open_root(root: Path) -> None:
+        """Point this running app at a KB root, creating it if needed."""
+        root = root.expanduser().resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        next_cfg = Config.for_root(root)
         next_store = Store(next_cfg.db_path)
         next_store.init_schema()
-        old_store = store
-        cfg = next_cfg
-        store = next_store
+
+        from verinote.engine import DEFAULT_POLICY
+        from verinote.pipeline.verify import POLICY_RELPATH
+
+        policy_path = root / POLICY_RELPATH
+        if not policy_path.exists():
+            policy_path.parent.mkdir(parents=True, exist_ok=True)
+            policy_path.write_text(DEFAULT_POLICY, encoding="utf-8")
+
+        save_active_root(root)
+        old_store = app.state.store
+        if old_store is not None:
+            old_store.close()
         app.state.cfg = next_cfg
         app.state.store = next_store
-        old_store.close()
+
+    def _kb_select(request: Request, *, error: str | None = None, status_code: int = 200):
+        return templates.TemplateResponse(
+            request,
+            "kb_select.html",
+            {"error": error, "config_path": app_config_path()},
+            status_code=status_code,
+        )
 
     def _fact_view(fact):
         if fact is None:
             return None
+        store = _active_store()
         view = dict(fact)
         try:
             terms = store.get_fact_terms(fact["id"])
@@ -93,6 +128,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _fact_edit_context(fact, *, error: str | None = None):
         kinds = {"subject": "string", "relation": "string", "object": "string"}
         if fact is not None:
+            store = _active_store()
             terms = store.get_fact_terms(fact["id"])
             if terms is not None:
                 kinds = {
@@ -112,6 +148,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
         from verinote.engine import coverage
 
+        if app.state.store is None:
+            return _kb_select(request, error=error, status_code=status_code)
+        store = _active_store()
+        cfg = _active_cfg()
         counts = store.status_counts()
         return templates.TemplateResponse(
             request,
@@ -133,6 +173,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
 
     def _sources(request: Request, *, error: str | None = None, status_code: int = 200):
+        if app.state.store is None:
+            return _kb_select(request, error=error, status_code=status_code)
+        store = _active_store()
         return templates.TemplateResponse(
             request,
             "sources.html",
@@ -149,12 +192,22 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def dashboard(request: Request):
         return _dashboard(request)
 
+    @app.post("/kb/select", response_class=HTMLResponse)
+    def select_kb(request: Request, root: str = Form(...)):
+        try:
+            _open_root(Path(root))
+        except OSError as e:
+            return _kb_select(request, error=f"could not open KB: {e}", status_code=400)
+        return RedirectResponse("/", status_code=303)
+
     @app.get("/sources", response_class=HTMLResponse)
     def sources_page(request: Request):
         return _sources(request)
 
     @app.post("/sources", response_class=HTMLResponse)
     async def upload_source(request: Request, file: UploadFile = File(...)):
+        store = _active_store()
+        cfg = _active_cfg()
         filename = Path(file.filename or "").name
         raw = await file.read()
         try:
@@ -178,32 +231,35 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/review", response_class=HTMLResponse)
     def review(request: Request):
+        store = _active_store()
         return templates.TemplateResponse(
             request, "review.html", {"queue": [_fact_view(f) for f in store.review_queue()]}
         )
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)
     def toggle(request: Request, fact_id: int):
-        return _row(request, store.toggle_review(fact_id))
+        return _row(request, _active_store().toggle_review(fact_id))
 
     @app.post("/facts/{fact_id}/accept", response_class=HTMLResponse)
     def accept(request: Request, fact_id: int):
-        return _row(request, store.set_status(fact_id, "confirmed", action="accepted"))
+        return _row(request, _active_store().set_status(fact_id, "confirmed", action="accepted"))
 
     @app.post("/facts/{fact_id}/reject", response_class=HTMLResponse)
     def reject(request: Request, fact_id: int):
-        return _row(request, store.set_status(fact_id, "superseded", action="rejected"))
+        return _row(request, _active_store().set_status(fact_id, "superseded", action="rejected"))
 
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):
         return templates.TemplateResponse(
-            request, "partials/fact_edit.html", _fact_edit_context(store.get_fact(fact_id))
+            request,
+            "partials/fact_edit.html",
+            _fact_edit_context(_active_store().get_fact(fact_id)),
         )
 
     @app.get("/facts/{fact_id}/row", response_class=HTMLResponse)
     def fact_row(request: Request, fact_id: int):
         # Re-render the read-only row (used to cancel an inline edit).
-        return _row(request, store.get_fact(fact_id))
+        return _row(request, _active_store().get_fact(fact_id))
 
     @app.post("/facts/{fact_id}/amend", response_class=HTMLResponse)
     def amend_fact(
@@ -225,10 +281,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return templates.TemplateResponse(
                 request,
                 "partials/fact_edit.html",
-                _fact_edit_context(store.get_fact(fact_id), error=str(e)),
+                _fact_edit_context(_active_store().get_fact(fact_id), error=str(e)),
                 status_code=400,
             )
-        amended = store.amend_fact(
+        amended = _active_store().amend_fact(
             fact_id,
             subject=subject_value,
             relation=relation_value,
@@ -239,6 +295,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/facts/{fact_id}/provenance", response_class=HTMLResponse)
     def provenance(request: Request, fact_id: int):
+        store = _active_store()
         fact = store.get_fact(fact_id)
         run = store.get_run(fact["run_id"]) if fact and fact["run_id"] else None
         return templates.TemplateResponse(
@@ -248,6 +305,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
 
     def _questions(request: Request, *, error: str | None = None, status_code: int = 200):
+        if app.state.store is None:
+            return _kb_select(request, error=error, status_code=status_code)
+        store = _active_store()
         return templates.TemplateResponse(
             request,
             "questions.html",
@@ -261,11 +321,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/questions", response_class=HTMLResponse)
     def add_question(request: Request, text: str = Form(...)):
-        store.add_question(text)
+        _active_store().add_question(text)
         return RedirectResponse("/questions", status_code=303)
 
     @app.post("/questions/translate", response_class=HTMLResponse)
     def translate(request: Request):
+        store = _active_store()
+        cfg = _active_cfg()
         try:
             translate_questions(store, get_client(app.state.cfg), root=cfg.root)
         except LLMError as e:
@@ -274,6 +336,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/questions/repair", response_class=HTMLResponse)
     def repair(request: Request):
+        store = _active_store()
+        cfg = _active_cfg()
         try:
             client = get_client(app.state.cfg)
         except LLMError as e:
@@ -283,16 +347,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/report", response_class=HTMLResponse)
     def report(request: Request):
-        return templates.TemplateResponse(request, "report.html", {"rep": verify(store)})
+        return templates.TemplateResponse(request, "report.html", {"rep": verify(_active_store())})
 
     @app.get("/analytics", response_class=HTMLResponse)
     def analytics(request: Request):
         from verinote.store.analytics import compute
 
-        return templates.TemplateResponse(request, "analytics.html", {"a": compute(cfg.db_path)})
+        return templates.TemplateResponse(request, "analytics.html", {"a": compute(_active_cfg().db_path)})
 
     def _settings(request: Request, *, test_result=None, error=None, status_code=200):
         c = app.state.cfg
+        if c is None:
+            return _kb_select(request)
         return templates.TemplateResponse(
             request,
             "settings.html",
@@ -323,6 +389,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         model: str = Form(""),
         base_url: str = Form(""),
     ):
+        cfg = _active_cfg()
         save_settings(cfg.root, provider=provider, model=model, base_url=base_url or None)
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)
@@ -334,7 +401,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if not path:
             return _settings(request, error="KB directory is required", status_code=400)
         try:
-            _switch_root(Path(path))
+            _open_root(Path(path))
         except OSError as e:
             return _settings(request, error=f"could not open KB directory: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
@@ -342,6 +409,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/settings/test", response_class=HTMLResponse)
     def test_connection(request: Request):
         c = app.state.cfg
+        if c is None:
+            return _kb_select(request)
         if c.provider not in TESTABLE_PROVIDERS:
             return _settings(
                 request,

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -11,6 +11,7 @@ header { display: flex; align-items: center; gap: 1.5rem;
 nav a { color: var(--muted); text-decoration: none; margin-right: 1rem; }
 nav a:hover { color: var(--fg); }
 main { max-width: 1000px; margin: 0 auto; padding: 1.6rem 1.4rem; }
+main.chooser { max-width: 560px; padding-top: 12vh; }
 h1 { font-size: 1.4rem; } h2 { font-size: 1.05rem; margin-top: 1.8rem; }
 .muted { color: var(--muted); } code { color: var(--accent); }
 

--- a/verinote/web/templates/kb_select.html
+++ b/verinote/web/templates/kb_select.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Select KB — verinote</title>
+  <link rel="stylesheet" href="/static/app.css">
+</head>
+<body>
+  <main class="chooser">
+    <h1>Select a knowledge base</h1>
+    <p class="muted">Choose a KB folder to open. If it does not exist yet,
+      verinote will create it and initialise <code>kb.sqlite</code>.</p>
+
+    {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+
+    <form class="settings" action="/kb/select" method="post">
+      <label>KB folder
+        <input type="text" name="root" value="./data" placeholder="/path/to/verinote-kb" required>
+      </label>
+      <button class="btn" type="submit">Open KB</button>
+    </form>
+
+    <p class="muted">The active KB path is saved in
+      <code>{{ config_path }}</code>. <code>VERINOTE_ROOT</code> overrides it.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a startup flow for choosing an active verinote knowledge base instead of implicitly creating `./data` whenever the web app starts.

## What changed

- Added platform-native app config storage for the active KB path, with `VERINOTE_ROOT` still taking precedence.
- Changed `verinote ui` and the FastAPI app so a missing active KB renders a selection screen.
- Selecting a KB initializes `kb.sqlite`, scaffolds the default policy, persists the active root, and opens the dashboard.
- Added tests for active-root resolution and the KB selection route, plus README notes for the new launch behavior.

## Impact

First launch now asks users where their KB should live. Later launches open the selected KB directly. Scripts can continue to use `VERINOTE_ROOT` for explicit control.

## Validation

- `PYTHONPATH=. python3 -m py_compile verinote/config.py verinote/web/app.py verinote/cli.py`
- `PYTHONPATH=. pytest -q tests/test_config.py`

Note: web route tests are skipped in this local environment because `fastapi` is not installed. The broader suite still requires the native `libwirelog` dependency for `pyrewire` checks.
