### PR TITLE
[codex] Downgrade invalid extracted terms to strings

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -61,17 +61,60 @@ def test_parse_facts_accepts_explicit_term_slots():
     assert fact.note == "source-backed"
 
 
+def test_parse_facts_downgrades_invalid_term_slots_to_strings():
+    facts = parse_facts(
+        {
+            "facts": [
+                {
+                    "subject": {"kind": "term", "value": "Example Corp"},
+                    "relation": {"kind": "string", "value": "legal_representative"},
+                    "object": {"kind": "term", "value": 'person("Ada")'},
+                    "confidence": 1,
+                    "note": "",
+                }
+            ]
+        }
+    )
+
+    fact = facts[0]
+    assert fact.subject == "Example Corp"
+    assert fact.object == 'person("Ada")'
+    assert (fact.subject_kind, fact.relation_kind, fact.object_kind) == (
+        "string",
+        "string",
+        "term",
+    )
+    assert "subject marked term but stored as string" in fact.note
+
+
+def test_parse_facts_downgrades_variable_bearing_term_slots_to_strings():
+    fact = parse_facts(
+        {
+            "facts": [
+                {
+                    "subject": {"kind": "term", "value": "person(Name)"},
+                    "relation": {"kind": "string", "value": "has_role"},
+                    "object": {"kind": "string", "value": "PI"},
+                    "confidence": 0.9,
+                    "note": "",
+                }
+            ]
+        }
+    )[0]
+
+    assert fact.subject_kind == "string"
+    assert "structural term must be ground" in fact.note
+
+
 @pytest.mark.parametrize(
     "slot",
     [
         {"kind": "bogus", "value": "Ada"},
-        {"kind": "term", "value": 'person("Ada"'},
-        {"kind": "term", "value": "person(Name)"},
         {"kind": "string", "value": ""},
         {"kind": "term"},
     ],
 )
-def test_parse_facts_rejects_invalid_explicit_slots(slot):
+def test_parse_facts_rejects_malformed_explicit_slots(slot):
     with pytest.raises(LLMError):
         parse_facts(
             {

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -129,6 +129,72 @@ def test_extract_source_stores_mixed_string_and_structural_terms(tmp_path, fake_
     assert "stored as string" in fact["note"]
 
 
+def test_extract_source_drops_string_to_term_normalization_bridge(
+    tmp_path, fake_client
+):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact(
+                "Ada",
+                "주체",
+                'person("Ada")',
+                1.0,
+                object_kind="term",
+            )
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_id,
+        )
+        == 0
+    )
+
+    assert s.facts() == []
+    assert [source["path"] for source in s.sources()] == ["sources/x.txt"]
+
+
+def test_extract_source_keeps_real_relation_to_structural_object(tmp_path, fake_client):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact(
+                "Example Corp",
+                "legal_representative",
+                'person("Ada")',
+                1.0,
+                object_kind="term",
+            )
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    fact = s.facts()[0]
+    assert s.get_fact_terms(fact["id"]) == (
+        StringLit("Example Corp"),
+        StringLit("legal_representative"),
+        Compound("person", (StringLit("Ada"),)),
+    )
+
+
 def test_extract_source_rejects_invalid_structural_term_without_partial_facts(
     tmp_path, fake_client
 ):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -91,6 +91,44 @@ def test_extract_source_stores_explicit_structural_terms(tmp_path, fake_client):
     )
 
 
+def test_extract_source_stores_mixed_string_and_structural_terms(tmp_path, fake_client):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact(
+                "Example Corp",
+                "legal_representative",
+                'person("Ada")',
+                1.0,
+                subject_kind="string",
+                relation_kind="string",
+                object_kind="term",
+                note="subject marked term but stored as string",
+            )
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    fact = s.facts()[0]
+    assert s.get_fact_terms(fact["id"]) == (
+        StringLit("Example Corp"),
+        StringLit("legal_representative"),
+        Compound("person", (StringLit("Ada"),)),
+    )
+    assert "stored as string" in fact["note"]
+
+
 def test_extract_source_rejects_invalid_structural_term_without_partial_facts(
     tmp_path, fake_client
 ):

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -53,7 +53,9 @@ EXTRACTION_SYSTEM = (
     "object) triple with a confidence in [0,1]. The subject, relation, and object "
     "must each be an object {\"kind\":\"string|term\", \"value\":\"...\"}. Use "
     "kind=\"term\" only for explicit, fully ground Datalog terms such as "
-    "person(\"Ada\") or role(person(\"Ada\"), \"PI\"); otherwise use kind=\"string\". "
+    "person(\"Ada\") or role(person(\"Ada\"), \"PI\"). Bare names, labels, Korean, "
+    "Chinese, whitespace, or punctuation outside quoted string arguments are not "
+    "valid terms; use kind=\"string\" for those values. "
     "Use note=\"\" when there is no extra source note. Do not invent facts. Emit JSON "
     "matching the provided schema."
 )
