### PR TITLE
Create corroboration and conflict workbench

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -286,6 +286,90 @@ def test_review_filters_by_deterministic_trust_signals(tmp_path):
     assert f'href="/facts/{corroborated}/provenance"' in corroborated_body
 
 
+def test_workbench_renders_corroboration_conflicts_and_normalization(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\n'
+        'functional("published_year").\n'
+        'functional("revenue").\n',
+        encoding="utf-8",
+    )
+    (policy / "relation-aliases.md").write_text(
+        "- `pub_year` -> `published_year`\n",
+        encoding="utf-8",
+    )
+    (policy / "typed-relations.md").write_text(
+        "- revenue : amount as revenue_scalar\n",
+        encoding="utf-8",
+    )
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    source_c = store.add_source("sources/c.txt")
+    candidate_source = store.add_source("sources/candidate.txt")
+    fact_id = store.add_fact(
+        "Sample Report",
+        "pub_year",
+        "2024",
+        status="confirmed",
+        source_id=source_a,
+    )
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="accepted",
+        source_id=source_b,
+    )
+    candidate_id = store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=candidate_source,
+    )
+    store.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(5000,"억")',
+        status="confirmed",
+        source_id=source_a,
+    )
+    store.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(0.54,"조")',
+        status="accepted",
+        source_id=source_b,
+    )
+    store.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(5400,"억")',
+        status="confirmed",
+        source_id=source_c,
+    )
+
+    body = unescape(c.get("/workbench").text)
+
+    assert "Trust workbench" in body
+    assert "Corroborated facts" in body
+    assert "Sample Report" in body
+    assert "pub_year -> published_year" in body
+    assert "sources/a.txt" in body
+    assert "sources/b.txt" in body
+    assert "Related candidates" in body
+    assert f'href="/facts/{candidate_id}/provenance"' in body
+    assert "Single-valued conflicts" in body
+    assert "Sample Company" in body
+    assert 'amount(5000,"억")' in body
+    assert 'amount(0.54,"조")' in body
+    assert "revenue_scalar=540000000000" in body
+    assert f'href="/facts/{fact_id}/provenance"' in body
+
+
 def test_toggle_endpoint_swaps_row(tmp_path):
     c = _client(tmp_path)
     r = c.post(f"/facts/{c.fact_id}/toggle")

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.pipeline.workbench import trust_workbench
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _write_policy(tmp_path) -> None:
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\n'
+        'functional("published_year").\n'
+        'functional("revenue").\n',
+        encoding="utf-8",
+    )
+    (policy / "relation-aliases.md").write_text(
+        "- `pub_year` -> `published_year`\n",
+        encoding="utf-8",
+    )
+    (policy / "typed-relations.md").write_text(
+        "- revenue : amount as revenue_scalar\n",
+        encoding="utf-8",
+    )
+
+
+def test_workbench_groups_corroboration_with_alias_and_candidates(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    candidate_source = s.add_source("sources/candidate.txt")
+    first = s.add_fact(
+        "Sample Report",
+        "pub_year",
+        "2024",
+        status="confirmed",
+        source_id=source_a,
+    )
+    second = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="accepted",
+        source_id=source_b,
+    )
+    candidate = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=candidate_source,
+    )
+
+    workbench = trust_workbench(s)
+
+    assert len(workbench.corroborated) == 1
+    group = workbench.corroborated[0]
+    assert (group.subject, group.relation, group.object) == (
+        "Sample Report",
+        "published_year",
+        "2024",
+    )
+    assert group.sources == ("sources/a.txt", "sources/b.txt")
+    assert [fact.id for fact in group.facts] == [first, second]
+    assert group.facts[0].relation_alias == "pub_year -> published_year"
+    assert [fact.id for fact in group.related_candidates] == [candidate]
+
+
+def test_workbench_conflicts_use_typed_scalar_groups_and_separate_candidates(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    source_c = s.add_source("sources/c.txt")
+    candidate_source = s.add_source("sources/candidate.txt")
+    s.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(5000,"억")',
+        status="confirmed",
+        source_id=source_a,
+    )
+    s.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(0.54,"조")',
+        status="accepted",
+        source_id=source_b,
+    )
+    s.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(5400,"억")',
+        status="confirmed",
+        source_id=source_c,
+    )
+    candidate = s.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(7000,"억")',
+        status="candidate",
+        source_id=candidate_source,
+    )
+
+    workbench = trust_workbench(s)
+
+    assert len(workbench.conflicts) == 1
+    conflict = workbench.conflicts[0]
+    assert (conflict.subject, conflict.relation) == ("Sample Company", "revenue")
+    assert [(value.object, value.source_count) for value in conflict.values] == [
+        ('amount(0.54,"조")', 2),
+        ('amount(5000,"억")', 1),
+    ]
+    assert [value.typed_normalization for value in conflict.values] == [
+        "revenue_scalar=540000000000",
+        "revenue_scalar=500000000000",
+    ]
+    assert [fact.id for fact in conflict.related_candidates] == [candidate]

