### PR TITLE
Add conservative accept recommendations

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.pipeline.acceptance import (
+    accept_recommendation,
+    apply_auto_accept_recommendations,
+    RULE_NAME,
+)
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _write_policy(tmp_path) -> None:
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\n'
+        'functional("published_year").\n'
+        'functional("revenue").\n',
+        encoding="utf-8",
+    )
+    (policy / "relation-aliases.md").write_text(
+        "- `sales` -> `revenue`\n",
+        encoding="utf-8",
+    )
+    (policy / "typed-relations.md").write_text(
+        "- revenue : amount as revenue_scalar\n",
+        encoding="utf-8",
+    )
+
+
+def _done_job(store: Store, source_id: int) -> int:
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id,
+        source_id=source_id,
+        chunks=["Sample body"],
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_done(chunk_id, candidates=1)
+    store.finish_extraction_job(job_id)
+    return job_id
+
+
+def test_accept_recommendation_requires_distinct_completed_source_support(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    job_a = _done_job(s, source_a)
+    job_b = _done_job(s, source_b)
+    fact_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        confidence=0.01,
+        source_id=source_a,
+        job_id=job_a,
+    )
+    support_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        confidence=0.99,
+        source_id=source_b,
+        job_id=job_b,
+    )
+
+    recommendation = accept_recommendation(s, fact_id)
+
+    assert recommendation is not None
+    assert recommendation.eligible is True
+    assert recommendation.reasons == ()
+    assert recommendation.support_sources == ("sources/a.txt", "sources/b.txt")
+    assert recommendation.support_fact_ids == (fact_id, support_id)
+
+
+def test_accept_recommendation_rejects_same_source_duplicates(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/a.txt")
+    job_id = _done_job(s, source_id)
+    fact_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_id,
+        job_id=job_id,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=source_id,
+        job_id=job_id,
+    )
+
+    recommendation = accept_recommendation(s, fact_id)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "insufficient_distinct_source_support" in recommendation.reasons
+
+
+def test_accept_recommendation_rejects_incomplete_source_analysis(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    job_b = _done_job(s, source_b)
+    fact_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_a,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=source_b,
+        job_id=job_b,
+    )
+
+    recommendation = accept_recommendation(s, fact_id)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "source_analysis_incomplete" in recommendation.reasons
+
+
+def test_accept_recommendation_rejects_single_valued_conflicts(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    source_c = s.add_source("sources/c.txt")
+    job_a = _done_job(s, source_a)
+    job_b = _done_job(s, source_b)
+    job_c = _done_job(s, source_c)
+    fact_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_a,
+        job_id=job_a,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=source_b,
+        job_id=job_b,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2025",
+        status="confirmed",
+        source_id=source_c,
+        job_id=job_c,
+    )
+
+    recommendation = accept_recommendation(s, fact_id)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "single_valued_conflict" in recommendation.reasons
+
+
+def test_accept_recommendation_uses_alias_and_typed_scalar_normalization(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    job_a = _done_job(s, source_a)
+    job_b = _done_job(s, source_b)
+    fact_id = s.add_fact(
+        "Sample Company",
+        "sales",
+        'amount(5400,"억")',
+        status="candidate",
+        source_id=source_a,
+        job_id=job_a,
+    )
+    s.add_fact(
+        "Sample Company",
+        "revenue",
+        'amount(0.54,"조")',
+        status="confirmed",
+        source_id=source_b,
+        job_id=job_b,
+    )
+
+    recommendation = accept_recommendation(s, fact_id)
+
+    assert recommendation is not None
+    assert recommendation.eligible is True
+    assert recommendation.canonical_relation == "revenue"
+    assert recommendation.typed_normalization == "revenue_scalar=540000000000"
+
+
+def test_accept_recommendation_rejects_previous_rejection(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/a.txt")
+    job_id = _done_job(s, source_id)
+    fact_id = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_id,
+        job_id=job_id,
+    )
+    s.set_status(fact_id, "superseded", action="rejected")
+
+    recommendation = accept_recommendation(s, fact_id)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "previously_rejected_or_superseded" in recommendation.reasons
+
+
+def test_apply_auto_accept_promotes_only_eligible_facts_and_records_rule_event(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    job_a = _done_job(s, source_a)
+    job_b = _done_job(s, source_b)
+    eligible = s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_a,
+        job_id=job_a,
+    )
+    s.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=source_b,
+        job_id=job_b,
+    )
+    ineligible = s.add_fact(
+        "Unsupported Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_a,
+        job_id=job_a,
+    )
+
+    applied = apply_auto_accept_recommendations(s)
+
+    assert [recommendation.fact_id for recommendation in applied] == [eligible]
+    assert s.get_fact(eligible)["status"] == "accepted"
+    assert s.get_fact(ineligible)["status"] == "candidate"
+    events = s.fact_events(eligible)
+    assert [event["event_type"] for event in events][-2:] == [
+        "auto_accepted",
+        "auto_accept_applied",
+    ]
+    assert events[-1]["actor"] == "rule"
+    assert events[-1]["rule_name"] == RULE_NAME

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ def _clear_env(monkeypatch):
         "VERINOTE_EXTRACTION_CHUNK_CHARS",
         "VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS",
         "VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK",
