### PR TITLE
[codex] Add requirements for ingest dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e .[anthropic,ingest,test]


### PR DESCRIPTION
## Summary

- Add `requirements.txt` for local development installs.
- Include the `ingest` extra so PDF uploads install `pypdf` alongside docx support.
- Keep the install editable so local source changes are reflected during development.

## Why

PDF source uploads fail with `pdf ingestion needs pip install verinote[ingest]` when the environment was installed from a requirements flow that did not include the ingest extra.

## Validation

- `python -m pip install -r requirements.txt`
- `python -m pytest tests/test_ingest.py tests/test_web.py -q`