--- a/verinote/pipeline/workbench.py
+++ b/verinote/pipeline/workbench.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Review workbench view models for deterministic trust signals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import unicodedata
+
+from verinote.pipeline.corroboration import (
+    canonical_relation,
+    normalize_typed_value,
+    store_functional_relations,
+    store_relation_aliases,
+    store_typed_relations,
+    TypedRelationSpec,
+)
+from verinote.store import ENGINE_STATUSES, REVIEW_STATUSES, Store
+
+
+@dataclass(frozen=True)
+class WorkbenchFact:
+    id: int
+    subject: str
+    relation: str
+    object: str
+    status: str
+    source: str
+    canonical_relation: str
+    relation_alias: str
+    typed_normalization: str
+
+
+@dataclass(frozen=True)
+class CorroboratedGroup:
+    subject: str
+    relation: str
+    object: str
+    sources: tuple[str, ...]
+    facts: tuple[WorkbenchFact, ...]
+    related_candidates: tuple[WorkbenchFact, ...]
+
+    @property
+    def source_count(self) -> int:
+        return len(self.sources)
+
+
+@dataclass(frozen=True)
+class ConflictValue:
+    object: str
+    sources: tuple[str, ...]
+    facts: tuple[WorkbenchFact, ...]
+    typed_normalization: str
+
+    @property
+    def source_count(self) -> int:
+        return len(self.sources)
+
+
+@dataclass(frozen=True)
+class ConflictGroup:
+    subject: str
+    relation: str
+    values: tuple[ConflictValue, ...]
+    related_candidates: tuple[WorkbenchFact, ...]
+
+
+@dataclass(frozen=True)
+class TrustWorkbench:
+    corroborated: tuple[CorroboratedGroup, ...]
+    conflicts: tuple[ConflictGroup, ...]
+
+
+def trust_workbench(store: Store) -> TrustWorkbench:
+    """Build source-backed review tasks without trusting model confidence."""
+    aliases = store_relation_aliases(store)
+    typed = store_typed_relations(store)
+    single_valued = {canonical_relation(r, aliases) for r in store_functional_relations(store)}
+
+    engine: dict[tuple[str, str, tuple[str, object]], list[WorkbenchFact]] = {}
+    candidates: dict[tuple[str, str, tuple[str, object]], list[WorkbenchFact]] = {}
+    by_subject_relation: dict[
+        tuple[str, str], dict[tuple[str, object], list[WorkbenchFact]]
+    ] = {}
+    candidate_by_subject_relation: dict[tuple[str, str], list[WorkbenchFact]] = {}
+
+    for row in store.facts():
+        status = str(row["status"])
+        source = str(row["source_path"] or "").strip()
+        if not source:
+            continue
+        subject = str(row["subject"])
+        relation = str(row["relation"])
+        obj = str(row["object"])
+        canonical = canonical_relation(relation, aliases)
+        spec = _typed_spec(canonical, typed)
+        object_key, normalization = _normalized_object_key(obj, spec)
+        fact = WorkbenchFact(
+            id=int(row["id"]),
+            subject=subject,
+            relation=relation,
+            object=obj,
+            status=status,
+            source=source,
+            canonical_relation=canonical,
+            relation_alias=_relation_alias(relation, canonical),
+            typed_normalization=normalization,
+        )
+        key = (subject, canonical, object_key)
+        sr_key = (subject, canonical)
+        if status in ENGINE_STATUSES:
+            engine.setdefault(key, []).append(fact)
+            if canonical in single_valued:
+                by_subject_relation.setdefault(sr_key, {}).setdefault(object_key, []).append(fact)
+        elif status in REVIEW_STATUSES:
+            candidates.setdefault(key, []).append(fact)
+            candidate_by_subject_relation.setdefault(sr_key, []).append(fact)
+
+    corroborated = []
+    for (subject, relation, object_key), facts in sorted(engine.items()):
+        sources = tuple(sorted({fact.source for fact in facts}))
+        if len(sources) < 2:
+            continue
+        representative = sorted({fact.object for fact in facts})[0]
+        corroborated.append(
+            CorroboratedGroup(
+                subject=subject,
+                relation=relation,
+                object=representative,
+                sources=sources,
+                facts=tuple(sorted(facts, key=lambda fact: fact.id)),
+                related_candidates=tuple(
+                    sorted(
+                        candidates.get((subject, relation, object_key), []),
+                        key=lambda fact: fact.id,
+                    )
+                ),
+            )
+        )
+
+    conflicts = []
+    for (subject, relation), value_groups in sorted(by_subject_relation.items()):
+        if len(value_groups) < 2:
+            continue
+        values = []
+        for facts in value_groups.values():
+            sources = tuple(sorted({fact.source for fact in facts}))
+            representative = sorted({fact.object for fact in facts})[0]
+            normalization = sorted(
+                {fact.typed_normalization for fact in facts if fact.typed_normalization}
+            )
+            values.append(
+                ConflictValue(
+                    object=representative,
+                    sources=sources,
+                    facts=tuple(sorted(facts, key=lambda fact: fact.id)),
+                    typed_normalization=normalization[0] if normalization else "",
+                )
+            )
+        conflicts.append(
+            ConflictGroup(
+                subject=subject,
+                relation=relation,
+                values=tuple(sorted(values, key=lambda value: value.object)),
+                related_candidates=tuple(
+                    sorted(
+                        candidate_by_subject_relation.get((subject, relation), []),
+                        key=lambda fact: fact.id,
+                    )
+                ),
+            )
+        )
+
+    return TrustWorkbench(
+        corroborated=tuple(corroborated),
+        conflicts=tuple(conflicts),
+    )
+
+
+def _typed_spec(
+    relation: str, typed: dict[str, TypedRelationSpec]
+) -> TypedRelationSpec | None:
+    return typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+
+
+def _normalized_object_key(
+    obj: str, spec: TypedRelationSpec | None
+) -> tuple[tuple[str, object], str]:
+    if spec is None:
+        return ("raw", obj), ""
+    scalar = normalize_typed_value(spec.type, obj, spec.units)
+    if scalar is None:
+        return ("raw", obj), ""
+    return ("scalar", scalar), f"{spec.alias}={scalar}"
+
+
+def _relation_alias(relation: str, canonical: str) -> str:
+    if unicodedata.normalize("NFC", relation) == canonical:
+        return ""
+    return f"{relation} -> {canonical}"

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -43,6 +43,7 @@ from verinote.pipeline.corroboration import (
     store_corroboration,
     store_single_valued_conflicts,
 )
