### PR TITLE
[codex] Summarize source analysis status

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -159,8 +159,56 @@ def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):
     assert rows[0]["path"] == "sources/report.pdf"
     assert rows[0]["kind"] == "binary"
     assert rows[0]["fact_count"] == 1
-    assert "artifacts/sources/1/aaa.txt" in rows[0]["artifact_paths"]
-    assert "artifacts/sources/1/bbb.txt" in rows[0]["artifact_paths"]
+    assert rows[0]["candidate_count"] == 1
+    assert rows[0]["needs_review_count"] == 0
+    assert rows[0]["engine_count"] == 0
+    assert "artifact_paths" not in rows[0].keys()
+
+
+def test_sources_with_counts_includes_latest_analysis_summary(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/report.pdf", kind="binary")
+    artifact_id = s.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path="artifacts/sources/1/text.txt",
+        checksum="text",
+    )
+    old_job = s.create_extraction_job(
+        source_id=sid,
+        artifact_id=artifact_id,
+        provider="ollama",
+        model="old",
+        total_chunks=1,
+    )
+    old_chunk = s.add_source_chunks(job_id=old_job, source_id=sid, chunks=["old"])[0]
+    s.mark_extraction_job_running(old_job)
+    s.mark_chunk_running(old_chunk)
+    s.mark_chunk_done(old_chunk, candidates=1)
+    job_id = s.create_extraction_job(
+        source_id=sid,
+        artifact_id=artifact_id,
+        provider="ollama",
+        model="qwen3.5:9b",
+        total_chunks=2,
+    )
+    chunks = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b"])
+    s.mark_extraction_job_running(job_id)
+    s.mark_chunk_running(chunks[0])
+    s.mark_chunk_done(chunks[0], candidates=3)
+    s.mark_chunk_running(chunks[1])
+    s.mark_chunk_failed(chunks[1], "provider down")
+
+    row = s.sources_with_counts()[0]
+
+    assert row["job_id"] == job_id
+    assert row["analysis_status"] == "failed"
+    assert row["completed_chunks"] == 1
+    assert row["total_chunks"] == 2
+    assert row["failed_chunks"] == 1
+    assert row["analysis_candidate_count"] == 3
+    assert row["provider"] == "ollama"
+    assert row["model"] == "qwen3.5:9b"
 
 
 def test_extraction_job_rejects_artifact_from_another_source(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -195,10 +195,30 @@ def test_sources_page_lists_sources(tmp_path):
     store = c.app.state.store
     sid = store.add_source("sources/a.txt", kind="text")
     store.add_fact("A", "is_a", "B", status="candidate", source_id=sid)
+    job_id = store.create_extraction_job(
+        source_id=sid,
+        provider="ollama",
+        model="qwen3.5:9b",
+        total_chunks=2,
+    )
+    chunks = store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b"])
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunks[0])
+    store.mark_chunk_done(chunks[0], candidates=1)
+    store.mark_chunk_running(chunks[1])
+    store.mark_chunk_failed(chunks[1], "provider down")
+
     r = c.get("/sources")
+
     assert r.status_code == 200
     assert "sources/a.txt" in r.text
     assert "text" in r.text
+    assert "failed" in r.text
+    assert "1/2 chunk(s)" in r.text
+    assert "1 candidate(s)" in r.text
+    assert "ollama" in r.text
+    assert "qwen3.5:9b" in r.text
+    assert "Retry" in r.text
 
 
 def test_delete_source_removes_file_and_extracted_facts(tmp_path):
@@ -323,10 +343,11 @@ def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
     assert "binary" in kinds
     sources_body = c.get("/sources").text
     assert "sources/report.docx" in sources_body
-    assert "artifacts/sources/1/" in sources_body
+    assert "artifacts/sources/1/" not in sources_body
 
     def extracted():
         assert any(row["subject"] == "X" for row in c.app.state.store.review_queue())
+        assert "complete" in c.get("/sources").text
 
     _wait_for(extracted)
     fact = [row for row in c.app.state.store.review_queue() if row["subject"] == "X"][0]

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -106,16 +106,29 @@ class Store:
         ).fetchone()
 
     def sources_with_counts(self) -> list[sqlite3.Row]:
-        """Sources plus how many facts cite each — for the Sources listing."""
+        """Sources plus analysis and fact summaries for the Sources listing."""
         return list(
             self._conn.execute(
                 "SELECT s.id, s.path, s.kind, s.added_at, "
-                "GROUP_CONCAT(a.path, '\n') AS artifact_paths, "
-                "COUNT(DISTINCT f.id) AS fact_count "
+                "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id) "
+                "AS fact_count, "
+                "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
+                "AND f.status = 'candidate') AS candidate_count, "
+                "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
+                "AND f.status = 'needs_review') AS needs_review_count, "
+                "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
+                "AND f.status IN ('confirmed','accepted')) AS engine_count, "
+                "j.id AS job_id, j.status AS analysis_status, "
+                "j.total_chunks, j.completed_chunks, j.failed_chunks, "
+                "j.candidate_count AS analysis_candidate_count, "
+                "j.message AS analysis_message, j.provider, j.model, "
+                "j.updated_at AS last_analyzed_at "
                 "FROM sources s "
-                "LEFT JOIN source_artifacts a ON a.source_id = s.id "
-                "LEFT JOIN facts f ON f.source_id = s.id "
-                "GROUP BY s.id ORDER BY s.path"
+                "LEFT JOIN extraction_jobs j ON j.id = ("
+                "  SELECT MAX(j2.id) FROM extraction_jobs j2 "
+                "  WHERE j2.source_id = s.id"
+                ") "
+                "ORDER BY s.path"
             )
         )
 

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -2,7 +2,7 @@
 {% block title %}Sources — verinote{% endblock %}
 {% block content %}
 <h1>Sources</h1>
