### PR TITLE
[codex] Make extraction chunking configurable

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,9 @@ def _clear_env(monkeypatch):
         "VERINOTE_BASE_URL",
         "VERINOTE_API_KEY",
         "VERINOTE_LLM_TIMEOUT",
+        "VERINOTE_EXTRACTION_CHUNK_CHARS",
+        "VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS",
+        "VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK",
         "VERINOTE_ROOT",
         "XDG_CONFIG_HOME",
     ):
@@ -54,12 +57,41 @@ def test_default_model_when_nothing_set(tmp_path, monkeypatch):
     cfg = Config.for_root(tmp_path)  # no settings file, no env
     assert (cfg.provider, cfg.model) == ("anthropic", "claude-opus-4-8")
     assert cfg.llm_timeout_seconds == 600.0
+    assert cfg.extraction_chunk_chars == 300
+    assert cfg.extraction_chunk_overlap_chars == 40
+    assert cfg.extraction_max_facts_per_chunk == 8
 
 
 def test_llm_timeout_env_override(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     monkeypatch.setenv("VERINOTE_LLM_TIMEOUT", "900")
     assert Config.for_root(tmp_path).llm_timeout_seconds == 900.0
+
+
+def test_extraction_settings_round_trip_and_env_override(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    save_settings(
+        tmp_path,
+        provider="ollama",
+        model="qwen3.5:9b",
+        extraction_chunk_chars=450,
+        extraction_chunk_overlap_chars=25,
+        extraction_max_facts_per_chunk=6,
+    )
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.extraction_chunk_chars == 450
+    assert cfg.extraction_chunk_overlap_chars == 25
+    assert cfg.extraction_max_facts_per_chunk == 6
+
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "200")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK", "3")
+    cfg = Config.for_root(tmp_path)
+    assert cfg.extraction_chunk_chars == 200
+    assert cfg.extraction_chunk_overlap_chars == 0
+    assert cfg.extraction_max_facts_per_chunk == 3
 
 
 def test_claude_cli_provider_is_available():

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -49,6 +49,39 @@ def test_parse_facts_accepts_legacy_string_slots():
     )
 
 
+def test_parse_facts_accepts_top_level_array_from_local_models():
+    facts = parse_facts(
+        [
+            {
+                "subject": "Ada",
+                "relation": "is_a",
+                "object": "mathematician",
+                "confidence": 0.9,
+                "note": "",
+            }
+        ]
+    )
+
+    assert facts[0].subject == "Ada"
+    assert facts[0].relation == "is_a"
+    assert facts[0].object == "mathematician"
+
+
+def test_parse_facts_uses_first_json_value_from_noisy_local_output():
+    facts = parse_facts(
+        '```json\n'
+        '[{"subject":"Ada","relation":"is_a","object":"mathematician",'
+        '"confidence":0.9,"note":""}]\n'
+        '```\n'
+        '[{"subject":"ignored","relation":"ignored","object":"ignored",'
+        '"confidence":0.1,"note":""}]'
+    )
+
+    assert [(fact.subject, fact.relation, fact.object) for fact in facts] == [
+        ("Ada", "is_a", "mathematician")
+    ]
+
+
 def test_parse_facts_accepts_explicit_term_slots():
     facts = parse_facts(
         {
@@ -143,3 +176,30 @@ def test_parse_facts_rejects_malformed_explicit_slots(slot):
                 ]
             }
         )
+
+
+def test_parse_facts_skips_malformed_items_when_valid_facts_remain():
+    facts = parse_facts(
+        {
+            "facts": [
+                {
+                    "subject": "Ada",
+                    "relation": "",
+                    "object": "mathematician",
+                    "confidence": 0.9,
+                    "note": "",
+                },
+                {
+                    "subject": "Ada",
+                    "relation": "is_a",
+                    "object": "mathematician",
+                    "confidence": 0.9,
+                    "note": "",
+                },
+            ]
+        }
+    )
+
+    assert [(fact.subject, fact.relation, fact.object) for fact in facts] == [
+        ("Ada", "is_a", "mathematician")
+    ]

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -19,6 +19,9 @@ def _cfg(tmp_path, *, timeout: float = 900.0) -> Config:
 
 
 class _Response:
+    def __init__(self, content=None):
+        self.content = content
+
     def __enter__(self):
         return self
 
@@ -26,22 +29,25 @@ class _Response:
         return None
 
     def read(self):
