### PR TITLE
[codex] Split original sources from extraction artifacts

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 import verinote.cli as cli
 from verinote.engine import DEFAULT_POLICY
 from verinote.llm.base import ExtractedFact, LLMError
+from verinote.pipeline.ingest import register_converter
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
 
@@ -69,6 +70,30 @@ def test_ingest_registers_text_source(tmp_path, monkeypatch, capsys):
     assert [(r["path"], r["kind"]) for r in s.sources_with_counts()] == [
         ("sources/doc.txt", "text")
     ]
+
+
+def test_sync_uses_registered_artifact_after_binary_ingest(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    _env(monkeypatch, tmp_path)
+    register_converter(".rtfx", lambda raw: raw.decode("utf-8"))
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+    src = tmp_path / "report.rtfx"
+    src.write_bytes(b"artifact text")
+
+    assert cli.main(["ingest", str(src)]) == 0
+    assert cli.main(["sync"]) == 0
+
+    out = capsys.readouterr().out
+    assert "sources/report.rtfx: 1 candidate(s)" in out
+    s = Store(tmp_path / "kb.sqlite")
+    fact = s.review_queue()[0]
+    job = s.get_extraction_job_detail(fact["job_id"])
+    assert fact["source_path"] == "sources/report.rtfx"
+    assert job["artifact_path"].startswith("artifacts/sources/")
 
 
 def test_ingest_unsupported_type_errors(tmp_path, monkeypatch, capsys):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -5,6 +5,7 @@ import pytest
 
 from verinote.pipeline import ingest_bytes, ingest_file, supported_suffixes
 from verinote.pipeline.ingest import IngestError
+from verinote.pipeline.ingest import register_converter
 from verinote.store import Store
 
 
@@ -42,7 +43,7 @@ def test_non_utf8_text_raises():
 
 def test_docx_converts_to_text():
     text, kind = ingest_bytes(_docx_bytes("hello world"), "report.docx")
-    assert kind == "conversion"
+    assert kind == "binary"
     assert "hello world" in text
 
 
@@ -69,8 +70,51 @@ def test_ingest_file_converts_binary_source(tmp_path):
     src = tmp_path / "report.docx"
     src.write_bytes(_docx_bytes("converted body"))
     result = ingest_file(s, src, root=tmp_path)
-    assert result["kind"] == "conversion"
-    # the produced text file lives under sources/ as .txt
-    assert result["citation"] == "sources/report.txt"
-    assert "converted body" in (tmp_path / "sources" / "report.txt").read_text()
-    assert s.sources_with_counts()[0]["kind"] == "conversion"
+    assert result["kind"] == "binary"
+    assert result["citation"] == "sources/report.docx"
+    assert (tmp_path / "sources" / "report.docx").read_bytes() == src.read_bytes()
+    assert result["artifact_path"].startswith("artifacts/sources/1/")
+    assert result["artifact_path"].endswith(".txt")
+    assert "converted body" in (tmp_path / result["artifact_path"]).read_text()
+    assert s.sources_with_counts()[0]["kind"] == "binary"
+
+
+def test_binary_sources_with_same_stem_keep_distinct_originals_and_artifacts(tmp_path):
+    register_converter(".pptx", lambda raw: raw.decode("utf-8"))
+    register_converter(".pdfx", lambda raw: raw.decode("utf-8"))
+    s = _store(tmp_path)
+
+    pptx = tmp_path / "report.pptx"
+    pdf = tmp_path / "report.pdfx"
+    pptx.write_bytes(b"slides")
+    pdf.write_bytes(b"document")
+
+    first = ingest_file(s, pptx, root=tmp_path)
+    second = ingest_file(s, pdf, root=tmp_path)
+
+    assert first["citation"] == "sources/report.pptx"
+    assert second["citation"] == "sources/report.pdfx"
+    assert first["artifact_path"].startswith("artifacts/sources/1/")
+    assert second["artifact_path"].startswith("artifacts/sources/2/")
+    assert (tmp_path / first["artifact_path"]).read_text() == "slides"
+    assert (tmp_path / second["artifact_path"]).read_text() == "document"
+    assert [row["path"] for row in s.sources()] == [
+        "sources/report.pdfx",
+        "sources/report.pptx",
+    ]
+
+
+def test_reingesting_same_source_keeps_previous_text_artifact(tmp_path):
+    register_converter(".rtfx", lambda raw: raw.decode("utf-8"))
+    s = _store(tmp_path)
+    src = tmp_path / "report.rtfx"
+    src.write_bytes(b"first")
+    first = ingest_file(s, src, root=tmp_path)
+
+    src.write_bytes(b"second")
+    second = ingest_file(s, src, root=tmp_path)
+
+    assert first["source_id"] == second["source_id"]
+    assert first["artifact_id"] != second["artifact_id"]
+    assert (tmp_path / first["artifact_path"]).read_text() == "first"
+    assert (tmp_path / second["artifact_path"]).read_text() == "second"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -109,32 +109,79 @@ def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):
     first = s.add_source_artifact(
         source_id=sid,
         kind="extracted_text",
-        path="artifacts/sources/1/extracted.txt",
+        path="artifacts/sources/1/aaa.txt",
+        checksum="aaa",
     )
     second = s.add_source_artifact(
         source_id=sid,
         kind="extracted_text",
-        path="artifacts/sources/1/extracted-v2.txt",
-    )
-    s.add_source_artifact(
-        source_id=sid,
-        kind="original_text",
-        path="sources/report.pdf",
-        content_type="application/pdf",
+        path="artifacts/sources/1/bbb.txt",
+        checksum="bbb",
     )
     s.add_fact("A", "r", "B", status="candidate", source_id=sid)
 