+        "VERINOTE_AUTO_ACCEPT_RECOMMENDATIONS",
         "VERINOTE_ROOT",
         "XDG_CONFIG_HOME",
     ):
@@ -60,6 +61,7 @@ def test_default_model_when_nothing_set(tmp_path, monkeypatch):
     assert cfg.extraction_chunk_chars == 300
     assert cfg.extraction_chunk_overlap_chars == 40
     assert cfg.extraction_max_facts_per_chunk == 8
+    assert cfg.auto_accept_recommendations is False
 
 
 def test_llm_timeout_env_override(tmp_path, monkeypatch):
@@ -77,6 +79,7 @@ def test_extraction_settings_round_trip_and_env_override(tmp_path, monkeypatch):
         extraction_chunk_chars=450,
         extraction_chunk_overlap_chars=25,
         extraction_max_facts_per_chunk=6,
+        auto_accept_recommendations=True,
     )
 
     cfg = Config.for_root(tmp_path)
@@ -84,14 +87,17 @@ def test_extraction_settings_round_trip_and_env_override(tmp_path, monkeypatch):
     assert cfg.extraction_chunk_chars == 450
     assert cfg.extraction_chunk_overlap_chars == 25
     assert cfg.extraction_max_facts_per_chunk == 6
+    assert cfg.auto_accept_recommendations is True
 
     monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "200")
     monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
     monkeypatch.setenv("VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK", "3")
+    monkeypatch.setenv("VERINOTE_AUTO_ACCEPT_RECOMMENDATIONS", "false")
     cfg = Config.for_root(tmp_path)
     assert cfg.extraction_chunk_chars == 200
     assert cfg.extraction_chunk_overlap_chars == 0
     assert cfg.extraction_max_facts_per_chunk == 3
+    assert cfg.auto_accept_recommendations is False
 
 
 def test_claude_cli_provider_is_available():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -370,6 +370,61 @@ def test_workbench_renders_corroboration_conflicts_and_normalization(tmp_path):
     assert f'href="/facts/{fact_id}/provenance"' in body
 
 
+def test_review_shows_accept_recommendation(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("published_year").\n',
+        encoding="utf-8",
+    )
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    job_a = store.create_extraction_job(
+        source_id=source_a,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    job_b = store.create_extraction_job(
+        source_id=source_b,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_a = store.add_source_chunks(job_id=job_a, source_id=source_a, chunks=["a"])[0]
+    chunk_b = store.add_source_chunks(job_id=job_b, source_id=source_b, chunks=["b"])[0]
+    store.mark_extraction_job_running(job_a)
+    store.mark_chunk_running(chunk_a)
+    store.mark_chunk_done(chunk_a, candidates=1)
+    store.finish_extraction_job(job_a)
+    store.mark_extraction_job_running(job_b)
+    store.mark_chunk_running(chunk_b)
+    store.mark_chunk_done(chunk_b, candidates=1)
+    store.finish_extraction_job(job_b)
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="candidate",
+        source_id=source_a,
+        job_id=job_a,
+    )
+    store.add_fact(
+        "Sample Report",
+        "published_year",
+        "2024",
+        status="confirmed",
+        source_id=source_b,
+        job_id=job_b,
+    )
+
+    body = unescape(c.get("/review").text)
+
+    assert "accept recommended" in body
+
+
 def test_toggle_endpoint_swaps_row(tmp_path):
     c = _client(tmp_path)
     r = c.post(f"/facts/{c.fact_id}/toggle")
@@ -1308,6 +1363,7 @@ def test_settings_page_renders(tmp_path):
     assert 'name="extraction_chunk_chars"' in r.text
     assert 'name="extraction_chunk_overlap_chars"' in r.text
     assert 'name="extraction_max_facts_per_chunk"' in r.text
+    assert 'name="auto_accept_recommendations"' in r.text
 
 
 def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
@@ -1323,6 +1379,7 @@ def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
             "extraction_chunk_chars": "500",
             "extraction_chunk_overlap_chars": "20",
             "extraction_max_facts_per_chunk": "5",
+            "auto_accept_recommendations": "on",
         },
         follow_redirects=False,
     )
