### PR TITLE
Preserve source language in extraction prompt

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -2,11 +2,16 @@
 import pytest
 
 from verinote.llm import LLMError
-from verinote.llm.schema import FACT_OBJECT_SCHEMA, parse_facts
+from verinote.llm.schema import EXTRACTION_SYSTEM, FACT_OBJECT_SCHEMA, parse_facts
 
 
 def test_fact_schema_requires_every_property_for_strict_outputs():
     assert set(FACT_OBJECT_SCHEMA["required"]) == set(FACT_OBJECT_SCHEMA["properties"])
+
+
+def test_extraction_prompt_preserves_source_language():
+    assert "Preserve the source document's language" in EXTRACTION_SYSTEM
+    assert "do not translate" in EXTRACTION_SYSTEM
 
 
 def test_parse_facts_accepts_legacy_string_slots():

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -56,6 +56,9 @@ EXTRACTION_SYSTEM = (
     "person(\"Ada\") or role(person(\"Ada\"), \"PI\"). Bare names, labels, Korean, "
     "Chinese, whitespace, or punctuation outside quoted string arguments are not "
     "valid terms; use kind=\"string\" for those values. "
+    "Preserve the source document's language in extracted strings and relation "
+    "labels; do not translate, romanize, or summarize names, labels, or facts "
+    "into another language. "
     "Use note=\"\" when there is no extra source note. Do not invent facts. Emit JSON "
     "matching the provided schema."
 )


### PR DESCRIPTION
## Summary
- add an extraction prompt rule requiring facts to preserve the source document language
- explicitly tell the extractor not to translate, romanize, or summarize names, labels, or facts into another language
- add a prompt regression test

## Tests
- .venv/bin/python -m pytest -q