+        content = self.content
+        if content is None:
+            content = json.dumps(
+                {
+                    "facts": [
+                        {
+                            "subject": {"kind": "string", "value": "Ada"},
+                            "relation": {"kind": "string", "value": "is_a"},
+                            "object": {"kind": "string", "value": "person"},
+                            "confidence": 0.9,
+                            "note": "",
+                        }
+                    ]
+                }
+            )
         return json.dumps(
             {
                 "message": {
-                    "content": json.dumps(
-                        {
-                            "facts": [
-                                {
-                                    "subject": {"kind": "string", "value": "Ada"},
-                                    "relation": {"kind": "string", "value": "is_a"},
-                                    "object": {"kind": "string", "value": "person"},
-                                    "confidence": 0.9,
-                                    "note": "",
-                                }
-                            ]
-                        }
-                    )
+                    "content": content
                 }
             }
         ).encode("utf-8")
@@ -61,5 +67,30 @@ def test_ollama_extract_uses_configured_timeout(tmp_path, monkeypatch):
     assert calls[0].timeout == 900.0
     payload = json.loads(calls[0].req.data.decode("utf-8"))
     assert payload["think"] is False
-    assert payload["options"] == {"temperature": 0}
+    assert payload["options"] == {"temperature": 0, "num_predict": 1800}
+    assert payload["format"]["type"] == "array"
+    assert payload["format"]["items"]["properties"]["subject"] == {"type": "string"}
+    assert "document chunk" in payload["messages"][0]["content"]
+    assert "up to 8 facts" in payload["messages"][0]["content"]
     assert facts[0].subject == "Ada"
+
+
+def test_ollama_extract_ignores_malformed_only_fact_payload(tmp_path, monkeypatch):
+    def fake_urlopen(req, *, timeout):
+        return _Response(
+            json.dumps(
+                [
+                    {
+                        "subject": "Ada",
+                        "relation": "is_a",
+                        "object": None,
+                        "confidence": 0.9,
+                        "note": "",
+                    }
+                ]
+            )
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada") == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -891,6 +891,9 @@ def test_settings_page_renders(tmp_path):
     assert "Provider" in r.text and "Anthropic" in r.text
     assert "ClaudeCLI" in r.text
     assert str(tmp_path) in r.text
+    assert 'name="extraction_chunk_chars"' in r.text
+    assert 'name="extraction_chunk_overlap_chars"' in r.text
+    assert 'name="extraction_max_facts_per_chunk"' in r.text
 
 
 def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
@@ -899,12 +902,22 @@ def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
     c = _client(tmp_path)
     r = c.post(
         "/settings",
-        data={"provider": "ollama", "model": "llama3.1", "base_url": ""},
+        data={
+            "provider": "ollama",
+            "model": "llama3.1",
+            "base_url": "",
+            "extraction_chunk_chars": "500",
+            "extraction_chunk_overlap_chars": "20",
+            "extraction_max_facts_per_chunk": "5",
+        },
         follow_redirects=False,
     )
     assert r.status_code == 303
     # the next get_client would pick the ollama adapter — no code change
     assert c.app.state.cfg.provider == "ollama"
+    assert c.app.state.cfg.extraction_chunk_chars == 500
+    assert c.app.state.cfg.extraction_chunk_overlap_chars == 20
+    assert c.app.state.cfg.extraction_max_facts_per_chunk == 5
     assert (tmp_path / "config.json").is_file()
 
 

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -159,8 +159,15 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     source_text=source.text,
                     provider=cfg.provider,
                     model=cfg.model,
+                    chunk_chars=cfg.extraction_chunk_chars,
+                    chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
                 )
-                outcome = process_extraction_job(store, client, job_id=job_id)
+                outcome = process_extraction_job(
+                    store,
+                    client,
+                    job_id=job_id,
+                    schema_hint=cfg.extraction_schema_hint(),
+                )
                 per_source.append((source.source_path, outcome.candidates))
                 total += outcome.candidates
                 run_id = job_id

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -131,7 +131,14 @@ def read_settings(root: Path) -> dict:
 
 
 def save_settings(
-    root: Path, *, provider: str, model: str, base_url: str | None = None
+    root: Path,
+    *,
+    provider: str,
+    model: str,
+    base_url: str | None = None,
+    extraction_chunk_chars: int | None = None,
+    extraction_chunk_overlap_chars: int | None = None,
+    extraction_max_facts_per_chunk: int | None = None,
 ) -> None:
     """Persist non-secret settings to `<root>/config.json` (never the API key)."""
     root.mkdir(parents=True, exist_ok=True)
