### PR TITLE
[codex] Add deterministic fact trust summaries

### DIFF
--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.pipeline.trust import fact_trust_summary
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_fact_trust_summary_handles_fact_without_source_metadata(tmp_path):
+    s = _store(tmp_path)
+    fact_id = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        confidence=0.99,
+    )
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.display.subject == "Sample Company"
+    assert summary.canonical_terms is not None
+    assert summary.canonical_terms.object == '"Sample Service"'
+    assert summary.source is None
+    assert summary.run is None
+    assert summary.job is None
+    assert summary.evidence == ()
+    assert summary.support.source_count == 0
+    assert summary.conflict is None
+    assert summary.review_eligible is True
+    assert summary.engine_input is False
+    assert summary.trust_labels == ("evidence_missing", "unsupported")
+
+
+def test_fact_trust_summary_includes_source_run_job_evidence_and_audit(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/sample-source.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=source_id,
+        kind="original_text",
+        path="sources/sample-source.txt",
+    )
+    job_id = s.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_id = s.add_source_chunks(
+        job_id=job_id,
+        source_id=source_id,
+        chunks=["Sample Company uses Sample Service."],
+    )[0]
+    s.mark_extraction_job_running(job_id)
+    s.mark_chunk_running(chunk_id)
+    s.mark_chunk_done(chunk_id, candidates=1)
+    run_id = s.add_run(provider="fake", model="sample-model", summary="sample run")
+    fact_id = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="needs_review",
+        source_id=source_id,
+        run_id=run_id,
+        job_id=job_id,
+    )
+    s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=source_id,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        snippet="Sample Company uses Sample Service.",
+    )
+    s.toggle_review(fact_id)
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.source is not None
+    assert summary.source.path == "sources/sample-source.txt"
+    assert summary.run is not None
+    assert summary.run.model == "sample-model"
+    assert summary.job is not None
+    assert summary.job.status == "done"
+    assert len(summary.evidence) == 1
+    assert summary.evidence[0].chunk_index == 0
+    assert summary.evidence[0].chunk_status == "done"
+    assert summary.evidence[0].snippet == "Sample Company uses Sample Service."
+    assert [entry.action for entry in summary.audit] == ["toggled"]
+    assert summary.trust_labels == ("source_backed", "single_source", "reviewed")
+
+
+def test_fact_trust_summary_counts_distinct_engine_source_support(tmp_path):
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/sample-a.txt")
+    source_b = s.add_source("sources/sample-b.txt")
+    first = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="confirmed",
+        source_id=source_a,
+    )
+    s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="accepted",
+        source_id=source_b,
+    )
+    s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        source_id=source_b,
+    )
+
+    summary = fact_trust_summary(s, first)
+
+    assert summary is not None
+    assert summary.support.source_count == 2
+    assert summary.support.sources == (
+        "sources/sample-a.txt",
+        "sources/sample-b.txt",
+    )
+    assert "corroborated" in summary.trust_labels
+
+
+def test_fact_trust_summary_includes_single_valued_conflict(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("published_year").\n',
+        encoding="utf-8",
+    )
+    source_a = s.add_source("sources/sample-a.txt")
+    source_b = s.add_source("sources/sample-b.txt")
+    fact_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=source_a,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2025",
+        status="accepted",
+        source_id=source_b,
+    )
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.conflict is not None
+    assert summary.conflict.relation == "published_year"
+    assert [value.object for value in summary.conflict.values] == ["2024", "2025"]
+    assert "conflicted" in summary.trust_labels
+
+
+def test_fact_trust_summary_applies_relation_aliases(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text(
+        "- `publication_year` -> `published_year`\n",
+        encoding="utf-8",
+    )
+    fact_id = s.add_fact(
+        "Sample Report",
+        "publication_year",
+        "2024",
+        status="candidate",
+    )
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.canonical_relation == "published_year"
+
+
+def test_fact_trust_summary_counts_alias_canonical_source_support(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text(
+        "- `publication_year` -> `published_year`\n",
+        encoding="utf-8",
+    )
+    source_a = s.add_source("sources/sample-a.txt")
+    source_b = s.add_source("sources/sample-b.txt")
+    fact_id = s.add_fact(
+        "Sample Report",
+        "publication_year",
+        "2024",
+        status="confirmed",
+        source_id=source_a,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="accepted",
+        source_id=source_b,
+    )
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.support.source_count == 2
+    assert summary.support.sources == (
+        "sources/sample-a.txt",
+        "sources/sample-b.txt",
+    )
+
+
+def test_fact_trust_summary_normalizes_typed_scalar_value(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "typed-relations.md").write_text(
+        "- rank : ordinal as rank_number\n",
+        encoding="utf-8",
+    )
+    fact_id = s.add_fact(
+        "Sample Service",
+        "rank",
+        "3rd",
+        status="candidate",
+    )
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.typed_value is not None
+    assert summary.typed_value.type == "ordinal"
+    assert summary.typed_value.alias == "rank_number"
+    assert summary.typed_value.normalized_value == 3
+
+
+def test_fact_trust_summary_counts_typed_scalar_source_support(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "typed-relations.md").write_text(
+        "- rank : ordinal as rank_number\n",
+        encoding="utf-8",
+    )
+    source_a = s.add_source("sources/sample-a.txt")
+    source_b = s.add_source("sources/sample-b.txt")
+    fact_id = s.add_fact(
+        "Sample Service",
+        "rank",
+        "3rd",
+        status="confirmed",
+        source_id=source_a,
+    )
+    s.add_fact(
+        "Sample Service",
+        "rank",
+        "ordinal(3)",
+        status="accepted",
+        source_id=source_b,
+    )
+
+    summary = fact_trust_summary(s, fact_id)
+
+    assert summary is not None
+    assert summary.support.source_count == 2
+    assert "corroborated" in summary.trust_labels
+
+
+def test_fact_trust_summary_labels_do_not_depend_on_confidence(tmp_path):
+    s = _store(tmp_path)
+    low = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        confidence=0.01,
+    )
+    high = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        confidence=0.99,
+    )
+
+    low_summary = fact_trust_summary(s, low)
+    high_summary = fact_trust_summary(s, high)
+
+    assert low_summary is not None
+    assert high_summary is not None
+    assert low_summary.confidence == 0.01
+    assert high_summary.confidence == 0.99
+    assert low_summary.trust_labels == high_summary.trust_labels

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -22,6 +22,7 @@ from verinote.pipeline.ingest import (
 )
 from verinote.pipeline.query import translate_questions, write_query_file
 from verinote.pipeline.repair import repair_questions
