### PR TITLE
[codex] Add source analysis inspector

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -351,10 +351,96 @@ def test_sources_page_lists_sources(tmp_path):
     assert "text" in r.text
     assert "failed" in r.text
     assert "1/2 chunk(s)" in r.text
+    assert "provider down" in r.text
     assert "1 candidate(s)" in r.text
+    assert "1 unsupported" in r.text
     assert "ollama" in r.text
     assert "qwen3.5:9b" in r.text
     assert "Retry" in r.text
+
+
+def test_sources_page_shows_trust_counts_and_evidence_snippets(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("published_year").\n',
+        encoding="utf-8",
+    )
+    source_id = store.add_source("sources/sample-source.txt", kind="text")
+    artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="original_text",
+        path="sources/sample-source.txt",
+    )
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id,
+        source_id=source_id,
+        chunks=["Sample Report was published in 2024."],
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_done(chunk_id, candidates=1)
+    fact_id = store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_id,
+        job_id=job_id,
+    )
+    store.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=source_id,
+        artifact_id=artifact_id,
+        job_id=job_id,
+        chunk_id=chunk_id,
+        snippet="Sample Report was published in 2024.",
+    )
+    support_a = store.add_source("sources/sample-support-a.txt")
+    support_b = store.add_source("sources/sample-support-b.txt")
+    conflict = store.add_source("sources/sample-conflict.txt")
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="accepted",
+        source_id=support_a,
+    )
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=support_b,
+    )
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2025",
+        status="accepted",
+        source_id=conflict,
+    )
+
+    body = unescape(c.get("/sources").text)
+
+    assert "sources/sample-source.txt" in body
+    assert "original_text" in body
+    assert "sample-model" in body
+    assert "chunk size" in body
+    assert "max facts" in body
+    assert "0 unsupported" in body
+    assert "1 conflicted" in body
+    assert "1 corroborated" in body
+    assert "Sample Report was published in 2024." in body
 
 
 def test_delete_source_removes_file_and_extracted_facts(tmp_path):
@@ -479,7 +565,8 @@ def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
     assert "binary" in kinds
     sources_body = c.get("/sources").text
     assert "sources/report.docx" in sources_body
-    assert "artifacts/sources/1/" not in sources_body
+    assert "artifacts/sources/1/" in sources_body
+    assert "extracted_text" in sources_body
 
     def extracted():
         assert any(row["subject"] == "X" for row in c.app.state.store.review_queue())

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -182,6 +182,62 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             if row["trust"] is not None and label in row["trust"].trust_labels
         ]
 
+    def _source_inspector_rows(store: Store) -> list[dict[str, object]]:
+        facts = store.facts()
+        facts_by_source: dict[int, list[object]] = {}
+        for fact in facts:
+            if fact["source_id"] is None:
+                continue
+            facts_by_source.setdefault(int(fact["source_id"]), []).append(fact)
+
+        rows = []
+        for source in store.sources_with_counts():
+            row = dict(source)
+            source_id = int(source["id"])
+            summaries = [
+                fact_trust_summary(store, int(fact["id"]))
+                for fact in facts_by_source.get(source_id, [])
+            ]
+            summaries = [summary for summary in summaries if summary is not None]
+            row["unsupported_count"] = sum(
+                1 for summary in summaries if "unsupported" in summary.trust_labels
+            )
+            row["conflicted_count"] = sum(
+                1 for summary in summaries if "conflicted" in summary.trust_labels
+            )
+            row["corroborated_count"] = sum(
+                1 for summary in summaries if "corroborated" in summary.trust_labels
+            )
+            row["evidence_snippets"] = _source_evidence_snippets(summaries, source_id)
+            row["artifacts"] = [dict(artifact) for artifact in store.source_artifacts(source_id)]
+            row["failed_chunk_details"] = []
+            row["pending_chunks"] = 0
+            if source["job_id"]:
+                chunks = store.source_chunks(int(source["job_id"]))
+                row["failed_chunk_details"] = [
+                    dict(chunk) for chunk in chunks if chunk["status"] == "failed"
+                ]
+                row["pending_chunks"] = sum(
+                    1 for chunk in chunks if chunk["status"] in {"pending", "running"}
+                )
+            rows.append(row)
+        return rows
+
+    def _source_evidence_snippets(summaries, source_id: int) -> list[str]:
+        snippets: list[str] = []
+        seen: set[str] = set()
+        for summary in summaries:
+            for evidence in summary.evidence:
+                if evidence.source_id != source_id or not evidence.snippet:
+                    continue
+                if evidence.snippet in seen:
+                    continue
+                snippets.append(evidence.snippet)
+                seen.add(evidence.snippet)
+                if len(snippets) == 2:
+                    return snippets
+        return snippets
+
     def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
         from verinote.engine import coverage
 