-    assert first == second
+    assert first != second
     artifacts = s.source_artifacts(sid)
     assert [(a["kind"], a["path"]) for a in artifacts] == [
-        ("extracted_text", "artifacts/sources/1/extracted-v2.txt"),
-        ("original_text", "sources/report.pdf"),
+        ("extracted_text", "artifacts/sources/1/aaa.txt"),
+        ("extracted_text", "artifacts/sources/1/bbb.txt"),
     ]
     rows = s.sources_with_counts()
     assert rows[0]["path"] == "sources/report.pdf"
     assert rows[0]["kind"] == "binary"
     assert rows[0]["fact_count"] == 1
-    assert "artifacts/sources/1/extracted-v2.txt" in rows[0]["artifact_paths"]
+    assert "artifacts/sources/1/aaa.txt" in rows[0]["artifact_paths"]
+    assert "artifacts/sources/1/bbb.txt" in rows[0]["artifact_paths"]
+
+
+def test_extraction_job_rejects_artifact_from_another_source(tmp_path):
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.pdf", kind="binary")
+    source_b = s.add_source("sources/b.pdf", kind="binary")
+    artifact_b = s.add_source_artifact(
+        source_id=source_b,
+        kind="extracted_text",
+        path="artifacts/sources/2/bbb.txt",
+        checksum="bbb",
+    )
+
+    import sqlite3
+
+    try:
+        s.create_extraction_job(
+            source_id=source_a,
+            artifact_id=artifact_b,
+            provider="fake",
+            model="m",
+            total_chunks=1,
+        )
+    except sqlite3.IntegrityError as exc:
+        assert "artifact must belong" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected IntegrityError")
+
+
+def test_source_text_inputs_use_latest_artifact_per_source(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/report.pdf", kind="binary")
+    s.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path="artifacts/sources/1/old.txt",
+        checksum="old",
+    )
+    latest = s.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path="artifacts/sources/1/new.txt",
+        checksum="new",
+    )
+
+    rows = s.source_text_inputs()
+
+    assert [(row["source_path"], row["artifact_id"], row["artifact_path"]) for row in rows] == [
+        ("sources/report.pdf", latest, "artifacts/sources/1/new.txt")
+    ]
 
 
 def test_extraction_job_tracks_chunk_progress_and_retry(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -75,10 +75,13 @@ def test_amend_missing_fact_returns_none(tmp_path):
 def test_delete_source_removes_source_facts_and_terms(tmp_path):
     s = _store(tmp_path)
     sid = s.add_source("sources/a.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a.txt"
+    )
     source_fact = s.add_fact("A", "r", "B", status="candidate", source_id=sid)
     unrelated_fact = s.add_fact("C", "r", "D", status="candidate")
     job_id = s.create_extraction_job(
-        source_id=sid, provider="fake", model="m", total_chunks=1
+        source_id=sid, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
     )
     s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["body"])
 
@@ -92,11 +95,46 @@ def test_delete_source_removes_source_facts_and_terms(tmp_path):
     assert s.get_fact_terms(unrelated_fact) is not None
     assert s.get_extraction_job(job_id) is None
     assert s.source_chunks(job_id) == []
+    assert s.source_artifacts(sid) == []
 
 
 def test_delete_missing_source_returns_none(tmp_path):
     s = _store(tmp_path)
     assert s.delete_source(999) is None
