### PR TITLE
Replace source analysis with chunked resumable extraction

### DIFF
--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+from verinote.pipeline.chunk import chunk_text
+
+
+def test_chunk_text_returns_empty_for_blank_source():
+    assert chunk_text(" \n\n ") == []
+
+
+def test_chunk_text_keeps_small_source_as_one_chunk():
+    assert chunk_text("alpha\n\nbeta", max_chars=100) == ["alpha\n\nbeta"]
+
+
+def test_chunk_text_splits_on_paragraph_boundaries_with_overlap():
+    chunks = chunk_text("alpha one\n\nbeta two\n\ngamma three", max_chars=15, overlap_chars=5)
+
+    assert len(chunks) == 3
+    assert chunks[0] == "alpha one"
+    assert chunks[1].startswith("a one\n\nbeta two")
+    assert chunks[2].startswith("a two\n\ngamma three")
+
+
+def test_chunk_text_splits_long_paragraphs():
+    chunks = chunk_text("abcdefghij", max_chars=4, overlap_chars=0)
+
+    assert chunks == ["abcd", "efgh", "ij"]
+
+
+def test_chunk_text_rejects_non_positive_max_chars():
+    with pytest.raises(ValueError):
+        chunk_text("body", max_chars=0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ def _clear_env(monkeypatch):
         "VERINOTE_MODEL",
         "VERINOTE_BASE_URL",
         "VERINOTE_API_KEY",
+        "VERINOTE_LLM_TIMEOUT",
         "VERINOTE_ROOT",
         "XDG_CONFIG_HOME",
     ):
@@ -52,6 +53,13 @@ def test_default_model_when_nothing_set(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     cfg = Config.for_root(tmp_path)  # no settings file, no env
     assert (cfg.provider, cfg.model) == ("anthropic", "claude-opus-4-8")
+    assert cfg.llm_timeout_seconds == 600.0
+
+
+def test_llm_timeout_env_override(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("VERINOTE_LLM_TIMEOUT", "900")
+    assert Config.for_root(tmp_path).llm_timeout_seconds == 900.0
 
 
 def test_claude_cli_provider_is_available():

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -9,9 +9,11 @@ def test_fact_schema_requires_every_property_for_strict_outputs():
     assert set(FACT_OBJECT_SCHEMA["required"]) == set(FACT_OBJECT_SCHEMA["properties"])
 
 
-def test_extraction_prompt_preserves_source_language():
-    assert "Preserve the source document's language" in EXTRACTION_SYSTEM
+def test_extraction_prompt_extracts_verbatim_source_text():
+    assert "verbatim from the source document" in EXTRACTION_SYSTEM
+    assert "exact language, spelling, script, casing, and wording" in EXTRACTION_SYSTEM
     assert "do not translate" in EXTRACTION_SYSTEM
+    assert "paraphrase" in EXTRACTION_SYSTEM
 
 
 def test_parse_facts_accepts_legacy_string_slots():

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MPL-2.0
+import json
+from types import SimpleNamespace
+
+from verinote.config import Config
+from verinote.llm.ollama_adapter import OllamaAdapter
+
+
+def _cfg(tmp_path, *, timeout: float = 900.0) -> Config:
+    return Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="ollama",
+        model="qwen3:8b",
+        api_key=None,
+        base_url="http://localhost:11434",
+        llm_timeout_seconds=timeout,
+    )
+
+
+class _Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return None
+
+    def read(self):
+        return json.dumps(
+            {
+                "message": {
+                    "content": json.dumps(
+                        {
+                            "facts": [
+                                {
+                                    "subject": {"kind": "string", "value": "Ada"},
+                                    "relation": {"kind": "string", "value": "is_a"},
+                                    "object": {"kind": "string", "value": "person"},
+                                    "confidence": 0.9,
+                                    "note": "",
+                                }
+                            ]
+                        }
+                    )
+                }
+            }
+        ).encode("utf-8")
+
+
+def test_ollama_extract_uses_configured_timeout(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, *, timeout):
+        calls.append(SimpleNamespace(req=req, timeout=timeout))
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    facts = OllamaAdapter(_cfg(tmp_path, timeout=900.0)).extract_facts(source_text="Ada")
+
+    assert calls[0].timeout == 900.0
+    assert facts[0].subject == "Ada"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -372,7 +372,9 @@ def test_process_extraction_job_extracts_chunks_and_tracks_progress(tmp_path):
     assert result.completed_chunks == 2
     assert result.failed_chunks == 0
     assert s.get_extraction_job(job_id)["status"] == "done"
-    assert [f["subject"] for f in s.facts()] == ["alpha", "beta"]
+    facts = s.facts()
+    assert [f["subject"] for f in facts] == ["alpha", "beta"]
+    assert {f["job_id"] for f in facts} == {job_id}
 
 
 def test_process_extraction_job_keeps_successful_chunks_when_one_fails(tmp_path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,7 +2,12 @@
 import pytest
 
 from verinote.llm.base import ExtractedFact, LLMError
-from verinote.pipeline import extract_source, sync_sources
+from verinote.pipeline import (
+    create_chunked_extraction_job,
+    extract_source,
+    process_extraction_job,
+    sync_sources,
+)
 from verinote.store import Store
 from verinote.engine.terms import Atom, Compound, StringLit
 
@@ -320,3 +325,84 @@ def test_sync_sources_propagates_llm_error(tmp_path, fake_client):
 
     with pytest.raises(LLMError):
         sync_sources(s, client, [("sources/a.txt", "t")], provider="fake", model="m")
+
+
+class _ChunkAwareClient:
+    name = "chunk-aware"
+
+    def __init__(self):
+        self.calls = 0
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        self.calls += 1
+        if "bad" in source_text:
+            raise LLMError("provider down")
+        label = "alpha" if "alpha" in source_text else "beta"
+        return [ExtractedFact(label, "seen_in", "source", 0.9)]
+
+
+def test_create_chunked_extraction_job_persists_chunks(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    text = "alpha\n\n" + ("b" * 6100)
+
+    job_id = create_chunked_extraction_job(
+        s, source_id=sid, source_text=text, provider="fake", model="m"
+    )
+
+    job = s.get_extraction_job(job_id)
+    chunks = s.source_chunks(job_id)
+    assert job["source_id"] == sid
+    assert job["total_chunks"] == len(chunks)
+    assert len(chunks) >= 2
+    assert chunks[0]["status"] == "pending"
+
+
+def test_process_extraction_job_extracts_chunks_and_tracks_progress(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["alpha", "beta"])
+
+    result = process_extraction_job(s, _ChunkAwareClient(), job_id=job_id)
+
+    assert result.candidates == 2
+    assert result.completed_chunks == 2
+    assert result.failed_chunks == 0
+    assert s.get_extraction_job(job_id)["status"] == "done"
+    assert [f["subject"] for f in s.facts()] == ["alpha", "beta"]
+
+
+def test_process_extraction_job_keeps_successful_chunks_when_one_fails(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["alpha", "bad"])
+
+    result = process_extraction_job(s, _ChunkAwareClient(), job_id=job_id)
+
+    assert result.candidates == 1
+    assert result.completed_chunks == 1
+    assert result.failed_chunks == 1
+    assert s.get_extraction_job(job_id)["status"] == "failed"
+    assert [chunk["status"] for chunk in s.source_chunks(job_id)] == ["done", "failed"]
+    assert [f["subject"] for f in s.facts()] == ["alpha"]
+
+
+def test_process_extraction_job_dedupes_chunk_facts_by_source(tmp_path, fake_client):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["alpha", "alpha again"])
+    client = fake_client([ExtractedFact("alpha", "seen_in", "source", 0.9)])
+
+    result = process_extraction_job(s, client, job_id=job_id)
+
+    assert result.candidates == 1
+    assert len(s.facts()) == 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -195,6 +195,71 @@ def test_extract_source_keeps_real_relation_to_structural_object(tmp_path, fake_
     )
 
 
+def test_extract_source_drops_chinese_translation_from_korean_source(
+    tmp_path, fake_client
+):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact(
+                "现代格林食品",
+                "拥有",
+                "700多家场所",
+                0.9,
+            )
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="현대그린푸드는 700여 개 사업장을 운영한다.",
+            run_id=run_id,
+        )
+        == 0
+    )
+
+    assert s.facts() == []
+
+
+def test_extract_source_keeps_han_text_that_appears_in_korean_source(
+    tmp_path, fake_client
+):
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact(
+                "법인",
+                "法定代表人",
+                "Ada",
+                0.9,
+            )
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="이 문서는 법인의 法定代表人을 명시한다.",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    fact = s.facts()[0]
+    assert s.get_fact_terms(fact["id"]) == (
+        StringLit("법인"),
+        StringLit("法定代表人"),
+        StringLit("Ada"),
+    )
+
+
 def test_extract_source_rejects_invalid_structural_term_without_partial_facts(
     tmp_path, fake_client
 ):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -77,6 +77,10 @@ def test_delete_source_removes_source_facts_and_terms(tmp_path):
     sid = s.add_source("sources/a.txt")
     source_fact = s.add_fact("A", "r", "B", status="candidate", source_id=sid)
     unrelated_fact = s.add_fact("C", "r", "D", status="candidate")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=1