@@ -1332,6 +1389,7 @@ def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
     assert c.app.state.cfg.extraction_chunk_chars == 500
     assert c.app.state.cfg.extraction_chunk_overlap_chars == 20
     assert c.app.state.cfg.extraction_max_facts_per_chunk == 5
+    assert c.app.state.cfg.auto_accept_recommendations is True
     assert (tmp_path / "config.json").is_file()
 
 

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -139,6 +139,7 @@ def save_settings(
     extraction_chunk_chars: int | None = None,
     extraction_chunk_overlap_chars: int | None = None,
     extraction_max_facts_per_chunk: int | None = None,
+    auto_accept_recommendations: bool | None = None,
 ) -> None:
     """Persist non-secret settings to `<root>/config.json` (never the API key)."""
     root.mkdir(parents=True, exist_ok=True)
@@ -153,6 +154,8 @@ def save_settings(
         payload["extraction_chunk_overlap_chars"] = extraction_chunk_overlap_chars
     if extraction_max_facts_per_chunk is not None:
         payload["extraction_max_facts_per_chunk"] = extraction_max_facts_per_chunk
+    if auto_accept_recommendations is not None:
+        payload["auto_accept_recommendations"] = bool(auto_accept_recommendations)
     _settings_path(root).write_text(
         json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
@@ -191,6 +194,17 @@ def _pick_int(env: str, saved: object, default: int, *, minimum: int = 1) -> int
     return value if value >= minimum else default
 
 
+def _pick_bool(env: str, saved: object, default: bool) -> bool:
+    raw = os.environ.get(env)
+    if raw is None:
+        raw = saved
+    if raw is None or raw == "":
+        return default
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
 @dataclass(frozen=True)
 class Config:
     root: Path
@@ -203,6 +217,7 @@ class Config:
     extraction_chunk_chars: int = 300
     extraction_chunk_overlap_chars: int = 40
     extraction_max_facts_per_chunk: int = 8
+    auto_accept_recommendations: bool = False
 
     def extraction_schema_hint(self) -> str:
         return (
@@ -235,6 +250,11 @@ class Config:
             saved.get("extraction_max_facts_per_chunk"),
             8,
         )
+        auto_accept = _pick_bool(
+            "VERINOTE_AUTO_ACCEPT_RECOMMENDATIONS",
+            saved.get("auto_accept_recommendations"),
+            False,
+        )
         return cls(
             root=root,
             db_path=root / "kb.sqlite",
@@ -246,6 +266,7 @@ class Config:
             extraction_chunk_chars=chunk_chars,
             extraction_chunk_overlap_chars=chunk_overlap,
             extraction_max_facts_per_chunk=max_facts,
+            auto_accept_recommendations=auto_accept,
         )
 
     @classmethod

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Conservative deterministic accept recommendations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import unicodedata
+
+from verinote.pipeline.corroboration import (
+    canonical_relation,
+    normalize_typed_value,
+    store_functional_relations,
+    store_relation_aliases,
+    store_typed_relations,
+    TypedRelationSpec,
+)
+from verinote.store import ENGINE_STATUSES, REVIEW_STATUSES, Store
+
+RULE_NAME = "corroborated_no_conflict"
+
+
+@dataclass(frozen=True)
+class AcceptRecommendation:
+    fact_id: int
+    eligible: bool
+    reasons: tuple[str, ...]
+    support_sources: tuple[str, ...]
+    support_fact_ids: tuple[int, ...]
+    canonical_relation: str
+    typed_normalization: str
+
+
+def accept_recommendation(store: Store, fact_id: int) -> AcceptRecommendation | None:
+    fact = store.get_fact(fact_id)
+    if fact is None:
+        return None
+    return _engine(store).recommend(fact)
+
+
+def accept_recommendations(store: Store) -> dict[int, AcceptRecommendation]:
+    engine = _engine(store)
+    recommendations = {}
+    for fact in store.facts(statuses=REVIEW_STATUSES):
+        recommendations[int(fact["id"])] = engine.recommend(fact)
+    return recommendations
+
+
+def apply_auto_accept_recommendations(store: Store) -> list[AcceptRecommendation]:
+    applied = []
+    for recommendation in accept_recommendations(store).values():
+        if not recommendation.eligible:
+            continue
+        store.set_status(
+            recommendation.fact_id,
+            "accepted",
+            action="auto_accepted",
+            actor="rule",
+            rule_name=RULE_NAME,
+        )
+        store.add_fact_event(
+            fact_id=recommendation.fact_id,
+            event_type="auto_accept_applied",
+            actor="rule",
+            rule_name=RULE_NAME,
+            after={
+                "support_sources": list(recommendation.support_sources),
+                "support_fact_ids": list(recommendation.support_fact_ids),
+                "canonical_relation": recommendation.canonical_relation,
+                "typed_normalization": recommendation.typed_normalization,
+            },
+        )
+        applied.append(recommendation)
+    return applied
+
+
+@dataclass(frozen=True)
+class _FactView:
+    id: int
+    subject: str
+    relation: str
+    object: str
+    status: str
+    source: str
+    job_id: int | None
+    canonical_relation: str
+    object_key: tuple[str, object]
+    typed_normalization: str
+
+
+class _RecommendationEngine:
+    def __init__(
+        self,
+        store: Store,
+        aliases: dict[str, str],
+        typed: dict[str, TypedRelationSpec],
+        single_valued: set[str],
+    ) -> None:
+        self.store = store
+        self.aliases = aliases
+        self.typed = typed
+        self.single_valued = single_valued
+        self.facts = [_view_fact(row, aliases, typed) for row in store.facts()]
+
+    def recommend(self, fact_row) -> AcceptRecommendation:
+        target = _view_fact(fact_row, self.aliases, self.typed)
+        reasons = []
+        if target.status not in REVIEW_STATUSES:
+            reasons.append("not_review_candidate")
+        if not target.source:
+            reasons.append("source_missing")
+        if not _job_done(self.store, target.job_id):
+            reasons.append("source_analysis_incomplete")
+        if target.status == "superseded" or _was_rejected(self.store, target.id):
+            reasons.append("previously_rejected_or_superseded")
+
+        support = self._supporting_facts(target)
+        support_sources = tuple(sorted({fact.source for fact in support if fact.source}))
+        if len(support_sources) < 2:
+            reasons.append("insufficient_distinct_source_support")
+        if any(not _job_done(self.store, fact.job_id) for fact in support):
+            if "source_analysis_incomplete" not in reasons:
+                reasons.append("source_analysis_incomplete")
+        if self._has_single_valued_conflict(target):
+            reasons.append("single_valued_conflict")
+
+        return AcceptRecommendation(
+            fact_id=target.id,
+            eligible=not reasons,
+            reasons=tuple(dict.fromkeys(reasons)),
+            support_sources=support_sources,
+            support_fact_ids=tuple(sorted(fact.id for fact in support)),
+            canonical_relation=target.canonical_relation,
+            typed_normalization=target.typed_normalization,
+        )
+
+    def _supporting_facts(self, target: _FactView) -> list[_FactView]:
+        return [
+            fact
+            for fact in self.facts
+            if fact.status in REVIEW_STATUSES | ENGINE_STATUSES
+            and fact.subject == target.subject
+            and fact.canonical_relation == target.canonical_relation
+            and fact.object_key == target.object_key
+            and fact.source
+        ]
+
+    def _has_single_valued_conflict(self, target: _FactView) -> bool:
+        if target.canonical_relation not in self.single_valued:
+            return False
+        for fact in self.facts:
+            if fact.status not in ENGINE_STATUSES:
+                continue
+            if fact.subject != target.subject:
+                continue
+            if fact.canonical_relation != target.canonical_relation:
+                continue
+            if fact.object_key != target.object_key:
+                return True
+        return False
+
+
+def _engine(store: Store) -> _RecommendationEngine:
+    aliases = store_relation_aliases(store)
+    typed = store_typed_relations(store)
+    single_valued = {canonical_relation(r, aliases) for r in store_functional_relations(store)}
+    return _RecommendationEngine(store, aliases, typed, single_valued)
+
+
+def _view_fact(
+    row, aliases: dict[str, str], typed: dict[str, TypedRelationSpec]
+) -> _FactView:
+    relation = str(row["relation"])
+    canonical = canonical_relation(relation, aliases)
+    spec = _typed_spec(canonical, typed)
+    object_key, typed_normalization = _object_key(str(row["object"]), spec)
+    return _FactView(
+        id=int(row["id"]),
+        subject=str(row["subject"]),
+        relation=relation,
+        object=str(row["object"]),
+        status=str(row["status"]),
+        source=str(row["source_path"] or "").strip(),
+        job_id=int(row["job_id"]) if row["job_id"] is not None else None,
+        canonical_relation=canonical,
+        object_key=object_key,
+        typed_normalization=typed_normalization,
+    )
+
+
+def _typed_spec(
+    relation: str, typed: dict[str, TypedRelationSpec]
+) -> TypedRelationSpec | None:
+    return typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+
+
+def _object_key(
+    obj: str, spec: TypedRelationSpec | None
+) -> tuple[tuple[str, object], str]:
+    if spec is None:
+        return ("raw", obj), ""
+    scalar = normalize_typed_value(spec.type, obj, spec.units)
+    if scalar is None:
+        return ("raw", obj), ""
+    return ("scalar", scalar), f"{spec.alias}={scalar}"
+
+
+def _job_done(store: Store, job_id: int | None) -> bool:
+    if job_id is None:
+        return False
+    job = store.get_extraction_job(job_id)
+    return job is not None and job["status"] == "done"
+
+
+def _was_rejected(store: Store, fact_id: int) -> bool:
+    return any(event["event_type"] == "rejected" for event in store.fact_events(fact_id))

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -747,7 +747,15 @@ class Store:
         rows = self._conn.execute("SELECT status, COUNT(*) c FROM facts GROUP BY status")
         return {r["status"]: r["c"] for r in rows}
 
-    def set_status(self, fact_id: int, status: str, *, action: str = "set_status") -> sqlite3.Row | None:
+    def set_status(
+        self,
+        fact_id: int,
+        status: str,
+        *,
+        action: str = "set_status",
+        actor: str = "human",
+        rule_name: str = "",
+    ) -> sqlite3.Row | None:
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
@@ -757,7 +765,7 @@ class Store:
                 (status, fact_id),
             )
             after = self.get_fact(fact_id)
-            self._log(fact_id, action, before, after)
+            self._log(fact_id, action, before, after, actor=actor, rule_name=rule_name)
             return after
 
     def toggle_review(self, fact_id: int) -> sqlite3.Row | None:
@@ -882,7 +890,14 @@ class Store:
             )
 
     def _log(
-        self, fact_id: int, action: str, before: sqlite3.Row | None, after: sqlite3.Row | None
+        self,
+        fact_id: int,
+        action: str,
+        before: sqlite3.Row | None,
+        after: sqlite3.Row | None,
+        *,
+        actor: str = "human",
+        rule_name: str = "",
     ) -> None:
         source_id = int(after["source_id"]) if after and after["source_id"] is not None else None
         job_id = int(after["job_id"]) if after and after["job_id"] is not None else None
