### PR TITLE
Add report fact traceability

### DIFF
--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MPL-2.0
+from verinote.pipeline.query import query_path
+from verinote.pipeline.report_trace import report_trace
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_report_trace_links_direct_answers_to_engine_facts_and_evidence(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact(
+        "Sample Person",
+        "born_in",
+        "Sample City",
+        status="confirmed",
+        source_id=source_id,
+    )
+    s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=source_id,
+        snippet="Sample Person was born in Sample City.",
+    )
+    s.add_fact(
+        "Candidate Person",
+        "born_in",
+        "Draft City",
+        status="candidate",
+        source_id=source_id,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    trace = report_trace(s)
+
+    assert trace.excluded_candidate_count == 1
+    assert len(trace.answers) == 1
+    answer = trace.answers[0]
+    assert (answer.qid, answer.value, answer.conflicted) == ("1", "Sample City", False)
+    assert [fact.id for fact in answer.facts] == [fact_id]
+    assert answer.facts[0].source == "sources/sample.txt"
+    assert answer.facts[0].evidence == "Sample Person was born in Sample City."
+
+
+def test_report_trace_marks_answers_from_conflicted_relations(tmp_path):
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    first = s.add_fact(
+        "Sample Org",
+        "established_on",
+        "2020",
+        status="confirmed",
+        source_id=source_a,
+    )
+    second = s.add_fact(
+        "Sample Org",
+        "established_on",
+        "2021",
+        status="accepted",
+        source_id=source_b,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Org", "established_on", O).\n',
+        encoding="utf-8",
+    )
+
+    trace = report_trace(s)
+
+    assert [(answer.value, answer.conflicted) for answer in trace.answers] == [
+        ("2020", True),
+        ("2021", True),
+    ]
+    assert {fact.id for answer in trace.answers for fact in answer.facts} == {
+        first,
+        second,
+    }
+
+
+def test_report_trace_skips_non_direct_query_rules(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample City", status="confirmed")
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "born_in", O), O != "Other".\n',
+        encoding="utf-8",
+    )
+
+    trace = report_trace(s)
+
+    assert trace.answers == ()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -815,6 +815,46 @@ def test_report_ok_for_consistent_kb(tmp_path):
     assert "backend: DuckDB" in r.text
 
 