+    )
+    s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["body"])
 
     deleted = s.delete_source(sid)
 
@@ -86,11 +90,58 @@ def test_delete_source_removes_source_facts_and_terms(tmp_path):
     assert [f["id"] for f in s.facts()] == [unrelated_fact]
     assert s.get_fact_terms(source_fact) is None
     assert s.get_fact_terms(unrelated_fact) is not None
+    assert s.get_extraction_job(job_id) is None
+    assert s.source_chunks(job_id) == []
 
 
 def test_delete_missing_source_returns_none(tmp_path):
     s = _store(tmp_path)
     assert s.delete_source(999) is None
+
+
+def test_extraction_job_tracks_chunk_progress_and_retry(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid,
+        provider="fake",
+        model="m",
+        total_chunks=2,
+        message="queued",
+    )
+    chunk_ids = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b"])
+
+    s.mark_extraction_job_running(job_id)
+    assert s.mark_chunk_running(chunk_ids[0])["attempts"] == 1
+    s.mark_chunk_done(chunk_ids[0], candidates=2)
+    s.mark_chunk_running(chunk_ids[1])
+    s.mark_chunk_failed(chunk_ids[1], "provider down")
+
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "failed"
+    assert job["completed_chunks"] == 1
+    assert job["failed_chunks"] == 1
+    assert job["candidate_count"] == 2
+    assert "1 chunk(s) failed" in job["message"]
+
+    assert s.retry_failed_chunks(job_id) == 1
+    assert s.source_chunks(job_id)[1]["status"] == "pending"
+
+
+def test_reset_running_chunks_makes_job_resumable(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])[0]
+
+    s.mark_extraction_job_running(job_id)
+    s.mark_chunk_running(chunk_id)
+
+    assert s.reset_running_chunks(job_id) == 1
+    assert s.next_pending_chunk(job_id)["id"] == chunk_id
+    assert s.get_extraction_job(job_id)["status"] == "pending"
 
 
 def test_fact_log_orders_decisions(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -144,6 +144,18 @@ def test_reset_running_chunks_makes_job_resumable(tmp_path):
     assert s.get_extraction_job(job_id)["status"] == "pending"
 
 
+def test_mark_chunk_running_returns_none_when_chunk_already_claimed(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])[0]
+
+    assert s.mark_chunk_running(chunk_id) is not None
+    assert s.mark_chunk_running(chunk_id) is None
+
+
 def test_fact_log_orders_decisions(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("A", "r", "B", status="needs_review")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -13,6 +13,7 @@ from verinote.config import Config  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
 from verinote.pipeline.query import query_path  # noqa: E402
+from verinote.store import Store  # noqa: E402
 from verinote.store.fact_input import structural_term  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
@@ -151,7 +152,8 @@ def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
     def extracted():
         assert "is_a" in c.get("/review").text
         body = c.get("/sources").text
-        assert "Analysis complete: 1 candidate(s)" in body
+        assert "Analysis complete: 1/1 chunk(s)" in body
+        assert "1 candidate(s)" in body
 
     _wait_for(extracted)
 
@@ -193,6 +195,7 @@ def test_delete_source_removes_file_and_extracted_facts(tmp_path):
     assert store.get_fact(source_fact) is None
     assert store.get_fact_terms(source_fact) is None
     assert store.get_fact(unrelated_fact) is not None
+    assert store.source_extraction_jobs() == []
 
 
 def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
@@ -247,9 +250,76 @@ def test_upload_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
 
     def failed():
         body = c.get("/sources").text
-        assert "extraction failed: provider down" in body
+        assert "Analysis failed: 1 chunk(s) failed" in body
+        assert "provider down" in body
 
     _wait_for(failed)
+
+
+def test_retry_failed_source_chunks(tmp_path, monkeypatch, fake_client):
+    state = {"error": LLMError("provider down")}
+
+    def client_factory(cfg):
+        if state["error"] is not None:
+            return fake_client(error=state["error"])
+        return fake_client([ExtractedFact("X", "is_a", "Y", 0.9)])
+
+    monkeypatch.setattr(webapp, "get_client", client_factory)
+    c = _client(tmp_path)
+    upload = c.post(
+        "/sources",
+        files={"file": ("note.txt", b"some text", "text/plain")},
+        follow_redirects=False,
+    )
+    assert upload.status_code == 303
+
+    def failed():
+        assert "provider down" in c.get("/sources").text
+
+    _wait_for(failed)
+    job_id = c.app.state.store.source_extraction_jobs()[0]["id"]
+    state["error"] = None
+
+    retry = c.post(f"/sources/jobs/{job_id}/retry", follow_redirects=False)
+
+    assert retry.status_code == 303
+
+    def retried():
+        assert "is_a" in c.get("/review").text
+        assert "Analysis complete: 1/1 chunk(s)" in c.get("/sources").text
+
+    _wait_for(retried)
+
+
+def test_create_app_resumes_pending_source_jobs(tmp_path, monkeypatch, fake_client):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        sid = store.add_source("sources/a.txt")
+        job_id = store.create_extraction_job(
+            source_id=sid, provider="anthropic", model="m", total_chunks=1
+        )
+        store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["some text"])
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    c = TestClient(create_app(cfg))
+
+    def resumed():
+        assert "is_a" in c.get("/review").text
+        assert "Analysis complete: 1/1 chunk(s)" in c.get("/sources").text
+
+    _wait_for(resumed)
 
 
 def test_report_ok_for_consistent_kb(tmp_path):

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -154,6 +154,17 @@ def _pick(env: str, saved: str | None, default: str | None) -> str | None:
     return default
 
 
