### PR TITLE
[codex] Add source-backed fact evidence anchors

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -34,6 +34,10 @@ def test_extract_source_persists_candidates_with_linkage(tmp_path, fake_client):
     assert [f["status"] for f in facts] == ["candidate", "candidate"]
     assert {f["run_id"] for f in facts} == {run_id}
     assert {f["source_path"] for f in facts} == {"sources/x.txt"}
+    evidence = [s.fact_evidence(f["id"])[0] for f in facts]
+    assert {e["evidence_kind"] for e in evidence} == {"chunk"}
+    assert {e["locator"] for e in evidence} == {"source"}
+    assert {e["snippet"] for e in evidence} == {"..."}
 
 
 def test_extract_source_stores_term_syntax_as_plain_strings(tmp_path, fake_client):
@@ -721,6 +725,10 @@ def test_process_extraction_job_extracts_chunks_and_tracks_progress(tmp_path):
     facts = s.facts()
     assert [f["subject"] for f in facts] == ["alpha", "beta"]
     assert {f["job_id"] for f in facts} == {job_id}
+    evidence = [s.fact_evidence(f["id"])[0] for f in facts]
+    assert [e["chunk_index"] for e in evidence] == [0, 1]
+    assert {e["job_id"] for e in evidence} == {job_id}
+    assert [e["snippet"] for e in evidence] == ["alpha", "beta"]
 
 
 def test_process_extraction_job_runs_focused_role_pass_with_original_note(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import pytest
+
 from verinote.engine import compile_dl
 from verinote.store import ENGINE_STATUSES, Store
 
@@ -102,6 +104,42 @@ def test_delete_source_removes_source_facts_and_terms(tmp_path):
     assert s.source_artifacts(sid) == []
 
 
+def test_delete_source_removes_fact_evidence(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/sample.txt"
+    )
+    job_id = s.create_extraction_job(
+        source_id=sid, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = s.add_source_chunks(
+        job_id=job_id, source_id=sid, chunks=["Sample Company uses Sample Service."]
+    )[0]
+    fact_id = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        source_id=sid,
+        job_id=job_id,
+    )
+    evidence_id = s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=sid,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        snippet="Sample Company uses Sample Service.",
+    )
+
+    assert evidence_id > 0
+    assert s.fact_evidence(fact_id)
+
+    s.delete_source(sid)
+
+    assert list(s._conn.execute("SELECT * FROM fact_evidence")) == []
+
+
 def test_delete_missing_source_returns_none(tmp_path):
     s = _store(tmp_path)
     assert s.delete_source(999) is None
@@ -130,6 +168,128 @@ def test_clear_source_analysis_keeps_source_and_artifacts(tmp_path):
     assert s.get_fact_terms(unrelated_fact) is not None
     assert s.get_extraction_job(job_id) is None
     assert s.source_chunks(job_id) == []
