### PR TITLE
Add source deletion

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -72,6 +72,27 @@ def test_amend_missing_fact_returns_none(tmp_path):
     assert s.amend_fact(999, subject="x", relation="y", obj="z") is None
 
 
+def test_delete_source_removes_source_facts_and_terms(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    source_fact = s.add_fact("A", "r", "B", status="candidate", source_id=sid)
+    unrelated_fact = s.add_fact("C", "r", "D", status="candidate")
+
+    deleted = s.delete_source(sid)
+
+    assert deleted is not None
+    assert deleted["path"] == "sources/a.txt"
+    assert s.sources() == []
+    assert [f["id"] for f in s.facts()] == [unrelated_fact]
+    assert s.get_fact_terms(source_fact) is None
+    assert s.get_fact_terms(unrelated_fact) is not None
+
+
+def test_delete_missing_source_returns_none(tmp_path):
+    s = _store(tmp_path)
+    assert s.delete_source(999) is None
+
+
 def test_fact_log_orders_decisions(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("A", "r", "B", status="needs_review")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -174,6 +174,27 @@ def test_sources_page_lists_sources(tmp_path):
     assert "text" in r.text
 
 
+def test_delete_source_removes_file_and_extracted_facts(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    source_path = tmp_path / "sources" / "a.txt"
+    source_path.parent.mkdir()
+    source_path.write_text("source body", encoding="utf-8")
+    sid = store.add_source("sources/a.txt", kind="text")
+    source_fact = store.add_fact("A", "is_a", "B", status="candidate", source_id=sid)
+    unrelated_fact = c.fact_id
+
+    r = c.post(f"/sources/{sid}/delete", follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/sources"
+    assert not source_path.exists()
+    assert store.sources() == []
+    assert store.get_fact(source_fact) is None
+    assert store.get_fact_terms(source_fact) is None
+    assert store.get_fact(unrelated_fact) is not None
+
+
 def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
     import io
 

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -117,6 +117,42 @@ class Store:
             )
         )
 
+    def delete_source(self, source_id: int) -> sqlite3.Row | None:
+        """Delete a source and every fact extracted from it.
+
+        Returns the deleted source row, or None if it did not exist. Facts are
+        deleted with their DuckDB term rows so source removal does not leave
+        engine-side term data behind.
+        """
+        with self._lock:
+            source = self._conn.execute(
+                "SELECT * FROM sources WHERE id = ?", (source_id,)
+            ).fetchone()
+            if source is None:
+                return None
+            fact_ids = [
+                int(row["id"])
+                for row in self._conn.execute(
+                    "SELECT id FROM facts WHERE source_id = ? ORDER BY id",
+                    (source_id,),
+                )
+            ]
+            deleted_terms: list[int] = []
+            self._conn.execute("BEGIN")
+            try:
+                for fact_id in fact_ids:
+                    self.fact_terms.delete_fact_terms(fact_id)
+                    deleted_terms.append(fact_id)
+                self._conn.execute("DELETE FROM facts WHERE source_id = ?", (source_id,))
+                self._conn.execute("DELETE FROM sources WHERE id = ?", (source_id,))
+                self._conn.execute("COMMIT")
+                return source
+            except Exception:
+                self._rollback_quietly()
+                for fact_id in deleted_terms:
+                    self._restore_fact_terms_from_row_quietly(fact_id)
+                raise
+
     # --- runs ------------------------------------------------------------
     def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:
         """Open an extraction run; facts produced by it cite the returned id."""
@@ -386,6 +422,18 @@ class Store:
                 self.fact_terms.delete_fact_terms(fact_id)
             else:
                 self.fact_terms.put_fact_terms(fact_id, *terms)
+        except Exception:
+            pass
+
+    def _restore_fact_terms_from_row_quietly(self, fact_id: int) -> None:
+        try:
+            row = self._conn.execute(
+                "SELECT subject, relation, object FROM facts WHERE id = ?", (fact_id,)
+            ).fetchone()
+            if row is not None:
+                self.fact_terms.put_fact_terms(
+                    fact_id, row["subject"], row["relation"], row["object"]
+                )
         except Exception:
             pass
 

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -55,6 +55,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app.state.store = None
     app.state.source_jobs = {}
     app.state.source_jobs_lock = threading.Lock()
+    app.state.deleted_source_paths = set()
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
@@ -209,8 +210,21 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             if job is not None:
                 job.update(updates)
 
+    def _source_was_deleted(citation: str) -> bool:
+        with app.state.source_jobs_lock:
+            return citation in app.state.deleted_source_paths
+
+    def _forget_source_deletion(citation: str) -> None:
+        with app.state.source_jobs_lock:
+            app.state.deleted_source_paths.discard(citation)
+
+    def _mark_source_deleted(citation: str) -> None:
+        with app.state.source_jobs_lock:
+            app.state.deleted_source_paths.add(citation)
+
     def _start_source_extraction(citation: str, text: str, cfg: Config) -> None:
         job_id = uuid4().hex
+        _forget_source_deletion(citation)
         with app.state.source_jobs_lock:
             app.state.source_jobs[job_id] = {
                 "id": job_id,
@@ -222,6 +236,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         def run() -> None:
             try:
+                if _source_was_deleted(citation):
+                    _set_source_job(job_id, status="done", message="Source deleted")
+                    return
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
                     client = get_client(cfg)
@@ -232,6 +249,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         provider=cfg.provider,
                         model=cfg.model,
                     )
+                    if _source_was_deleted(citation):
+                        source = next(
+                            (
+                                row
+                                for row in worker_store.sources()
+                                if row["path"] == citation
+                            ),
+                            None,
+                        )
+                        if source is not None:
+                            worker_store.delete_source(source["id"])
+                        _set_source_job(job_id, status="done", message="Source deleted")
+                        return
                 _set_source_job(
                     job_id,
                     status="done",
@@ -247,6 +277,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             name=f"verinote-source-extract-{job_id}",
             daemon=True,
         ).start()
+
+    def _delete_source_file(source_path: str, root: Path) -> None:
+        path = (root / source_path).resolve()
+        try:
+            path.relative_to(root.resolve())
+        except ValueError as e:
+            raise OSError(f"refusing to delete source outside KB root: {source_path}") from e
+        if path.is_file():
+            path.unlink()
 
     @app.get("/", response_class=HTMLResponse)
     def dashboard(request: Request):
@@ -277,6 +316,23 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         citation = store_source(store, cfg.root, filename, text, kind)
         _start_source_extraction(citation, text, app.state.cfg)
+        return RedirectResponse("/sources", status_code=303)
+
+    @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
+    def delete_source(request: Request, source_id: int):
+        store = _active_store()
+        cfg = _active_cfg()
+        source = store.delete_source(source_id)
+        if source is not None:
+            _mark_source_deleted(source["path"])
+            try:
+                _delete_source_file(source["path"], cfg.root)
+            except OSError as e:
+                return _sources(
+                    request,
+                    error=f"source deleted, but file removal failed: {e}",
+                    status_code=500,
+                )
         return RedirectResponse("/sources", status_code=303)
 
     @app.get("/review", response_class=HTMLResponse)

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -30,7 +30,7 @@
 {% if sources %}
 <table class="sources">
   <thead>
-    <tr><th>Path</th><th>Kind</th><th>Facts</th><th>Added</th></tr>
+    <tr><th>Path</th><th>Kind</th><th>Facts</th><th>Added</th><th>Actions</th></tr>
   </thead>
   <tbody>
     {% for s in sources %}
@@ -39,6 +39,11 @@
       <td><span class="badge">{{ s["kind"] }}</span></td>
       <td class="conf">{{ s["fact_count"] }}</td>
       <td class="src">{{ s["added_at"] }}</td>
+      <td class="actions">
+        <form action="/sources/{{ s["id"] }}/delete" method="post">
+          <button class="danger" type="submit">Delete</button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- add Store.delete_source to remove a source and its extracted facts, including DuckDB fact term rows
- add a Sources page Delete action and route that also removes the uploaded source file under the KB root
- guard background source analysis so deleting a source while analysis is running does not re-add it

## Tests
- .venv/bin/python -m pytest -q