@@ -898,9 +913,10 @@ class Store:
         self._add_fact_event(
             fact_id=fact_id,
             event_type=action,
-            actor="human",
+            actor=actor,
             source_id=source_id,
             job_id=job_id,
+            rule_name=rule_name,
             before=before,
             after=after,
         )

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -39,6 +39,10 @@ from verinote.pipeline import (
     verify,
     write_query_file,
 )
+from verinote.pipeline.acceptance import (
+    accept_recommendations,
+    apply_auto_accept_recommendations,
+)
 from verinote.pipeline.corroboration import (
     store_corroboration,
     store_single_valued_conflicts,
@@ -130,10 +134,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             view[f"{field}_kind"] = term_input_kind(term)
         return view
 
-    def _fact_row_context(fact):
+    def _fact_row_context(fact, recommendations=None):
         view = _fact_view(fact)
         trust = fact_trust_summary(_active_store(), int(fact["id"])) if fact else None
-        return {"f": view, "trust": trust}
+        if fact and recommendations is None:
+            recommendations = accept_recommendations(_active_store())
+        recommendation = recommendations.get(int(fact["id"])) if fact else None
+        return {"f": view, "trust": trust, "recommendation": recommendation}
+
+    def _maybe_apply_auto_accept() -> None:
+        if _active_cfg().auto_accept_recommendations:
+            apply_auto_accept_recommendations(_active_store())
 
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
@@ -302,6 +313,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         job_id=job_id,
                         schema_hint=cfg.extraction_schema_hint(),
                     )