+from verinote.pipeline.workbench import trust_workbench
 from verinote.engine.terms import StringLit, render_term
 from verinote.store import Store
 from verinote.store.fact_input import structural_term, term_input_kind
@@ -483,6 +484,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "active_filter": filter,
                 "filters": _review_filters(),
             },
+        )
+
+    @app.get("/workbench", response_class=HTMLResponse)
+    def workbench(request: Request):
+        return templates.TemplateResponse(
+            request,
+            "workbench.html",
+            {"workbench": trust_workbench(_active_store())},
         )
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -14,6 +14,7 @@
       <a href="/">Dashboard</a>
       <a href="/sources">Sources</a>
       <a href="/review">Review</a>
+      <a href="/workbench">Workbench</a>
       <a href="/questions">Questions</a>
       <a href="/report">Report</a>
       <a href="/analytics">Analytics</a>

--- a/verinote/web/templates/workbench.html
+++ b/verinote/web/templates/workbench.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+{% block title %}Trust workbench - verinote{% endblock %}
+{% block content %}
+<h1>Trust workbench</h1>
+<p class="muted">Source-backed corroboration and single-valued conflicts for reviewed engine-input facts.</p>
+
+<h2>Corroborated facts <span class="muted">- grouped by normalized SPO</span></h2>
+{% if workbench.corroborated %}
+<table class="counts">
+  <thead><tr><th>Normalized fact</th><th>Source support</th><th>Facts</th></tr></thead>
+  <tbody>
+    {% for group in workbench.corroborated %}
+    <tr>
+      <td>
+        <code>{{ group.subject }}</code> /
+        <code>{{ group.relation }}</code> /
+        <code>{{ group.object }}</code>
+      </td>
+      <td>
+        <strong>{{ group.source_count }}</strong>
+        <div class="mini-list">
+          {% for source in group.sources %}<div><code>{{ source }}</code></div>{% endfor %}
+        </div>
+      </td>
+      <td>
+        {% for fact in group.facts %}
+        <div class="mini-list">
+          <a href="/facts/{{ fact.id }}/provenance">#{{ fact.id }}</a>
+          <span class="badge badge-{{ fact.status }}">{{ fact.status }}</span>
+          <code>{{ fact.relation }}</code> / <code>{{ fact.object }}</code>
+          {% if fact.relation_alias %}<span class="muted">alias {{ fact.relation_alias }}</span>{% endif %}
+          {% if fact.typed_normalization %}<span class="muted">{{ fact.typed_normalization }}</span>{% endif %}
+        </div>
+        {% endfor %}
+        {% if group.related_candidates %}
+        <div class="mini-list"><strong>Related candidates</strong></div>
+        {% for fact in group.related_candidates %}
+        <div class="mini-list">
+          <a href="/facts/{{ fact.id }}/provenance">#{{ fact.id }}</a>
+          <span class="badge badge-{{ fact.status }}">{{ fact.status }}</span>
+          <code>{{ fact.source }}</code>
+        </div>
+        {% endfor %}
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="muted">No facts are corroborated by multiple distinct sources.</p>
+{% endif %}
+
+<h2>Single-valued conflicts <span class="muted">- engine-input facts only</span></h2>
+{% if workbench.conflicts %}
+<table class="counts">
+  <thead><tr><th>Subject / relation</th><th>Competing values</th><th>Related candidates</th></tr></thead>
+  <tbody>
+    {% for conflict in workbench.conflicts %}
+    <tr>
+      <td><code>{{ conflict.subject }}</code> / <code>{{ conflict.relation }}</code></td>
+      <td>
+        {% for value in conflict.values %}
+        <div class="evidence">
+          <code>{{ value.object }}</code>
+          <span class="muted">{{ value.source_count }} source{% if value.source_count != 1 %}s{% endif %}</span>
+          {% if value.typed_normalization %}<span class="muted">{{ value.typed_normalization }}</span>{% endif %}
+          <div class="mini-list">
+            {% for source in value.sources %}<div><code>{{ source }}</code></div>{% endfor %}
+          </div>
+          {% for fact in value.facts %}
+          <div class="mini-list">
+            <a href="/facts/{{ fact.id }}/provenance">#{{ fact.id }}</a>
+            <span class="badge badge-{{ fact.status }}">{{ fact.status }}</span>
+            <code>{{ fact.relation }}</code> / <code>{{ fact.object }}</code>
+            {% if fact.relation_alias %}<span class="muted">alias {{ fact.relation_alias }}</span>{% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        {% endfor %}
+      </td>
+      <td>
+        {% if conflict.related_candidates %}
+          {% for fact in conflict.related_candidates %}
+          <div class="mini-list">
+            <a href="/facts/{{ fact.id }}/provenance">#{{ fact.id }}</a>
+            <span class="badge badge-{{ fact.status }}">{{ fact.status }}</span>
+            <code>{{ fact.object }}</code>
+          </div>
+          {% endfor %}
+        {% else %}
+          <span class="muted">None</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="muted">No source-backed single-valued conflicts.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a trust workbench view model that groups reviewed engine-input facts by normalized SPO and keeps candidate facts separate
- add a /workbench UI with corroborated fact groups, single-valued conflicts, source support, relation alias details, typed scalar normalization, and provenance links
- cover corroboration, conflict grouping, aliasing, typed normalization, and candidate separation with synthetic tests

Closes #90

## Tests
- .venv/bin/python -m ruff check verinote tests
- .venv/bin/python -m pytest tests/test_workbench.py tests/test_web.py tests/test_corroboration.py -q
- .venv/bin/python -m pytest -q