+
+
+def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/report.pdf", kind="binary")
+    first = s.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path="artifacts/sources/1/extracted.txt",
+    )
+    second = s.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path="artifacts/sources/1/extracted-v2.txt",
+    )
+    s.add_source_artifact(
+        source_id=sid,
+        kind="original_text",
+        path="sources/report.pdf",
+        content_type="application/pdf",
+    )
+    s.add_fact("A", "r", "B", status="candidate", source_id=sid)
+
+    assert first == second
+    artifacts = s.source_artifacts(sid)
+    assert [(a["kind"], a["path"]) for a in artifacts] == [
+        ("extracted_text", "artifacts/sources/1/extracted-v2.txt"),
+        ("original_text", "sources/report.pdf"),
+    ]
+    rows = s.sources_with_counts()
+    assert rows[0]["path"] == "sources/report.pdf"
+    assert rows[0]["kind"] == "binary"
+    assert rows[0]["fact_count"] == 1
+    assert "artifacts/sources/1/extracted-v2.txt" in rows[0]["artifact_paths"]
 
 
 def test_extraction_job_tracks_chunk_progress_and_retry(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -208,6 +208,14 @@ def test_delete_source_removes_file_and_extracted_facts(tmp_path):
     source_path.parent.mkdir()
     source_path.write_text("source body", encoding="utf-8")
     sid = store.add_source("sources/a.txt", kind="text")
+    artifact_path = tmp_path / "artifacts" / "sources" / str(sid) / "extracted.txt"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("artifact body", encoding="utf-8")
+    store.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path=f"artifacts/sources/{sid}/extracted.txt",
+    )
     source_fact = store.add_fact("A", "is_a", "B", status="candidate", source_id=sid)
     unrelated_fact = c.fact_id
 
@@ -216,6 +224,7 @@ def test_delete_source_removes_file_and_extracted_facts(tmp_path):
     assert r.status_code == 303
     assert r.headers["location"] == "/sources"
     assert not source_path.exists()
+    assert not artifact_path.exists()
     assert store.sources() == []
     assert store.get_fact(source_fact) is None
     assert store.get_fact_terms(source_fact) is None
@@ -249,15 +258,25 @@ def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
         follow_redirects=False,
     )
     assert r.status_code == 303
-    # the binary was converted to a text file and registered as a conversion
-    assert (tmp_path / "sources" / "report.txt").read_text().strip() == "converted text"
+    # the original file is preserved and converted text is tracked as an artifact.
+    assert (tmp_path / "sources" / "report.docx").is_file()
+    artifact_files = list((tmp_path / "artifacts" / "sources" / "1").glob("*.txt"))
+    assert len(artifact_files) == 1
+    assert artifact_files[0].read_text().strip() == "converted text"
     kinds = {s["kind"] for s in c.app.state.store.sources_with_counts()}
-    assert "conversion" in kinds
+    assert "binary" in kinds
+    sources_body = c.get("/sources").text
+    assert "sources/report.docx" in sources_body
+    assert "artifacts/sources/1/" in sources_body
 
     def extracted():
-        assert "is_a" in c.get("/review").text
+        assert any(row["subject"] == "X" for row in c.app.state.store.review_queue())
 
     _wait_for(extracted)
+    fact = [row for row in c.app.state.store.review_queue() if row["subject"] == "X"][0]
+    provenance = c.get(f"/facts/{fact['id']}/provenance").text
+    assert "sources/report.docx" in provenance
+    assert "artifacts/sources/1/" in provenance
 
 
 def test_upload_surfaces_llm_error(tmp_path, monkeypatch, fake_client):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import sys
 from pathlib import Path
 
@@ -21,6 +22,21 @@ _DEMO_FACTS = [
     ("Demo Project", "has_participant", "Example Org", "confirmed", 0.92, "sources/example-grant.txt", ""),
     ("wirelog", "is_a", "deterministic logic engine", "candidate", 0.90, "sources/example-notes.txt", ""),
 ]
+
+
+@dataclass(frozen=True)
+class _SourceInput:
+    source_path: str
+    text: str
+    source_id: int | None = None
+    artifact_id: int | None = None
+
+
+@dataclass(frozen=True)
+class _SyncSummary:
+    per_source: list[tuple[str, int]]
+    total: int
+    run_id: int
 
 
 def _store(cfg: Config) -> Store:
@@ -81,26 +97,45 @@ def _rel_to_root(root: Path, p: Path) -> str:
         return str(p)
 
 
-def _resolve_sources(cfg: Config, path: str | None) -> list[tuple[str, str]]:
-    """Resolve a file path (or all sources under `<root>/sources/`) to (citation, text)."""
+def _resolve_sources(cfg: Config, store: Store, path: str | None) -> list[_SourceInput]:
+    """Resolve a file path or registered text artifacts to extraction inputs."""
     if path:
         f = Path(path)
         if not f.is_file():
             raise FileNotFoundError(f"no such file: {path}")
