### PR TITLE
[codex] Add source reanalysis

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -16,6 +16,14 @@ def test_extraction_prompt_extracts_verbatim_source_text():
     assert "paraphrase" in EXTRACTION_SYSTEM
 
 
+def test_extraction_prompt_biases_toward_explicit_fact_recall():
+    assert "Extract all explicit factual triples" in EXTRACTION_SYSTEM
+    assert "not only the most important ones" in EXTRACTION_SYSTEM
+    assert "many small source-backed triples" in EXTRACTION_SYSTEM
+    assert "For each sentence, table row, or bullet" in EXTRACTION_SYSTEM
+    assert "Do not omit explicit facts" in EXTRACTION_SYSTEM
+
+
 def test_parse_facts_accepts_legacy_string_slots():
     facts = parse_facts(
         {

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -59,4 +59,7 @@ def test_ollama_extract_uses_configured_timeout(tmp_path, monkeypatch):
     facts = OllamaAdapter(_cfg(tmp_path, timeout=900.0)).extract_facts(source_text="Ada")
 
     assert calls[0].timeout == 900.0
+    payload = json.loads(calls[0].req.data.decode("utf-8"))
+    assert payload["think"] is False
+    assert payload["options"] == {"temperature": 0}
     assert facts[0].subject == "Ada"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -81,7 +81,11 @@ def test_delete_source_removes_source_facts_and_terms(tmp_path):
     source_fact = s.add_fact("A", "r", "B", status="candidate", source_id=sid)
     unrelated_fact = s.add_fact("C", "r", "D", status="candidate")
     job_id = s.create_extraction_job(
-        source_id=sid, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
+        source_id=sid,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="m",
+        total_chunks=1,
     )
     s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["body"])
 
@@ -101,6 +105,31 @@ def test_delete_source_removes_source_facts_and_terms(tmp_path):
 def test_delete_missing_source_returns_none(tmp_path):
     s = _store(tmp_path)
     assert s.delete_source(999) is None
+
+
+def test_clear_source_analysis_keeps_source_and_artifacts(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a.txt"
+    )
+    source_fact = s.add_fact("A", "r", "B", status="candidate", source_id=sid)
+    unrelated_fact = s.add_fact("C", "r", "D", status="candidate")
+    job_id = s.create_extraction_job(
+        source_id=sid, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
+    )
+    s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["body"])
+
+    removed = s.clear_source_analysis(sid)
+
+    assert removed == 1
+    assert s.get_source(sid)["path"] == "sources/a.txt"
+    assert [a["id"] for a in s.source_artifacts(sid)] == [artifact_id]
+    assert [f["id"] for f in s.facts()] == [unrelated_fact]
+    assert s.get_fact_terms(source_fact) is None
+    assert s.get_fact_terms(unrelated_fact) is not None
+    assert s.get_extraction_job(job_id) is None
+    assert s.source_chunks(job_id) == []
 
 
 def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -232,6 +232,62 @@ def test_delete_source_removes_file_and_extracted_facts(tmp_path):
     assert store.source_extraction_jobs() == []
 
 
