### PR TITLE
[codex] Isolate Claude CLI extraction

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -45,10 +45,14 @@ def test_claude_cli_extracts_facts_from_stdout(tmp_path, monkeypatch):
 
     assert facts[0].subject == "Ada"
     assert calls[0][0][0] == "claude"
+    assert "--safe-mode" in calls[0][0]
+    assert "--no-session-persistence" in calls[0][0]
     assert "--json-schema" in calls[0][0]
     assert "--system-prompt" in calls[0][0]
     assert "-p" in calls[0][0]
     assert calls[0][1]["capture_output"] is True
+    assert "cwd" in calls[0][1]
+    assert calls[0][1]["stdin"] is subprocess.DEVNULL
 
 
 def test_claude_cli_uses_model_when_configured(tmp_path, monkeypatch):
@@ -67,6 +71,7 @@ def test_claude_cli_uses_model_when_configured(tmp_path, monkeypatch):
     line = ClaudeCliAdapter(_cfg(tmp_path, model="sonnet")).translate_query(question="Who?", qid=7)
 
     assert commands[0][0:3] == ["claude", "--model", "sonnet"]
+    assert "--safe-mode" in commands[0]
     assert line.startswith("answer_q7")
 
 

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import tempfile
 from typing import Any
 
 from verinote.config import Config
@@ -45,6 +46,8 @@ class ClaudeCliAdapter:
         schema_json = json.dumps(schema, ensure_ascii=False)
         cmd = [
             "claude",
+            "--safe-mode",
+            "--no-session-persistence",
             "--system-prompt",
             prompt.system,
             "--json-schema",
@@ -55,13 +58,16 @@ class ClaudeCliAdapter:
         if self.cfg.model:
             cmd = ["claude", "--model", self.cfg.model, *cmd[1:]]
         try:
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                check=False,
-                text=True,
-                timeout=180,
-            )
+            with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    check=False,
+                    cwd=tmpdir,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                    timeout=180,
+                )
         except FileNotFoundError as exc:
             raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
         except subprocess.TimeoutExpired as exc:


### PR DESCRIPTION
## Summary
- run ClaudeCLI from an isolated temporary directory
- disable session persistence and custom project context with safe mode
- close inherited stdin so shell/Python heredoc content cannot leak into extraction

## Validation
- `.venv/bin/python -m pytest tests/test_claude_cli_adapter.py -q`
- real ClaudeCLI extraction with synthetic input returned only the expected source fact
- `.venv/bin/python -m pytest -q`