### PR TITLE
[codex] Run source extraction asynchronously

### DIFF
--- a/tests/test_fact_term_e2e.py
+++ b/tests/test_fact_term_e2e.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 from html import unescape
+import time
 
 import pytest
 
@@ -12,6 +13,20 @@ from verinote.llm.base import ExtractedFact  # noqa: E402
 from verinote.pipeline.query import query_path  # noqa: E402
 from verinote.store.fact_input import structural_term  # noqa: E402
 from verinote.web import create_app  # noqa: E402
+
+
+def _wait_for(assertion, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            assertion()
+            return
+        except AssertionError as e:
+            last_error = e
+            time.sleep(0.01)
+    if last_error is not None:
+        raise last_error
 
 
 def test_plain_extraction_and_structural_fact_report_end_to_end(
@@ -41,7 +56,17 @@ def test_plain_extraction_and_structural_fact_report_end_to_end(
     )
     assert upload.status_code == 303
     store = client.app.state.store
-    extracted = store.review_queue()[0]
+
+    extracted = None
+
+    def extracted_fact_exists():
+        nonlocal extracted
+        queue = store.review_queue()
+        assert queue
+        extracted = queue[0]
+
+    _wait_for(extracted_fact_exists)
+    assert extracted is not None
 
     review_body = unescape(client.get("/review").text)
     assert 'class="subj term-string" title="string">"person(\\"Ada\\")"' in review_body

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+import time
 from html import unescape
 
 import pytest
@@ -26,6 +27,20 @@ def _client(tmp_path) -> TestClient:
     store = app.state.store
     client.fact_id = store.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
     return client
+
+
+def _wait_for(assertion, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            assertion()
+            return
+        except AssertionError as e:
+            last_error = e
+            time.sleep(0.01)
+    if last_error is not None:
+        raise last_error
 
 
 def test_dashboard_renders(tmp_path):
@@ -129,10 +144,16 @@ def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
         follow_redirects=False,
     )
     assert r.status_code == 303
-    assert r.headers["location"] == "/review"
-    # the file was saved under the KB's sources/ dir and the candidate is queued
+    assert r.headers["location"] == "/sources"
+    # the file is saved immediately; extraction finishes in a background job.
     assert (tmp_path / "sources" / "note.txt").read_text() == "some text"
-    assert "is_a" in c.get("/review").text
+
+    def extracted():
+        assert "is_a" in c.get("/review").text
+        body = c.get("/sources").text
+        assert "Analysis complete: 1 candidate(s)" in body
+
+    _wait_for(extracted)
 
 
 def test_upload_rejects_unsupported_type(tmp_path):
@@ -184,16 +205,30 @@ def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
     kinds = {s["kind"] for s in c.app.state.store.sources_with_counts()}
     assert "conversion" in kinds
 
+    def extracted():
+        assert "is_a" in c.get("/review").text
+
+    _wait_for(extracted)
+
 
 def test_upload_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
     monkeypatch.setattr(
         webapp, "get_client", lambda cfg: fake_client(error=LLMError("provider down"))
     )
     c = _client(tmp_path)
-    r = c.post("/sources", files={"file": ("note.txt", b"x", "text/plain")})
-    # surfaced as a page, not a 500
-    assert r.status_code == 502
-    assert "extraction failed: provider down" in r.text
+    r = c.post(
+        "/sources",
+        files={"file": ("note.txt", b"x", "text/plain")},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    assert r.headers["location"] == "/sources"
+
+    def failed():
+        body = c.get("/sources").text
+        assert "extraction failed: provider down" in body
+
+    _wait_for(failed)
 
 
 def test_report_ok_for_consistent_kb(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 from importlib import resources
 from pathlib import Path
+import threading
+import time
+from uuid import uuid4
 
 from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -49,6 +52,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app = FastAPI(title="verinote")
     app.state.cfg = cfg
     app.state.store = None
+    app.state.source_jobs = {}
+    app.state.source_jobs_lock = threading.Lock()
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
@@ -176,6 +181,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if app.state.store is None:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
+        with app.state.source_jobs_lock:
+            jobs = sorted(
+                app.state.source_jobs.values(),
+                key=lambda job: job["created_at"],
+                reverse=True,
+            )
+        has_running_jobs = any(job["status"] == "running" for job in jobs)
         return templates.TemplateResponse(
             request,
             "sources.html",
@@ -184,9 +196,56 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "suffixes": ", ".join(sorted(supported_suffixes())),
                 "accept": ",".join(sorted(supported_suffixes())),
                 "error": error,
+                "jobs": jobs,
+                "has_running_jobs": has_running_jobs,
             },
             status_code=status_code,
         )
+
+    def _set_source_job(job_id: str, **updates: object) -> None:
+        with app.state.source_jobs_lock:
+            job = app.state.source_jobs.get(job_id)
+            if job is not None:
+                job.update(updates)
+
+    def _start_source_extraction(citation: str, text: str, cfg: Config) -> None:
+        job_id = uuid4().hex
+        with app.state.source_jobs_lock:
+            app.state.source_jobs[job_id] = {
+                "id": job_id,
+                "source": citation,
+                "status": "running",
+                "message": "Analyzing source...",
+                "created_at": time.time(),
+            }
+
+        def run() -> None:
+            try:
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    client = get_client(cfg)
+                    result = sync_sources(
+                        worker_store,
+                        client,
+                        [(citation, text)],
+                        provider=cfg.provider,
+                        model=cfg.model,
+                    )
+                _set_source_job(
+                    job_id,
+                    status="done",
+                    message=f"Analysis complete: {result.total} candidate(s)",
+                )
+            except LLMError as e:
+                _set_source_job(job_id, status="failed", message=f"extraction failed: {e}")
+            except Exception as e:  # noqa: BLE001 - keep background failures visible in UI
+                _set_source_job(job_id, status="failed", message=f"analysis failed: {e}")
+
+        threading.Thread(
+            target=run,
+            name=f"verinote-source-extract-{job_id}",
+            daemon=True,
+        ).start()
 
     @app.get("/", response_class=HTMLResponse)
     def dashboard(request: Request):
@@ -216,18 +275,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _sources(request, error=str(e), status_code=400)
 
         citation = store_source(store, cfg.root, filename, text, kind)
-        try:
-            client = get_client(app.state.cfg)
-            sync_sources(
-                store,
-                client,
-                [(citation, text)],
-                provider=app.state.cfg.provider,
-                model=app.state.cfg.model,
-            )
-        except LLMError as e:
-            return _sources(request, error=f"extraction failed: {e}", status_code=502)
-        return RedirectResponse("/review", status_code=303)
+        _start_source_extraction(citation, text, app.state.cfg)
+        return RedirectResponse("/sources", status_code=303)
 
     @app.get("/review", response_class=HTMLResponse)
     def review(request: Request):

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -76,6 +76,13 @@ tr.editing td { background: rgba(91, 157, 255, .06); }
   padding: 1rem; margin: 1.2rem 0; }
 .upload label { display: flex; align-items: center; gap: .6rem; color: var(--muted); }
 .upload button { border: 0; cursor: pointer; }
+.jobs { margin: 1rem 0; }
+.job { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  padding: .6rem .8rem; }
+.job-running .badge { color: var(--warn); border-color: var(--warn); }
+.job-done .badge { color: var(--ok); border-color: var(--ok); }
+.job-failed .badge { color: var(--danger); border-color: var(--danger); }
 .report { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 1rem; overflow-x: auto; white-space: pre-wrap; }
 .findings { margin: 1rem 0; padding-left: 1.2rem; }
 .findings li { font-family: ui-monospace, monospace; font-size: .9rem; margin: .2rem 0; }

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -11,8 +11,21 @@
   <label>Add a source
     <input type="file" name="file" accept="{{ accept }}" required>
   </label>
-  <button class="btn" type="submit">Upload &amp; extract</button>
+  <button class="btn" type="submit">Upload &amp; analyze</button>
 </form>
+
+{% if jobs %}
+<div class="jobs" aria-live="polite"
+     {% if has_running_jobs %}hx-get="/sources" hx-trigger="every 2s" hx-target="main" hx-select="main" hx-swap="outerHTML"{% endif %}>
+  {% for job in jobs %}
+  <p class="job job-{{ job["status"] }}">
+    <span class="badge">{{ job["status"] }}</span>
+    <code>{{ job["source"] }}</code>
+    <span>{{ job["message"] }}</span>
+  </p>
+  {% endfor %}
+</div>
+{% endif %}
 
 {% if sources %}
 <table class="sources">


### PR DESCRIPTION
## Summary

- Decouple source upload from LLM extraction so uploads return immediately after storing the source.
- Run extraction in a background thread with a separate store connection and visible running/done/failed status on Sources.
- Auto-refresh Sources while analysis is running and update tests for the asynchronous flow.

## Why

Large PDFs or slow local LLM calls can exceed the upload request timeout when extraction runs synchronously inside `POST /sources`. The upload route now avoids holding the browser request open while analysis is in progress.

## Validation

- `python -m pytest -q`