@@ -140,6 +147,12 @@ def save_settings(
         "model": model,
         "base_url": base_url or None,
     }
+    if extraction_chunk_chars is not None:
+        payload["extraction_chunk_chars"] = extraction_chunk_chars
+    if extraction_chunk_overlap_chars is not None:
+        payload["extraction_chunk_overlap_chars"] = extraction_chunk_overlap_chars
+    if extraction_max_facts_per_chunk is not None:
+        payload["extraction_max_facts_per_chunk"] = extraction_max_facts_per_chunk
     _settings_path(root).write_text(
         json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
@@ -165,6 +178,19 @@ def _llm_timeout_seconds() -> float:
     return value if value > 0 else 600.0
 
 
+def _pick_int(env: str, saved: object, default: int, *, minimum: int = 1) -> int:
+    raw = os.environ.get(env)
+    if raw is None:
+        raw = saved
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value >= minimum else default
+
+
 @dataclass(frozen=True)
 class Config:
     root: Path
@@ -174,6 +200,16 @@ class Config:
     api_key: str | None
     base_url: str | None
     llm_timeout_seconds: float = 600.0
+    extraction_chunk_chars: int = 300
+    extraction_chunk_overlap_chars: int = 40
+    extraction_max_facts_per_chunk: int = 8
+
+    def extraction_schema_hint(self) -> str:
+        return (
+            f"Extract at most {self.extraction_max_facts_per_chunk} facts from "
+            "this chunk. Prefer the most explicit source-backed facts when more "
+            "facts are available."
+        )
 
     @classmethod
     def for_root(cls, root: Path) -> "Config":
@@ -183,6 +219,22 @@ class Config:
         )
         model = _pick("VERINOTE_MODEL", saved.get("model"), _MODEL_DEFAULTS.get(provider, "")) or ""
         base_url = _pick("VERINOTE_BASE_URL", saved.get("base_url"), None)
+        chunk_chars = _pick_int(
+            "VERINOTE_EXTRACTION_CHUNK_CHARS",
+            saved.get("extraction_chunk_chars"),
+            300,
+        )
+        chunk_overlap = _pick_int(
+            "VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS",
+            saved.get("extraction_chunk_overlap_chars"),
+            40,
+            minimum=0,
+        )
+        max_facts = _pick_int(
+            "VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK",
+            saved.get("extraction_max_facts_per_chunk"),
+            8,
+        )
         return cls(
             root=root,
             db_path=root / "kb.sqlite",
@@ -191,6 +243,9 @@ class Config:
             api_key=os.environ.get("VERINOTE_API_KEY"),  # secrets only from env
             base_url=base_url,
             llm_timeout_seconds=_llm_timeout_seconds(),
+            extraction_chunk_chars=chunk_chars,
+            extraction_chunk_overlap_chars=chunk_overlap,
+            extraction_max_facts_per_chunk=max_facts,
         )
 
     @classmethod

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -13,12 +13,37 @@ import urllib.request
 from verinote.config import Config
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.llm.schema import (
-    EXTRACTION_SYSTEM,
-    FACT_ARRAY_SCHEMA,
     QUERY_SCHEMA,
     parse_facts,
     parse_query,
     query_system,
+)
+
+
+OLLAMA_FACT_ARRAY_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "required": ["subject", "relation", "object", "confidence", "note"],
+        "additionalProperties": False,
+        "properties": {
+            "subject": {"type": "string"},
+            "relation": {"type": "string"},
+            "object": {"type": "string"},
+            "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+            "note": {"type": "string"},
+        },
+    },
+}
+
+OLLAMA_EXTRACTION_SYSTEM = (
+    "Extract explicit source-backed factual triples from the document chunk. "
+    "Return a JSON array only. Each item must have string fields subject, "
+    "relation, object, note and numeric confidence. Extract many small facts "
+    "from each sentence, bullet, or table row, up to {max_facts} facts for this chunk. "
+    "Preserve the source language and wording; do not translate, romanize, "
+    "summarize, or invent facts. Skip facts that cannot be expressed with a "
+    "non-empty subject, relation, and object."
 )
 
 