+def test_reanalyze_source_reuses_artifact_and_replaces_extracted_facts(
+    tmp_path, monkeypatch, fake_client
+):
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("New", "is_a", "Fact", 0.9)]),
+    )
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/a.txt", kind="text")
+    artifact_path = tmp_path / "sources" / "a.txt"
+    artifact_path.parent.mkdir()
+    artifact_path.write_text("source body", encoding="utf-8")
+    artifact_id = store.add_source_artifact(
+        source_id=sid,
+        kind="original_text",
+        path="sources/a.txt",
+    )
+    store.add_fact("Old", "is_a", "Fact", status="candidate", source_id=sid)
+    old_job = store.create_extraction_job(
+        source_id=sid,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="old",
+        total_chunks=1,
+    )
+    old_chunk = store.add_source_chunks(
+        job_id=old_job, source_id=sid, chunks=["old body"]
+    )[0]
+    store.mark_extraction_job_running(old_job)
+    store.mark_chunk_running(old_chunk)
+    store.mark_chunk_done(old_chunk, candidates=1)
+
+    body = c.get("/sources").text
+    assert "Re-analyze" in body
+
+    r = c.post(f"/sources/{sid}/reanalyze", follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/sources"
+
+    def reanalyzed():
+        assert any(row["subject"] == "New" for row in store.review_queue())
+        assert "Analysis complete: 1/1 chunk(s)" in c.get("/sources").text
+
+    _wait_for(reanalyzed)
+    assert not any(row["subject"] == "Old" for row in store.review_queue())
+    assert len(store.source_extraction_jobs()) == 1
+    assert store.get_source(sid)["path"] == "sources/a.txt"
+    assert artifact_path.read_text(encoding="utf-8") == "source body"
+    fact = [row for row in store.review_queue() if row["subject"] == "New"][0]
+    assert fact["source_id"] == sid
+    assert store.get_extraction_job_detail(fact["job_id"])["artifact_id"] == artifact_id
+
+
 def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
     import io
 
@@ -906,7 +962,10 @@ def test_settings_enables_connection_test_for_ollama(tmp_path):
     assert 'aria-disabled="true"' not in r.text
 
 
-def test_settings_switches_active_kb_root(tmp_path):
+def test_settings_switches_active_kb_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
     c = _client(tmp_path)
     other = tmp_path / "other-kb"
 

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -30,13 +30,16 @@ class OllamaAdapter:
         self.base_url = (cfg.base_url or "http://localhost:11434").rstrip("/")
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        system = EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else "")
         payload = {
             "model": self.cfg.model,
             "stream": False,
+            "think": False,
             # Ollama accepts a JSON schema in `format` to constrain output.
             "format": FACT_ARRAY_SCHEMA,
+            "options": {"temperature": 0},
             "messages": [
-                {"role": "system", "content": EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else "")},
+                {"role": "system", "content": system},
                 {"role": "user", "content": source_text},
             ],
         }
@@ -56,12 +59,15 @@ class OllamaAdapter:
         return parse_facts(body.get("message", {}).get("content", ""))
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        system = query_system(qid) + ("\n" + schema_hint if schema_hint else "")
         payload = {
             "model": self.cfg.model,
             "stream": False,
+            "think": False,
             "format": QUERY_SCHEMA,
+            "options": {"temperature": 0},
             "messages": [
-                {"role": "system", "content": query_system(qid) + ("\n" + schema_hint if schema_hint else "")},
+                {"role": "system", "content": system},
                 {"role": "user", "content": question},
             ],
         }

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -49,9 +49,14 @@ FACT_ARRAY_SCHEMA: dict[str, Any] = {
 
 EXTRACTION_SYSTEM = (
     "You extract source-backed factual triples from a document. Return ONLY facts "
-    "stated or directly entailed by the text. Each fact is a (subject, relation, "
-    "object) triple with a confidence in [0,1]. The subject, relation, and object "
-    "must each be an object {\"kind\":\"string|term\", \"value\":\"...\"}. Use "
+    "explicitly stated by the text. Extract all explicit factual triples, not only "
+    "the most important ones. Prefer many small source-backed triples over one broad "
+    "summary triple. For each sentence, table row, or bullet, extract every distinct "
+    "subject-predicate-object fact that is explicitly stated. Do not omit explicit "
+    "facts merely because they seem repetitive or low importance. Each fact is a "
+    "(subject, relation, object) triple with a confidence in [0,1]. The subject, "
+    "relation, and object must each be an object "
+    "{\"kind\":\"string|term\", \"value\":\"...\"}. Use "
     "kind=\"term\" only for explicit, fully ground Datalog terms such as "
     "person(\"Ada\") or role(person(\"Ada\"), \"PI\"). Bare names, labels, Korean, "
     "Chinese, whitespace, or punctuation outside quoted string arguments are not "

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -168,6 +168,14 @@ class Store:
             )
         )
 
