### PR TITLE
[codex] Canonicalize relation aliases in conflict view

### DIFF
--- a/tests/test_corroboration.py
+++ b/tests/test_corroboration.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
+import unicodedata
+
 from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
     corroboration,
     functional_relations,
+    relation_aliases,
     single_valued_conflicts,
     store_corroboration,
     store_single_valued_conflicts,
@@ -141,3 +145,145 @@ def test_store_single_valued_conflicts_use_default_policy(tmp_path):
     conflicts = store_single_valued_conflicts(s)
 
     assert [(c.subject, c.relation) for c in conflicts] == [("Org", "established_on")]
+
+
+def test_relation_aliases_collapse_surface_variants_for_conflicts():
+    rows = [
+        {
+            "subject": "논문A",
+            "relation": "게재연도",
+            "object": "2005",
+            "status": "confirmed",
+            "source": "sources/a.md",
+        },
+        {
+            "subject": "논문A",
+            "relation": "발행년도",
+            "object": "2007",
+            "status": "confirmed",
+            "source": "sources/b.md",
+        },
+    ]
+    aliases = {
+        "게재연도": "published_year",
+        "발행년도": "published_year",
+    }
+
+    conflicts = single_valued_conflicts(rows, {"published_year"}, aliases)
+
+    assert [(c.subject, c.relation) for c in conflicts] == [
+        ("논문A", "published_year")
+    ]
+    assert [value.object for value in conflicts[0].values] == ["2005", "2007"]
+
+
+def test_relation_aliases_same_value_across_variants_is_not_conflict():
+    rows = [
+        {
+            "subject": "논문A",
+            "relation": "게재연도",
+            "object": "2005",
+            "status": "confirmed",
+            "source": "sources/a.md",
+        },
+        {
+            "subject": "논문A",
+            "relation": "발행년도",
+            "object": "2005",
+            "status": "confirmed",
+            "source": "sources/b.md",
+        },
+    ]
+
+    conflicts = single_valued_conflicts(
+        rows,
+        {"published_year"},
+        {"게재연도": "published_year", "발행년도": "published_year"},
+    )
+
+    assert conflicts == []
+
+
+def test_relation_aliases_are_opt_in_for_cross_variant_conflicts():
+    rows = [
+        {
+            "subject": "논문A",
+            "relation": "게재연도",
+            "object": "2005",
+            "status": "confirmed",
+            "source": "sources/a.md",
+        },
+        {
+            "subject": "논문A",
+            "relation": "발행년도",
+            "object": "2007",
+            "status": "confirmed",
+            "source": "sources/b.md",
+        },
+    ]
+
+    assert single_valued_conflicts(rows, {"published_year"}) == []
+
+
+def test_relation_aliases_normalize_nfd_surface_names():
+    nfd_relation = unicodedata.normalize("NFD", "게재연도")
+    rows = [
+        {
+            "subject": "논문A",
+            "relation": nfd_relation,
+            "object": "2005",
+            "status": "confirmed",
+            "source": "sources/a.md",
+        },
+        {
+            "subject": "논문A",
+            "relation": "발행년도",
+            "object": "2007",
+            "status": "confirmed",
+            "source": "sources/b.md",
+        },
+    ]
+
+    conflicts = single_valued_conflicts(
+        rows,
+        {"published_year"},
+        {"게재연도": "published_year", "발행년도": "published_year"},
+    )
+
+    assert [(c.subject, c.relation) for c in conflicts] == [
+        ("논문A", "published_year")
+    ]
+
+
+def test_relation_aliases_parser_rejects_self_map():
+    try:
+        relation_aliases("- `published_year` -> `published_year`\n")
+    except CorroborationPolicyError as exc:
+        assert "self-map" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected CorroborationPolicyError")
+
+
+def test_store_single_valued_conflicts_loads_relation_alias_file(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("published_year").\n',
+        encoding="utf-8",
+    )
+    (policy / "relation-aliases.md").write_text(
+        "- `게재연도` -> `published_year`\n"
+        "- `발행년도` -> `published_year`\n",
+        encoding="utf-8",
+    )
+    a = s.add_source("sources/a.md")
+    b = s.add_source("sources/b.md")
+    s.add_fact("논문A", "게재연도", "2005", status="confirmed", source_id=a)
+    s.add_fact("논문A", "발행년도", "2007", status="confirmed", source_id=b)
+
+    store_conflicts = store_single_valued_conflicts(s)
+
+    assert [(c.subject, c.relation) for c in store_conflicts] == [
+        ("논문A", "published_year")
+    ]

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
+import unicodedata
 from typing import Any, Iterable, Mapping
 
 from verinote.engine import DEFAULT_POLICY
 from verinote.store import ENGINE_STATUSES, Store
 
 _FUNCTIONAL_RE = re.compile(r'functional\("((?:\\.|[^"\\])*)"\)\.')