@@ -30,14 +55,17 @@ class OllamaAdapter:
         self.base_url = (cfg.base_url or "http://localhost:11434").rstrip("/")
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
-        system = EXTRACTION_SYSTEM + ("\n" + schema_hint if schema_hint else "")
+        system = OLLAMA_EXTRACTION_SYSTEM.format(
+            max_facts=self.cfg.extraction_max_facts_per_chunk
+        )
+        system += "\n" + schema_hint if schema_hint else ""
         payload = {
             "model": self.cfg.model,
             "stream": False,
             "think": False,
-            # Ollama accepts a JSON schema in `format` to constrain output.
-            "format": FACT_ARRAY_SCHEMA,
-            "options": {"temperature": 0},
+            # Ollama local models are much more reliable with flat string slots.
+            "format": OLLAMA_FACT_ARRAY_SCHEMA,
+            "options": {"temperature": 0, "num_predict": 1800},
             "messages": [
                 {"role": "system", "content": system},
                 {"role": "user", "content": source_text},
@@ -56,7 +84,12 @@ class OllamaAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
             raise LLMError(f"ollama request failed: {exc}") from exc
 
-        return parse_facts(body.get("message", {}).get("content", ""))
+        try:
+            return parse_facts(body.get("message", {}).get("content", ""))
+        except LLMError as exc:
+            if "malformed fact object" in str(exc):
+                return []
+            raise
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
         system = query_system(qid) + ("\n" + schema_hint if schema_hint else "")
@@ -65,7 +98,7 @@ class OllamaAdapter:
             "stream": False,
             "think": False,
             "format": QUERY_SCHEMA,
-            "options": {"temperature": 0},
+            "options": {"temperature": 0, "num_predict": 512},
             "messages": [
                 {"role": "system", "content": system},
                 {"role": "user", "content": question},

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -109,15 +109,16 @@ def parse_query(raw: str | dict[str, Any]) -> str:
     return line
 
 
-def parse_facts(raw: str | dict[str, Any]) -> list[ExtractedFact]:
+def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
     """Parse provider output (a JSON string or already-decoded dict) into facts."""
     try:
-        data = json.loads(raw) if isinstance(raw, str) else raw
-        items = data["facts"]
+        data = _decode_first_json(raw) if isinstance(raw, str) else raw
+        items = data if isinstance(data, list) else data["facts"]
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         raise LLMError(f"extractor output did not match schema: {exc}") from exc
 
     facts: list[ExtractedFact] = []
+    errors = []
     for item in items:
         try:
             subject, subject_kind, subject_warning = _parse_fact_slot(item, "subject")
@@ -140,8 +141,25 @@ def parse_facts(raw: str | dict[str, Any]) -> list[ExtractedFact]:
                 )
             )
         except (KeyError, TypeError, ValueError, TermParseError) as exc:
-            raise LLMError(f"malformed fact object {item!r}: {exc}") from exc
+            errors.append(f"malformed fact object {item!r}: {exc}")
+            continue
+    if not facts and errors:
+        raise LLMError(errors[0])
     return facts
+
+
+def _decode_first_json(raw: str) -> Any:
+    text = raw.strip()
+    if not text:
+        raise json.JSONDecodeError("empty provider output", raw, 0)
+    decoder = json.JSONDecoder()
+    try:
+        return decoder.raw_decode(text)[0]
+    except json.JSONDecodeError:
+        starts = [idx for idx in (text.find("["), text.find("{")) if idx >= 0]
+        if not starts:
+            raise
+        return decoder.raw_decode(text[min(starts):])[0]
 
 
 def _parse_fact_slot(item: dict[str, Any], field: str) -> tuple[str, str, str]:

--- a/verinote/pipeline/chunk.py
+++ b/verinote/pipeline/chunk.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import re
 
 
-DEFAULT_CHUNK_CHARS = 6000
-DEFAULT_OVERLAP_CHARS = 500
+DEFAULT_CHUNK_CHARS = 300
+DEFAULT_OVERLAP_CHARS = 40
 
 
 def chunk_text(

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -72,9 +72,16 @@ def create_chunked_extraction_job(
     source_text: str,
     provider: str | None,
     model: str | None,
+    chunk_chars: int | None = None,
+    chunk_overlap_chars: int | None = None,
 ) -> int:
     """Create a durable extraction job and its source chunks."""
-    chunks = chunk_text(source_text)
+    kwargs = {}
+    if chunk_chars is not None:
+        kwargs["max_chars"] = chunk_chars
+    if chunk_overlap_chars is not None:
+        kwargs["overlap_chars"] = chunk_overlap_chars
+    chunks = chunk_text(source_text, **kwargs)
     job_id = store.create_extraction_job(
         source_id=source_id,
         artifact_id=artifact_id,

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -207,7 +207,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
                     client = get_client(cfg)
-                    process_extraction_job(worker_store, client, job_id=job_id)
+                    process_extraction_job(
+                        worker_store,
+                        client,
+                        job_id=job_id,
+                        schema_hint=cfg.extraction_schema_hint(),
+                    )
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
@@ -291,6 +296,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             source_text=text,
             provider=cfg.provider,
             model=cfg.model,
+            chunk_chars=cfg.extraction_chunk_chars,
+            chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
         )
         _start_source_extraction(job_id, app.state.cfg)
         return RedirectResponse("/sources", status_code=303)
@@ -345,6 +352,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             source_text=source_text,
             provider=cfg.provider,
             model=cfg.model,
+            chunk_chars=cfg.extraction_chunk_chars,
+            chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
         )
         _start_source_extraction(job_id, cfg)
         return RedirectResponse("/sources", status_code=303)
@@ -530,6 +539,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "provider_label": PROVIDER_LABELS.get(c.provider, c.provider),
                 "model": c.model,
                 "base_url": c.base_url or "",
+                "extraction_chunk_chars": c.extraction_chunk_chars,
+                "extraction_chunk_overlap_chars": c.extraction_chunk_overlap_chars,
+                "extraction_max_facts_per_chunk": c.extraction_max_facts_per_chunk,
                 "root": c.root,
                 "has_key": bool(c.api_key),  # never render the key itself
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
@@ -549,9 +561,20 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         provider: str = Form(...),
         model: str = Form(""),
         base_url: str = Form(""),
+        extraction_chunk_chars: int = Form(300),
+        extraction_chunk_overlap_chars: int = Form(40),
+        extraction_max_facts_per_chunk: int = Form(8),
     ):
         cfg = _active_cfg()