-        files = [f]
-    else:
-        sources_dir = cfg.root / "sources"
-        files = sorted(sources_dir.glob("*.txt")) + sorted(sources_dir.glob("*.md"))
-    return [(_rel_to_root(cfg.root, f), f.read_text(encoding="utf-8")) for f in files]
+        return [_SourceInput(_rel_to_root(cfg.root, f), f.read_text(encoding="utf-8"))]
+
+    inputs = [
+        _SourceInput(
+            source_path=row["source_path"],
+            text=(cfg.root / row["artifact_path"]).read_text(encoding="utf-8"),
+            source_id=int(row["source_id"]),
+            artifact_id=int(row["artifact_id"]),
+        )
+        for row in store.source_text_inputs()
+    ]
+    if inputs:
+        return inputs
+
+    sources_dir = cfg.root / "sources"
+    files = sorted(sources_dir.glob("*.txt")) + sorted(sources_dir.glob("*.md"))
+    return [
+        _SourceInput(_rel_to_root(cfg.root, f), f.read_text(encoding="utf-8"))
+        for f in files
+    ]
 
 
 def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
-    from verinote.pipeline import sync_sources
+    from verinote.pipeline import (
+        create_chunked_extraction_job,
+        process_extraction_job,
+        sync_sources,
+    )
 
     store = _store(cfg)
     try:
-        sources = _resolve_sources(cfg, args.path)
+        sources = _resolve_sources(cfg, store, args.path)
     except (FileNotFoundError, OSError) as e:
         print(f"error: {e}", file=sys.stderr)
         store.close()
@@ -111,7 +146,28 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     try:
         client = get_client(cfg)