-<p class="muted">Facts cite original files. Text artifacts used for extraction are tracked separately.</p>
+<p class="muted">Review uploaded sources, analysis progress, fact counts, and next actions.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 
@@ -13,47 +13,50 @@
   <button class="btn" type="submit">Upload &amp; analyze</button>
 </form>
 
-{% if jobs %}
-<div class="jobs" aria-live="polite"
-     {% if has_running_jobs %}hx-get="/sources" hx-trigger="every 2s" hx-target="main" hx-select="main" hx-swap="outerHTML"{% endif %}>
-  {% for job in jobs %}
-  <p class="job job-{{ job["status"] }}">
-    <span class="badge">{{ job["status"] }}</span>
-    <code>{{ job["source_path"] }}</code>
-    <span>{{ job["message"] }}</span>
-    <span class="conf">{{ job["candidate_count"] }} candidate(s)</span>
-    {% if job["failed_chunks"] %}
-    <form action="/sources/jobs/{{ job["id"] }}/retry" method="post">
-      <button class="btn ghost" type="submit">Retry failed chunks</button>
-    </form>
-    {% endif %}
-  </p>
-  {% endfor %}
-</div>
-{% endif %}
-
 {% if sources %}
-<table class="sources">
+<table class="sources" aria-live="polite"
+       {% if has_running_jobs %}hx-get="/sources" hx-trigger="every 2s" hx-target="main" hx-select="main" hx-swap="outerHTML"{% endif %}>
   <thead>
-    <tr><th>Source</th><th>Kind</th><th>Artifact</th><th>Facts</th><th>Added</th><th>Actions</th></tr>
+    <tr><th>Source</th><th>Type</th><th>Analysis</th><th>Facts</th><th>Last analyzed</th><th>Model</th><th>Actions</th></tr>
   </thead>
   <tbody>
     {% for s in sources %}
     <tr>
       <td><code>{{ s["path"] }}</code></td>
       <td><span class="badge">{{ s["kind"] }}</span></td>
+      <td>
+        {% if s["analysis_status"] %}
+          <span class="badge">{{ 'complete' if s["analysis_status"] == 'done' else s["analysis_status"] }}</span>
+          <span>{{ s["completed_chunks"] }}/{{ s["total_chunks"] }} chunk(s)</span>
+          {% if s["failed_chunks"] %}
+            <span class="error">{{ s["failed_chunks"] }} failed</span>
+          {% endif %}
+          {% if s["analysis_message"] %}
+            <br><span class="muted">{{ s["analysis_message"] }}</span>
+          {% endif %}
+        {% else %}
+          <span class="muted">Not analyzed</span>
+        {% endif %}
+      </td>
+      <td class="conf">
+        {{ s["candidate_count"] }} candidate(s)
+        {% if s["needs_review_count"] %}<br>{{ s["needs_review_count"] }} needs review{% endif %}
+        {% if s["engine_count"] %}<br>{{ s["engine_count"] }} confirmed{% endif %}
+      </td>
+      <td class="src">{{ s["last_analyzed_at"] or '—' }}</td>
       <td class="src">
-        {% if s["artifact_paths"] %}
-          {% for path in s["artifact_paths"].split("\n") %}
-            <code>{{ path }}</code>{% if not loop.last %}<br>{% endif %}
-          {% endfor %}
+        {% if s["provider"] or s["model"] %}
+          {{ s["provider"] or '—' }} / <code>{{ s["model"] or '—' }}</code>
         {% else %}
           —
         {% endif %}
       </td>
-      <td class="conf">{{ s["fact_count"] }}</td>
-      <td class="src">{{ s["added_at"] }}</td>
       <td class="actions">
+        {% if s["job_id"] and s["failed_chunks"] %}
+        <form action="/sources/jobs/{{ s["job_id"] }}/retry" method="post">
+          <button class="btn ghost" type="submit">Retry</button>
+        </form>
+        {% endif %}
         <form action="/sources/{{ s["id"] }}/reanalyze" method="post">
           <button class="btn ghost" type="submit">Re-analyze</button>
         </form>


### PR DESCRIPTION
## Summary
- replace the Sources table artifact column with source-level analysis status
- show latest job progress, failed chunk count, last analyzed time, and provider/model per source
- summarize fact counts by candidate/review/confirmed state
- move retry failed chunks into the source row actions

## Why
Artifact paths are internal implementation details and become noisy when repeated. The Sources tab should help users understand whether each document was analyzed, how far it got, how many facts it produced, and what action to take next.

## Validation
- `.venv/bin/python -m pytest tests/test_store.py tests/test_web.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m compileall -q verinote`
