### PR TITLE
Add dashboard action queues

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -76,6 +76,81 @@ def test_dashboard_shows_factlog_borrowed_source_signals(tmp_path):
     assert "(1 source)" in body
 
 
+def test_dashboard_shows_action_queue_counts_and_links(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    c = TestClient(create_app(cfg))
+    store = c.app.state.store
+    store.add_fact("Unsupported Sample", "uses", "Sample Service", status="candidate")
+    review_source = store.add_source("sources/review.txt")
+    support_a = store.add_source("sources/support-a.txt")
+    support_b = store.add_source("sources/support-b.txt")
+    store.add_fact(
+        "Reviewed Sample",
+        "uses",
+        "Sample Service",
+        status="candidate",
+        source_id=review_source,
+    )
+    store.add_fact(
+        "Reviewed Sample",
+        "uses",
+        "Sample Service",
+        status="confirmed",
+        source_id=support_a,
+    )
+    store.add_fact(
+        "Reviewed Sample",
+        "uses",
+        "Sample Service",
+        status="accepted",
+        source_id=support_b,
+    )
+    conflict_a = store.add_source("sources/conflict-a.txt")
+    conflict_b = store.add_source("sources/conflict-b.txt")
+    store.add_fact("Org", "established_on", "2020", status="confirmed", source_id=conflict_a)
+    store.add_fact("Org", "established_on", "2021", status="accepted", source_id=conflict_b)
+    failed_source = store.add_source("sources/failed.txt")
+    job_id = store.create_extraction_job(
+        source_id=failed_source,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id,
+        source_id=failed_source,
+        chunks=["Sample body"],
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_failed(chunk_id, "provider down")
+    changed = store.add_fact("Changed Sample", "uses", "Service", status="confirmed")
+    store.amend_fact(changed, subject="Changed Sample", relation="uses", obj="Service v2")
+
+    body = unescape(c.get("/").text)
+
+    assert "Action queues" in body
+    assert "Unsupported review items" in body
+    assert "Corroborated review targets" in body
+    assert "Single-valued conflicts" in body
+    assert "Failed source analyses" in body
+    assert "Recent lifecycle changes" in body
+    assert "Source-backed engine facts" in body
+    assert 'href="/review?filter=unsupported"' in body
+    assert 'href="/review?filter=corroborated"' in body
+    assert 'href="/workbench"' in body
+    assert 'href="/sources"' in body
+    assert ">1</td>" in body
+    assert ">3</td>" in body
+
+
 def test_no_active_kb_shows_selector(tmp_path, monkeypatch):
     monkeypatch.delenv("VERINOTE_ROOT", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -863,6 +863,18 @@ class Store:
             )
         )
 
+    def count_facts_with_events(self, event_types: Iterable[str]) -> int:
+        event_types = tuple(event_types)
+        if not event_types:
+            return 0
+        placeholders = ",".join("?" * len(event_types))
+        row = self._conn.execute(
+            "SELECT COUNT(DISTINCT fact_id) AS c FROM fact_events "
+            f"WHERE fact_id IS NOT NULL AND event_type IN ({placeholders})",
+            event_types,
+        ).fetchone()
+        return int(row["c"])
+
     def add_fact_event(
         self,
         *,

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -251,6 +251,54 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     return snippets
         return snippets
 
+    def _dashboard_queues(store: Store) -> list[dict[str, object]]:
+        review_summaries = [
+            fact_trust_summary(store, int(fact["id"])) for fact in store.review_queue()
+        ]
+        review_summaries = [summary for summary in review_summaries if summary is not None]
+        jobs = store.source_extraction_jobs()
+        workbench = trust_workbench(store)
+        corroboration = store_corroboration(store)
+        recent_lifecycle = store.count_facts_with_events(("amended", "reanalyzed"))
+        return [
+            {
+                "label": "Unsupported review items",
+                "count": sum(1 for summary in review_summaries if "unsupported" in summary.trust_labels),
+                "href": "/review?filter=unsupported",
+                "detail": "candidate facts without deterministic source support",
+            },
+            {
+                "label": "Corroborated review targets",
+                "count": sum(1 for summary in review_summaries if "corroborated" in summary.trust_labels),
+                "href": "/review?filter=corroborated",
+                "detail": "review items backed by repeated source support",
+            },
+            {
+                "label": "Single-valued conflicts",
+                "count": len(workbench.conflicts),
+                "href": "/workbench",
+                "detail": "accepted/confirmed values competing under functional rules",
+            },
+            {
+                "label": "Failed source analyses",
+                "count": sum(1 for job in jobs if job["status"] == "failed"),
+                "href": "/sources",
+                "detail": "sources with failed extraction chunks ready for retry",
+            },
+            {
+                "label": "Recent lifecycle changes",
+                "count": int(recent_lifecycle),
+                "href": "/review",
+                "detail": "facts amended or reanalyzed after extraction",
+            },
+            {
+                "label": "Source-backed engine facts",
+                "count": len(corroboration),
+                "href": "/workbench",
+                "detail": "accepted/confirmed facts with source support",
+            },
+        ]
+
     def _dashboard(request: Request, *, error: str | None = None, status_code: int = 200):
         from verinote.engine import coverage
 
@@ -269,6 +317,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "coverage": coverage(store, root=cfg.root),
                 "corroboration": store_corroboration(store),
                 "single_valued_conflicts": store_single_valued_conflicts(store),
+                "queues": _dashboard_queues(store),
                 "provider": app.state.cfg.provider,
                 "provider_label": PROVIDER_LABELS.get(
                     app.state.cfg.provider, app.state.cfg.provider

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -11,6 +11,23 @@
   <div class="card ok"><div class="num">{{ counts.get('confirmed', 0) + counts.get('accepted', 0) }}</div><div class="lbl">engine input</div></div>
 </section>
 
+<h2>Action queues</h2>
+<table class="counts">
+  <thead><tr><th>Queue</th><th>Count</th><th>Next step</th></tr></thead>
+  <tbody>
+    {% for queue in queues %}
+    <tr>
+      <td>
+        <strong>{{ queue.label }}</strong>
+        <div class="src">{{ queue.detail }}</div>
+      </td>
+      <td class="conf">{{ queue.count }}</td>
+      <td><a class="btn ghost" href="{{ queue.href }}">Open</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
 <h2>By status</h2>
 <table class="counts">
   <tbody>


### PR DESCRIPTION
## Summary
- add dashboard action queues for unsupported review items, corroborated review targets, conflicts, failed source analyses, lifecycle changes, and source-backed engine facts
- link each queue to the appropriate review/source/workbench surface instead of duplicating detailed workflows
- cover deterministic queue counts and navigation links with synthetic data

Closes #94

## Tests
- .venv/bin/python -m ruff check verinote tests
- .venv/bin/python -m pytest tests/test_web.py tests/test_store.py -q
- .venv/bin/python -m pytest -q