### PR TITLE
[codex] Support compound-term fact extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ and analytics use SQLite metadata; relation analytics intentionally summarize th
 SQLite display mirror rather than acting as logical inference input.
 
 Plain extractor output remains `StringLit` by default, so text such as
-`person("Ada")` is not reinterpreted as a compound term. Structural facts must be
+`person("Ada")` is not reinterpreted as a compound term. Source extraction can
+produce structural facts only by explicitly marking a slot as a term, for example
+`{"kind": "term", "value": "person(\"Ada\")"}`. Structural facts can also be
 entered through explicit term mode or `structural_term(...)`. Legacy SQLite rows
 without DuckDB term rows are backfilled as `StringLit` values the first time they
 are selected for verification.

--- a/tests/test_fact_term_e2e.py
+++ b/tests/test_fact_term_e2e.py
@@ -93,3 +93,68 @@ def test_plain_extraction_and_structural_fact_report_end_to_end(
     assert 'q1: role(person("Ada"), "PI")' in report
     assert 'relation("person(\\"Ada\\")", "has_role", "role(person(\\"Ada\\"), \\"PI\\")")' in report
     assert 'relation(person("Ada"), has_role, role(person("Ada"), "PI"))' in report
+
+
+def test_explicit_structural_extraction_answers_compound_query(
+    tmp_path, monkeypatch, fake_client
+):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(
+            [
+                ExtractedFact(
+                    'person("Ada")',
+                    "has_role",
+                    'role(person("Ada"), "PI")',
+                    0.9,
+                    subject_kind="term",
+                    relation_kind="term",
+                    object_kind="term",
+                )
+            ]
+        ),
+    )
+    client = TestClient(create_app(cfg))
+
+    upload = client.post(
+        "/sources",
+        files={"file": ("note.txt", b"Ada has a role.", "text/plain")},
+        follow_redirects=False,
+    )
+    assert upload.status_code == 303
+    store = client.app.state.store
+
+    extracted = None
+
+    def extracted_fact_exists():
+        nonlocal extracted
+        queue = store.review_queue()
+        assert queue
+        extracted = queue[0]
+
+    _wait_for(extracted_fact_exists)
+    assert extracted is not None
+
+    review_body = unescape(client.get("/review").text)
+    assert 'class="subj term-term" title="term">person("Ada")' in review_body
+    assert client.post(f"/facts/{extracted['id']}/accept").status_code == 200
+
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation(person("Ada"), has_role, O).\n',
+        encoding="utf-8",
+    )
+
+    report = unescape(client.get("/report").text)
+    assert 'q1: role(person("Ada"), "PI")' in report

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+from verinote.llm import LLMError
+from verinote.llm.schema import parse_facts
+
+
+def test_parse_facts_accepts_legacy_string_slots():
+    facts = parse_facts(
+        {
+            "facts": [
+                {
+                    "subject": 'person("Ada")',
+                    "relation": "has_role",
+                    "object": 'role(person("Ada"), "PI")',
+                    "confidence": 0.9,
+                }
+            ]
+        }
+    )
+
+    fact = facts[0]
+    assert fact.subject == 'person("Ada")'
+    assert fact.relation == "has_role"
+    assert fact.object == 'role(person("Ada"), "PI")'
+    assert (fact.subject_kind, fact.relation_kind, fact.object_kind) == (
+        "string",
+        "string",
+        "string",
+    )
+
+
+def test_parse_facts_accepts_explicit_term_slots():
+    facts = parse_facts(
+        {
+            "facts": [
+                {
+                    "subject": {"kind": "term", "value": 'person("Ada")'},
+                    "relation": {"kind": "term", "value": "has_role"},
+                    "object": {"kind": "term", "value": 'role(person("Ada"), "PI")'},
+                    "confidence": 0.9,
+                    "note": "source-backed",
+                }
+            ]
+        }
+    )
+
+    fact = facts[0]
+    assert fact.subject == 'person("Ada")'
+    assert fact.relation == "has_role"
+    assert fact.object == 'role(person("Ada"), "PI")'
+    assert (fact.subject_kind, fact.relation_kind, fact.object_kind) == (
+        "term",
+        "term",
+        "term",
+    )
+    assert fact.note == "source-backed"
+
+
+@pytest.mark.parametrize(
+    "slot",
+    [
+        {"kind": "bogus", "value": "Ada"},
+        {"kind": "term", "value": 'person("Ada"'},
+        {"kind": "term", "value": "person(Name)"},
+        {"kind": "string", "value": ""},
+        {"kind": "term"},
+    ],
+)
+def test_parse_facts_rejects_invalid_explicit_slots(slot):
+    with pytest.raises(LLMError):
+        parse_facts(
+            {
+                "facts": [
+                    {
+                        "subject": slot,
+                        "relation": "has_role",
+                        "object": "PI",
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -2,7 +2,11 @@
 import pytest
 
 from verinote.llm import LLMError
-from verinote.llm.schema import parse_facts
+from verinote.llm.schema import FACT_OBJECT_SCHEMA, parse_facts
+
+
+def test_fact_schema_requires_every_property_for_strict_outputs():
+    assert set(FACT_OBJECT_SCHEMA["required"]) == set(FACT_OBJECT_SCHEMA["properties"])
 
 
 def test_parse_facts_accepts_legacy_string_slots():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,7 +4,7 @@ import pytest
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline import extract_source, sync_sources
 from verinote.store import Store
-from verinote.engine.terms import StringLit
+from verinote.engine.terms import Atom, Compound, StringLit
 
 
 def _store(tmp_path) -> Store:
@@ -53,6 +53,72 @@ def test_extract_source_stores_term_syntax_as_plain_strings(tmp_path, fake_clien
         StringLit("is_a"),
         StringLit("person"),
     )
+
+
+def test_extract_source_stores_explicit_structural_terms(tmp_path, fake_client):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact(
+                'person("Ada")',
+                "has_role",
+                'role(person("Ada"), "PI")',
+                0.9,
+                subject_kind="term",
+                relation_kind="term",
+                object_kind="term",
+            )
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    fact = s.facts()[0]
+    assert s.get_fact_terms(fact["id"]) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("has_role"),
+        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+    )
+
+
+def test_extract_source_rejects_invalid_structural_term_without_partial_facts(
+    tmp_path, fake_client
+):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact("A", "is_a", "B", 0.9),
+            ExtractedFact(
+                "person(Name)",
+                "has_role",
+                "PI",
+                0.9,
+                subject_kind="term",
+            ),
+        ]
+    )
+
+    with pytest.raises(LLMError, match="malformed extracted structural term"):
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_id,
+        )
+
+    assert s.facts() == []
 
 
 def test_sync_sources_opens_run_and_summarises(tmp_path, fake_client):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -119,6 +119,7 @@ def test_extract_source_rejects_invalid_structural_term_without_partial_facts(
         )
 
     assert s.facts() == []