+
+
+def test_clear_source_analysis_removes_fact_evidence(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/sample.txt"
+    )
+    job_id = s.create_extraction_job(
+        source_id=sid, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["evidence"])[0]
+    fact_id = s.add_fact("Sample Company", "uses", "Sample Service", source_id=sid)
+    s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=sid,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        snippet="evidence",
+    )
+
+    assert s.clear_source_analysis(sid) == 1
+
+    assert list(s._conn.execute("SELECT * FROM fact_evidence")) == []
+
+
+def test_fact_evidence_persists_chunk_and_span_references(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/sample.txt"
+    )
+    job_id = s.create_extraction_job(
+        source_id=sid, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = s.add_source_chunks(
+        job_id=job_id,
+        source_id=sid,
+        chunks=["Sample Company provides Sample Service."],
+    )[0]
+    fact_id = s.add_fact(
+        "Sample Company",
+        "provides",
+        "Sample Service",
+        source_id=sid,
+        job_id=job_id,
+    )
+
+    s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=sid,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        evidence_kind="span",
+        start_offset=0,
+        end_offset=14,
+        locator="paragraph:1",
+        snippet="Sample Company",
+    )
+
+    evidence = s.fact_evidence(fact_id)[0]
+    assert evidence["evidence_kind"] == "span"
+    assert evidence["source_path"] == "sources/sample.txt"
+    assert evidence["artifact_path"] == "sources/sample.txt"
+    assert evidence["chunk_index"] == 0
+    assert evidence["start_offset"] == 0
+    assert evidence["end_offset"] == 14
+    assert evidence["locator"] == "paragraph:1"
+    assert evidence["snippet"] == "Sample Company"
+
+
+def test_fact_evidence_allows_future_evidence_kinds(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact("Sample Company", "uses", "Sample Service", source_id=sid)
+
+    s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=sid,
+        evidence_kind="layout_region",
+        locator="page:1:x:0:y:0",
+        snippet="Sample Company",
+    )
+
+    assert s.fact_evidence(fact_id)[0]["evidence_kind"] == "layout_region"
+
+
+def test_fact_evidence_bounds_snippet_text(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact("Sample Company", "uses", "Sample Service", source_id=sid)
+
+    s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=sid,
+        snippet="x" * 1200,
+    )
+
+    assert len(s.fact_evidence(fact_id)[0]["snippet"]) == 1000
+
+
+def test_fact_evidence_rejects_mismatched_chunk_source(tmp_path):
+    import sqlite3
+
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    fact_id = s.add_fact("Sample Company", "uses", "Sample Service", source_id=source_a)
+    job_b = s.create_extraction_job(
+        source_id=source_b, provider="fake", model="m", total_chunks=1
+    )
+    chunk_b = s.add_source_chunks(job_id=job_b, source_id=source_b, chunks=["body"])[0]
+
+    with pytest.raises(sqlite3.IntegrityError, match="chunk must belong"):
+        s.add_fact_evidence(
+            fact_id=fact_id,
+            source_id=source_a,
+            chunk_id=chunk_b,
+            snippet="body",
+        )
 
 
 def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -83,7 +83,7 @@ def extract_source(
 
     source_id = store.add_source(source_path)
     for subject, relation, obj, f in rows:
-        store.add_fact(
+        fact_id = store.add_fact(
             subject,
             relation,
             obj,
@@ -92,6 +92,13 @@ def extract_source(
             source_id=source_id,
             run_id=run_id,
             note=f.note,
+        )
+        store.add_fact_evidence(
+            fact_id=fact_id,
+            source_id=source_id,
+            evidence_kind="chunk",
+            locator="source",
+            snippet=analysis_text,
         )
     return len(rows)
 
@@ -171,6 +178,10 @@ def process_extraction_job(
                 source_text=str(running["text"]),
                 run_id=run_id,
                 job_id=job_id,
+                artifact_id=(
+                    int(job["artifact_id"]) if job["artifact_id"] is not None else None
+                ),
+                chunk_id=int(running["id"]),
                 schema_hint=schema_hint,
             )
         except LLMError as exc:
@@ -203,6 +214,8 @@ def _extract_chunk(
     source_text: str,
     run_id: int,
     job_id: int,
+    artifact_id: int | None = None,
+    chunk_id: int | None = None,
     schema_hint: str = "",
 ) -> int:
     facts = _extract_chunk_facts(client, source_text=source_text, schema_hint=schema_hint)
@@ -213,7 +226,7 @@ def _extract_chunk(
             source_id=source_id, subject=subject, relation=relation, obj=obj
         ):
             continue
-        store.add_fact(
+        fact_id = store.add_fact(
             subject,
             relation,
             obj,
@@ -223,6 +236,16 @@ def _extract_chunk(
             run_id=run_id,
             job_id=job_id,
             note=f.note,
+        )
+        store.add_fact_evidence(
+            fact_id=fact_id,
+            source_id=source_id,
+            artifact_id=artifact_id,
+            job_id=job_id,
+            chunk_id=chunk_id,
+            evidence_kind="chunk",
+            locator="chunk",
+            snippet=source_text,
         )
         inserted += 1
     return inserted

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -19,6 +19,7 @@ from typing import Any, Iterable
 # Status tiers (kept in code so the web/pipeline layers share one definition).
 REVIEW_STATUSES = frozenset({"candidate", "needs_review"})
 ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
+MAX_EVIDENCE_SNIPPET_CHARS = 1000
 
 
 def _load_schema() -> str:
@@ -464,6 +465,66 @@ class Store:
         ).fetchone()
         return row is not None
 
+    # --- fact evidence ---------------------------------------------------
+    def add_fact_evidence(
+        self,
+        *,
+        fact_id: int,
+        source_id: int,
+        artifact_id: int | None = None,
+        job_id: int | None = None,
+        chunk_id: int | None = None,
+        evidence_kind: str = "chunk",
+        start_offset: int | None = None,
+        end_offset: int | None = None,
+        locator: str = "",
+        snippet: str = "",
+    ) -> int:
+        """Persist a bounded source-backed evidence anchor for a fact."""
+        snippet = snippet[:MAX_EVIDENCE_SNIPPET_CHARS]
+        with self._lock:
+            self._validate_fact_evidence_refs(
+                fact_id=fact_id,
+                source_id=source_id,
+                artifact_id=artifact_id,
+                job_id=job_id,
+                chunk_id=chunk_id,
+            )
+            cur = self._conn.execute(
+                "INSERT INTO fact_evidence("
+                "fact_id, source_id, artifact_id, job_id, chunk_id, "
+                "evidence_kind, start_offset, end_offset, locator, snippet"
+                ") VALUES(?,?,?,?,?,?,?,?,?,?) RETURNING id",
+                (
+                    fact_id,
+                    source_id,
+                    artifact_id,
+                    job_id,
+                    chunk_id,
+                    evidence_kind,
+                    start_offset,
+                    end_offset,
+                    locator,
+                    snippet,
+                ),
+            )
+            return int(cur.fetchone()[0])
+
+    def fact_evidence(self, fact_id: int) -> list[sqlite3.Row]:
+        """Evidence anchors for one fact, oldest first."""
+        return list(
+            self._conn.execute(
+                "SELECT e.*, s.path AS source_path, a.path AS artifact_path, "
+                "c.chunk_index "
+                "FROM fact_evidence e "
+                "JOIN sources s ON s.id = e.source_id "
+                "LEFT JOIN source_artifacts a ON a.id = e.artifact_id "
+                "LEFT JOIN source_chunks c ON c.id = e.chunk_id "
+                "WHERE e.fact_id = ? ORDER BY e.id",
+                (fact_id,),
+            )
+        )
+
     # --- runs ------------------------------------------------------------
     def add_run(self, *, provider: str | None, model: str | None, summary: str = "") -> int:
         """Open an extraction run; facts produced by it cite the returned id."""
@@ -752,6 +813,43 @@ class Store:
         except Exception:
             pass
 
+    def _validate_fact_evidence_refs(
+        self,
+        *,
+        fact_id: int,
+        source_id: int,
+        artifact_id: int | None,
+        job_id: int | None,
+        chunk_id: int | None,
+    ) -> None:
+        fact = self.get_fact(fact_id)
+        if fact is None:
+            raise sqlite3.IntegrityError("fact evidence fact does not exist")
+        if fact["source_id"] is not None and int(fact["source_id"]) != source_id:
+            raise sqlite3.IntegrityError("fact evidence source must match the fact")
+        if self.get_source(source_id) is None:
+            raise sqlite3.IntegrityError("fact evidence source does not exist")
+        if artifact_id is not None:
+            artifact = self.get_source_artifact(artifact_id)
+            if artifact is None or int(artifact["source_id"]) != source_id:
+                raise sqlite3.IntegrityError(
+                    "fact evidence artifact must belong to the source"
+                )
+        if job_id is not None:
+            job = self.get_extraction_job(job_id)
+            if job is None or int(job["source_id"]) != source_id:
+                raise sqlite3.IntegrityError("fact evidence job must belong to the source")
+        if chunk_id is not None:
+            chunk = self.get_source_chunk(chunk_id)
+            if chunk is None or int(chunk["source_id"]) != source_id:
+                raise sqlite3.IntegrityError(
+                    "fact evidence chunk must belong to the source"
+                )
+            if job_id is not None and int(chunk["job_id"]) != job_id:
+                raise sqlite3.IntegrityError(
+                    "fact evidence chunk must belong to the job"
+                )
+
     def _ensure_schema_migrations(self) -> None:
         self._conn.executescript(
             """
@@ -792,6 +890,38 @@ class Store:
                 "ALTER TABLE facts ADD COLUMN job_id INTEGER "
                 "REFERENCES extraction_jobs(id) ON DELETE SET NULL"
             )
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS fact_evidence (
+                id            INTEGER PRIMARY KEY,
+                fact_id       INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+                source_id     INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+                artifact_id   INTEGER REFERENCES source_artifacts(id) ON DELETE SET NULL,
+                job_id        INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
+                chunk_id      INTEGER REFERENCES source_chunks(id) ON DELETE SET NULL,
+                evidence_kind TEXT NOT NULL DEFAULT 'chunk',
+                start_offset  INTEGER,
+                end_offset    INTEGER,
+                locator       TEXT NOT NULL DEFAULT '',
+                snippet       TEXT NOT NULL DEFAULT '',
+                created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                CHECK (length(evidence_kind) > 0),
+                CHECK (start_offset IS NULL OR start_offset >= 0),
+                CHECK (end_offset IS NULL OR end_offset >= 0),
+                CHECK (
+                    start_offset IS NULL
+                    OR end_offset IS NULL
+                    OR end_offset >= start_offset
+                )
+            );
+            CREATE INDEX IF NOT EXISTS idx_fact_evidence_fact
+                ON fact_evidence(fact_id);
+            CREATE INDEX IF NOT EXISTS idx_fact_evidence_source
+                ON fact_evidence(source_id);
+            CREATE INDEX IF NOT EXISTS idx_fact_evidence_chunk
+                ON fact_evidence(chunk_id);
+            """
+        )
 
     def _refresh_extraction_job(self, job_id: int, *, final: bool = False) -> None:
         counts = self._conn.execute(

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -101,6 +101,34 @@ CREATE TABLE IF NOT EXISTS facts (
 CREATE INDEX IF NOT EXISTS idx_facts_status ON facts(status);
 CREATE INDEX IF NOT EXISTS idx_facts_triple ON facts(subject, relation, object);
 
+-- Source-backed evidence anchors for extracted facts. Chunk-level anchors are
+-- available for every chunked extraction; exact spans/table cells can be added
+-- later without changing the fact contract.
+CREATE TABLE IF NOT EXISTS fact_evidence (
+    id            INTEGER PRIMARY KEY,
+    fact_id       INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+    source_id     INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    artifact_id   INTEGER REFERENCES source_artifacts(id) ON DELETE SET NULL,
+    job_id        INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
+    chunk_id      INTEGER REFERENCES source_chunks(id) ON DELETE SET NULL,
+    evidence_kind TEXT NOT NULL DEFAULT 'chunk',
+    start_offset  INTEGER,
+    end_offset    INTEGER,
+    locator       TEXT NOT NULL DEFAULT '',
+    snippet       TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (length(evidence_kind) > 0),
+    CHECK (start_offset IS NULL OR start_offset >= 0),
+    CHECK (end_offset IS NULL OR end_offset >= 0),
+    CHECK (
+        start_offset IS NULL OR end_offset IS NULL OR end_offset >= start_offset
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_fact_evidence_fact ON fact_evidence(fact_id);
+CREATE INDEX IF NOT EXISTS idx_fact_evidence_source ON fact_evidence(source_id);
+CREATE INDEX IF NOT EXISTS idx_fact_evidence_chunk ON fact_evidence(chunk_id);
+
 -- Natural-language questions translated to a Datalog query draft (#3). status:
 -- pending -> translated (an `answer_q<id>` rule) | review_required (untranslatable).
 CREATE TABLE IF NOT EXISTS questions (


### PR DESCRIPTION
## Summary

- add a `fact_evidence` store table for source-backed fact evidence anchors
- persist bounded evidence snippets with source/artifact/job/chunk references
- record evidence for both chunked extraction jobs and legacy source extraction
- validate evidence references so chunks, jobs, and artifacts cannot be attached across sources

## Why

Facts need a deterministic source-backed evidence path before later trust-summary, provenance, and hallucination-risk work can reliably tell whether a candidate is grounded in source text. This adds the storage and extraction foundation without changing review or auto-accept behavior.

Closes #93.

## Validation

- `.venv/bin/pytest tests/test_store.py tests/test_pipeline.py`
- `.venv/bin/pytest`