+def test_report_shows_query_trace_links_and_candidate_exclusion(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    source_id = store.add_source("sources/sample.txt")
+    fact_id = store.add_fact(
+        "Sample Person",
+        "born_in",
+        "Sample City",
+        status="confirmed",
+        source_id=source_id,
+    )
+    store.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=source_id,
+        snippet="Sample Person was born in Sample City.",
+    )
+    store.add_fact(
+        "Candidate Person",
+        "born_in",
+        "Draft City",
+        status="candidate",
+        source_id=source_id,
+    )
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    body = unescape(c.get("/report").text)
+
+    assert "Traceability" in body
+    assert "candidate/needs-review fact(s) were excluded from engine input" in body
+    assert f'href="/facts/{fact_id}/provenance"' in body
+    assert "Sample Person was born in Sample City." in body
+    assert "Draft City" not in body
+
+
 def test_report_gates_on_contradiction(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Trace direct query/report outputs back to engine-input facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from verinote.engine.datalog import (
+    AtomExpr,
+    Comparison,
+    DatalogParseError,
+    DatalogValidationError,
+    parse_and_validate_program,
+)
+from verinote.engine.terms import Compound, StringLit, Term, Var, render_term
+from verinote.pipeline.query import load_query
+from verinote.pipeline.trust import fact_trust_summary
+from verinote.store import Store
+
+_RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+_ANSWER_RE = re.compile(r"answer_q(?P<qid>[0-9]+)\Z")
+
+
+@dataclass(frozen=True)
+class TraceFact:
+    id: int
+    subject: str
+    relation: str
+    object: str
+    source: str
+    evidence: str
+    conflicted: bool
+
+
+@dataclass(frozen=True)
+class AnswerTrace:
+    qid: str
+    value: str
+    facts: tuple[TraceFact, ...]
+    conflicted: bool
+
+
+@dataclass(frozen=True)
+class ReportTrace:
+    answers: tuple[AnswerTrace, ...]
+    excluded_candidate_count: int
+
+
+def report_trace(store: Store) -> ReportTrace:
+    candidates = store.status_counts().get("candidate", 0) + store.status_counts().get(
+        "needs_review", 0
+    )
+    query = load_query(store)
+    if not query:
+        return ReportTrace(answers=(), excluded_candidate_count=candidates)
+
+    try:
+        program = parse_and_validate_program(_RELATION_DECL + query)
+    except (DatalogParseError, DatalogValidationError):
+        return ReportTrace(answers=(), excluded_candidate_count=candidates)
+
+    facts = store.engine_fact_terms()
+    fact_rows = {int(row["id"]): store.get_fact(int(row["id"])) for row in facts}
+    traces = []
+    seen: set[tuple[str, str, tuple[int, ...]]] = set()
+    for rule in program.rules:
+        qid = _answer_qid(rule.head.predicate)
+        if qid is None:
+            continue
+        relation_atom = _direct_relation_atom(rule.body)
+        if relation_atom is None:
+            continue
+        matches = _match_relation_atom(relation_atom, facts, rule.head.args)
+        for value, fact_ids in sorted(matches.items()):
+            key = (qid, value, tuple(sorted(fact_ids)))
+            if key in seen:
+                continue
+            seen.add(key)
+            trace_facts = tuple(
+                _trace_fact(store, fact_id, fact_rows[fact_id])
+                for fact_id in sorted(fact_ids)
+                if fact_rows[fact_id] is not None
+            )
+            traces.append(
+                AnswerTrace(
+                    qid=qid,
+                    value=value,
+                    facts=trace_facts,
+                    conflicted=any(fact.conflicted for fact in trace_facts),
+                )
+            )
+    return ReportTrace(
+        answers=tuple(sorted(traces, key=lambda trace: (int(trace.qid), trace.value))),
+        excluded_candidate_count=candidates,
+    )
+
+
+def _answer_qid(predicate: str) -> str | None:
+    match = _ANSWER_RE.fullmatch(predicate)
+    return match.group("qid") if match else None
+
+
+def _direct_relation_atom(body: tuple[AtomExpr | Comparison, ...]) -> AtomExpr | None:
+    atoms = [item for item in body if isinstance(item, AtomExpr)]
+    comparisons = [item for item in body if isinstance(item, Comparison)]
+    if len(atoms) != 1 or comparisons:
+        return None
+    atom = atoms[0]
+    if atom.predicate != "relation" or len(atom.args) != 3:
+        return None
+    if any(_has_vars(term) and not isinstance(term, Var) for term in atom.args):
+        return None
+    return atom
+
+
+def _match_relation_atom(
+    atom: AtomExpr,
+    facts: list[dict[str, object]],
+    head_args: tuple[Term, ...],
+) -> dict[str, set[int]]:
+    if len(head_args) != 1:
+        return {}
+    matches: dict[str, set[int]] = {}
+    for fact in facts:
+        bindings: dict[str, Term] = {}
+        if not _match_term(atom.args[0], fact["subject"], bindings):
+            continue
+        if not _match_term(atom.args[1], fact["relation"], bindings):
+            continue
+        if not _match_term(atom.args[2], fact["object"], bindings):
+            continue
+        value = _head_value(head_args[0], bindings)
+        if value is None:
+            continue
+        matches.setdefault(_render_answer_value(value), set()).add(int(fact["id"]))
+    return matches
+
+
+def _match_term(pattern: Term, value: object, bindings: dict[str, Term]) -> bool:
+    if not isinstance(value, Term):
+        return False
+    if isinstance(pattern, Var):
+        bound = bindings.get(pattern.name)
+        if bound is None:
+            bindings[pattern.name] = value
+            return True
+        return bound == value
+    return pattern == value
+
+
+def _head_value(term: Term, bindings: dict[str, Term]) -> Term | None:
+    if isinstance(term, Var):
+        return bindings.get(term.name)
+    if _has_vars(term):
+        return None
+    return term
+
+
+def _trace_fact(
+    store: Store,
+    fact_id: int,
+    row,
+) -> TraceFact:
+    summary = fact_trust_summary(store, fact_id)
+    evidence = ""
+    if summary is not None and summary.evidence:
+        evidence = summary.evidence[0].snippet or summary.evidence[0].source_path or ""
+    conflicted = summary is not None and summary.conflict is not None
+    return TraceFact(
+        id=fact_id,
+        subject=str(row["subject"]),
+        relation=str(row["relation"]),
+        object=str(row["object"]),
+        source=str(row["source_path"] or ""),
+        evidence=evidence,
+        conflicted=conflicted,
+    )
+
+
+def _render_answer_value(term: Term) -> str:
+    if isinstance(term, StringLit):
+        return term.value
+    return render_term(term)
+
+
+def _has_vars(term: Term) -> bool:
+    if isinstance(term, Var):
+        return True
+    if isinstance(term, Compound):
+        return any(_has_vars(arg) for arg in term.args)
+    return False

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -43,6 +43,7 @@ from verinote.pipeline.acceptance import (
     accept_recommendations,
     apply_auto_accept_recommendations,
 )
+from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.corroboration import (
     store_corroboration,
     store_single_valued_conflicts,
@@ -639,7 +640,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/report", response_class=HTMLResponse)
     def report(request: Request):
-        return templates.TemplateResponse(request, "report.html", {"rep": verify(_active_store())})
+        store = _active_store()
+        return templates.TemplateResponse(
+            request,
+            "report.html",
+            {"rep": verify(store), "trace": report_trace(store)},
+        )
 
     @app.get("/analytics", response_class=HTMLResponse)
     def analytics(request: Request):

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -28,5 +28,40 @@
   {% for a in rep.answers %}<li>{{ a }}</li>{% endfor %}
 </ul>
 {% endif %}
+<h2>Traceability</h2>
+{% if trace.excluded_candidate_count %}
+<p class="muted">{{ trace.excluded_candidate_count }} candidate/needs-review fact(s) were excluded from engine input.</p>
+{% else %}
+<p class="muted">No candidate facts were included in engine input.</p>
+{% endif %}
+{% if trace.answers %}
+<table class="counts">
+  <thead><tr><th>Answer</th><th>Contributing facts</th></tr></thead>
+  <tbody>
+    {% for answer in trace.answers %}
+    <tr>
+      <td>
+        q{{ answer.qid }}: <code>{{ answer.value }}</code>
+        {% if answer.conflicted %}<span class="badge trust-conflicted">conflict</span>{% endif %}
+      </td>
+      <td>
+        {% for fact in answer.facts %}
+        <div class="mini-list">
+          <a href="/facts/{{ fact.id }}/provenance">#{{ fact.id }}</a>
+          <code>{{ fact.subject }}</code> / <code>{{ fact.relation }}</code> /
+          <code>{{ fact.object }}</code>
+          {% if fact.source %}<span class="muted">{{ fact.source }}</span>{% endif %}
+          {% if fact.conflicted %}<span class="badge trust-conflicted">conflicted relation</span>{% endif %}
+          {% if fact.evidence %}<div class="snippet">{{ fact.evidence }}</div>{% endif %}
+        </div>
+        {% endfor %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="muted">No direct relation fact traces are available for these report rows.</p>
+{% endif %}
 <pre class="report">{{ rep.text }}</pre>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add direct query answer tracing from supported answer_q rules back to engine-input fact ids
- render report traceability with fact dossier links, source/evidence snippets, conflict indicators, and candidate exclusion count
- cover direct traces, conflict warnings, non-direct query fallback, and report UI with synthetic tests

Closes #92

## Tests
- .venv/bin/python -m ruff check verinote tests
- .venv/bin/python -m pytest tests/test_report_trace.py tests/test_verify.py tests/test_web.py -q
- .venv/bin/python -m pytest -q