+from verinote.pipeline.trust import fact_trust_summary
 from verinote.pipeline.verify import verify
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "translate_questions",
     "write_query_file",
     "repair_questions",
+    "fact_trust_summary",
 ]

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -283,6 +283,11 @@ def _source_ref(row: Mapping[str, object]) -> str:
 
 
 def _canonical_relation(relation: str, aliases: dict[str, str]) -> str:
+    return canonical_relation(relation, aliases)
+
+
+def canonical_relation(relation: str, aliases: dict[str, str]) -> str:
+    """Return the relation name used for alias-aware trust comparisons."""
     if not aliases:
         return relation
     normalized = unicodedata.normalize("NFC", relation)

--- a/verinote/pipeline/trust.py
+++ b/verinote/pipeline/trust.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Deterministic trust summary read model for facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import unicodedata
+from typing import Any
+
+from verinote.engine.terms import render_term
+from verinote.pipeline.corroboration import (
+    CompetingValue,
+    canonical_relation,
+    normalize_typed_value,
+    store_relation_aliases,
+    store_single_valued_conflicts,
+    store_typed_relations,
+    TypedRelationSpec,
+)
+from verinote.store import ENGINE_STATUSES, REVIEW_STATUSES, Store
+
+
+@dataclass(frozen=True)
+class FactTriple:
+    subject: str
+    relation: str
+    object: str
+
+
+@dataclass(frozen=True)
+class SourceMetadata:
+    id: int
+    path: str
+    kind: str
+
+
+@dataclass(frozen=True)
+class RunMetadata:
+    id: int
+    provider: str | None
+    model: str | None
+    summary: str
+
+
+@dataclass(frozen=True)
+class JobMetadata:
+    id: int
+    status: str
+    provider: str | None
+    model: str | None
+    artifact_path: str | None
+    total_chunks: int
+    completed_chunks: int
+    failed_chunks: int
+    message: str
+
+
+@dataclass(frozen=True)
+class EvidenceAnchor:
+    id: int
+    source_id: int
+    source_path: str
+    artifact_id: int | None
+    artifact_path: str | None
+    job_id: int | None
+    chunk_id: int | None
+    chunk_index: int | None
+    chunk_status: str | None
+    evidence_kind: str
+    start_offset: int | None
+    end_offset: int | None
+    locator: str
+    snippet: str
+
+
+@dataclass(frozen=True)
+class SupportSummary:
+    source_count: int
+    sources: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ConflictValueSummary:
+    object: str
+    source_count: int
+    sources: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ConflictSummary:
+    subject: str
+    relation: str
+    values: tuple[ConflictValueSummary, ...]
+
+
+@dataclass(frozen=True)
+class TypedValueSummary:
+    relation: str
+    type: str
+    alias: str
+    normalized_value: int | None
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    id: int
+    action: str
+    at: str
+
+
+@dataclass(frozen=True)
+class FactTrustSummary:
+    fact_id: int
+    display: FactTriple
+    canonical_terms: FactTriple | None
+    status: str
+    review_eligible: bool
+    engine_input: bool
+    confidence: float
+    note: str
+    source: SourceMetadata | None
+    run: RunMetadata | None
+    job: JobMetadata | None
+    evidence: tuple[EvidenceAnchor, ...]
+    support: SupportSummary
+    canonical_relation: str
+    typed_value: TypedValueSummary | None
+    conflict: ConflictSummary | None
+    audit: tuple[AuditEntry, ...]
+    trust_labels: tuple[str, ...]
+
+    @property
+    def source_backed(self) -> bool:
+        return bool(self.evidence)
+
+    @property
+    def conflicted(self) -> bool:
+        return self.conflict is not None
+
+
+def fact_trust_summary(store: Store, fact_id: int) -> FactTrustSummary | None:
+    """Return deterministic trust metadata for one fact, or None if missing."""
+    fact = store.get_fact(fact_id)
+    if fact is None:
+        return None
+
+    display = FactTriple(
+        subject=str(fact["subject"]),
+        relation=str(fact["relation"]),
+        object=str(fact["object"]),
+    )
+    aliases = store_relation_aliases(store)
+    typed = store_typed_relations(store)
+    relation = canonical_relation(display.relation, aliases)
+    support = _support_summary(store, display, aliases, typed)
+    conflict = _conflict_summary(store, display.subject, relation)
+    typed_value = _typed_value_summary(typed, relation, display.object)
+    evidence = tuple(_evidence_anchor(row) for row in store.fact_evidence(fact_id))
+    status = str(fact["status"])
+
+    return FactTrustSummary(
+        fact_id=int(fact["id"]),
+        display=display,
+        canonical_terms=_canonical_terms(store, fact_id),
+        status=status,
+        review_eligible=status in REVIEW_STATUSES,
+        engine_input=status in ENGINE_STATUSES,
+        confidence=float(fact["confidence"]),
+        note=str(fact["note"]),
+        source=_source_metadata(store, fact["source_id"]),
+        run=_run_metadata(store, fact["run_id"]),
+        job=_job_metadata(store, fact["job_id"]),
+        evidence=evidence,
+        support=support,
+        canonical_relation=relation,
+        typed_value=typed_value,
+        conflict=conflict,
+        audit=tuple(
+            AuditEntry(id=int(row["id"]), action=str(row["action"]), at=str(row["at"]))
+            for row in store.fact_log(fact_id)
+        ),
+        trust_labels=_trust_labels(
+            status=status,
+            evidence=evidence,
+            support=support,
+            conflict=conflict,
+        ),
+    )
+
+
+def _support_summary(
+    store: Store,
+    display: FactTriple,
+    aliases: dict[str, str],
+    typed: dict[str, TypedRelationSpec],
+) -> SupportSummary:
+    relation = canonical_relation(display.relation, aliases)
+    object_key = _object_key(relation, display.object, typed)
+    sources: set[str] = set()
+    for row in store.facts(statuses=ENGINE_STATUSES):
+        if str(row["subject"]) != display.subject:
+            continue
+        row_relation = canonical_relation(str(row["relation"]), aliases)
+        if row_relation != relation:
+            continue
+        if _object_key(row_relation, str(row["object"]), typed) != object_key:
+            continue
+        source_path = str(row["source_path"] or "").strip()
+        if source_path:
+            sources.add(source_path)
+    return SupportSummary(source_count=len(sources), sources=tuple(sorted(sources)))
+
+
+def _conflict_summary(
+    store: Store, subject: str, relation: str
+) -> ConflictSummary | None:
+    for item in store_single_valued_conflicts(store):
+        if item.subject == subject and item.relation == relation:
+            return ConflictSummary(
+                subject=item.subject,
+                relation=item.relation,
+                values=tuple(_conflict_value(value) for value in item.values),
+            )
+    return None
+
+
+def _conflict_value(value: CompetingValue) -> ConflictValueSummary:
+    return ConflictValueSummary(
+        object=value.object,
+        source_count=value.source_count,
+        sources=value.sources,
+    )
+
+
+def _typed_value_summary(
+    typed: dict[str, Any], relation: str, obj: str
+) -> TypedValueSummary | None:
+    spec = _typed_spec(typed, relation)
+    if spec is None:
+        return None
+    return TypedValueSummary(
+        relation=relation,
+        type=spec.type,
+        alias=spec.alias,
+        normalized_value=normalize_typed_value(spec.type, obj, spec.units),
+    )
+
+
+def _object_key(
+    relation: str, obj: str, typed: dict[str, TypedRelationSpec]
+) -> tuple[str, object]:
+    spec = _typed_spec(typed, relation)
+    if spec is not None:
+        scalar = normalize_typed_value(spec.type, obj, spec.units)
+        if scalar is not None:
+            return ("scalar", scalar)
+    return ("raw", obj)
+
+
+def _typed_spec(
+    typed: dict[str, TypedRelationSpec], relation: str
+) -> TypedRelationSpec | None:
+    return typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+
+
+def _canonical_terms(store: Store, fact_id: int) -> FactTriple | None:
+    terms = store.get_fact_terms(fact_id)
+    if terms is None:
+        return None
+    return FactTriple(
+        subject=render_term(terms[0]),
+        relation=render_term(terms[1]),
+        object=render_term(terms[2]),
+    )
+
+
+def _source_metadata(store: Store, source_id: object) -> SourceMetadata | None:
+    if source_id is None:
+        return None
+    row = store.get_source(int(source_id))
+    if row is None:
+        return None
+    return SourceMetadata(id=int(row["id"]), path=str(row["path"]), kind=str(row["kind"]))
+
+
+def _run_metadata(store: Store, run_id: object) -> RunMetadata | None:
+    if run_id is None:
+        return None
+    row = store.get_run(int(run_id))
+    if row is None:
+        return None
+    return RunMetadata(
+        id=int(row["id"]),
+        provider=row["provider"],
+        model=row["model"],
+        summary=str(row["summary"]),
+    )
+
+
+def _job_metadata(store: Store, job_id: object) -> JobMetadata | None:
+    if job_id is None:
+        return None
+    row = store.get_extraction_job_detail(int(job_id))
+    if row is None:
+        return None
+    return JobMetadata(
+        id=int(row["id"]),
+        status=str(row["status"]),
+        provider=row["provider"],
+        model=row["model"],
+        artifact_path=row["artifact_path"],
+        total_chunks=int(row["total_chunks"]),
+        completed_chunks=int(row["completed_chunks"]),
+        failed_chunks=int(row["failed_chunks"]),
+        message=str(row["message"]),
+    )
+
+
+def _evidence_anchor(row: Any) -> EvidenceAnchor:
+    return EvidenceAnchor(
+        id=int(row["id"]),
+        source_id=int(row["source_id"]),
+        source_path=str(row["source_path"]),
+        artifact_id=_optional_int(row["artifact_id"]),
+        artifact_path=row["artifact_path"],
+        job_id=_optional_int(row["job_id"]),
+        chunk_id=_optional_int(row["chunk_id"]),
+        chunk_index=_optional_int(row["chunk_index"]),
+        chunk_status=row["chunk_status"],
+        evidence_kind=str(row["evidence_kind"]),
+        start_offset=_optional_int(row["start_offset"]),
+        end_offset=_optional_int(row["end_offset"]),
+        locator=str(row["locator"]),
+        snippet=str(row["snippet"]),
+    )
+
+
+def _trust_labels(
+    *,
+    status: str,
+    evidence: tuple[EvidenceAnchor, ...],
+    support: SupportSummary,
+    conflict: ConflictSummary | None,
+) -> tuple[str, ...]:
+    labels = ["source_backed" if evidence else "evidence_missing"]
+    if support.source_count == 0:
+        labels.append("unsupported")
+    elif support.source_count == 1:
+        labels.append("single_source")
+    else:
+        labels.append("corroborated")
+    if conflict is not None:
+        labels.append("conflicted")
+    if status in ENGINE_STATUSES:
+        labels.append("reviewed")
+    if status == "superseded":
+        labels.append("superseded")
+    return tuple(labels)
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -515,7 +515,7 @@ class Store:
         return list(
             self._conn.execute(
                 "SELECT e.*, s.path AS source_path, a.path AS artifact_path, "
-                "c.chunk_index "
+                "c.chunk_index, c.status AS chunk_status "
                 "FROM fact_evidence e "
                 "JOIN sources s ON s.id = e.source_id "
                 "LEFT JOIN source_artifacts a ON a.id = e.artifact_id "


### PR DESCRIPTION
## Summary

- add a deterministic `fact_trust_summary` read model for a single fact
- include display/canonical terms, review status, source/run/job metadata, evidence anchors, audit entries, source support, conflicts, relation aliases, and typed scalar normalization
- keep confidence as metadata only; trust labels are based on deterministic state, evidence, support, and conflicts
- expose canonical relation normalization for reuse by trust logic

## Why

Review, provenance, conflict inspection, and future query traceability need one stable read model instead of rebuilding partial metadata in each screen. This gives later UI issues a deterministic trust object while preserving the existing extractor and review behavior.

Depends on #95 for `fact_evidence` storage and chunk evidence anchors.

Closes #85.

## Validation

- `.venv/bin/pytest tests/test_trust.py tests/test_corroboration.py tests/test_store.py`
- `.venv/bin/pytest`
- `.venv/bin/ruff check .`