+    assert s.sources() == []
 
 
 def test_sync_sources_opens_run_and_summarises(tmp_path, fake_client):

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from dataclasses import KW_ONLY, dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+FactSlotKind = Literal["string", "term"]
 
 
 class LLMError(RuntimeError):
@@ -24,6 +26,16 @@ class ExtractedFact:
     object: str
     confidence: float
     note: str = ""
+    _: KW_ONLY
+    subject_kind: FactSlotKind = "string"
+    relation_kind: FactSlotKind = "string"
+    object_kind: FactSlotKind = "string"
+
+    def __post_init__(self) -> None:
+        for name in ("subject_kind", "relation_kind", "object_kind"):
+            value = getattr(self, name)
+            if value not in {"string", "term"}:
+                raise ValueError(f"{name} must be 'string' or 'term', got {value!r}")
 
 
 @runtime_checkable

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -29,7 +29,7 @@ FACT_SLOT_SCHEMA: dict[str, Any] = {
 
 FACT_OBJECT_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "required": ["subject", "relation", "object", "confidence"],
+    "required": ["subject", "relation", "object", "confidence", "note"],
     "additionalProperties": False,
     "properties": {
         "subject": FACT_SLOT_SCHEMA,
@@ -54,7 +54,8 @@ EXTRACTION_SYSTEM = (
     "must each be an object {\"kind\":\"string|term\", \"value\":\"...\"}. Use "
     "kind=\"term\" only for explicit, fully ground Datalog terms such as "
     "person(\"Ada\") or role(person(\"Ada\"), \"PI\"); otherwise use kind=\"string\". "
-    "Do not invent facts. Emit JSON matching the provided schema."
+    "Use note=\"\" when there is no extra source note. Do not invent facts. Emit JSON "
+    "matching the provided schema."
 )
 
 

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -51,10 +51,10 @@ EXTRACTION_SYSTEM = (
     "You extract source-backed factual triples from a document. Return ONLY facts "
     "stated or directly entailed by the text. Each fact is a (subject, relation, "
     "object) triple with a confidence in [0,1]. The subject, relation, and object "
-    "may each be either a plain string or an object {\"kind\":\"string|term\", "
-    "\"value\":\"...\"}. Use kind=\"term\" only for explicit, fully ground Datalog "
-    "terms such as person(\"Ada\") or role(person(\"Ada\"), \"PI\"); otherwise use "
-    "plain strings. Do not invent facts. Emit JSON matching the provided schema."
+    "must each be an object {\"kind\":\"string|term\", \"value\":\"...\"}. Use "
+    "kind=\"term\" only for explicit, fully ground Datalog terms such as "
+    "person(\"Ada\") or role(person(\"Ada\"), \"PI\"); otherwise use kind=\"string\". "
+    "Do not invent facts. Emit JSON matching the provided schema."
 )
 
 

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -12,18 +12,29 @@ import json
 from typing import Any
 
 from verinote.llm.base import ExtractedFact, LLMError
+from verinote.engine.terms import Compound, Term, TermParseError, Var, parse_term
 
 # JSON Schema for a batch of extracted facts. Adapters pass this to whatever
 # structured-output mechanism the provider offers (tool use / response_format /
 # json mode) so the model is constrained to emit exactly this shape.
+FACT_SLOT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["kind", "value"],
+    "additionalProperties": False,
+    "properties": {
+        "kind": {"type": "string", "enum": ["string", "term"]},
+        "value": {"type": "string", "minLength": 1},
+    },
+}
+
 FACT_OBJECT_SCHEMA: dict[str, Any] = {
     "type": "object",
     "required": ["subject", "relation", "object", "confidence"],
     "additionalProperties": False,
     "properties": {
-        "subject": {"type": "string", "minLength": 1},
-        "relation": {"type": "string", "minLength": 1},
-        "object": {"type": "string", "minLength": 1},
+        "subject": FACT_SLOT_SCHEMA,
+        "relation": FACT_SLOT_SCHEMA,
+        "object": FACT_SLOT_SCHEMA,
         "confidence": {"type": "number", "minimum": 0, "maximum": 1},
         "note": {"type": "string"},
     },
@@ -39,8 +50,11 @@ FACT_ARRAY_SCHEMA: dict[str, Any] = {
 EXTRACTION_SYSTEM = (
     "You extract source-backed factual triples from a document. Return ONLY facts "
     "stated or directly entailed by the text. Each fact is a (subject, relation, "
-    "object) triple with a confidence in [0,1]. Do not invent facts. Emit JSON "
-    "matching the provided schema."
+    "object) triple with a confidence in [0,1]. The subject, relation, and object "
+    "may each be either a plain string or an object {\"kind\":\"string|term\", "
+    "\"value\":\"...\"}. Use kind=\"term\" only for explicit, fully ground Datalog "
+    "terms such as person(\"Ada\") or role(person(\"Ada\"), \"PI\"); otherwise use "
+    "plain strings. Do not invent facts. Emit JSON matching the provided schema."
 )
 
 
@@ -94,15 +108,50 @@ def parse_facts(raw: str | dict[str, Any]) -> list[ExtractedFact]:
     facts: list[ExtractedFact] = []
     for item in items:
         try:
+            subject, subject_kind = _parse_fact_slot(item, "subject")
+            relation, relation_kind = _parse_fact_slot(item, "relation")
+            obj, object_kind = _parse_fact_slot(item, "object")
             facts.append(
                 ExtractedFact(
-                    subject=str(item["subject"]).strip(),
-                    relation=str(item["relation"]).strip(),
-                    object=str(item["object"]).strip(),
+                    subject=subject,
+                    relation=relation,
+                    object=obj,
                     confidence=float(item["confidence"]),
                     note=str(item.get("note", "")).strip(),
+                    subject_kind=subject_kind,
+                    relation_kind=relation_kind,
+                    object_kind=object_kind,
                 )
             )
-        except (KeyError, TypeError, ValueError) as exc:
+        except (KeyError, TypeError, ValueError, TermParseError) as exc:
             raise LLMError(f"malformed fact object {item!r}: {exc}") from exc
     return facts
+
+
+def _parse_fact_slot(item: dict[str, Any], field: str) -> tuple[str, str]:
+    raw = item[field]
+    if isinstance(raw, str):
+        value = raw.strip()
+        kind = "string"
+    elif isinstance(raw, dict):
+        kind = str(raw["kind"]).strip()
+        value = str(raw["value"]).strip()
+    else:
+        raise TypeError(f"{field} must be a string or {{kind,value}} object")
+    if kind not in {"string", "term"}:
+        raise ValueError(f"{field}.kind must be 'string' or 'term'")
+    if not value:
+        raise ValueError(f"{field} was empty")
+    if kind == "term":
+        term = parse_term(value)
+        if not _is_ground_term(term):
+            raise TermParseError(f"{field} structural term must be ground")
+    return value, kind
+
+
+def _is_ground_term(term: Term) -> bool:
+    if isinstance(term, Var):
+        return False
+    if isinstance(term, Compound):
+        return all(_is_ground_term(arg) for arg in term.args)
+    return True

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -31,7 +31,6 @@ def extract_source(
     after passing the human review gate (see the web review queue). Each fact
     cites its `source` and (when given) the `run` that produced it.
     """
-    source_id = store.add_source(source_path)
     facts = client.extract_facts(source_text=source_text, schema_hint=schema_hint)
     rows = []
     try:
@@ -47,6 +46,7 @@ def extract_source(
     except TermParseError as exc:
         raise LLMError(f"malformed extracted structural term: {exc}") from exc
 
+    source_id = store.add_source(source_path)
     for subject, relation, obj, f in rows:
         store.add_fact(
             subject,

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable
 
-from verinote.llm.base import LLMClient
+from verinote.engine.terms import TermParseError
+from verinote.llm.base import LLMClient, LLMError
 from verinote.store import Store
+from verinote.store.fact_input import structural_term
 
 
 def extract_source(
@@ -31,11 +33,25 @@ def extract_source(
     """
     source_id = store.add_source(source_path)
     facts = client.extract_facts(source_text=source_text, schema_hint=schema_hint)
-    for f in facts:
+    rows = []
+    try:
+        for f in facts:
+            rows.append(
+                (
+                    _extracted_value(f.subject, f.subject_kind),
+                    _extracted_value(f.relation, f.relation_kind),
+                    _extracted_value(f.object, f.object_kind),
+                    f,
+                )
+            )
+    except TermParseError as exc:
+        raise LLMError(f"malformed extracted structural term: {exc}") from exc
+
+    for subject, relation, obj, f in rows:
         store.add_fact(
-            f.subject,
-            f.relation,
-            f.object,
+            subject,
+            relation,
+            obj,
             status="candidate",
             confidence=f.confidence,
             source_id=source_id,
@@ -43,6 +59,12 @@ def extract_source(
             note=f.note,
         )
     return len(facts)
+
+
+def _extracted_value(value: str, kind: str) -> object:
+    if kind == "term":
+        return structural_term(value)
+    return value
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Add explicit `string`/`term` metadata for extracted fact subject/relation/object slots.
- Parse only slots marked `kind="term"` as structural terms; legacy string extraction remains `StringLit`.
- Validate explicit terms before persistence to avoid partial source/fact writes on malformed or variable-bearing terms.
- Document the explicit extracted term boundary.

Closes #65

## Validation

- `python -m pytest -q` -> `330 passed, 7 skipped`
- `git diff --check main..HEAD`
- Implementation Skill review loop:
  - Architect/explorer design pass completed.
  - Reviewer found strict schema and partial-write concerns.
  - Implementer addressed both concerns.
  - Architect/Critic final validation found no blocking issues.

## Notes

OpenAI strict structured output requires every property to be required; `note` is now required in the provider schema and should be emitted as `""` when unused. The parser remains backward-compatible with legacy missing-note and string-slot payloads.