-        result = sync_sources(store, client, sources, provider=cfg.provider, model=cfg.model)
+        registered = [source for source in sources if source.source_id is not None]
+        if registered:
+            per_source = []
+            total = 0
+            run_id = 0
+            for source in registered:
+                job_id = create_chunked_extraction_job(
+                    store,
+                    source_id=source.source_id,
+                    artifact_id=source.artifact_id,
+                    source_text=source.text,
+                    provider=cfg.provider,
+                    model=cfg.model,
+                )
+                outcome = process_extraction_job(store, client, job_id=job_id)
+                per_source.append((source.source_path, outcome.candidates))
+                total += outcome.candidates
+                run_id = job_id
+            result = _SyncSummary(per_source=per_source, total=total, run_id=run_id)
+        else:
+            pairs = [(source.source_path, source.text) for source in sources]
+            result = sync_sources(store, client, pairs, provider=cfg.provider, model=cfg.model)
     except LLMError as e:
         print(f"extraction failed: {e}", file=sys.stderr)
         store.close()

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -68,6 +68,7 @@ def create_chunked_extraction_job(
     store: Store,
     *,
     source_id: int,
+    artifact_id: int | None = None,
     source_text: str,
     provider: str | None,
     model: str | None,
@@ -76,6 +77,7 @@ def create_chunked_extraction_job(
     chunks = chunk_text(source_text)
     job_id = store.create_extraction_job(
         source_id=source_id,
+        artifact_id=artifact_id,
         provider=provider,
         model=model,
         total_chunks=len(chunks),

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Source ingestion: register text sources, convert binaries (docx/pdf) to text.
+"""Source ingestion: register original sources and extraction text artifacts.
 
-Extraction reads text, but real sources are often docx/pdf. This turns a file
-into a text source under the KB so the extractor — and the coverage view — can
-use it. Text files are stored as-is (`kind='text'`); a binary is run through a
-per-extension converter and stored as a `.txt` alongside, with the registered
-source marked `kind='conversion'`.
+Extraction reads text, but facts cite original files. Text uploads are stored
+under `sources/` and reused as their own extraction artifact. Binary uploads are
+stored under `sources/` with their original filename, converted through a
+per-extension converter, and the converted text is stored separately under
+`artifacts/sources/<source_id>/`.
 
 The converter table is open: `register_converter('.ext', fn)` adds a format.
 The built-in docx/pdf converters import their (optional) library lazily and
@@ -15,6 +15,7 @@ raise a helpful `IngestError` when it is missing — install with
 
 from __future__ import annotations
 
+import hashlib
 from io import BytesIO
 from pathlib import Path
 from typing import Callable
@@ -72,7 +73,7 @@ register_converter(".pdf", _convert_pdf)
 
 
 def ingest_bytes(raw: bytes, filename: str) -> tuple[str, str]:
-    """Resolve raw upload bytes to ``(text, kind)``; kind is ``text``/``conversion``.
+    """Resolve raw upload bytes to ``(text, kind)``; kind is ``text``/``binary``.
 
     Raises `IngestError` for unsupported suffixes or conversion failures.
     """
@@ -83,20 +84,44 @@ def ingest_bytes(raw: bytes, filename: str) -> tuple[str, str]:
         except UnicodeDecodeError as e:
             raise IngestError("file is not valid UTF-8 text") from e
     if suffix in _CONVERTERS:
-        return _CONVERTERS[suffix](raw), "conversion"
+        return _CONVERTERS[suffix](raw), "binary"
     raise IngestError(f"unsupported source type: {suffix or filename!r}")
 
 
-def store_source(store: Store, root: Path, filename: str, text: str, kind: str) -> str:
-    """Write `text` under `<root>/sources/` and register it. Returns the citation."""
+def store_source(
+    store: Store, root: Path, filename: str, raw: bytes, text: str, kind: str
+) -> dict:
+    """Persist an original source and its extraction text artifact."""
     sources_dir = root / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
     name = Path(filename).name
-    out_name = name if kind == "text" else f"{Path(name).stem}.txt"
-    (sources_dir / out_name).write_text(text, encoding="utf-8")
-    citation = f"sources/{out_name}"
-    store.add_source(citation, kind=kind)
-    return citation
+    source_path = sources_dir / name
+    source_path.write_bytes(raw)
+    citation = f"sources/{name}"
+    source_id = store.add_source(citation, kind=kind)
+
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    artifact_dir = root / "artifacts" / "sources" / str(source_id)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / f"{digest}.txt"
+    if not artifact_path.exists():
+        artifact_path.write_text(text, encoding="utf-8")
+    artifact_relpath = f"artifacts/sources/{source_id}/{digest}.txt"
+
+    artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path=artifact_relpath,
+        checksum=digest,
+    )
+    return {
+        "citation": citation,
+        "text": text,
+        "kind": kind,
+        "source_id": source_id,
+        "artifact_id": artifact_id,
+        "artifact_path": artifact_relpath,
+    }
 
 
 def ingest_file(store: Store, src: Path, *, root: Path) -> dict:
@@ -104,6 +129,6 @@ def ingest_file(store: Store, src: Path, *, root: Path) -> dict:
     src = Path(src)
     if not src.is_file():
         raise IngestError(f"no such file: {src}")
-    text, kind = ingest_bytes(src.read_bytes(), src.name)
-    citation = store_source(store, root, src.name, text, kind)
-    return {"citation": citation, "text": text, "kind": kind}
+    raw = src.read_bytes()
+    text, kind = ingest_bytes(raw, src.name)
+    return store_source(store, root, src.name, raw, text, kind)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -80,7 +80,7 @@ class Store:
 
     # --- sources ---------------------------------------------------------
     def add_source(self, path: str, kind: str = "text") -> int:
-        # kind is set at first registration (e.g. ingest marks 'conversion') and
+        # kind is set at first registration (e.g. upload marks 'binary') and
         # preserved on re-registration — the no-op SET keeps the existing kind
         # while still letting RETURNING hand back the id on conflict, so a later
         # extraction pass over the same path doesn't downgrade it to 'text'.
@@ -109,9 +109,40 @@ class Store:
         """Sources plus how many facts cite each — for the Sources listing."""
         return list(
             self._conn.execute(
-                "SELECT s.id, s.path, s.kind, s.added_at, COUNT(f.id) AS fact_count "
-                "FROM sources s LEFT JOIN facts f ON f.source_id = s.id "
+                "SELECT s.id, s.path, s.kind, s.added_at, "
+                "GROUP_CONCAT(a.path, '\n') AS artifact_paths, "
+                "COUNT(DISTINCT f.id) AS fact_count "
+                "FROM sources s "
+                "LEFT JOIN source_artifacts a ON a.source_id = s.id "
+                "LEFT JOIN facts f ON f.source_id = s.id "
                 "GROUP BY s.id ORDER BY s.path"
+            )
+        )
+
+    def add_source_artifact(
+        self,
+        *,
+        source_id: int,
+        kind: str,
+        path: str,
+        content_type: str = "text/plain",
+    ) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO source_artifacts(source_id, kind, path, content_type) "
+                "VALUES(?,?,?,?) "
+                "ON CONFLICT(source_id, kind) DO UPDATE SET "
+                "path=excluded.path, content_type=excluded.content_type "
+                "RETURNING id",
+                (source_id, kind, path, content_type),
+            )
+            return int(cur.fetchone()[0])
+
+    def source_artifacts(self, source_id: int) -> list[sqlite3.Row]:
+        return list(
+            self._conn.execute(
+                "SELECT * FROM source_artifacts WHERE source_id = ? ORDER BY id",
+                (source_id,),
             )
         )
 
@@ -132,8 +163,9 @@ class Store:
         """Latest extraction jobs, newest first, for the Sources listing."""
         return list(
             self._conn.execute(
-                "SELECT j.*, s.path AS source_path "
+                "SELECT j.*, s.path AS source_path, a.path AS artifact_path "
                 "FROM extraction_jobs j JOIN sources s ON s.id = j.source_id "
+                "LEFT JOIN source_artifacts a ON a.id = j.artifact_id "
                 "ORDER BY j.id DESC"
             )
         )
@@ -179,6 +211,7 @@ class Store:
         self,
         *,
         source_id: int,
+        artifact_id: int | None = None,
         provider: str | None,
         model: str | None,
         total_chunks: int,
@@ -187,9 +220,9 @@ class Store:
         with self._lock:
             cur = self._conn.execute(
                 "INSERT INTO extraction_jobs("
-                "source_id, provider, model, total_chunks, message"
-                ") VALUES(?,?,?,?,?) RETURNING id",
-                (source_id, provider, model, total_chunks, message),
+                "source_id, artifact_id, provider, model, total_chunks, message"
+                ") VALUES(?,?,?,?,?,?) RETURNING id",
+                (source_id, artifact_id, provider, model, total_chunks, message),
             )
             return int(cur.fetchone()[0])
 
@@ -622,6 +655,28 @@ class Store:
             pass
 
     def _ensure_schema_migrations(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS source_artifacts (
+                id           INTEGER PRIMARY KEY,
+                source_id    INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+                kind         TEXT NOT NULL CHECK (kind IN ('original_text','extracted_text')),
+                path         TEXT NOT NULL UNIQUE,
+                content_type TEXT NOT NULL DEFAULT 'text/plain',
+                created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(source_id, kind)
+            );
+            """
+        )
+        job_columns = {
+            row["name"]
+            for row in self._conn.execute("PRAGMA table_info(extraction_jobs)")
+        }
+        if "artifact_id" not in job_columns:
+            self._conn.execute(
+                "ALTER TABLE extraction_jobs ADD COLUMN artifact_id INTEGER "
+                "REFERENCES source_artifacts(id) ON DELETE SET NULL"
+            )
         fact_columns = {
             row["name"] for row in self._conn.execute("PRAGMA table_info(facts)")
         }

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -126,23 +126,62 @@ class Store:
         kind: str,
         path: str,
         content_type: str = "text/plain",
+        checksum: str = "",
     ) -> int:
         with self._lock:
-            cur = self._conn.execute(
-                "INSERT INTO source_artifacts(source_id, kind, path, content_type) "
-                "VALUES(?,?,?,?) "
-                "ON CONFLICT(source_id, kind) DO UPDATE SET "
-                "path=excluded.path, content_type=excluded.content_type "
-                "RETURNING id",
-                (source_id, kind, path, content_type),
+            self._conn.execute(
+                "INSERT INTO source_artifacts("
+                "source_id, kind, path, content_type, checksum"
+                ") VALUES(?,?,?,?,?) "
+                "ON CONFLICT(source_id, kind, checksum) DO NOTHING",
+                (source_id, kind, path, content_type, checksum),
             )
-            return int(cur.fetchone()[0])
+            row = self._conn.execute(
+                "SELECT id FROM source_artifacts "
+                "WHERE source_id = ? AND kind = ? AND checksum = ?",
+                (source_id, kind, checksum),
+            ).fetchone()
+            if row is None:
+                raise sqlite3.IntegrityError("source artifact insert failed")
+            return int(row["id"])
+
+    def get_source_artifact(self, artifact_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM source_artifacts WHERE id = ?", (artifact_id,)
+        ).fetchone()
+
+    def get_extraction_job_detail(self, job_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT j.*, s.path AS source_path, a.path AS artifact_path "
+            "FROM extraction_jobs j "
+            "JOIN sources s ON s.id = j.source_id "
+            "LEFT JOIN source_artifacts a ON a.id = j.artifact_id "
+            "WHERE j.id = ?",
+            (job_id,),
+        ).fetchone()
 
     def source_artifacts(self, source_id: int) -> list[sqlite3.Row]:
         return list(
             self._conn.execute(
                 "SELECT * FROM source_artifacts WHERE source_id = ? ORDER BY id",
                 (source_id,),
+            )
+        )
+
+    def source_text_inputs(self) -> list[sqlite3.Row]:
+        """Original source path plus the text artifact path to feed extraction."""
+        return list(
+            self._conn.execute(
+                "SELECT s.id AS source_id, s.path AS source_path, "
+                "a.id AS artifact_id, a.path AS artifact_path "
+                "FROM sources s JOIN source_artifacts a ON a.source_id = s.id "
+                "WHERE a.kind IN ('original_text','extracted_text') "
+                "AND a.id = ("
+                "  SELECT MAX(a2.id) FROM source_artifacts a2 "
+                "  WHERE a2.source_id = s.id "
+                "  AND a2.kind IN ('original_text','extracted_text')"
+                ") "
+                "ORDER BY s.path, a.id"
             )
         )
 
@@ -218,6 +257,12 @@ class Store:
         message: str = "",
     ) -> int:
         with self._lock:
+            if artifact_id is not None:
+                artifact = self.get_source_artifact(artifact_id)
+                if artifact is None or int(artifact["source_id"]) != source_id:
+                    raise sqlite3.IntegrityError(
+                        "extraction job artifact must belong to the source"
+                    )
             cur = self._conn.execute(
                 "INSERT INTO extraction_jobs("
                 "source_id, artifact_id, provider, model, total_chunks, message"
@@ -663,11 +708,20 @@ class Store:
                 kind         TEXT NOT NULL CHECK (kind IN ('original_text','extracted_text')),
                 path         TEXT NOT NULL UNIQUE,
                 content_type TEXT NOT NULL DEFAULT 'text/plain',
+                checksum     TEXT NOT NULL DEFAULT '',
                 created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-                UNIQUE(source_id, kind)
+                UNIQUE(source_id, kind, checksum)
             );
             """
         )
+        artifact_columns = {
+            row["name"]
+            for row in self._conn.execute("PRAGMA table_info(source_artifacts)")
+        }
+        if "checksum" not in artifact_columns:
+            self._conn.execute(
+                "ALTER TABLE source_artifacts ADD COLUMN checksum TEXT NOT NULL DEFAULT ''"
+            )
         job_columns = {
             row["name"]
             for row in self._conn.execute("PRAGMA table_info(extraction_jobs)")

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -7,12 +7,25 @@
 PRAGMA journal_mode = WAL;        -- concurrent readers + a single writer
 PRAGMA foreign_keys = ON;
 
--- A source document the facts are extracted from and cited against.
+-- A source document the facts are cited against. For binary uploads this is the
+-- original file, not the converted text used for extraction.
 CREATE TABLE IF NOT EXISTS sources (
     id         INTEGER PRIMARY KEY,
     path       TEXT NOT NULL UNIQUE,      -- relative path under the KB root
-    kind       TEXT NOT NULL DEFAULT 'text',  -- text | conversion | binary
+    kind       TEXT NOT NULL DEFAULT 'text',  -- text | binary
     added_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Text artifacts used by extraction. Text sources point at their original file;
+-- binary sources point at a derived UTF-8 text artifact.
+CREATE TABLE IF NOT EXISTS source_artifacts (
+    id           INTEGER PRIMARY KEY,
+    source_id    INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    kind         TEXT NOT NULL CHECK (kind IN ('original_text','extracted_text')),
+    path         TEXT NOT NULL UNIQUE,
+    content_type TEXT NOT NULL DEFAULT 'text/plain',
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(source_id, kind)
 );
 
 -- One extraction run (an LLM pass over sources). Facts cite the run that
@@ -30,6 +43,7 @@ CREATE TABLE IF NOT EXISTS runs (
 CREATE TABLE IF NOT EXISTS extraction_jobs (
     id               INTEGER PRIMARY KEY,
     source_id        INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    artifact_id      INTEGER REFERENCES source_artifacts(id) ON DELETE SET NULL,
     status           TEXT NOT NULL DEFAULT 'pending'
                        CHECK (status IN ('pending','running','done','failed','canceled')),
     provider         TEXT,

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -24,8 +24,9 @@ CREATE TABLE IF NOT EXISTS source_artifacts (
     kind         TEXT NOT NULL CHECK (kind IN ('original_text','extracted_text')),
     path         TEXT NOT NULL UNIQUE,
     content_type TEXT NOT NULL DEFAULT 'text/plain',
+    checksum     TEXT NOT NULL DEFAULT '',
     created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(source_id, kind)
+    UNIQUE(source_id, kind, checksum)
 );
 
 -- One extraction run (an LLM pass over sources). Facts cite the run that

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -223,14 +223,24 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             daemon=True,
         ).start()
 
-    def _delete_source_file(source_path: str, root: Path) -> None:
+    def _source_file_path(source_path: str, root: Path) -> Path:
         path = (root / source_path).resolve()
         try:
             path.relative_to(root.resolve())
         except ValueError as e:
             raise OSError(f"refusing to delete source outside KB root: {source_path}") from e
+        return path
+
+    def _delete_source_file(source_path: str, root: Path) -> None:
+        path = _source_file_path(source_path, root)
         if path.is_file():
             path.unlink()
+
+    def _delete_source_files(paths: set[str], root: Path) -> None:
+        for path in paths:
+            _source_file_path(path, root)
+        for path in sorted(paths):
+            _delete_source_file(path, root)
 
     def _resume_source_extraction_jobs() -> None:
         if app.state.store is None or app.state.cfg is None:
@@ -266,17 +276,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         except IngestError as e:
             return _sources(request, error=str(e), status_code=400)
 
-        citation = store_source(store, cfg.root, filename, text, kind)
-        source = store.get_source_by_path(citation)
+        result = store_source(store, cfg.root, filename, raw, text, kind)
+        source = store.get_source_by_path(result["citation"])
         if source is None:
             return _sources(
                 request,
-                error=f"source registration failed: {citation}",
+                error=f"source registration failed: {result['citation']}",
                 status_code=500,
             )
         job_id = create_chunked_extraction_job(
             store,
             source_id=int(source["id"]),
+            artifact_id=int(result["artifact_id"]),
             source_text=text,
             provider=cfg.provider,
             model=cfg.model,
@@ -296,10 +307,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def delete_source(request: Request, source_id: int):
         store = _active_store()
         cfg = _active_cfg()
+        source = store.get_source(source_id)
+        paths = {source["path"]} if source is not None else set()
+        paths.update(row["path"] for row in store.source_artifacts(source_id))
+        try:
+            for path in paths:
+                _source_file_path(path, cfg.root)
+        except OSError as e:
+            return _sources(request, error=f"source removal failed: {e}", status_code=500)
         source = store.delete_source(source_id)
         if source is not None:
             try:
-                _delete_source_file(source["path"], cfg.root)
+                _delete_source_files(paths, cfg.root)
             except OSError as e:
                 return _sources(
                     request,
@@ -377,10 +396,20 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         store = _active_store()
         fact = store.get_fact(fact_id)
         run = store.get_run(fact["run_id"]) if fact and fact["run_id"] else None
+        job = (
+            store.get_extraction_job_detail(fact["job_id"])
+            if fact and fact["job_id"]
+            else None
+        )
         return templates.TemplateResponse(
             request,
             "provenance.html",
-            {"f": _fact_view(fact), "run": run, "log": store.fact_log(fact_id) if fact else []},
+            {
+                "f": _fact_view(fact),
+                "run": run,
+                "job": job,
+                "log": store.fact_log(fact_id) if fact else [],
+            },
         )
 
     def _questions(request: Request, *, error: str | None = None, status_code: int = 200):

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -22,6 +22,11 @@
         {% if run["summary"] %}<span class="muted">({{ run["summary"] }})</span>{% endif %}
       {% else %}— (seeded or hand-entered){% endif %}
     </td></tr>
+    <tr><td>extraction</td><td>
+      {% if job %}
+        job #{{ job["id"] }} · artifact <code>{{ job["artifact_path"] or "—" }}</code>
+      {% else %}—{% endif %}
+    </td></tr>
     <tr><td>created</td><td class="src">{{ f["created_at"] }}</td></tr>
     <tr><td>updated</td><td class="src">{{ f["updated_at"] }}</td></tr>
   </tbody>

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -2,8 +2,7 @@
 {% block title %}Sources — verinote{% endblock %}
 {% block content %}
 <h1>Sources</h1>
-<p class="muted">Files facts are extracted from and cited against. Text is stored
-  as-is; binaries ({{ suffixes }}) are converted to text on upload.</p>
+<p class="muted">Facts cite original files. Text artifacts used for extraction are tracked separately.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 
@@ -36,13 +35,22 @@
 {% if sources %}
 <table class="sources">
   <thead>
-    <tr><th>Path</th><th>Kind</th><th>Facts</th><th>Added</th><th>Actions</th></tr>
+    <tr><th>Source</th><th>Kind</th><th>Artifact</th><th>Facts</th><th>Added</th><th>Actions</th></tr>
   </thead>
   <tbody>
     {% for s in sources %}
     <tr>
       <td><code>{{ s["path"] }}</code></td>
       <td><span class="badge">{{ s["kind"] }}</span></td>
+      <td class="src">
+        {% if s["artifact_paths"] %}
+          {% for path in s["artifact_paths"].split("\n") %}
+            <code>{{ path }}</code>{% if not loop.last %}<br>{% endif %}
+          {% endfor %}
+        {% else %}
+          —
+        {% endif %}
+      </td>
       <td class="conf">{{ s["fact_count"] }}</td>
       <td class="src">{{ s["added_at"] }}</td>
       <td class="actions">


### PR DESCRIPTION
## Summary
- model sources as original files and move extraction text into source_artifacts
- preserve uploaded binary filenames under sources/ while storing converted text as checksum-addressed immutable artifacts
- link extraction jobs to artifact_id and reject cross-source artifact/job mismatches
- update upload, delete, provenance, sources UI, and CLI sync to use source artifacts

## Why
Binary conversions were previously stored as stem-based `.txt` files under sources/. Files such as `report.pdf` and `report.pptx` could collapse into the same `sources/report.txt`, losing original identity and corrupting provenance.

## Validation
- `.venv/bin/python -m pytest -q` -> 381 passed, 7 skipped

## Notes
- `.omc/` remains untracked locally and is not included.