+    def latest_source_text_artifact(self, source_id: int) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM source_artifacts "
+            "WHERE source_id = ? AND kind IN ('original_text','extracted_text') "
+            "ORDER BY id DESC LIMIT 1",
+            (source_id,),
+        ).fetchone()
+
     def source_text_inputs(self) -> list[sqlite3.Row]:
         """Original source path plus the text artifact path to feed extraction."""
         return list(
@@ -239,6 +247,38 @@ class Store:
                 self._conn.execute("DELETE FROM sources WHERE id = ?", (source_id,))
                 self._conn.execute("COMMIT")
                 return source
+            except Exception:
+                self._rollback_quietly()
+                for fact_id in deleted_terms:
+                    self._restore_fact_terms_from_row_quietly(fact_id)
+                raise
+
+    def clear_source_analysis(self, source_id: int) -> int:
+        """Remove extracted facts and extraction jobs while keeping source files.
+
+        Returns the number of facts removed. DuckDB term rows are deleted in the
+        same logical operation so re-analysis starts from a clean source state.
+        """
+        with self._lock:
+            fact_ids = [
+                int(row["id"])
+                for row in self._conn.execute(
+                    "SELECT id FROM facts WHERE source_id = ? ORDER BY id",
+                    (source_id,),
+                )
+            ]
+            deleted_terms: list[int] = []
+            self._conn.execute("BEGIN")
+            try:
+                for fact_id in fact_ids:
+                    self.fact_terms.delete_fact_terms(fact_id)
+                    deleted_terms.append(fact_id)
+                self._conn.execute("DELETE FROM facts WHERE source_id = ?", (source_id,))
+                self._conn.execute(
+                    "DELETE FROM extraction_jobs WHERE source_id = ?", (source_id,)
+                )
+                self._conn.execute("COMMIT")
+                return len(fact_ids)
             except Exception:
                 self._rollback_quietly()
                 for fact_id in deleted_terms:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -303,6 +303,52 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             _start_source_extraction(job_id, _active_cfg())
         return RedirectResponse("/sources", status_code=303)
 
+    @app.post("/sources/{source_id}/reanalyze", response_class=HTMLResponse)
+    def reanalyze_source(request: Request, source_id: int):
+        store = _active_store()
+        cfg = _active_cfg()
+        source = store.get_source(source_id)
+        if source is None:
+            return _sources(request, error="source not found", status_code=404)
+        if any(
+            int(job["source_id"]) == source_id
+            and job["status"] in {"pending", "running"}
+            for job in store.source_extraction_jobs()
+        ):
+            return _sources(
+                request,
+                error=f"analysis already running for {source['path']}",
+                status_code=409,
+            )
+        artifact = store.latest_source_text_artifact(source_id)
+        if artifact is None:
+            return _sources(
+                request,
+                error=f"source has no extraction text artifact: {source['path']}",
+                status_code=400,
+            )
+        try:
+            artifact_path = _source_file_path(str(artifact["path"]), cfg.root)
+            source_text = artifact_path.read_text(encoding="utf-8")
+        except OSError as e:
+            return _sources(
+                request,
+                error=f"could not read source artifact: {e}",
+                status_code=500,
+            )
+
+        store.clear_source_analysis(source_id)
+        job_id = create_chunked_extraction_job(
+            store,
+            source_id=source_id,
+            artifact_id=int(artifact["id"]),
+            source_text=source_text,
+            provider=cfg.provider,
+            model=cfg.model,
+        )
+        _start_source_extraction(job_id, cfg)
+        return RedirectResponse("/sources", status_code=303)
+
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
     def delete_source(request: Request, source_id: int):
         store = _active_store()

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -54,6 +54,9 @@
       <td class="conf">{{ s["fact_count"] }}</td>
       <td class="src">{{ s["added_at"] }}</td>
       <td class="actions">
+        <form action="/sources/{{ s["id"] }}/reanalyze" method="post">
+          <button class="btn ghost" type="submit">Re-analyze</button>
+        </form>
         <form action="/sources/{{ s["id"] }}/delete" method="post">
           <button class="danger" type="submit">Delete</button>
         </form>


### PR DESCRIPTION
## Summary
- add a source-level Re-analyze action that reuses the latest extraction text artifact
- clear prior extracted facts/jobs for that source before creating a fresh extraction job
- tune extraction prompt and Ollama requests toward explicit fact recall and deterministic non-thinking output
- prevent tests from writing to the user's real app config

## Why
Completed source jobs did not re-run after prompt/model changes, so users had to delete and re-upload sources to test improved extraction. The new flow preserves original source files and artifacts while replacing the prior analysis results.

## Validation
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest tests/test_web.py tests/test_store.py tests/test_ollama_adapter.py tests/test_llm_schema.py -q`
- `.venv/bin/python -m compileall -q verinote`
