### PR TITLE
[codex] Add question deletion

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -89,3 +89,6 @@ def test_questions_add_list_and_translate(tmp_path):
     s.set_question_query(qid, ".decl answer_q1(value: symbol)", "translated")
     assert s.questions(pending_only=True) == []
     assert s.questions()[0]["status"] == "translated"
+
+    s.delete_question(qid)
+    assert s.questions() == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -621,6 +621,27 @@ def test_add_question_persists(tmp_path):
     assert [q["text"] for q in c.app.state.store.questions()] == ["Where was Ada born?"]
 
 
+def test_delete_question_removes_query_file_entry(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    qid = store.add_question("Where was Ada born?")
+    store.set_question_query(
+        qid,
+        '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).',
+        "translated",
+    )
+    query_file = query_path(tmp_path)
+    query_file.parent.mkdir(parents=True, exist_ok=True)
+    query_file.write_text(store.questions()[0]["query_dl"] + "\n", encoding="utf-8")
+
+    r = c.post(f"/questions/{qid}/delete", follow_redirects=False)
+
+    assert r.status_code == 303
+    assert store.questions() == []
+    assert query_file.read_text(encoding="utf-8") == ""
+    assert "No questions yet" in c.get("/questions").text
+
+
 def test_translate_and_report_answers(tmp_path, monkeypatch, fake_client):
     # canned translator: answer_q<id>(O) :- relation("Ada","born_in",O)
     monkeypatch.setattr(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -341,6 +341,10 @@ class Store:
                 (query_dl, status, question_id),
             )
 
+    def delete_question(self, question_id: int) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM questions WHERE id = ?", (question_id,))
+
     # --- audit -----------------------------------------------------------
     def fact_log(self, fact_id: int) -> list[sqlite3.Row]:
         """Audit trail (oldest first) for one fact — drives the provenance view."""

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -37,6 +37,7 @@ from verinote.pipeline import (
     sync_sources,
     translate_questions,
     verify,
+    write_query_file,
 )
 from verinote.engine.terms import StringLit, render_term
 from verinote.store import Store
@@ -371,6 +372,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/questions", response_class=HTMLResponse)
     def add_question(request: Request, text: str = Form(...)):
         _active_store().add_question(text)
+        return RedirectResponse("/questions", status_code=303)
+
+    @app.post("/questions/{question_id}/delete", response_class=HTMLResponse)
+    def delete_question(request: Request, question_id: int):
+        store = _active_store()
+        store.delete_question(question_id)
+        write_query_file(store, _active_cfg().root)
         return RedirectResponse("/questions", status_code=303)
 
     @app.post("/questions/translate", response_class=HTMLResponse)

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -39,6 +39,7 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
   border-radius: 6px; padding: .25rem .5rem; margin-right: .3rem; cursor: pointer; font-size: .82rem; }
 .actions button:hover { border-color: var(--accent); }
 .actions button.danger:hover { border-color: var(--danger); color: var(--danger); }
+.actions form { display: inline; }
 .actions .srclink { color: var(--muted); text-decoration: none; font-size: .82rem; margin-left: .3rem; }
 .actions .srclink:hover { color: var(--accent); }
 .amend { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -26,7 +26,7 @@
 
 {% if questions %}
 <table class="counts">
-  <thead><tr><th>#</th><th>Question</th><th>Status</th><th>Query</th></tr></thead>
+  <thead><tr><th>#</th><th>Question</th><th>Status</th><th>Query</th><th>Actions</th></tr></thead>
   <tbody>
     {% for q in questions %}
     <tr>
@@ -34,6 +34,11 @@
       <td>{{ q["text"] }}</td>
       <td><span class="badge">{{ q["status"] }}</span></td>
       <td><pre class="report">{{ q["query_dl"] or "—" }}</pre></td>
+      <td class="actions">
+        <form action="/questions/{{ q['id'] }}/delete" method="post">
+          <button class="danger" type="submit">Delete</button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary

- Add a delete action for questions in the Questions table.
- Remove deleted questions from SQLite and rewrite `facts/query.dl` so translated query rules do not linger.
- Cover store deletion and web deletion behavior with tests.

## Why

Questions could be added and translated, but there was no way to remove obsolete or mistaken questions from the UI. Deleting translated questions also needs to keep the generated Datalog query file in sync.

## Validation

- `python -m pytest -q`