+                    if cfg.auto_accept_recommendations:
+                        apply_auto_accept_recommendations(worker_store)
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
@@ -474,7 +487,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.get("/review", response_class=HTMLResponse)
     def review(request: Request, filter: str = "needs-human-decision"):
         store = _active_store()
-        rows = [_fact_row_context(f) for f in store.review_queue()]
+        _maybe_apply_auto_accept()
+        recommendations = accept_recommendations(store)
+        rows = [_fact_row_context(f, recommendations) for f in store.review_queue()]
         rows = _filter_review_rows(rows, filter)
         return templates.TemplateResponse(
             request,
@@ -649,6 +664,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "extraction_chunk_chars": c.extraction_chunk_chars,
                 "extraction_chunk_overlap_chars": c.extraction_chunk_overlap_chars,
                 "extraction_max_facts_per_chunk": c.extraction_max_facts_per_chunk,
+                "auto_accept_recommendations": c.auto_accept_recommendations,
                 "root": c.root,
                 "has_key": bool(c.api_key),  # never render the key itself
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
@@ -671,6 +687,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         extraction_chunk_chars: int = Form(300),
         extraction_chunk_overlap_chars: int = Form(40),
         extraction_max_facts_per_chunk: int = Form(8),
+        auto_accept_recommendations: str | None = Form(None),
     ):
         cfg = _active_cfg()
         save_settings(
@@ -681,6 +698,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             extraction_chunk_chars=extraction_chunk_chars,
             extraction_chunk_overlap_chars=extraction_chunk_overlap_chars,
             extraction_max_facts_per_chunk=extraction_max_facts_per_chunk,
+            auto_accept_recommendations=auto_accept_recommendations == "on",
         )
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -67,6 +67,8 @@ tr.editing td { background: rgba(91, 157, 255, .06); }
 .settings label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); }
 .settings select, .settings input { background: var(--bg); color: var(--fg);
   border: 1px solid var(--line); border-radius: 6px; padding: .4rem .55rem; }