@@ -109,16 +111,20 @@ def parse_facts(raw: str | dict[str, Any]) -> list[ExtractedFact]:
     facts: list[ExtractedFact] = []
     for item in items:
         try:
-            subject, subject_kind = _parse_fact_slot(item, "subject")
-            relation, relation_kind = _parse_fact_slot(item, "relation")
-            obj, object_kind = _parse_fact_slot(item, "object")
+            subject, subject_kind, subject_warning = _parse_fact_slot(item, "subject")
+            relation, relation_kind, relation_warning = _parse_fact_slot(item, "relation")
+            obj, object_kind, object_warning = _parse_fact_slot(item, "object")
+            note = str(item.get("note", "")).strip()
+            warnings = [w for w in (subject_warning, relation_warning, object_warning) if w]
+            if warnings:
+                note = "; ".join([part for part in (note, *warnings) if part])
             facts.append(
                 ExtractedFact(
                     subject=subject,
                     relation=relation,
                     object=obj,
                     confidence=float(item["confidence"]),
-                    note=str(item.get("note", "")).strip(),
+                    note=note,
                     subject_kind=subject_kind,
                     relation_kind=relation_kind,
                     object_kind=object_kind,
@@ -129,7 +135,7 @@ def parse_facts(raw: str | dict[str, Any]) -> list[ExtractedFact]:
     return facts
 
 
-def _parse_fact_slot(item: dict[str, Any], field: str) -> tuple[str, str]:
+def _parse_fact_slot(item: dict[str, Any], field: str) -> tuple[str, str, str]:
     raw = item[field]
     if isinstance(raw, str):
         value = raw.strip()
@@ -144,10 +150,13 @@ def _parse_fact_slot(item: dict[str, Any], field: str) -> tuple[str, str]:
     if not value:
         raise ValueError(f"{field} was empty")
     if kind == "term":
-        term = parse_term(value)
-        if not _is_ground_term(term):
-            raise TermParseError(f"{field} structural term must be ground")
-    return value, kind
+        try:
+            term = parse_term(value)
+            if not _is_ground_term(term):
+                raise TermParseError(f"{field} structural term must be ground")
+        except TermParseError as exc:
+            return value, "string", f"{field} marked term but stored as string: {exc}"
+    return value, kind, ""
 
 
 def _is_ground_term(term: Term) -> bool:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -11,9 +11,20 @@ from dataclasses import dataclass, field
 from typing import Iterable
 
 from verinote.engine.terms import TermParseError
-from verinote.llm.base import LLMClient, LLMError
+from verinote.llm.base import ExtractedFact, LLMClient, LLMError
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
+
+
+_NORMALIZATION_BRIDGE_RELATIONS = {
+    "주체",
+    "subject",
+    "entity",
+    "normalized",
+    "normalized_as",
+    "canonical",
+    "canonical_form",
+}
 
 
 def extract_source(
@@ -35,6 +46,8 @@ def extract_source(
     rows = []
     try:
         for f in facts:
+            if _is_normalization_bridge(f):
+                continue
             rows.append(
                 (
                     _extracted_value(f.subject, f.subject_kind),
@@ -58,7 +71,15 @@ def extract_source(
             run_id=run_id,
             note=f.note,
         )
-    return len(facts)
+    return len(rows)
+
+
+def _is_normalization_bridge(f: ExtractedFact) -> bool:
+    relation = f.relation.strip().lower()
+    relation_kind = f.relation_kind
+    if relation_kind != "string" or relation not in _NORMALIZATION_BRIDGE_RELATIONS:
+        return False
+    return f.subject_kind == "term" or f.object_kind == "term"
 
 
 def _extracted_value(value: str, kind: str) -> object:


### PR DESCRIPTION
## Summary

- Downgrade invalid extracted `kind="term"` slots to strings instead of failing the whole source analysis.
- Preserve valid structural slots in the same fact, so mixed string/compound facts still work.
- Tighten the extraction prompt to tell models that bare Korean/Chinese labels and non-Datalog text must be `kind="string"`.

## Why

Local Ollama extraction marked a Korean company name as `kind="term"`, which failed parsing and caused source analysis to fail. The safer review behavior is to keep the invalid slot as a `StringLit`, preserve the valid compound slot, and surface the downgrade reason in the candidate note.

## Validation

- `python -m pytest tests/test_llm_schema.py tests/test_pipeline.py tests/test_fact_term_e2e.py -q`
- `python -m pytest -q`
