### PR TITLE
Add fact lifecycle event audit

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import json
+
 import pytest
 
 from verinote.engine import compile_dl
@@ -484,6 +486,148 @@ def test_fact_log_orders_decisions(tmp_path):
     s.toggle_review(fid)
     s.amend_fact(fid, subject="A", relation="r", obj="B2")
     assert [e["action"] for e in s.fact_log(fid)] == ["toggled", "amended"]
+
+
+def test_fact_events_record_creation_and_review_lifecycle(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fid = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="needs_review",
+        source_id=sid,
+    )
+
+    s.toggle_review(fid)
+    s.amend_fact(
+        fid,
+        subject="Sample Company",
+        relation="uses",
+        obj="Sample Service v2",
+    )
+
+    events = s.fact_events(fid)
+    assert [event["event_type"] for event in events] == [
+        "candidate_created",
+        "toggled",
+        "amended",
+    ]
+    assert [event["actor"] for event in events] == ["system", "human", "human"]
+    assert [event["action"] for event in s.fact_log(fid)] == ["toggled", "amended"]
+    assert json.loads(events[0]["after_json"]) == {
+        "status": "needs_review",
+        "run_id": None,
+        "has_note": False,
+    }
+    assert json.loads(events[-1]["after_json"])["object"] == "Sample Service v2"
+
+
+def test_fact_events_can_represent_rule_and_reanalysis_events(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    fid = s.add_fact(
+        "Sample Company",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        source_id=sid,
+        job_id=job_id,
+    )
+
+    s.add_fact_event(
+        fact_id=fid,
+        event_type="auto_accept_recommended",
+        actor="rule",
+        source_id=sid,
+        job_id=job_id,
+        rule_name="corroborated_no_conflict",
+        after={"support_sources": 2},
+    )
+    s.add_fact_event(
+        fact_id=fid,
+        event_type="reanalyzed",
+        actor="system",
+        source_id=sid,
+        job_id=job_id,
+        after={"replacement_candidate_id": 123},
+    )
+
+    events = s.fact_events(fid)
+    assert [event["event_type"] for event in events] == [
+        "candidate_created",
+        "auto_accept_recommended",
+        "reanalyzed",
+    ]
+    assert events[1]["actor"] == "rule"
+    assert events[1]["rule_name"] == "corroborated_no_conflict"
+    assert json.loads(events[1]["after_json"])["support_sources"] == 2
+    assert json.loads(events[2]["after_json"])["replacement_candidate_id"] == 123
+
+
+def test_extraction_job_records_lifecycle_events(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    failed_job = s.create_extraction_job(
+        source_id=sid,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    failed_chunk = s.add_source_chunks(
+        job_id=failed_job,
+        source_id=sid,
+        chunks=["Sample body"],
+    )[0]
+
+    s.mark_extraction_job_running(failed_job)
+    s.mark_chunk_running(failed_chunk)
+    s.mark_chunk_failed(failed_chunk, "provider down")
+    s.retry_failed_chunks(failed_job)
+    s.fail_extraction_job(failed_job, "analysis failed")
+
+    done_job = s.create_extraction_job(
+        source_id=sid,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    done_chunk = s.add_source_chunks(
+        job_id=done_job,
+        source_id=sid,
+        chunks=["Sample body"],
+    )[0]
+    s.mark_extraction_job_running(done_job)
+    s.mark_chunk_running(done_chunk)
+    s.mark_chunk_done(done_chunk, candidates=1)
+    s.finish_extraction_job(done_job)
+
+    events = list(
+        s._conn.execute(
+            "SELECT event_type, actor, job_id, chunk_id, after_json "
+            "FROM fact_events ORDER BY id"
+        )
+    )
+    event_types = [event["event_type"] for event in events]
+    assert event_types == [
+        "extraction_job_started",
+        "chunk_failed",
+        "chunk_retried",
+        "extraction_job_failed",
+        "extraction_job_started",
+        "extraction_job_completed",
+    ]
+    assert {event["actor"] for event in events} == {"system"}
+    failed_event = [event for event in events if event["event_type"] == "chunk_failed"][0]
+    assert failed_event["job_id"] == failed_job
+    assert failed_event["chunk_id"] == failed_chunk
+    assert json.loads(failed_event["after_json"])["error"] == "provider down"
 
 
 def test_questions_add_list_and_translate(tmp_path):

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -92,7 +92,10 @@ def test_fact_trust_summary_includes_source_run_job_evidence_and_audit(tmp_path)
     assert summary.evidence[0].chunk_index == 0
     assert summary.evidence[0].chunk_status == "done"
     assert summary.evidence[0].snippet == "Sample Company uses Sample Service."
-    assert [entry.action for entry in summary.audit] == ["toggled"]
+    assert [entry.action for entry in summary.audit] == ["candidate_created", "toggled"]
+    assert [entry.actor for entry in summary.audit] == ["system", "human"]
+    assert summary.audit[0].source_id == source_id
+    assert summary.audit[0].job_id == job_id
     assert summary.trust_labels == ("source_backed", "single_source", "reviewed")
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -990,7 +990,10 @@ def test_provenance_shows_source_and_audit(tmp_path):
     r = c.get(f"/facts/{fid}/provenance")
     assert r.status_code == 200
     assert "sources/x.txt" in r.text
+    assert "candidate_created" in r.text
+    assert "system" in r.text
     assert "toggled" in r.text
+    assert "human" in r.text
 
 
 def test_provenance_renders_trust_dossier_sections(tmp_path):
@@ -1066,7 +1069,9 @@ def test_provenance_renders_trust_dossier_sections(tmp_path):
     assert "2024" in body
     assert "2025" in body
     assert "Lifecycle timeline" in body
+    assert "candidate_created" in body
     assert "accepted" in body
+    assert f"job #{job_id}" in body
     assert "Source evidence" in body
     assert "Sample Report was published in 2024." in body
     assert "Metadata" in body

--- a/verinote/pipeline/trust.py
+++ b/verinote/pipeline/trust.py
@@ -104,8 +104,17 @@ class TypedValueSummary:
 @dataclass(frozen=True)
 class AuditEntry:
     id: int
-    action: str
+    event_type: str
+    actor: str
+    source_id: int | None
+    job_id: int | None
+    chunk_id: int | None
+    rule_name: str
     at: str
+
+    @property
+    def action(self) -> str:
+        return self.event_type
 
 
 @dataclass(frozen=True)
@@ -176,8 +185,17 @@ def fact_trust_summary(store: Store, fact_id: int) -> FactTrustSummary | None:
         typed_value=typed_value,
         conflict=conflict,
         audit=tuple(
-            AuditEntry(id=int(row["id"]), action=str(row["action"]), at=str(row["at"]))
-            for row in store.fact_log(fact_id)
+            AuditEntry(
+                id=int(row["id"]),
+                event_type=str(row["event_type"]),
+                actor=str(row["actor"]),
+                source_id=_optional_int(row["source_id"]),
+                job_id=_optional_int(row["job_id"]),
+                chunk_id=_optional_int(row["chunk_id"]),
+                rule_name=str(row["rule_name"]),
+                at=str(row["at"]),
+            )
+            for row in store.fact_events(fact_id)
         ),
         trust_labels=_trust_labels(
             status=status,

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -379,12 +379,24 @@ class Store:
 
     def mark_extraction_job_running(self, job_id: int) -> None:
         with self._lock:
+            job = self.get_extraction_job(job_id)
             self._conn.execute(
                 "UPDATE extraction_jobs SET status = 'running', "
                 "message = 'Analyzing chunks...', updated_at = datetime('now') "
                 "WHERE id = ? AND status != 'canceled'",
                 (job_id,),
             )
+            after = self.get_extraction_job(job_id)
+            if job is not None and after is not None:
+                self._add_fact_event(
+                    fact_id=None,
+                    event_type="extraction_job_started",
+                    actor="system",
+                    source_id=int(after["source_id"]),
+                    job_id=job_id,
+                    before=_job_event_payload(job),
+                    after=_job_event_payload(after),
+                )
 
     def mark_chunk_running(self, chunk_id: int) -> sqlite3.Row | None:
         with self._lock:
@@ -425,30 +437,83 @@ class Store:
                 "updated_at = datetime('now') WHERE id = ?",
                 (error, chunk_id),
             )
+            failed = self.get_source_chunk(chunk_id)
+            self._add_fact_event(
+                fact_id=None,
+                event_type="chunk_failed",
+                actor="system",
+                source_id=int(chunk["source_id"]),
+                job_id=int(chunk["job_id"]),
+                chunk_id=chunk_id,
+                before=_chunk_event_payload(chunk),
+                after=_chunk_event_payload(failed) if failed is not None else None,
+            )
             self._refresh_extraction_job(int(chunk["job_id"]))
 
     def retry_failed_chunks(self, job_id: int) -> int:
         with self._lock:
+            failed_chunks = list(
+                self._conn.execute(
+                    "SELECT * FROM source_chunks WHERE job_id = ? AND status = 'failed'",
+                    (job_id,),
+                )
+            )
             cur = self._conn.execute(
                 "UPDATE source_chunks SET status = 'pending', error = '', "
                 "updated_at = datetime('now') "
                 "WHERE job_id = ? AND status = 'failed'",
                 (job_id,),
             )
+            for chunk in failed_chunks:
+                pending = self.get_source_chunk(int(chunk["id"]))
+                self._add_fact_event(
+                    fact_id=None,
+                    event_type="chunk_retried",
+                    actor="system",
+                    source_id=int(chunk["source_id"]),
+                    job_id=job_id,
+                    chunk_id=int(chunk["id"]),
+                    before=_chunk_event_payload(chunk),
+                    after=_chunk_event_payload(pending) if pending is not None else None,
+                )
             self._refresh_extraction_job(job_id)
             return int(cur.rowcount)
 
     def finish_extraction_job(self, job_id: int) -> None:
         with self._lock:
+            before = self.get_extraction_job(job_id)
             self._refresh_extraction_job(job_id, final=True)
+            after = self.get_extraction_job(job_id)
+            if after is not None:
+                self._add_fact_event(
+                    fact_id=None,
+                    event_type="extraction_job_completed",
+                    actor="system",
+                    source_id=int(after["source_id"]),
+                    job_id=job_id,
+                    before=_job_event_payload(before) if before is not None else None,
+                    after=_job_event_payload(after),
+                )
 
     def fail_extraction_job(self, job_id: int, message: str) -> None:
         with self._lock:
+            before = self.get_extraction_job(job_id)
             self._conn.execute(
                 "UPDATE extraction_jobs SET status = 'failed', message = ?, "
                 "updated_at = datetime('now') WHERE id = ?",
                 (message, job_id),
             )
+            after = self.get_extraction_job(job_id)
+            if after is not None:
+                self._add_fact_event(
+                    fact_id=None,
+                    event_type="extraction_job_failed",
+                    actor="system",
+                    source_id=int(after["source_id"]),
+                    job_id=job_id,
+                    before=_job_event_payload(before) if before is not None else None,
+                    after=_job_event_payload(after),
+                )
 
     def fact_exists_for_source(
         self, *, source_id: int, subject: object, relation: object, obj: object
@@ -579,6 +644,18 @@ class Store:
                 )
                 fact_id = int(cur.fetchone()[0])
                 self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
+                self._add_fact_event(
+                    fact_id=fact_id,
+                    event_type="candidate_created",
+                    actor="system",
+                    source_id=source_id,
+                    job_id=job_id,
+                    after={
+                        "status": status,
+                        "run_id": run_id,
+                        "has_note": bool(note),
+                    },
+                )
                 self._conn.execute("COMMIT")
                 return fact_id
             except Exception:
@@ -767,7 +844,48 @@ class Store:
             )
         )
 
-    def _log(self, fact_id: int, action: str, before: sqlite3.Row | None, after: sqlite3.Row | None) -> None:
+    def fact_events(self, fact_id: int) -> list[sqlite3.Row]:
+        """Lifecycle events (oldest first) for one fact."""
+        return list(
+            self._conn.execute(
+                "SELECT id, fact_id, event_type, actor, source_id, job_id, chunk_id, "
+                "rule_name, before_json, after_json, at "
+                "FROM fact_events WHERE fact_id = ? ORDER BY id",
+                (fact_id,),
+            )
+        )
+
+    def add_fact_event(
+        self,
+        *,
+        fact_id: int | None,
+        event_type: str,
+        actor: str = "system",
+        source_id: int | None = None,
+        job_id: int | None = None,
+        chunk_id: int | None = None,
+        rule_name: str = "",
+        before: dict[str, object] | sqlite3.Row | None = None,
+        after: dict[str, object] | sqlite3.Row | None = None,
+    ) -> int:
+        with self._lock:
+            return self._add_fact_event(
+                fact_id=fact_id,
+                event_type=event_type,
+                actor=actor,
+                source_id=source_id,
+                job_id=job_id,
+                chunk_id=chunk_id,
+                rule_name=rule_name,
+                before=before,
+                after=after,
+            )
+
+    def _log(
+        self, fact_id: int, action: str, before: sqlite3.Row | None, after: sqlite3.Row | None
+    ) -> None:
+        source_id = int(after["source_id"]) if after and after["source_id"] is not None else None
+        job_id = int(after["job_id"]) if after and after["job_id"] is not None else None
         self._conn.execute(
             "INSERT INTO review_log(fact_id, action, before_json, after_json) VALUES(?,?,?,?)",
             (
@@ -777,6 +895,47 @@ class Store:
                 json.dumps(dict(after), ensure_ascii=False) if after else None,
             ),
         )
+        self._add_fact_event(
+            fact_id=fact_id,
+            event_type=action,
+            actor="human",
+            source_id=source_id,
+            job_id=job_id,
+            before=before,
+            after=after,
+        )
+
+    def _add_fact_event(
+        self,
+        *,
+        fact_id: int | None,
+        event_type: str,
+        actor: str = "system",
+        source_id: int | None = None,
+        job_id: int | None = None,
+        chunk_id: int | None = None,
+        rule_name: str = "",
+        before: dict[str, object] | sqlite3.Row | None = None,
+        after: dict[str, object] | sqlite3.Row | None = None,
+    ) -> int:
+        cur = self._conn.execute(
+            "INSERT INTO fact_events("
+            "fact_id, event_type, actor, source_id, job_id, chunk_id, "
+            "rule_name, before_json, after_json"
+            ") VALUES(?,?,?,?,?,?,?,?,?) RETURNING id",
+            (
+                fact_id,
+                event_type,
+                actor,
+                source_id,
+                job_id,
+                chunk_id,
+                rule_name,
+                _json_payload(before),
+                _json_payload(after),
+            ),
+        )
+        return int(cur.fetchone()[0])
 
     def _rollback_quietly(self) -> None:
         try:
@@ -922,6 +1081,29 @@ class Store:
                 ON fact_evidence(chunk_id);
             """
         )
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS fact_events (
+                id          INTEGER PRIMARY KEY,
+                fact_id     INTEGER REFERENCES facts(id) ON DELETE SET NULL,
+                event_type  TEXT NOT NULL,
+                actor       TEXT NOT NULL DEFAULT 'system',
+                source_id   INTEGER REFERENCES sources(id) ON DELETE SET NULL,
+                job_id      INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
+                chunk_id    INTEGER REFERENCES source_chunks(id) ON DELETE SET NULL,
+                rule_name   TEXT NOT NULL DEFAULT '',
+                before_json TEXT,
+                after_json  TEXT,
+                at          TEXT NOT NULL DEFAULT (datetime('now')),
+                CHECK (length(event_type) > 0),
+                CHECK (actor IN ('system','human','rule'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_fact_events_fact
+                ON fact_events(fact_id, id);
+            CREATE INDEX IF NOT EXISTS idx_fact_events_job
+                ON fact_events(job_id);
+            """
+        )
 
     def _refresh_extraction_job(self, job_id: int, *, final: bool = False) -> None:
         counts = self._conn.execute(
@@ -982,3 +1164,37 @@ def _display_fact_value(value: object) -> str:
     if isinstance(value, (Atom, Compound, NumberLit, StringLit, Var)):
         return render_term(value)
     return str(value)
+
+
+def _json_payload(value: dict[str, object] | sqlite3.Row | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(dict(value), ensure_ascii=False)
+
+
+def _job_event_payload(row: sqlite3.Row | None) -> dict[str, object] | None:
+    if row is None:
+        return None
+    return {
+        "status": row["status"],
+        "source_id": row["source_id"],
+        "artifact_id": row["artifact_id"],
+        "total_chunks": row["total_chunks"],
+        "completed_chunks": row["completed_chunks"],
+        "failed_chunks": row["failed_chunks"],
+        "candidate_count": row["candidate_count"],
+        "message": row["message"],
+    }
+
+
+def _chunk_event_payload(row: sqlite3.Row | None) -> dict[str, object] | None:
+    if row is None:
+        return None
+    return {
+        "status": row["status"],
+        "source_id": row["source_id"],
+        "job_id": row["job_id"],
+        "chunk_index": row["chunk_index"],
+        "attempts": row["attempts"],
+        "error": row["error"],
+    }

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -150,3 +150,25 @@ CREATE TABLE IF NOT EXISTS review_log (
     after_json  TEXT,
     at          TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Append-only lifecycle events for facts. Unlike review_log, this records
+-- system-origin events such as extraction and chunk processing as well as human
+-- review actions. Payloads carry metadata only, not source document bodies.
+CREATE TABLE IF NOT EXISTS fact_events (
+    id          INTEGER PRIMARY KEY,
+    fact_id     INTEGER REFERENCES facts(id) ON DELETE SET NULL,
+    event_type  TEXT NOT NULL,
+    actor       TEXT NOT NULL DEFAULT 'system',
+    source_id   INTEGER REFERENCES sources(id) ON DELETE SET NULL,
+    job_id      INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
+    chunk_id    INTEGER REFERENCES source_chunks(id) ON DELETE SET NULL,
+    rule_name   TEXT NOT NULL DEFAULT '',
+    before_json TEXT,
+    after_json  TEXT,
+    at          TEXT NOT NULL DEFAULT (datetime('now')),
+    CHECK (length(event_type) > 0),
+    CHECK (actor IN ('system','human','rule'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_fact_events_fact ON fact_events(fact_id, id);
+CREATE INDEX IF NOT EXISTS idx_fact_events_job ON fact_events(job_id);

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -113,7 +113,13 @@
       <tr><td class="src">—</td><td><span class="badge">extracted</span> job #{{ trust.job.id }} · {{ trust.job.status }}</td></tr>
       {% endif %}
       {% for e in trust.audit %}
-      <tr><td class="src">{{ e.at }}</td><td><span class="badge">{{ e.action }}</span></td></tr>
+      <tr><td class="src">{{ e.at }}</td><td>
+        <span class="badge">{{ e.event_type }}</span>
+        <span class="muted">{{ e.actor }}</span>
+        {% if e.job_id %}<span class="muted">job #{{ e.job_id }}</span>{% endif %}
+        {% if e.chunk_id %}<span class="muted">chunk #{{ e.chunk_id }}</span>{% endif %}
+        {% if e.rule_name %}<span class="muted">rule {{ e.rule_name }}</span>{% endif %}
+      </td></tr>
       {% endfor %}
       <tr><td class="src">{{ f["updated_at"] }}</td><td><span class="badge">updated</span></td></tr>
     </tbody>


### PR DESCRIPTION
## Summary
- add append-only fact lifecycle events for candidate creation, review actions, extraction job transitions, chunk failures, retries, and rule/system lifecycle markers
- expose lifecycle events through trust summaries and the provenance timeline while keeping review_log compatibility
- cover lifecycle, rule/reanalysis, extraction job, trust, and web rendering behavior with synthetic tests

Closes #89

## Tests
- .venv/bin/python -m ruff check verinote tests
- .venv/bin/python -m pytest tests/test_store.py tests/test_trust.py tests/test_web.py -q
- .venv/bin/python -m pytest -q