+.settings .inline-setting { flex-direction: row; align-items: center; color: var(--fg); }
+.settings .inline-setting input { width: auto; }
 .settings .btn { align-self: flex-start; }
 .ok-note { background: rgba(63, 185, 80, .12); border: 1px solid var(--ok); color: var(--ok);
   border-radius: 8px; padding: .6rem .9rem; margin: 1rem 0; }

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -24,6 +24,15 @@
       {% if trust.typed_value %}
         <span class="badge">{{ trust.typed_value.type }} <code>{{ trust.typed_value.alias }}</code></span>
       {% endif %}
+      {% if recommendation %}
+        {% if recommendation.eligible %}
+          <span class="badge trust-reviewed">accept recommended</span>
+        {% else %}
+          {% for reason in recommendation.reasons[:2] %}
+            <span class="badge trust-unsupported">{{ reason|replace("_", " ") }}</span>
+          {% endfor %}
+        {% endif %}
+      {% endif %}
     {% else %}
       <span class="badge trust-evidence_missing">trust unavailable</span>
     {% endif %}

--- a/verinote/web/templates/review.html
+++ b/verinote/web/templates/review.html
@@ -20,6 +20,7 @@
     {% for row in queue %}
       {% set f = row.f %}
       {% set trust = row.trust %}
+      {% set recommendation = row.recommendation %}
       {% include "partials/fact_row.html" %}
     {% endfor %}
   </tbody>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -40,6 +40,10 @@
   <label>Max facts per chunk
     <input type="number" name="extraction_max_facts_per_chunk" value="{{ extraction_max_facts_per_chunk }}" min="1" step="1">
   </label>
+  <label class="inline-setting">
+    <input type="checkbox" name="auto_accept_recommendations" {{ 'checked' if auto_accept_recommendations else '' }}>
+    Auto-accept eligible deterministic recommendations
+  </label>
   <button class="btn" type="submit">Save</button>
 </form>
 


### PR DESCRIPTION
## Summary
- add deterministic accept recommendation logic based on distinct completed source support, relation aliases, typed scalar normalization, conflict checks, and rejection history
- show accept recommendations in the review queue without using confidence
- add explicit opt-in auto-accept setting that promotes only eligible facts and records rule lifecycle events

Closes #91

## Tests
- .venv/bin/python -m ruff check verinote tests
- .venv/bin/python -m pytest tests/test_acceptance.py tests/test_config.py tests/test_web.py tests/test_store.py -q
- .venv/bin/python -m pytest -q