### PR TITLE
[codex] Handle local fact schema drift

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -79,6 +79,27 @@ def test_parse_facts_accepts_top_level_array_from_local_models():
     assert facts[0].object == "mathematician"
 
 
+def test_parse_facts_accepts_common_array_wrappers_from_local_models():
+    for key in ("facts", "items", "data", "results"):
+        facts = parse_facts(
+            {
+                key: [
+                    {
+                        "subject": "Ada",
+                        "relation": "is_a",
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    }
+                ]
+            }
+        )
+
+        assert [(fact.subject, fact.relation, fact.object) for fact in facts] == [
+            ("Ada", "is_a", "mathematician")
+        ]
+
+
 def test_parse_facts_uses_first_json_value_from_noisy_local_output():
     facts = parse_facts(
         '```json\n'

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -101,3 +101,22 @@ def test_ollama_extract_ignores_malformed_only_fact_payload(tmp_path, monkeypatc
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     assert OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada") == []
+
+
+def test_ollama_extract_ignores_schema_mismatch_payload(tmp_path, monkeypatch):
+    def fake_urlopen(req, *, timeout):
+        return _Response(
+            json.dumps(
+                {
+                    "subject": "Ada",
+                    "relation": "is_a",
+                    "object": "mathematician",
+                    "confidence": 0.9,
+                    "note": "",
+                }
+            )
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada") == []

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -101,7 +101,11 @@ class OllamaAdapter:
         try:
             return parse_facts(body.get("message", {}).get("content", ""))
         except LLMError as exc:
-            if "malformed fact object" in str(exc):
+            message = str(exc)
+            if (
+                "malformed fact object" in message
+                or "extractor output did not match schema" in message
+            ):
                 return []
             raise
 

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -126,7 +126,7 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
     """Parse provider output (a JSON string or already-decoded dict) into facts."""
     try:
         data = _decode_first_json(raw) if isinstance(raw, str) else raw
-        items = data if isinstance(data, list) else data["facts"]
+        items = _fact_items(data)
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         raise LLMError(f"extractor output did not match schema: {exc}") from exc
 
@@ -159,6 +159,18 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
     if not facts and errors:
         raise LLMError(errors[0])
     return facts
+
+
+def _fact_items(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, dict):
+        raise TypeError("facts output must be an array or object")
+    for key in ("facts", "items", "data", "results"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return value
+    raise KeyError("facts")
 
 
 def _decode_first_json(raw: str) -> Any:


### PR DESCRIPTION
## Summary
- accept common local-model fact array wrappers such as `items`, `data`, and `results`
- keep accepting top-level arrays and `{facts: [...]}`
- make the Ollama adapter treat schema drift the same way as malformed fact objects so a chunk does not fail the whole analysis

## Why
Local Ollama models can return JSON objects that do not contain a top-level `facts` key, causing source analysis to fail with `extractor output did not match schema: 'facts'`.

## Validation
- `.venv/bin/python -m pytest tests/test_llm_schema.py tests/test_ollama_adapter.py -q`
- `.venv/bin/python -m pytest -q`