### PR TITLE
[codex] Expand provenance into trust dossier

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -770,6 +770,87 @@ def test_provenance_shows_source_and_audit(tmp_path):
     assert "toggled" in r.text
 
 
+def test_provenance_renders_trust_dossier_sections(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("published_year").\n',
+        encoding="utf-8",
+    )
+    source_id = store.add_source("sources/sample-source.txt")
+    artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="original_text",
+        path="sources/sample-source.txt",
+    )
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id,
+        source_id=source_id,
+        chunks=["Sample Report was published in 2024."],
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_done(chunk_id, candidates=1)
+    run_id = store.add_run(provider="fake", model="sample-model", summary="sample run")
+    fact_id = store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        confidence=0.99,
+        source_id=source_id,
+        run_id=run_id,
+        job_id=job_id,
+        note="model note",
+    )
+    store.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=source_id,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        snippet="Sample Report was published in 2024.",
+    )
+    store.set_status(fact_id, "accepted", action="accepted")
+    other_source = store.add_source("sources/sample-conflict.txt")
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2025",
+        status="accepted",
+        source_id=other_source,
+    )
+
+    body = unescape(c.get(f"/facts/{fact_id}/provenance").text)
+
+    assert "Trust dossier" in body
+    assert "Trust summary" in body
+    assert "source backed" in body
+    assert "single source" in body
+    assert "conflicted" in body
+    assert "source support" in body
+    assert "sources/sample-source.txt" in body
+    assert "Conflict summary" in body
+    assert "2024" in body
+    assert "2025" in body
+    assert "Lifecycle timeline" in body
+    assert "accepted" in body
+    assert "Source evidence" in body
+    assert "Sample Report was published in 2024." in body
+    assert "Metadata" in body
+    assert "model metadata only" in body
+    assert body.index("Trust summary") < body.index("Metadata")
+
+
 def test_provenance_renders_structural_terms_from_duckdb(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -28,6 +28,7 @@ from verinote.config import (
 from verinote.llm import LLMError, get_client
 from verinote.pipeline import (
     create_chunked_extraction_job,
+    fact_trust_summary,
     IngestError,
     ingest_bytes,
     process_extraction_job,
@@ -450,6 +451,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def provenance(request: Request, fact_id: int):
         store = _active_store()
         fact = store.get_fact(fact_id)
+        trust = fact_trust_summary(store, fact_id) if fact else None
         run = store.get_run(fact["run_id"]) if fact and fact["run_id"] else None
         job = (
             store.get_extraction_job_detail(fact["job_id"])
@@ -461,6 +463,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             "provenance.html",
             {
                 "f": _fact_view(fact),
+                "trust": trust,
                 "run": run,
                 "job": job,
                 "log": store.fact_log(fact_id) if fact else [],

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -87,3 +87,12 @@ tr.editing td { background: rgba(91, 157, 255, .06); }
 .report { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 1rem; overflow-x: auto; white-space: pre-wrap; }
 .findings { margin: 1rem 0; padding-left: 1.2rem; }
 .findings li { font-family: ui-monospace, monospace; font-size: .9rem; margin: .2rem 0; }
+.trust-block { margin: 1.2rem 0; }
+.trust-labels { display: flex; flex-wrap: wrap; gap: .45rem; margin: .7rem 0; }
+.trust-corroborated, .trust-source_backed, .trust-reviewed { color: var(--ok); border-color: var(--ok); }
+.trust-conflicted, .trust-evidence_missing { color: var(--danger); border-color: var(--danger); }
+.trust-unsupported, .trust-single_source { color: var(--warn); border-color: var(--warn); }
+.evidence { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: .75rem; margin: .7rem 0; }
+.evidence pre { margin: .55rem 0 0; max-height: 14rem; overflow: auto; white-space: pre-wrap;
+  background: var(--bg); border: 1px solid var(--line); border-radius: 6px; padding: .65rem; }
+.error-inline { color: var(--danger); }

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -1,50 +1,158 @@
 {% extends "base.html" %}
-{% block title %}Provenance — verinote{% endblock %}
+{% block title %}Trust — verinote{% endblock %}
 {% block content %}
 {% if not f %}
 <div class="empty"><p>No such fact.</p></div>
 {% else %}
-<h1>Provenance — fact #{{ f["id"] }}</h1>
-<p class="triple">
-  <span class="subj term-{{ f['subject_kind'] }}" title="{{ f['subject_kind'] }}">{{ f["subject_display"] }}</span>
-  <span class="rel term-{{ f['relation_kind'] }}" title="{{ f['relation_kind'] }}">{{ f["relation_display"] }}</span>
-  <span class="obj term-{{ f['object_kind'] }}" title="{{ f['object_kind'] }}">{{ f["object_display"] }}</span>
-  <span class="badge badge-{{ f['status'] }}">{{ f["status"] }}</span>
-</p>
+<h1>Trust dossier — fact #{{ f["id"] }}</h1>
 
-<table class="counts">
-  <tbody>
-    <tr><td>source</td><td><code>{{ f["source_path"] or "—" }}</code></td></tr>
-    <tr><td>confidence</td><td class="conf">{{ '%.2f'|format(f["confidence"]) }}</td></tr>
-    <tr><td>note</td><td>{{ f["note"] or "—" }}</td></tr>
-    <tr><td>run</td><td>
-      {% if run %}#{{ run["id"] }} · {{ run["provider"] or "—" }}/{{ run["model"] or "—" }}
-        {% if run["summary"] %}<span class="muted">({{ run["summary"] }})</span>{% endif %}
-      {% else %}— (seeded or hand-entered){% endif %}
-    </td></tr>
-    <tr><td>extraction</td><td>
-      {% if job %}
-        job #{{ job["id"] }} · artifact <code>{{ job["artifact_path"] or "—" }}</code>
-      {% else %}—{% endif %}
-    </td></tr>
-    <tr><td>created</td><td class="src">{{ f["created_at"] }}</td></tr>
-    <tr><td>updated</td><td class="src">{{ f["updated_at"] }}</td></tr>
-  </tbody>
-</table>
-
-<h2>Audit trail</h2>
-{% if log %}
-<table class="counts">
-  <thead><tr><th>when</th><th>action</th></tr></thead>
-  <tbody>
-    {% for e in log %}
-    <tr><td class="src">{{ e["at"] }}</td><td><span class="badge">{{ e["action"] }}</span></td></tr>
+<section class="trust-block">
+  <h2>Trust summary</h2>
+  <div class="trust-labels" aria-label="trust signals">
+    {% for label in trust.trust_labels %}
+      <span class="badge trust-{{ label }}">{{ label|replace("_", " ") }}</span>
     {% endfor %}
-  </tbody>
-</table>
-{% else %}
-<p class="muted">No review decisions recorded yet.</p>
-{% endif %}
+  </div>
+  <table class="counts">
+    <tbody>
+      <tr>
+        <td>source support</td>
+        <td>
+          {{ trust.support.source_count }} source{% if trust.support.source_count != 1 %}s{% endif %}
+          {% if trust.support.sources %}
+            <span class="muted">— {{ trust.support.sources|join(", ") }}</span>
+          {% else %}
+            <span class="muted">— no accepted/confirmed source support</span>
+          {% endif %}
+        </td>
+      </tr>
+      <tr><td>source evidence</td><td>{{ trust.evidence|length }} anchor{% if trust.evidence|length != 1 %}s{% endif %}</td></tr>
+      <tr><td>canonical relation</td><td><code>{{ trust.canonical_relation }}</code></td></tr>
+      {% if trust.typed_value %}
+      <tr>
+        <td>typed value</td>
+        <td>
+          {{ trust.typed_value.type }} as <code>{{ trust.typed_value.alias }}</code>
+          {% if trust.typed_value.normalized_value is not none %}
+            <span class="muted">normalized: {{ trust.typed_value.normalized_value }}</span>
+          {% else %}
+            <span class="muted">not normalized</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endif %}
+    </tbody>
+  </table>
+</section>
+
+<section class="trust-block">
+  <h2>Fact identity</h2>
+  <p class="triple">
+    <span class="subj term-{{ f['subject_kind'] }}" title="{{ f['subject_kind'] }}">{{ f["subject_display"] }}</span>
+    <span class="rel term-{{ f['relation_kind'] }}" title="{{ f['relation_kind'] }}">{{ f["relation_display"] }}</span>
+    <span class="obj term-{{ f['object_kind'] }}" title="{{ f['object_kind'] }}">{{ f["object_display"] }}</span>
+    <span class="badge badge-{{ f['status'] }}">{{ f["status"] }}</span>
+  </p>
+  {% if trust.canonical_terms %}
+  <table class="counts">
+    <tbody>
+      <tr><td>canonical subject</td><td><code>{{ trust.canonical_terms.subject }}</code></td></tr>
+      <tr><td>canonical relation</td><td><code>{{ trust.canonical_terms.relation }}</code></td></tr>
+      <tr><td>canonical object</td><td><code>{{ trust.canonical_terms.object }}</code></td></tr>
+    </tbody>
+  </table>
+  {% endif %}
+</section>
+
+<section class="trust-block">
+  <h2>Evidence summary</h2>
+  <table class="counts">
+    <tbody>
+      <tr><td>source</td><td>{% if trust.source %}<code>{{ trust.source.path }}</code> <span class="badge">{{ trust.source.kind }}</span>{% else %}—{% endif %}</td></tr>
+      <tr><td>run</td><td>
+        {% if trust.run %}#{{ trust.run.id }} · {{ trust.run.provider or "—" }}/{{ trust.run.model or "—" }}
+          {% if trust.run.summary %}<span class="muted">({{ trust.run.summary }})</span>{% endif %}
+        {% else %}— (seeded or hand-entered){% endif %}
+      </td></tr>
+      <tr><td>extraction</td><td>
+        {% if trust.job %}
+          job #{{ trust.job.id }} · {{ trust.job.status }} · {{ trust.job.completed_chunks }}/{{ trust.job.total_chunks }} chunk(s)
+          {% if trust.job.failed_chunks %}<span class="error-inline">{{ trust.job.failed_chunks }} failed</span>{% endif %}
+          {% if trust.job.artifact_path %}<br><code>{{ trust.job.artifact_path }}</code>{% endif %}
+        {% else %}—{% endif %}
+      </td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="trust-block">
+  <h2>Conflict summary</h2>
+  {% if trust.conflict %}
+  <table class="counts">
+    <thead><tr><th>value</th><th>sources</th></tr></thead>
+    <tbody>
+      {% for value in trust.conflict.values %}
+      <tr>
+        <td><code>{{ value.object }}</code></td>
+        <td>{{ value.source_count }} source{% if value.source_count != 1 %}s{% endif %} <span class="muted">{{ value.sources|join(", ") }}</span></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No deterministic single-valued conflict for this fact.</p>
+  {% endif %}
+</section>
+
+<section class="trust-block">
+  <h2>Lifecycle timeline</h2>
+  <table class="counts">
+    <tbody>
+      <tr><td class="src">{{ f["created_at"] }}</td><td><span class="badge">created</span></td></tr>
+      {% if trust.job %}
+      <tr><td class="src">—</td><td><span class="badge">extracted</span> job #{{ trust.job.id }} · {{ trust.job.status }}</td></tr>
+      {% endif %}
+      {% for e in trust.audit %}
+      <tr><td class="src">{{ e.at }}</td><td><span class="badge">{{ e.action }}</span></td></tr>
+      {% endfor %}
+      <tr><td class="src">{{ f["updated_at"] }}</td><td><span class="badge">updated</span></td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="trust-block">
+  <h2>Source evidence</h2>
+  {% if trust.evidence %}
+    {% for e in trust.evidence %}
+    <div class="evidence">
+      <div>
+        <span class="badge">{{ e.evidence_kind }}</span>
+        <code>{{ e.source_path }}</code>
+        {% if e.artifact_path %}<span class="muted">artifact <code>{{ e.artifact_path }}</code></span>{% endif %}
+      </div>
+      <div class="src">
+        {% if e.chunk_index is not none %}chunk {{ e.chunk_index }}{% else %}source{% endif %}
+        {% if e.chunk_status %}· {{ e.chunk_status }}{% endif %}
+        {% if e.locator %}· {{ e.locator }}{% endif %}
+        {% if e.start_offset is not none or e.end_offset is not none %}· {{ e.start_offset or 0 }}..{{ e.end_offset or "?" }}{% endif %}
+      </div>
+      {% if e.snippet %}<pre>{{ e.snippet }}</pre>{% endif %}
+    </div>
+    {% endfor %}
+  {% else %}
+  <p class="muted">No source evidence anchors recorded for this fact.</p>
+  {% endif %}
+</section>
+
+<section class="trust-block">
+  <h2>Metadata</h2>
+  <table class="counts">
+    <tbody>
+      <tr><td>confidence</td><td class="conf">{{ '%.2f'|format(f["confidence"]) }} <span class="muted">model metadata only</span></td></tr>
+      <tr><td>note</td><td>{{ f["note"] or "—" }}</td></tr>
+    </tbody>
+  </table>
+</section>
 
 <p><a class="btn ghost" href="/review">← back to review</a></p>
 {% endif %}


### PR DESCRIPTION
## Summary

- expand the existing fact provenance route into a trust dossier page
- show deterministic trust labels, source support, canonical relation, typed value normalization, conflict groups, lifecycle timeline, and source evidence before raw metadata
- keep confidence visible only in the metadata section as model metadata
- add web coverage for trust summary, support, conflict, lifecycle, evidence, and metadata sections

## Why

Users need provenance to answer why a fact should be trusted, amended, rejected, or kept under review. This page now consumes the deterministic trust summary read model instead of presenting raw source/run fields first.

Closes #86.

## Validation

- `.venv/bin/pytest tests/test_web.py::test_provenance_shows_source_and_audit tests/test_web.py::test_provenance_renders_trust_dossier_sections tests/test_web.py::test_provenance_renders_structural_terms_from_duckdb tests/test_trust.py`
- `.venv/bin/pytest`
- `.venv/bin/ruff check .`
