### PR TITLE
[codex] Improve settings connection test feedback

### DIFF
--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -57,9 +57,16 @@ tr.editing td { background: rgba(91, 157, 255, .06); }
   border-radius: 8px; padding: .6rem .9rem; margin: 1rem 0; }
 
 .btn { display: inline-block; background: var(--accent); color: #06101f; text-decoration: none;
-  padding: .5rem .9rem; border-radius: 7px; font-weight: 600; }
+  padding: .5rem .9rem; border: 1px solid transparent; border-radius: 7px;
+  font-weight: 600; cursor: pointer; transition: transform .08s ease, filter .08s ease, opacity .08s ease; }
 .btn.ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); }
-.btn:disabled, .btn[aria-disabled="true"] { color: var(--muted); opacity: .55; }
+.btn:hover:not(:disabled) { filter: brightness(1.08); }
+.btn:active:not(:disabled) { transform: translateY(1px); filter: brightness(.95); }
+.btn:disabled, .btn[aria-disabled="true"] { color: var(--muted); opacity: .55; cursor: not-allowed; }
+.connection-test { display: flex; align-items: center; gap: .8rem; margin: 1rem 0 .6rem; }
+.htmx-indicator { display: none; }
+.htmx-request .htmx-indicator,
+.htmx-request.htmx-indicator { display: inline; }
 .empty { background: var(--panel); border: 1px dashed var(--line); border-radius: 10px; padding: 2rem; text-align: center; color: var(--muted); }
 .warn { color: var(--warn); }
 .error { background: rgba(240, 82, 109, .12); border: 1px solid var(--danger);

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}verinote{% endblock %}</title>
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
-  <link rel="stylesheet" href="/static/app.css">
+  <link rel="stylesheet" href="/static/app.css?v=2">
 </head>
 <body>
   <header>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -6,9 +6,6 @@
   freely. Non-secret model settings are saved to that KB's <code>config.json</code>;
   the API key stays in the environment (<code>VERINOTE_API_KEY</code>).</p>
 
-{% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
-{% if test_result %}<p class="ok-note" role="status">✓ {{ test_result }}</p>{% endif %}
-
 <h2>Knowledge base</h2>
 <form class="settings" action="/settings/root" method="post">
   <label>Directory
@@ -39,10 +36,18 @@
 
 <p class="muted">API key: {{ 'set (from environment)' if has_key else 'not set — export VERINOTE_API_KEY' }}</p>
 
-<p>
-  <button class="btn ghost" hx-post="/settings/test" hx-target="body" hx-swap="outerHTML"
-          {% if not connection_test_enabled %}aria-disabled="true"{% endif %}>
+<form class="connection-test" action="/settings/test" method="post"
+      hx-post="/settings/test" hx-target="main" hx-select="main" hx-swap="outerHTML"
+      hx-disabled-elt="find button" hx-indicator="#connection-testing">
+  <button class="btn ghost" type="submit"
+          {% if not connection_test_enabled %}disabled aria-disabled="true"{% endif %}>
     Test connection
   </button>
-</p>
+  <span id="connection-testing" class="htmx-indicator muted" role="status">Testing provider...</span>
+</form>
+
+<div id="connection-result" aria-live="polite">
+  {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+  {% if test_result %}<p class="ok-note" role="status">✓ {{ test_result }}</p>{% endif %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Make the Settings connection test work as a normal POST form as well as through HTMX.
- Add visible pressed, disabled, and in-flight feedback for the connection test action.
- Move connection test results next to the button in an aria-live region and cache-bust the app stylesheet.

## Why

The previous button depended on HTMX behavior and gave little visible feedback while the provider test was running. That made it hard to tell whether the click had registered or whether the test had completed.

## Validation

- `python -m pytest tests/test_web.py -q`
