### PR TITLE
[codex] Make review queue evidence first

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -125,6 +125,8 @@ def test_review_shows_queue(tmp_path):
     r = c.get("/review")
     assert r.status_code == 200
     assert "is_a" in r.text
+    assert "Inspect" in r.text
+    assert "Conf." not in r.text
 
 
 def test_review_renders_structural_terms_from_duckdb_and_distinguishes_strings(tmp_path):
@@ -148,6 +150,140 @@ def test_review_renders_structural_terms_from_duckdb_and_distinguishes_strings(t
     assert 'class="subj term-string" title="string">"person(\\"Ada\\")"' in body
     assert 'class="subj term-term" title="term">person("Ada")' in body
     assert 'class="obj term-term" title="term">role(person("Ada"), "PI")' in body
+
+
+def test_review_rows_show_trust_signals_evidence_and_inspect_link(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("published_year").\n',
+        encoding="utf-8",
+    )
+    (policy / "relation-aliases.md").write_text(
+        "- `publication_year` -> `published_year`\n",
+        encoding="utf-8",
+    )
+    (policy / "typed-relations.md").write_text(
+        "- published_year : number as year_number\n",
+        encoding="utf-8",
+    )
+    source_id = store.add_source("sources/sample-candidate.txt")
+    artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="original_text",
+        path="sources/sample-candidate.txt",
+    )
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id,
+        source_id=source_id,
+        chunks=["Sample Report was published in 2024."],
+    )[0]
+    fact_id = store.add_fact(
+        "Sample Report",
+        "publication_year",
+        "2024",
+        status="candidate",
+        source_id=source_id,
+        job_id=job_id,
+    )
+    store.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=source_id,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        snippet="Sample Report was published in 2024.",
+    )
+    support_a = store.add_source("sources/sample-support-a.txt")
+    support_b = store.add_source("sources/sample-support-b.txt")
+    conflict = store.add_source("sources/sample-conflict.txt")
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="accepted",
+        source_id=support_a,
+    )
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=support_b,
+    )
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2025",
+        status="accepted",
+        source_id=conflict,
+    )
+
+    body = unescape(c.get("/review").text)
+
+    assert "source backed" in body
+    assert "corroborated" in body
+    assert "conflicted" in body
+    assert "canonical" in body
+    assert "published_year" in body
+    assert "year_number" in body
+    assert "Sample Report was published in 2024." in body
+    assert f'href="/facts/{fact_id}/provenance"' in body
+    assert "Inspect" in body
+
+
+def test_review_filters_by_deterministic_trust_signals(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    unsupported = store.add_fact(
+        "Unsupported Sample",
+        "uses",
+        "Sample Service",
+        status="candidate",
+    )
+    source_a = store.add_source("sources/sample-a.txt")
+    source_b = store.add_source("sources/sample-b.txt")
+    reviewed = store.add_source("sources/sample-reviewed.txt")
+    corroborated = store.add_fact(
+        "Reviewed Sample",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        source_id=reviewed,
+    )
+    store.add_fact(
+        "Reviewed Sample",
+        "uses",
+        "Sample Service",
+        status="accepted",
+        source_id=source_a,
+    )
+    store.add_fact(
+        "Reviewed Sample",
+        "uses",
+        "Sample Service",
+        status="confirmed",
+        source_id=source_b,
+    )
+
+    unsupported_body = unescape(c.get("/review?filter=unsupported").text)
+    assert "Unsupported Sample" in unsupported_body
+    assert "Reviewed Sample" not in unsupported_body
+    assert f'href="/facts/{unsupported}/provenance"' in unsupported_body
+
+    corroborated_body = unescape(c.get("/review?filter=corroborated").text)
+    assert "Reviewed Sample" in corroborated_body
+    assert "Unsupported Sample" not in corroborated_body
+    assert f'href="/facts/{corroborated}/provenance"' in corroborated_body
 
 
 def test_toggle_endpoint_swaps_row(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -129,9 +129,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             view[f"{field}_kind"] = term_input_kind(term)
         return view
 
+    def _fact_row_context(fact):
+        view = _fact_view(fact)
+        trust = fact_trust_summary(_active_store(), int(fact["id"])) if fact else None
+        return {"f": view, "trust": trust}
+
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
-        return templates.TemplateResponse(request, "partials/fact_row.html", {"f": _fact_view(fact)})
+        return templates.TemplateResponse(
+            request, "partials/fact_row.html", _fact_row_context(fact)
+        )
 
     def _fact_edit_context(fact, *, error: str | None = None):
         kinds = {"subject": "string", "relation": "string", "object": "string"}
@@ -152,6 +159,28 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if kind == "term":
             return structural_term(value)
         raise ValueError(f"unknown fact input kind: {kind}")
+
+    def _review_filters() -> list[tuple[str, str]]:
+        return [
+            ("needs-human-decision", "Needs decision"),
+            ("unsupported", "Unsupported"),
+            ("single-source", "Single source"),
+            ("corroborated", "Corroborated"),
+            ("conflicted", "Conflicted"),
+        ]
+
+    def _filter_review_rows(rows: list[dict[str, object]], active_filter: str):
+        labels = {key for key, _ in _review_filters()}
+        if active_filter not in labels:
+            active_filter = "needs-human-decision"
+        if active_filter == "needs-human-decision":
+            return rows
+        label = active_filter.replace("-", "_")
+        return [
+            row
+            for row in rows
+            if row["trust"] is not None and label in row["trust"].trust_labels
+        ]
 
     def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
         from verinote.engine import coverage
@@ -384,10 +413,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return RedirectResponse("/sources", status_code=303)
 
     @app.get("/review", response_class=HTMLResponse)
-    def review(request: Request):
+    def review(request: Request, filter: str = "needs-human-decision"):
         store = _active_store()
+        rows = [_fact_row_context(f) for f in store.review_queue()]
+        rows = _filter_review_rows(rows, filter)
         return templates.TemplateResponse(
-            request, "review.html", {"queue": [_fact_view(f) for f in store.review_queue()]}
+            request,
+            "review.html",
+            {
+                "queue": rows,
+                "active_filter": filter,
+                "filters": _review_filters(),
+            },
         )
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -42,6 +42,16 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .actions form { display: inline; }
 .actions .srclink { color: var(--muted); text-decoration: none; font-size: .82rem; margin-left: .3rem; }
 .actions .srclink:hover { color: var(--accent); }
+.actions .btn { padding: .25rem .5rem; font-size: .82rem; margin-right: .3rem; }
+.filters { display: flex; gap: .45rem; flex-wrap: wrap; margin: 1rem 0; }
+.filters a { text-decoration: none; color: var(--muted); }
+.filters a.active { color: var(--accent); border-color: var(--accent); }
+.row-meta { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .35rem; }
+.signals { min-width: 13rem; }
+.signals .badge { display: inline-block; margin: .12rem .1rem; }
+.evidence-cell { min-width: 14rem; max-width: 24rem; }
+.snippet { color: var(--muted); font-size: .85rem; margin-top: .25rem;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .amend { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
 .amend input { background: var(--bg); color: var(--fg); border: 1px solid var(--line);
   border-radius: 6px; padding: .3rem .5rem; }

--- a/verinote/web/templates/partials/fact_edit.html
+++ b/verinote/web/templates/partials/fact_edit.html
@@ -1,7 +1,7 @@
 {# Inline edit form for one fact. Swapped in by HTMX from the row's ✎ edit;
    save POSTs /amend (re-renders the row), cancel GETs /row (reverts). #}
 <tr id="fact-{{ f['id'] }}" class="fact editing">
-  <td colspan="5">
+  <td colspan="4">
     {% if error %}
     <p class="error">{{ error }}</p>
     {% endif %}

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -1,14 +1,48 @@
 {# A single fact row. Re-rendered and swapped in place by HTMX after a decision. #}
 <tr id="fact-{{ f['id'] }}" class="fact status-{{ f['status'] }}">
   <td class="triple">
-    <span class="subj term-{{ f['subject_kind'] }}" title="{{ f['subject_kind'] }}">{{ f['subject_display'] }}</span>
-    <span class="rel term-{{ f['relation_kind'] }}" title="{{ f['relation_kind'] }}">{{ f['relation_display'] }}</span>
-    <span class="obj term-{{ f['object_kind'] }}" title="{{ f['object_kind'] }}">{{ f['object_display'] }}</span>
+    <div>
+      <span class="subj term-{{ f['subject_kind'] }}" title="{{ f['subject_kind'] }}">{{ f['subject_display'] }}</span>
+      <span class="rel term-{{ f['relation_kind'] }}" title="{{ f['relation_kind'] }}">{{ f['relation_display'] }}</span>
+      <span class="obj term-{{ f['object_kind'] }}" title="{{ f['object_kind'] }}">{{ f['object_display'] }}</span>
+    </div>
+    <div class="row-meta">
+      <span class="badge badge-{{ f['status'] }}">{{ f['status'] }}</span>
+      {% if f['source_path'] %}<code>{{ f['source_path'] }}</code>{% else %}<span class="muted">no source</span>{% endif %}
+    </div>
   </td>
-  <td><span class="badge badge-{{ f['status'] }}">{{ f['status'] }}</span></td>
-  <td class="conf">{{ '%.2f'|format(f['confidence']) }}</td>
-  <td class="src">{{ f['source_path'] or '—' }}</td>
+  <td class="signals">
+    {% if trust %}
+      {% for label in trust.trust_labels %}
+        <span class="badge trust-{{ label }}">{{ label|replace("_", " ") }}</span>
+      {% endfor %}
+      <span class="badge">{{ trust.support.source_count }} source{% if trust.support.source_count != 1 %}s{% endif %}</span>
+      {% if trust.conflict %}<span class="badge trust-conflicted">conflict</span>{% endif %}
+      {% if trust.canonical_relation != f['relation'] %}
+        <span class="badge">canonical <code>{{ trust.canonical_relation }}</code></span>
+      {% endif %}
+      {% if trust.typed_value %}
+        <span class="badge">{{ trust.typed_value.type }} <code>{{ trust.typed_value.alias }}</code></span>
+      {% endif %}
+    {% else %}
+      <span class="badge trust-evidence_missing">trust unavailable</span>
+    {% endif %}
+  </td>
+  <td class="evidence-cell">
+    {% if trust and trust.evidence %}
+      {% set e = trust.evidence[0] %}
+      <div><span class="badge">{{ e.evidence_kind }}</span> <code>{{ e.source_path }}</code></div>
+      <div class="src">
+        {% if e.chunk_index is not none %}chunk {{ e.chunk_index }}{% else %}source{% endif %}
+        {% if e.chunk_status %}· {{ e.chunk_status }}{% endif %}
+      </div>
+      {% if e.snippet %}<div class="snippet">{{ e.snippet }}</div>{% endif %}
+    {% else %}
+      <span class="muted">No evidence anchor</span>
+    {% endif %}
+  </td>
   <td class="actions">
+    <a class="btn ghost" href="/facts/{{ f['id'] }}/provenance" title="inspect trust dossier">Inspect</a>
     <button hx-post="/facts/{{ f['id'] }}/toggle"
             hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML"
             title="needs_review ⇄ confirmed">⇄ toggle</button>
@@ -19,6 +53,5 @@
             class="danger">✗ reject</button>
     <button hx-get="/facts/{{ f['id'] }}/edit"
             hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">✎ edit</button>
-    <a class="srclink" href="/facts/{{ f['id'] }}/provenance" title="source &amp; audit trail">ⓘ source</a>
   </td>
 </tr>

--- a/verinote/web/templates/review.html
+++ b/verinote/web/templates/review.html
@@ -5,20 +5,28 @@
 <p class="muted">Facts awaiting the human gate (<code>candidate</code> / <code>needs_review</code>).
   Toggle promotes to <code>confirmed</code>; accept/reject decide directly.</p>
 
+<nav class="filters" aria-label="review filters">
+  {% for key, label in filters %}
+    <a class="badge {% if active_filter == key %}active{% endif %}" href="/review?filter={{ key }}">{{ label }}</a>
+  {% endfor %}
+</nav>
+
 {% if queue %}
 <table class="facts">
   <thead>
-    <tr><th>Fact (subject · relation · object)</th><th>Status</th><th>Conf.</th><th>Source</th><th>Decision</th></tr>
+    <tr><th>Fact</th><th>Trust signals</th><th>Evidence</th><th>Decision</th></tr>
   </thead>
   <tbody>
-    {% for f in queue %}
+    {% for row in queue %}
+      {% set f = row.f %}
+      {% set trust = row.trust %}
       {% include "partials/fact_row.html" %}
     {% endfor %}
   </tbody>
 </table>
 {% else %}
 <div class="empty">
-  <p>✓ Review queue is empty — no <code>needs_review</code> or <code>candidate</code> facts.</p>
+  <p>Review queue is empty for this filter.</p>
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- make review rows evidence-first using the deterministic fact trust summary
- show trust labels, source support, conflict state, canonical relation, typed scalar normalization, and source evidence preview directly in the queue
- add review filters for unsupported, single-source, corroborated, conflicted, and needs-decision views
- keep accept/reject/toggle/edit row actions working with trust-aware row re-rendering

## Why

Reviewers should not have to rely on model confidence or manually open provenance before seeing whether a candidate is unsupported, corroborated, conflicted, or source-backed.

Closes #87.

## Validation

- `.venv/bin/pytest tests/test_web.py::test_review_shows_queue tests/test_web.py::test_review_rows_show_trust_signals_evidence_and_inspect_link tests/test_web.py::test_review_filters_by_deterministic_trust_signals tests/test_web.py::test_toggle_endpoint_swaps_row`
- `.venv/bin/pytest`
- `.venv/bin/ruff check .`