+def _llm_timeout_seconds() -> float:
+    raw = os.environ.get("VERINOTE_LLM_TIMEOUT")
+    if raw is None:
+        return 600.0
+    try:
+        value = float(raw)
+    except ValueError:
+        return 600.0
+    return value if value > 0 else 600.0
+
+
 @dataclass(frozen=True)
 class Config:
     root: Path
@@ -162,6 +173,7 @@ class Config:
     model: str
     api_key: str | None
     base_url: str | None
+    llm_timeout_seconds: float = 600.0
 
     @classmethod
     def for_root(cls, root: Path) -> "Config":
@@ -178,6 +190,7 @@ class Config:
             model=model,
             api_key=os.environ.get("VERINOTE_API_KEY"),  # secrets only from env
             base_url=base_url,
+            llm_timeout_seconds=_llm_timeout_seconds(),
         )
 
     @classmethod

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -46,7 +46,9 @@ class OllamaAdapter:
             headers={"Content-Type": "application/json"},
         )
         try:
-            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 - local trusted endpoint
+            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+                req, timeout=self.cfg.llm_timeout_seconds
+            ) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
         except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
             raise LLMError(f"ollama request failed: {exc}") from exc
@@ -69,7 +71,9 @@ class OllamaAdapter:
             headers={"Content-Type": "application/json"},
         )
         try:
-            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 - local trusted endpoint
+            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+                req, timeout=self.cfg.llm_timeout_seconds
+            ) as resp:
                 body = json.loads(resp.read().decode("utf-8"))
         except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
             raise LLMError(f"ollama request failed: {exc}") from exc

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -56,9 +56,10 @@ EXTRACTION_SYSTEM = (
     "person(\"Ada\") or role(person(\"Ada\"), \"PI\"). Bare names, labels, Korean, "
     "Chinese, whitespace, or punctuation outside quoted string arguments are not "
     "valid terms; use kind=\"string\" for those values. "
-    "Preserve the source document's language in extracted strings and relation "
-    "labels; do not translate, romanize, or summarize names, labels, or facts "
-    "into another language. "
+    "Extract strings and relation labels verbatim from the source document. "
+    "Preserve the source document's exact language, spelling, script, casing, "
+    "and wording; do not translate, romanize, normalize, paraphrase, summarize, "
+    "or replace source terms with labels from another language. "
     "Use note=\"\" when there is no extra source note. Do not invent facts. Emit JSON "
     "matching the provided schema."
 )

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -5,7 +5,14 @@ The pipeline is intentionally thin glue over store/, llm/ and engine/. The human
 review gate sits between extract and compile and is driven from the web UI.
 """
 
-from verinote.pipeline.extract import SyncResult, extract_source, sync_sources
+from verinote.pipeline.extract import (
+    ChunkedExtractionResult,
+    SyncResult,
+    create_chunked_extraction_job,
+    extract_source,
+    process_extraction_job,
+    sync_sources,
+)
 from verinote.pipeline.ingest import (
     IngestError,
     ingest_bytes,
@@ -19,8 +26,11 @@ from verinote.pipeline.verify import verify
 
 __all__ = [
     "extract_source",
+    "create_chunked_extraction_job",
+    "process_extraction_job",
     "sync_sources",
     "SyncResult",
+    "ChunkedExtractionResult",
     "verify",
     "ingest_bytes",
     "ingest_file",

--- a/verinote/pipeline/chunk.py
+++ b/verinote/pipeline/chunk.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Deterministic source-text chunking for resumable extraction."""
+
+from __future__ import annotations
+
+import re
+
+
+DEFAULT_CHUNK_CHARS = 6000
+DEFAULT_OVERLAP_CHARS = 500
+
+
+def chunk_text(
+    text: str,
+    *,
+    max_chars: int = DEFAULT_CHUNK_CHARS,
+    overlap_chars: int = DEFAULT_OVERLAP_CHARS,
+) -> list[str]:
+    """Split source text into stable chunks with light adjacent overlap."""
+    text = text.strip()
+    if not text:
+        return []
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    overlap_chars = max(0, min(overlap_chars, max_chars // 2))
+
+    chunks = _base_chunks(text, max_chars=max_chars)
+    if not overlap_chars or len(chunks) < 2:
+        return chunks
+
+    with_overlap = [chunks[0]]
+    for previous, chunk in zip(chunks, chunks[1:]):
+        overlap = previous[-overlap_chars:].strip()
+        with_overlap.append(f"{overlap}\n\n{chunk}" if overlap else chunk)
+    return with_overlap
+
+
+def _base_chunks(text: str, *, max_chars: int) -> list[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not paragraphs:
+        return []
+
+    chunks: list[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        if len(paragraph) > max_chars:
+            if current:
+                chunks.append(current)
+                current = ""
+            chunks.extend(_split_long_text(paragraph, max_chars=max_chars))
+            continue
+
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            chunks.append(current)
+            current = paragraph
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_long_text(text: str, *, max_chars: int) -> list[str]:
+    chunks: list[str] = []
+    start = 0
+    while start < len(text):
+        chunks.append(text[start : start + max_chars].strip())
+        start += max_chars
+    return [chunk for chunk in chunks if chunk]

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -13,6 +13,7 @@ from typing import Iterable
 
 from verinote.engine.terms import TermParseError
 from verinote.llm.base import ExtractedFact, LLMClient, LLMError
+from verinote.pipeline.chunk import chunk_text
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
 
@@ -46,6 +47,145 @@ def extract_source(
     cites its `source` and (when given) the `run` that produced it.
     """
     facts = client.extract_facts(source_text=source_text, schema_hint=schema_hint)
+    rows = _candidate_rows(facts, source_text)
+
+    source_id = store.add_source(source_path)
+    for subject, relation, obj, f in rows:
+        store.add_fact(
+            subject,
+            relation,
+            obj,
+            status="candidate",
+            confidence=f.confidence,
+            source_id=source_id,
+            run_id=run_id,
+            note=f.note,
+        )
+    return len(rows)
+
+
+def create_chunked_extraction_job(
+    store: Store,
+    *,
+    source_id: int,
+    source_text: str,
+    provider: str | None,
+    model: str | None,
+) -> int:
+    """Create a durable extraction job and its source chunks."""
+    chunks = chunk_text(source_text)
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        provider=provider,
+        model=model,
+        total_chunks=len(chunks),
+        message=f"Queued: 0/{len(chunks)} chunk(s) complete",
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=chunks)
+    if not chunks:
+        store.finish_extraction_job(job_id)
+    return job_id
+
+
+@dataclass(frozen=True)
+class ChunkedExtractionResult:
+    """Outcome of processing one persisted extraction job."""
+
+    job_id: int
+    candidates: int = 0
+    completed_chunks: int = 0
+    failed_chunks: int = 0
+
+
+def process_extraction_job(
+    store: Store,
+    client: LLMClient,
+    *,
+    job_id: int,
+    schema_hint: str = "",
+) -> ChunkedExtractionResult:
+    """Process pending chunks for one durable extraction job."""
+    job = store.get_extraction_job(job_id)
+    if job is None:
+        raise LLMError(f"missing extraction job: {job_id}")
+    source = store.get_source(int(job["source_id"]))
+    if source is None:
+        raise LLMError(f"missing source for extraction job: {job_id}")
+
+    store.reset_running_chunks(job_id)
+    store.mark_extraction_job_running(job_id)
+    run_id = store.add_run(provider=job["provider"], model=job["model"])
+
+    candidates = 0
+    while chunk := store.next_pending_chunk(job_id):
+        running = store.mark_chunk_running(int(chunk["id"]))
+        if running is None:
+            continue
+        try:
+            inserted = _extract_chunk(
+                store,
+                client,
+                source_id=int(source["id"]),
+                source_text=str(running["text"]),
+                run_id=run_id,
+                schema_hint=schema_hint,
+            )
+        except LLMError as exc:
+            store.mark_chunk_failed(int(running["id"]), str(exc))
+            continue
+        candidates += inserted
+        store.mark_chunk_done(int(running["id"]), candidates=inserted)
+
+    store.finish_extraction_job(job_id)
+    final = store.get_extraction_job(job_id)
+    summary = (
+        f"{source['path']}: {final['completed_chunks']}/{final['total_chunks']} "
+        f"chunk(s), {final['candidate_count']} candidate(s), "
+        f"{final['failed_chunks']} failed"
+    )
+    store.set_run_summary(run_id, summary)
+    return ChunkedExtractionResult(
+        job_id=job_id,
+        candidates=int(final["candidate_count"]),
+        completed_chunks=int(final["completed_chunks"]),
+        failed_chunks=int(final["failed_chunks"]),
+    )
+
+
+def _extract_chunk(
+    store: Store,
+    client: LLMClient,
+    *,
+    source_id: int,
+    source_text: str,
+    run_id: int,
+    schema_hint: str = "",
+) -> int:
+    facts = client.extract_facts(source_text=source_text, schema_hint=schema_hint)
+    rows = _candidate_rows(facts, source_text)
+    inserted = 0
+    for subject, relation, obj, f in rows:
+        if store.fact_exists_for_source(
+            source_id=source_id, subject=subject, relation=relation, obj=obj
+        ):
+            continue
+        store.add_fact(
+            subject,
+            relation,
+            obj,
+            status="candidate",
+            confidence=f.confidence,
+            source_id=source_id,
+            run_id=run_id,
+            note=f.note,
+        )
+        inserted += 1
+    return inserted
+
+
+def _candidate_rows(
+    facts: list[ExtractedFact], source_text: str
+) -> list[tuple[object, object, object, ExtractedFact]]:
     rows = []
     try:
         for f in facts:
@@ -63,20 +203,7 @@ def extract_source(
             )
     except TermParseError as exc:
         raise LLMError(f"malformed extracted structural term: {exc}") from exc
-
-    source_id = store.add_source(source_path)
-    for subject, relation, obj, f in rows:
-        store.add_fact(
-            subject,
-            relation,
-            obj,
-            status="candidate",
-            confidence=f.confidence,
-            source_id=source_id,
-            run_id=run_id,
-            note=f.note,
-        )
-    return len(rows)
+    return rows
 
 
 def _is_normalization_bridge(f: ExtractedFact) -> bool:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import re
 from typing import Iterable
 
 from verinote.engine.terms import TermParseError
@@ -25,6 +26,8 @@ _NORMALIZATION_BRIDGE_RELATIONS = {
     "canonical",
     "canonical_form",
 }
+_HANGUL_RE = re.compile(r"[\uac00-\ud7a3]")
+_HAN_RUN_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]+")
 
 
 def extract_source(
@@ -47,6 +50,8 @@ def extract_source(
     try:
         for f in facts:
             if _is_normalization_bridge(f):
+                continue
+            if _has_unbacked_han_translation(f, source_text):
                 continue
             rows.append(
                 (
@@ -80,6 +85,20 @@ def _is_normalization_bridge(f: ExtractedFact) -> bool:
     if relation_kind != "string" or relation not in _NORMALIZATION_BRIDGE_RELATIONS:
         return False
     return f.subject_kind == "term" or f.object_kind == "term"
+
+
+def _has_unbacked_han_translation(f: ExtractedFact, source_text: str) -> bool:
+    """Drop likely Chinese/Hanja translations hallucinated from Korean sources."""
+    if _HANGUL_RE.search(source_text) is None:
+        return False
+    return any(
+        _has_han_run_not_in_source(value, source_text)
+        for value in (f.subject, f.relation, f.object)
+    )
+
+
+def _has_han_run_not_in_source(value: str, source_text: str) -> bool:
+    return any(match.group(0) not in source_text for match in _HAN_RUN_RE.finditer(value))
 
 
 def _extracted_value(value: str, kind: str) -> object:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -128,6 +128,7 @@ def process_extraction_job(
                 source_id=int(source["id"]),
                 source_text=str(running["text"]),
                 run_id=run_id,
+                job_id=job_id,
                 schema_hint=schema_hint,
             )
         except LLMError as exc:
@@ -159,6 +160,7 @@ def _extract_chunk(
     source_id: int,
     source_text: str,
     run_id: int,
+    job_id: int,
     schema_hint: str = "",
 ) -> int:
     facts = client.extract_facts(source_text=source_text, schema_hint=schema_hint)
@@ -177,6 +179,7 @@ def _extract_chunk(
             confidence=f.confidence,
             source_id=source_id,
             run_id=run_id,
+            job_id=job_id,
             note=f.note,
         )
         inserted += 1

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -256,12 +256,14 @@ class Store:
 
     def mark_chunk_running(self, chunk_id: int) -> sqlite3.Row | None:
         with self._lock:
-            self._conn.execute(
+            cur = self._conn.execute(
                 "UPDATE source_chunks SET status = 'running', attempts = attempts + 1, "
                 "error = '', updated_at = datetime('now') "
                 "WHERE id = ? AND status = 'pending'",
                 (chunk_id,),
             )
+            if cur.rowcount != 1:
+                return None
             return self.get_source_chunk(chunk_id)
 
     def mark_chunk_done(self, chunk_id: int, *, candidates: int = 0) -> None:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -307,6 +307,14 @@ class Store:
         with self._lock:
             self._refresh_extraction_job(job_id, final=True)
 
+    def fail_extraction_job(self, job_id: int, message: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE extraction_jobs SET status = 'failed', message = ?, "
+                "updated_at = datetime('now') WHERE id = ?",
+                (message, job_id),
+            )
+
     def fact_exists_for_source(
         self, *, source_id: int, subject: object, relation: object, obj: object
     ) -> bool:
@@ -636,7 +644,16 @@ class Store:
         if status == "done":
             message = f"Analysis complete: {done}/{total} chunk(s)"
         elif status == "failed":
-            message = f"Analysis failed: {failed} chunk(s) failed, {done}/{total} complete"
+            error = self._conn.execute(
+                "SELECT error FROM source_chunks WHERE job_id = ? "
+                "AND status = 'failed' AND error != '' ORDER BY chunk_index LIMIT 1",
+                (job_id,),
+            ).fetchone()
+            detail = f": {error['error']}" if error is not None else ""
+            message = (
+                f"Analysis failed: {failed} chunk(s) failed, "
+                f"{done}/{total} complete{detail}"
+            )
         elif status == "running":
             message = f"Analyzing: {done}/{total} chunk(s) complete"
         else:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -94,6 +94,16 @@ class Store:
     def sources(self) -> list[sqlite3.Row]:
         return list(self._conn.execute("SELECT * FROM sources ORDER BY path"))
 
+    def get_source(self, source_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM sources WHERE id = ?", (source_id,)
+        ).fetchone()
+
+    def get_source_by_path(self, path: str) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM sources WHERE path = ?", (path,)
+        ).fetchone()
+
     def sources_with_counts(self) -> list[sqlite3.Row]:
         """Sources plus how many facts cite each — for the Sources listing."""
         return list(
@@ -298,12 +308,17 @@ class Store:
             self._refresh_extraction_job(job_id, final=True)
 
     def fact_exists_for_source(
-        self, *, source_id: int, subject: str, relation: str, obj: str
+        self, *, source_id: int, subject: object, relation: object, obj: object
     ) -> bool:
         row = self._conn.execute(
             "SELECT 1 FROM facts WHERE source_id = ? AND subject = ? "
             "AND relation = ? AND object = ? LIMIT 1",
-            (source_id, subject, relation, obj),
+            (
+                source_id,
+                _display_fact_value(subject),
+                _display_fact_value(relation),
+                _display_fact_value(obj),
+            ),
         ).fetchone()
         return row is not None
 

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -117,6 +117,16 @@ class Store:
             )
         )
 
+    def source_extraction_jobs(self) -> list[sqlite3.Row]:
+        """Latest extraction jobs, newest first, for the Sources listing."""
+        return list(
+            self._conn.execute(
+                "SELECT j.*, s.path AS source_path "
+                "FROM extraction_jobs j JOIN sources s ON s.id = j.source_id "
+                "ORDER BY j.id DESC"
+            )
+        )
+
     def delete_source(self, source_id: int) -> sqlite3.Row | None:
         """Delete a source and every fact extracted from it.
 
@@ -152,6 +162,150 @@ class Store:
                 for fact_id in deleted_terms:
                     self._restore_fact_terms_from_row_quietly(fact_id)
                 raise
+
+    # --- extraction jobs/chunks -----------------------------------------
+    def create_extraction_job(
+        self,
+        *,
+        source_id: int,
+        provider: str | None,
+        model: str | None,
+        total_chunks: int,
+        message: str = "",
+    ) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO extraction_jobs("
+                "source_id, provider, model, total_chunks, message"
+                ") VALUES(?,?,?,?,?) RETURNING id",
+                (source_id, provider, model, total_chunks, message),
+            )
+            return int(cur.fetchone()[0])
+
+    def add_source_chunks(
+        self, *, job_id: int, source_id: int, chunks: Iterable[str]
+    ) -> list[int]:
+        with self._lock:
+            ids: list[int] = []
+            for index, text in enumerate(chunks):
+                cur = self._conn.execute(
+                    "INSERT INTO source_chunks(source_id, job_id, chunk_index, text) "
+                    "VALUES(?,?,?,?) RETURNING id",
+                    (source_id, job_id, index, text),
+                )
+                ids.append(int(cur.fetchone()[0]))
+            return ids
+
+    def get_extraction_job(self, job_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM extraction_jobs WHERE id = ?", (job_id,)
+        ).fetchone()
+
+    def get_source_chunk(self, chunk_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM source_chunks WHERE id = ?", (chunk_id,)
+        ).fetchone()
+
+    def source_chunks(self, job_id: int) -> list[sqlite3.Row]:
+        return list(
+            self._conn.execute(
+                "SELECT * FROM source_chunks WHERE job_id = ? ORDER BY chunk_index",
+                (job_id,),
+            )
+        )
+
+    def reset_running_chunks(self, job_id: int) -> int:
+        """Return stale running chunks for a job to pending before resume."""
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE source_chunks SET status = 'pending', error = '', "
+                "updated_at = datetime('now') "
+                "WHERE job_id = ? AND status = 'running'",
+                (job_id,),
+            )
+            self._refresh_extraction_job(job_id)
+            return int(cur.rowcount)
+
+    def next_pending_chunk(self, job_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM source_chunks "
+            "WHERE job_id = ? AND status = 'pending' "
+            "ORDER BY chunk_index LIMIT 1",
+            (job_id,),
+        ).fetchone()
+
+    def mark_extraction_job_running(self, job_id: int) -> None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE extraction_jobs SET status = 'running', "
+                "message = 'Analyzing chunks...', updated_at = datetime('now') "
+                "WHERE id = ? AND status != 'canceled'",
+                (job_id,),
+            )
+
+    def mark_chunk_running(self, chunk_id: int) -> sqlite3.Row | None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE source_chunks SET status = 'running', attempts = attempts + 1, "
+                "error = '', updated_at = datetime('now') "
+                "WHERE id = ? AND status = 'pending'",
+                (chunk_id,),
+            )
+            return self.get_source_chunk(chunk_id)
+
+    def mark_chunk_done(self, chunk_id: int, *, candidates: int = 0) -> None:
+        with self._lock:
+            chunk = self.get_source_chunk(chunk_id)
+            if chunk is None:
+                return
+            self._conn.execute(
+                "UPDATE source_chunks SET status = 'done', error = '', "
+                "updated_at = datetime('now') WHERE id = ?",
+                (chunk_id,),
+            )
+            self._conn.execute(
+                "UPDATE extraction_jobs SET candidate_count = candidate_count + ?, "
+                "updated_at = datetime('now') WHERE id = ?",
+                (candidates, chunk["job_id"]),
+            )
+            self._refresh_extraction_job(int(chunk["job_id"]))
+
+    def mark_chunk_failed(self, chunk_id: int, error: str) -> None:
+        with self._lock:
+            chunk = self.get_source_chunk(chunk_id)
+            if chunk is None:
+                return
+            self._conn.execute(
+                "UPDATE source_chunks SET status = 'failed', error = ?, "
+                "updated_at = datetime('now') WHERE id = ?",
+                (error, chunk_id),
+            )
+            self._refresh_extraction_job(int(chunk["job_id"]))
+
+    def retry_failed_chunks(self, job_id: int) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE source_chunks SET status = 'pending', error = '', "
+                "updated_at = datetime('now') "
+                "WHERE job_id = ? AND status = 'failed'",
+                (job_id,),
+            )
+            self._refresh_extraction_job(job_id)
+            return int(cur.rowcount)
+
+    def finish_extraction_job(self, job_id: int) -> None:
+        with self._lock:
+            self._refresh_extraction_job(job_id, final=True)
+
+    def fact_exists_for_source(
+        self, *, source_id: int, subject: str, relation: str, obj: str
+    ) -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM facts WHERE source_id = ? AND subject = ? "
+            "AND relation = ? AND object = ? LIMIT 1",
+            (source_id, subject, relation, obj),
+        ).fetchone()
+        return row is not None
 
     # --- runs ------------------------------------------------------------
     def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:
@@ -436,6 +590,49 @@ class Store:
                 )
         except Exception:
             pass
+
+    def _refresh_extraction_job(self, job_id: int, *, final: bool = False) -> None:
+        counts = self._conn.execute(
+            "SELECT "
+            "COALESCE(SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END), 0) AS done, "
+            "COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) AS failed, "
+            "COALESCE(SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END), 0) AS running, "
+            "COUNT(*) AS total "
+            "FROM source_chunks WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+        if counts is None:
+            return
+        done = int(counts["done"])
+        failed = int(counts["failed"])
+        running = int(counts["running"])
+        total = int(counts["total"])
+        if final and failed:
+            status = "failed"
+        elif final or (total and done == total):
+            status = "done"
+        elif running:
+            status = "running"
+        elif failed:
+            status = "failed"
+        else:
+            status = "pending"
+
+        if status == "done":
+            message = f"Analysis complete: {done}/{total} chunk(s)"
+        elif status == "failed":
+            message = f"Analysis failed: {failed} chunk(s) failed, {done}/{total} complete"
+        elif status == "running":
+            message = f"Analyzing: {done}/{total} chunk(s) complete"
+        else:
+            message = f"Pending: {done}/{total} chunk(s) complete"
+
+        self._conn.execute(
+            "UPDATE extraction_jobs SET status = ?, completed_chunks = ?, "
+            "failed_chunks = ?, message = ?, updated_at = datetime('now') "
+            "WHERE id = ?",
+            (status, done, failed, message, job_id),
+        )
 
 
 def _display_fact_value(value: object) -> str:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -43,6 +43,7 @@ class Store:
     # --- lifecycle -------------------------------------------------------
     def init_schema(self) -> None:
         self._conn.executescript(_load_schema())
+        self._ensure_schema_migrations()
 
     def close(self) -> None:
         if self._inference_cache is not None:
@@ -358,6 +359,7 @@ class Store:
         confidence: float = 0.0,
         source_id: int | None = None,
         run_id: int | None = None,
+        job_id: int | None = None,
         note: str = "",
     ) -> int:
         with self._lock:
@@ -365,8 +367,10 @@ class Store:
             self._conn.execute("BEGIN")
             try:
                 cur = self._conn.execute(
-                    "INSERT INTO facts(subject, relation, object, status, confidence, source_id, run_id, note) "
-                    "VALUES(?,?,?,?,?,?,?,?) RETURNING id",
+                    "INSERT INTO facts("
+                    "subject, relation, object, status, confidence, source_id, "
+                    "run_id, job_id, note"
+                    ") VALUES(?,?,?,?,?,?,?,?,?) RETURNING id",
                     (
                         _display_fact_value(subject),
                         _display_fact_value(relation),
@@ -375,6 +379,7 @@ class Store:
                         confidence,
                         source_id,
                         run_id,
+                        job_id,
                         note,
                     ),
                 )
@@ -613,6 +618,16 @@ class Store:
                 )
         except Exception:
             pass
+
+    def _ensure_schema_migrations(self) -> None:
+        fact_columns = {
+            row["name"] for row in self._conn.execute("PRAGMA table_info(facts)")
+        }
+        if "job_id" not in fact_columns:
+            self._conn.execute(
+                "ALTER TABLE facts ADD COLUMN job_id INTEGER "
+                "REFERENCES extraction_jobs(id) ON DELETE SET NULL"
+            )
 
     def _refresh_extraction_job(self, job_id: int, *, final: bool = False) -> None:
         counts = self._conn.execute(

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS facts (
     confidence REAL NOT NULL DEFAULT 0.0,
     source_id  INTEGER REFERENCES sources(id) ON DELETE SET NULL,
     run_id     INTEGER REFERENCES runs(id) ON DELETE SET NULL,
+    job_id     INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
     note       TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -25,6 +25,42 @@ CREATE TABLE IF NOT EXISTS runs (
     summary    TEXT
 );
 
+-- Durable source-analysis progress. A job owns chunk rows so analysis can
+-- resume/retry without depending on an in-memory web process.
+CREATE TABLE IF NOT EXISTS extraction_jobs (
+    id               INTEGER PRIMARY KEY,
+    source_id        INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending','running','done','failed','canceled')),
+    provider         TEXT,
+    model            TEXT,
+    total_chunks     INTEGER NOT NULL DEFAULT 0,
+    completed_chunks INTEGER NOT NULL DEFAULT 0,
+    failed_chunks    INTEGER NOT NULL DEFAULT 0,
+    candidate_count  INTEGER NOT NULL DEFAULT 0,
+    message          TEXT NOT NULL DEFAULT '',
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS source_chunks (
+    id          INTEGER PRIMARY KEY,
+    source_id   INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    job_id      INTEGER NOT NULL REFERENCES extraction_jobs(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL,
+    text        TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending','running','done','failed')),
+    attempts    INTEGER NOT NULL DEFAULT 0,
+    error       TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(job_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_extraction_jobs_source ON extraction_jobs(source_id);
+CREATE INDEX IF NOT EXISTS idx_source_chunks_job_status ON source_chunks(job_id, status);
+
 -- A candidate/verified fact with review metadata. The subject/relation/object
 -- columns are text display mirrors and legacy backfill inputs; the authoritative
 -- logical terms live in DuckDB fact_terms keyed by this row id.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 import threading
-import time
-from uuid import uuid4
 
 from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -29,12 +27,13 @@ from verinote.config import (
 )
 from verinote.llm import LLMError, get_client
 from verinote.pipeline import (
+    create_chunked_extraction_job,
     IngestError,
     ingest_bytes,
+    process_extraction_job,
     store_source,
     supported_suffixes,
     repair_questions,
-    sync_sources,
     translate_questions,
     verify,
     write_query_file,
@@ -53,9 +52,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app = FastAPI(title="verinote")
     app.state.cfg = cfg
     app.state.store = None
-    app.state.source_jobs = {}
-    app.state.source_jobs_lock = threading.Lock()
-    app.state.deleted_source_paths = set()
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
@@ -183,13 +179,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if app.state.store is None:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
-        with app.state.source_jobs_lock:
-            jobs = sorted(
-                app.state.source_jobs.values(),
-                key=lambda job: job["created_at"],
-                reverse=True,
-            )
-        has_running_jobs = any(job["status"] == "running" for job in jobs)
+        jobs = store.source_extraction_jobs()
+        has_running_jobs = any(job["status"] in {"pending", "running"} for job in jobs)
         return templates.TemplateResponse(
             request,
             "sources.html",
@@ -204,73 +195,21 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             status_code=status_code,
         )
 
-    def _set_source_job(job_id: str, **updates: object) -> None:
-        with app.state.source_jobs_lock:
-            job = app.state.source_jobs.get(job_id)
-            if job is not None:
-                job.update(updates)
-
-    def _source_was_deleted(citation: str) -> bool:
-        with app.state.source_jobs_lock:
-            return citation in app.state.deleted_source_paths
-
-    def _forget_source_deletion(citation: str) -> None:
-        with app.state.source_jobs_lock:
-            app.state.deleted_source_paths.discard(citation)
-
-    def _mark_source_deleted(citation: str) -> None:
-        with app.state.source_jobs_lock:
-            app.state.deleted_source_paths.add(citation)
-
-    def _start_source_extraction(citation: str, text: str, cfg: Config) -> None:
-        job_id = uuid4().hex
-        _forget_source_deletion(citation)
-        with app.state.source_jobs_lock:
-            app.state.source_jobs[job_id] = {
-                "id": job_id,
-                "source": citation,
-                "status": "running",
-                "message": "Analyzing source...",
-                "created_at": time.time(),
-            }
-
+    def _start_source_extraction(job_id: int, cfg: Config) -> None:
         def run() -> None:
             try:
-                if _source_was_deleted(citation):
-                    _set_source_job(job_id, status="done", message="Source deleted")
-                    return
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
                     client = get_client(cfg)
-                    result = sync_sources(
-                        worker_store,
-                        client,
-                        [(citation, text)],
-                        provider=cfg.provider,
-                        model=cfg.model,
-                    )
-                    if _source_was_deleted(citation):
-                        source = next(
-                            (
-                                row
-                                for row in worker_store.sources()
-                                if row["path"] == citation
-                            ),
-                            None,
-                        )
-                        if source is not None:
-                            worker_store.delete_source(source["id"])
-                        _set_source_job(job_id, status="done", message="Source deleted")
-                        return
-                _set_source_job(
-                    job_id,
-                    status="done",
-                    message=f"Analysis complete: {result.total} candidate(s)",
-                )
+                    process_extraction_job(worker_store, client, job_id=job_id)
             except LLMError as e:
-                _set_source_job(job_id, status="failed", message=f"extraction failed: {e}")
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    worker_store.fail_extraction_job(job_id, f"extraction failed: {e}")
             except Exception as e:  # noqa: BLE001 - keep background failures visible in UI
-                _set_source_job(job_id, status="failed", message=f"analysis failed: {e}")
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    worker_store.fail_extraction_job(job_id, f"analysis failed: {e}")
 
         threading.Thread(
             target=run,
@@ -286,6 +225,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             raise OSError(f"refusing to delete source outside KB root: {source_path}") from e
         if path.is_file():
             path.unlink()
+
+    def _resume_source_extraction_jobs() -> None:
+        if app.state.store is None or app.state.cfg is None:
+            return
+        for job in app.state.store.source_extraction_jobs():
+            if job["status"] in {"pending", "running"}:
+                _start_source_extraction(int(job["id"]), app.state.cfg)
 
     @app.get("/", response_class=HTMLResponse)
     def dashboard(request: Request):
@@ -315,7 +261,29 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _sources(request, error=str(e), status_code=400)
 
         citation = store_source(store, cfg.root, filename, text, kind)
-        _start_source_extraction(citation, text, app.state.cfg)
+        source = store.get_source_by_path(citation)
+        if source is None:
+            return _sources(
+                request,
+                error=f"source registration failed: {citation}",
+                status_code=500,
+            )
+        job_id = create_chunked_extraction_job(
+            store,
+            source_id=int(source["id"]),
+            source_text=text,
+            provider=cfg.provider,
+            model=cfg.model,
+        )
+        _start_source_extraction(job_id, app.state.cfg)
+        return RedirectResponse("/sources", status_code=303)
+
+    @app.post("/sources/jobs/{job_id}/retry", response_class=HTMLResponse)
+    def retry_source_job(request: Request, job_id: int):
+        store = _active_store()
+        retried = store.retry_failed_chunks(job_id)
+        if retried:
+            _start_source_extraction(job_id, _active_cfg())
         return RedirectResponse("/sources", status_code=303)
 
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
@@ -324,7 +292,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         cfg = _active_cfg()
         source = store.delete_source(source_id)
         if source is not None:
-            _mark_source_deleted(source["path"])
             try:
                 _delete_source_file(source["path"], cfg.root)
             except OSError as e:
@@ -541,6 +508,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             request,
             test_result=f"{client.name} answered with {len(facts)} fact(s) from {c.model}",
         )
+
+    _resume_source_extraction_jobs()
 
     return app
 

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -20,8 +20,14 @@
   {% for job in jobs %}
   <p class="job job-{{ job["status"] }}">
     <span class="badge">{{ job["status"] }}</span>
-    <code>{{ job["source"] }}</code>
+    <code>{{ job["source_path"] }}</code>
     <span>{{ job["message"] }}</span>
+    <span class="conf">{{ job["candidate_count"] }} candidate(s)</span>
+    {% if job["failed_chunks"] %}
+    <form action="/sources/jobs/{{ job["id"] }}/retry" method="post">
+      <button class="btn ghost" type="submit">Retry failed chunks</button>
+    </form>
+    {% endif %}
   </p>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- replace monolithic web source analysis with durable extraction jobs and persisted source chunks
- process uploads chunk-by-chunk with progress, failed-chunk retry, resume on server restart, and duplicate chunk-claim protection
- link chunked candidate facts to source, run, and extraction job; clean jobs/chunks on source deletion
- preserve source text more strictly and drop translated Han facts from Korean sources
- make Ollama request timeout configurable while removing source analysis dependence on one long request

## Tests
- .venv/bin/python -m pytest -q

Closes #70