-        save_settings(cfg.root, provider=provider, model=model, base_url=base_url or None)
+        save_settings(
+            cfg.root,
+            provider=provider,
+            model=model,
+            base_url=base_url or None,
+            extraction_chunk_chars=extraction_chunk_chars,
+            extraction_chunk_overlap_chars=extraction_chunk_overlap_chars,
+            extraction_max_facts_per_chunk=extraction_max_facts_per_chunk,
+        )
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)
         return RedirectResponse("/settings", status_code=303)

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -31,6 +31,15 @@
   <label>Base URL <span class="muted">(optional)</span>
     <input type="text" name="base_url" value="{{ base_url }}" placeholder="https://…">
   </label>
+  <label>Chunk size
+    <input type="number" name="extraction_chunk_chars" value="{{ extraction_chunk_chars }}" min="1" step="50">
+  </label>
+  <label>Chunk overlap
+    <input type="number" name="extraction_chunk_overlap_chars" value="{{ extraction_chunk_overlap_chars }}" min="0" step="10">
+  </label>
+  <label>Max facts per chunk
+    <input type="number" name="extraction_max_facts_per_chunk" value="{{ extraction_max_facts_per_chunk }}" min="1" step="1">
+  </label>
   <button class="btn" type="submit">Save</button>
 </form>
 


### PR DESCRIPTION
## Summary
- make extraction chunk size, chunk overlap, and max facts per chunk configurable per KB
- expose those controls in Settings and support environment variable overrides
- pass extraction settings through web upload/re-analyze and CLI sync job creation
- make Ollama extraction use smaller configurable chunk-oriented output with more tolerant local-model parsing

## Why
Local models struggled when a whole source or large chunk had to produce one large JSON response. Smaller staged chunks and a per-chunk fact cap make extraction more reliable, and exposing the values lets users tune the recall/latency tradeoff for their model and document shape.

## Validation
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m pytest tests/test_config.py tests/test_web.py::test_settings_page_renders tests/test_web.py::test_settings_save_changes_active_provider tests/test_ollama_adapter.py tests/test_llm_schema.py tests/test_chunk.py -q`
- `.venv/bin/python -m compileall -q verinote`