+_ALIAS_RE = re.compile(r"`([^`]+)`\s*->\s*`([^`]+)`")
+RELATION_ALIASES_RELPATH = "policy/relation-aliases.md"
+
+
+class CorroborationPolicyError(ValueError):
+    """Raised when optional corroboration policy files are malformed."""
 
 
 @dataclass(frozen=True)
@@ -60,6 +67,46 @@ def store_functional_relations(store: Store) -> set[str]:
     return functional_relations(load_policy(store))
 
 
+def relation_aliases(text: str) -> dict[str, str]:
+    """Parse factlog-style relation aliases into ``{raw: canonical}``."""
+    aliases: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = re.sub(r"^\s*[-*]\s+", "", line.strip()).strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = _ALIAS_RE.fullmatch(stripped)
+        if match is None:
+            continue
+        raw = unicodedata.normalize("NFC", match.group(1).strip())
+        canonical = unicodedata.normalize("NFC", match.group(2).strip())
+        if not raw or not canonical:
+            continue
+        if raw == canonical:
+            raise CorroborationPolicyError(
+                f"relation-aliases.md: self-map {raw!r} is not allowed"
+            )
+        if raw in aliases and aliases[raw] != canonical:
+            raise CorroborationPolicyError(
+                f"relation-aliases.md: {raw!r} mapped to both "
+                f"{aliases[raw]!r} and {canonical!r}"
+            )
+        aliases[raw] = canonical
+    canonical_values = set(aliases.values())
+    for raw in aliases:
+        if raw in canonical_values:
+            raise CorroborationPolicyError(
+                f"relation-aliases.md: {raw!r} is both raw and canonical"
+            )
+    return aliases
+
+
+def store_relation_aliases(store: Store) -> dict[str, str]:
+    path = store.db_path.parent / RELATION_ALIASES_RELPATH
+    if not path.is_file():
+        return {}
+    return relation_aliases(path.read_text(encoding="utf-8"))
+
+
 def corroboration(facts: Iterable[Mapping[str, object]]) -> list[FactSupport]:
     """Return distinct-source support for confirmed/accepted SPO triples."""
     sources: dict[tuple[str, str, str], set[str]] = {}
@@ -78,15 +125,19 @@ def corroboration(facts: Iterable[Mapping[str, object]]) -> list[FactSupport]:
 
 
 def single_valued_conflicts(
-    facts: Iterable[Mapping[str, object]], single_valued: set[str]
+    facts: Iterable[Mapping[str, object]],
+    single_valued: set[str],
+    aliases: dict[str, str] | None = None,
 ) -> list[SingleValuedConflict]:
     """Return conflicting values for single-valued relations with source support."""
+    aliases = aliases or {}
+    canonical_single_valued = {_canonical_relation(r, aliases) for r in single_valued}
     by_subject_relation: dict[tuple[str, str], dict[str, set[str]]] = {}
     for row in facts:
         if str(_value(row, "status", "")) not in ENGINE_STATUSES:
             continue
-        relation = str(row["relation"])
-        if relation not in single_valued:
+        relation = _canonical_relation(str(row["relation"]), aliases)
+        if relation not in canonical_single_valued:
             continue
         source = _source_ref(row)
         if not source:
@@ -118,12 +169,25 @@ def store_corroboration(store: Store) -> list[FactSupport]:
 
 
 def store_single_valued_conflicts(store: Store) -> list[SingleValuedConflict]:
-    return single_valued_conflicts(store.facts(), store_functional_relations(store))
+    return single_valued_conflicts(
+        store.facts(), store_functional_relations(store), store_relation_aliases(store)
+    )
 
 
 def _source_ref(row: Mapping[str, object]) -> str:
     value = _value(row, "source_path", "") or _value(row, "source", "")
     return str(value).strip()
+
+
+def _canonical_relation(relation: str, aliases: dict[str, str]) -> str:
+    if not aliases:
+        return relation
+    normalized = unicodedata.normalize("NFC", relation)
+    if normalized in aliases:
+        return aliases[normalized]
+    if normalized in set(aliases.values()):
+        return normalized
+    return relation
 
 
 def _value(row: Mapping[str, object], key: str, default: object = None) -> Any:


### PR DESCRIPTION
## Summary
- parse factlog-style `policy/relation-aliases.md` mappings
- canonicalize relation surface variants before single-valued conflict grouping
- preserve opt-in behavior when no alias file or alias map is present

## Validation
- `.venv/bin/python -m pytest -q`