@@ -221,12 +277,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             request,
             "sources.html",
             {
-                "sources": store.sources_with_counts(),
+                "sources": _source_inspector_rows(store),
                 "suffixes": ", ".join(sorted(supported_suffixes())),
                 "accept": ",".join(sorted(supported_suffixes())),
                 "error": error,
                 "jobs": jobs,
                 "has_running_jobs": has_running_jobs,
+                "chunk_chars": app.state.cfg.extraction_chunk_chars,
+                "max_facts_per_chunk": app.state.cfg.extraction_max_facts_per_chunk,
             },
             status_code=status_code,
         )

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -52,6 +52,10 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .evidence-cell { min-width: 14rem; max-width: 24rem; }
 .snippet { color: var(--muted); font-size: .85rem; margin-top: .25rem;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.mini-list { margin-top: .45rem; color: var(--muted); font-size: .85rem; }
+.mini-list > div { margin-top: .2rem; }
+.analysis-cell { min-width: 16rem; }
+.source-trust { display: flex; gap: .35rem; flex-wrap: wrap; margin-top: .45rem; }
 .amend { display: flex; gap: .4rem; flex-wrap: wrap; align-items: center; }
 .amend input { background: var(--bg); color: var(--fg); border: 1px solid var(--line);
   border-radius: 6px; padding: .3rem .5rem; }

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -17,22 +17,50 @@
 <table class="sources" aria-live="polite"
        {% if has_running_jobs %}hx-get="/sources" hx-trigger="every 2s" hx-target="main" hx-select="main" hx-swap="outerHTML"{% endif %}>
   <thead>
-    <tr><th>Source</th><th>Type</th><th>Analysis</th><th>Facts</th><th>Last analyzed</th><th>Model</th><th>Actions</th></tr>
+    <tr><th>Source</th><th>Analysis</th><th>Trust counts</th><th>Evidence</th><th>Actions</th></tr>
   </thead>
   <tbody>
     {% for s in sources %}
     <tr>
-      <td><code>{{ s["path"] }}</code></td>
-      <td><span class="badge">{{ s["kind"] }}</span></td>
       <td>
+        <code>{{ s["path"] }}</code>
+        <div class="row-meta">
+          <span class="badge">{{ s["kind"] }}</span>
+          <span class="src">added {{ s["added_at"] }}</span>
+        </div>
+        {% if s["artifacts"] %}
+        <div class="mini-list">
+          {% for artifact in s["artifacts"] %}
+            <div><span class="badge">{{ artifact["kind"] }}</span> <code>{{ artifact["path"] }}</code></div>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </td>
+      <td class="analysis-cell">
         {% if s["analysis_status"] %}
           <span class="badge">{{ 'complete' if s["analysis_status"] == 'done' else s["analysis_status"] }}</span>
           <span>{{ s["completed_chunks"] }}/{{ s["total_chunks"] }} chunk(s)</span>
           {% if s["failed_chunks"] %}
-            <span class="error">{{ s["failed_chunks"] }} failed</span>
+            <span class="error-inline">{{ s["failed_chunks"] }} failed</span>
           {% endif %}
+          {% if s["pending_chunks"] %}
+            <span class="warn">{{ s["pending_chunks"] }} pending</span>
+          {% endif %}
+          <div class="src">
+            {{ s["provider"] or '—' }} / <code>{{ s["model"] or '—' }}</code>
+            · chunk size {{ chunk_chars }}
+            · max facts {{ max_facts_per_chunk }}
+          </div>
+          <div class="src">last analyzed {{ s["last_analyzed_at"] or '—' }}</div>
           {% if s["analysis_message"] %}
             <br><span class="muted">{{ s["analysis_message"] }}</span>
+          {% endif %}
+          {% if s["failed_chunk_details"] %}
+          <div class="mini-list">
+            {% for chunk in s["failed_chunk_details"] %}
+              <div><span class="badge trust-conflicted">chunk {{ chunk["chunk_index"] }}</span> {{ chunk["error"] or "failed" }}</div>
+            {% endfor %}
+          </div>
           {% endif %}
         {% else %}
           <span class="muted">Not analyzed</span>
@@ -42,13 +70,19 @@
         {{ s["candidate_count"] }} candidate(s)
         {% if s["needs_review_count"] %}<br>{{ s["needs_review_count"] }} needs review{% endif %}
         {% if s["engine_count"] %}<br>{{ s["engine_count"] }} confirmed{% endif %}
+        <div class="source-trust">
+          <span class="badge trust-unsupported">{{ s["unsupported_count"] }} unsupported</span>
+          <span class="badge trust-conflicted">{{ s["conflicted_count"] }} conflicted</span>
+          <span class="badge trust-corroborated">{{ s["corroborated_count"] }} corroborated</span>
+        </div>
       </td>
-      <td class="src">{{ s["last_analyzed_at"] or '—' }}</td>
-      <td class="src">
-        {% if s["provider"] or s["model"] %}
-          {{ s["provider"] or '—' }} / <code>{{ s["model"] or '—' }}</code>
+      <td class="evidence-cell">
+        {% if s["evidence_snippets"] %}
+          {% for snippet in s["evidence_snippets"] %}
+            <div class="snippet">{{ snippet }}</div>
+          {% endfor %}
         {% else %}
-          —
+          <span class="muted">No evidence snippets</span>
         {% endif %}
       </td>
       <td class="actions">


### PR DESCRIPTION
## Summary

- turn the Sources tab into an analysis-quality inspector
- show grouped source artifacts, provider/model, chunk progress, chunk configuration, pending/failed chunks, and failed chunk errors
- add source-level unsupported/conflicted/corroborated trust counts from deterministic trust summaries
- show representative source-backed evidence snippets per source

## Why

The source page should answer whether an uploaded file analyzed correctly, where it failed, and what review risks came out of that source, without duplicating the full review workflow.

Closes #88.

## Validation

- `.venv/bin/pytest tests/test_web.py::test_sources_page_lists_sources tests/test_web.py::test_sources_page_shows_trust_counts_and_evidence_snippets tests/test_web.py::test_retry_failed_source_chunks tests/test_trust.py`
- `.venv/bin/pytest`
- `.venv/bin/ruff check .`
