### PR TITLE
[codex] Normalize Claude CLI model aliases

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -75,6 +75,24 @@ def test_claude_cli_uses_model_when_configured(tmp_path, monkeypatch):
     assert line.startswith("answer_q7")
 
 
+def test_claude_cli_normalizes_display_model_names(tmp_path, monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{"facts":[]}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ClaudeCliAdapter(_cfg(tmp_path, model="Opus 4.8")).extract_facts(source_text="x")
+
+    assert commands[0][0:3] == ["claude", "--model", "opus"]
+
+
 def test_claude_cli_missing_binary_is_llm_error(tmp_path, monkeypatch):
     def fake_run(cmd, **kwargs):
         raise FileNotFoundError

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import tempfile
 from typing import Any
@@ -18,6 +19,12 @@ from verinote.llm.schema import (
     parse_query,
     query_system,
 )
+
+_MODEL_ALIASES = {
+    "fable": "fable",
+    "opus": "opus",
+    "sonnet": "sonnet",
+}
 
 
 class ClaudeCliAdapter:
@@ -55,8 +62,9 @@ class ClaudeCliAdapter:
             "-p",
             prompt.user,
         ]
-        if self.cfg.model:
-            cmd = ["claude", "--model", self.cfg.model, *cmd[1:]]
+        model = _cli_model(self.cfg.model)
+        if model:
+            cmd = ["claude", "--model", model, *cmd[1:]]
         try:
             with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
                 proc = subprocess.run(
@@ -100,3 +108,12 @@ def _prompt(*, system: str, schema: dict[str, Any], user: str) -> _Prompt:
             f"{user}"
         ),
     )
+
+
+def _cli_model(model: str) -> str:
+    """Convert UI/display model names to Claude CLI aliases."""
+    normalized = re.sub(r"[^a-z0-9]+", "", model.casefold())
+    for key, value in _MODEL_ALIASES.items():
+        if key in normalized:
+            return value
+    return model.strip()


### PR DESCRIPTION
## Summary
- normalize ClaudeCLI display model names such as `Opus 4.8` to CLI aliases like `opus`
- keep existing `sonnet`, `opus`, and `fable` alias usage working
- add regression coverage for display-name normalization

## Validation
- `.venv/bin/python -m pytest tests/test_claude_cli_adapter.py -q`
- real ClaudeCLI extraction with model `Opus 4.8` and synthetic input
- `.venv/bin/python -m pytest -q`