### PR TITLE
[codex] Add configurable relation aliases for queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Guidance
+
+## Data Privacy
+
+- Do not commit real customer, company, person, document, or source data to this repository.
+- Use synthetic fixtures and examples in code, tests, documentation, prompts, snapshots, and issue/PR text.
+- If a bug report requires demonstrating behavior from real input, reduce it to a synthetic minimal reproduction before adding it to the repository.
+- Before committing, search staged changes for real names, identifiers, document text, and copied source excerpts.

--- a/tests/test_corroboration.py
+++ b/tests/test_corroboration.py
@@ -266,6 +266,31 @@ def test_relation_aliases_parser_rejects_self_map():
         raise AssertionError("expected CorroborationPolicyError")
 
 
+def test_relation_aliases_parser_accepts_plain_arrow_lines():
+    assert relation_aliases("- role -> 역할\n- title -> 직함\n") == {
+        "role": "역할",
+        "title": "직함",
+    }
+
+
+def test_relation_aliases_parser_rejects_malformed_non_empty_lines():
+    try:
+        relation_aliases("- role 역할\n")
+    except CorroborationPolicyError as exc:
+        assert "expected `raw` -> `canonical`" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected CorroborationPolicyError")
+
+
+def test_relation_aliases_parser_rejects_malformed_backticks():
+    try:
+        relation_aliases("- `role -> 역할\n")
+    except CorroborationPolicyError as exc:
+        assert "malformed backtick alias" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected CorroborationPolicyError")
+
+
 def test_store_single_valued_conflicts_loads_relation_alias_file(tmp_path):
     s = _store(tmp_path)
     policy = tmp_path / "policy"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
-from verinote.pipeline.query import load_query, query_path, translate_questions
+import unicodedata
+
+from verinote.pipeline.query import (
+    expand_query_relation_aliases,
+    load_query,
+    query_path,
+    translate_questions,
+)
+from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.store import Store
 
 
@@ -26,6 +34,71 @@ def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
     assert draft.is_file()
     assert load_query(s) == draft.read_text(encoding="utf-8")
     assert f"answer_q{qid}" in load_query(s)
+
+
+def test_load_query_expands_relation_aliases(tmp_path, fake_client):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
+    qid = s.add_question("샘플인물의 역할은 무엇인가")
+    client = fake_client(
+        query=lambda question, qid: f'answer_q{qid}(V) :- relation("샘플인물", "role", V).'
+    )
+
+    translate_questions(s, client, root=tmp_path)
+
+    stored_query = s.questions()[0]["query_dl"]
+    assert f'answer_q{qid}(V) :- relation("샘플인물", "role", V).' in stored_query
+    assert f'answer_q{qid}(V) :- relation("샘플인물", "역할", V).' not in stored_query
+    loaded_query = load_query(s)
+    assert f'answer_q{qid}(V) :- relation("샘플인물", "role", V).' in loaded_query
+    assert f'answer_q{qid}(V) :- relation("샘플인물", "역할", V).' in loaded_query
+
+
+def test_expand_query_relation_aliases_handles_atoms_and_combinations():
+    query_dl = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("샘플인물", role, X), relation(X, "title", O).\n'
+    )
+
+    expanded = expand_query_relation_aliases(query_dl, {"role": "역할", "title": "직함"})
+
+    assert 'answer_q1(O) :- relation("샘플인물", role, X), relation(X, "title", O).' in expanded
+    assert 'answer_q1(O) :- relation("샘플인물", "역할", X), relation(X, "title", O).' in expanded
+    assert 'answer_q1(O) :- relation("샘플인물", role, X), relation(X, "직함", O).' in expanded
+    assert 'answer_q1(O) :- relation("샘플인물", "역할", X), relation(X, "직함", O).' in expanded
+
+
+def test_expand_query_relation_aliases_does_not_expand_variable_relations():
+    query_dl = ".decl answer_q1(value: symbol)\n" 'answer_q1(R) :- relation("샘플인물", R, O).\n'
+
+    assert expand_query_relation_aliases(query_dl, {"role": "역할"}) == query_dl
+
+
+def test_expand_query_relation_aliases_normalizes_query_relation_names():
+    decomposed = unicodedata.normalize("NFD", "역할")
+    query_dl = (
+        ".decl answer_q1(value: symbol)\n"
+        f'answer_q1(O) :- relation("샘플인물", "{decomposed}", O).\n'
+    )
+
+    expanded = expand_query_relation_aliases(query_dl, {"역할": "role"})
+
+    assert 'answer_q1(O) :- relation("샘플인물", "role", O).' in expanded
+
+
+def test_expand_query_relation_aliases_caps_combinations():
+    body = ", ".join(f'relation(X{i}, "r{i}", X{i + 1})' for i in range(7))
+    query_dl = ".decl answer_q1(value: symbol)\n" f"answer_q1(O) :- {body}.\n"
+    aliases = {f"r{i}": f"canonical_{i}" for i in range(7)}
+
+    try:
+        expand_query_relation_aliases(query_dl, aliases)
+    except CorroborationPolicyError as exc:
+        assert "query alias expansion exceeds" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected CorroborationPolicyError")
 
 
 def test_review_required_question_is_flagged_not_in_draft(tmp_path, fake_client):

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -50,6 +50,23 @@ def test_report_trace_links_direct_answers_to_engine_facts_and_evidence(tmp_path
     assert answer.facts[0].evidence == "Sample Person was born in Sample City."
 
 
+def test_report_trace_ignores_invalid_relation_alias_policy(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `role`\n", encoding="utf-8")
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "role", O).\n',
+        encoding="utf-8",
+    )
+
+    trace = report_trace(s)
+
+    assert trace.answers == ()
+
+
 def test_report_trace_marks_answers_from_conflicted_relations(tmp_path):
     s = _store(tmp_path)
     source_a = s.add_source("sources/a.txt")

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -75,6 +75,70 @@ def test_verify_loads_query_file(tmp_path):
     assert "--- query input ---" in rep.text
 
 
+def test_verify_answers_query_through_relation_alias(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("샘플인물", "역할", "샘플역할", status="confirmed")
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(V) :- relation("샘플인물", "role", V).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.answers == ["q1: 샘플역할"]
+
+
+def test_verify_answers_query_through_multiple_relation_aliases(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("샘플인물", "역할", "샘플과제", status="confirmed")
+    s.add_fact("샘플과제", "직함", "샘플역할", status="confirmed")
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text(
+        "- `role` -> `역할`\n- `title` -> `직함`\n",
+        encoding="utf-8",
+    )
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(V) :- relation("샘플인물", "role", X), relation(X, "title", V).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.answers == ["q1: 샘플역할"]
+
+
+def test_verify_reports_invalid_relation_alias_policy(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `role`\n", encoding="utf-8")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(V) :- relation("샘플인물", "role", V).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert "policy error" in rep.findings[0]
+
+
 def test_verify_uses_duckdb_fact_terms_for_structural_compounds(tmp_path):
     s = _store(tmp_path)
     s.add_fact(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -977,6 +977,48 @@ def test_report_surfaces_invalid_query_file(tmp_path):
     assert "bogus" in r.text
 
 
+def test_report_surfaces_invalid_relation_alias_policy(tmp_path):
+    c = _client(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `role`\n", encoding="utf-8")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "role", O).\n',
+        encoding="utf-8",
+    )
+
+    r = c.get("/report")
+
+    assert r.status_code == 200
+    assert "ERRORS" in r.text
+    assert "policy error" in r.text
+    assert "self-map" in r.text
+
+
+def test_questions_surfaces_invalid_relation_alias_policy(tmp_path):
+    c = _client(tmp_path)
+    c.app.state.store.add_question("What is the sample role?")
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `role`\n", encoding="utf-8")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "role", O).\n',
+        encoding="utf-8",
+    )
+
+    r = c.get("/questions")
+
+    assert r.status_code == 200
+    assert "policy error" in r.text
+    assert "self-map" in r.text
+
+
 def test_edit_form_renders(tmp_path):
     c = _client(tmp_path)
     r = c.get(f"/facts/{c.fact_id}/edit")
@@ -1479,6 +1521,63 @@ def test_settings_page_renders(tmp_path):
     assert 'name="extraction_chunk_overlap_chars"' in r.text
     assert 'name="extraction_max_facts_per_chunk"' in r.text
     assert 'name="auto_accept_recommendations"' in r.text
+    assert 'name="relation_aliases_text"' in r.text
+
+
+def test_settings_saves_relation_aliases(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": "- `role` -> `역할`"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 303
+    alias_path = tmp_path / "policy" / "relation-aliases.md"
+    assert alias_path.read_text(encoding="utf-8") == "- `role` -> `역할`\n"
+    body = c.get("/settings").text
+    assert "- `role` -&gt; `역할`" in body
+
+
+def test_settings_saves_plain_relation_aliases(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": "- role -> 역할"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 303
+    alias_path = tmp_path / "policy" / "relation-aliases.md"
+    assert alias_path.read_text(encoding="utf-8") == "- role -> 역할\n"
+
+
+def test_settings_rejects_invalid_relation_aliases(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": "- `role` -> `role`"},
+    )
+
+    assert r.status_code == 400
+    assert "self-map" in r.text
+    assert not (tmp_path / "policy" / "relation-aliases.md").exists()
+
+
+def test_settings_rejects_malformed_relation_aliases(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": "- role 역할"},
+    )
+
+    assert r.status_code == 400
+    assert "expected `raw` -&gt; `canonical`" in r.text
+    assert not (tmp_path / "policy" / "relation-aliases.md").exists()
 
 
 def test_settings_save_changes_active_provider(tmp_path, monkeypatch):

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -20,7 +20,6 @@ from verinote.engine import DEFAULT_POLICY
 from verinote.store import ENGINE_STATUSES, Store
 
 _FUNCTIONAL_RE = re.compile(r'functional\("((?:\\.|[^"\\])*)"\)\.')
-_ALIAS_RE = re.compile(r"`([^`]+)`\s*->\s*`([^`]+)`")
 _TYPED_REL_RE = re.compile(
     r"^(?:`(?P<qname>[^`]+)`|(?P<name>\S+))\s*:\s*(?P<type>\w+)\s+as\s+(?P<alias>\S+)"
     r"(?:\s*\((?P<units>[^)]*)\))?\s*$"
@@ -116,17 +115,17 @@ def store_functional_relations(store: Store) -> set[str]:
 def relation_aliases(text: str) -> dict[str, str]:
     """Parse factlog-style relation aliases into ``{raw: canonical}``."""
     aliases: dict[str, str] = {}
-    for line in text.splitlines():
+    for line_no, line in enumerate(text.splitlines(), start=1):
         stripped = re.sub(r"^\s*[-*]\s+", "", line.strip()).strip()
         if not stripped or stripped.startswith("#"):
             continue
-        match = _ALIAS_RE.fullmatch(stripped)
-        if match is None:
-            continue
-        raw = unicodedata.normalize("NFC", match.group(1).strip())
-        canonical = unicodedata.normalize("NFC", match.group(2).strip())
-        if not raw or not canonical:
-            continue
+        raw_text, separator, canonical_text = stripped.partition("->")
+        if not separator or "->" in canonical_text:
+            raise CorroborationPolicyError(
+                f"relation-aliases.md:{line_no}: expected `raw` -> `canonical`"
+            )
+        raw = _relation_alias_token(raw_text, line_no=line_no)
+        canonical = _relation_alias_token(canonical_text, line_no=line_no)
         if raw == canonical:
             raise CorroborationPolicyError(
                 f"relation-aliases.md: self-map {raw!r} is not allowed"
@@ -144,6 +143,34 @@ def relation_aliases(text: str) -> dict[str, str]:
                 f"relation-aliases.md: {raw!r} is both raw and canonical"
             )
     return aliases
+
+
+def _relation_alias_token(text: str, *, line_no: int) -> str:
+    token = text.strip()
+    if not token:
+        raise CorroborationPolicyError(
+            f"relation-aliases.md:{line_no}: alias names must not be empty"
+        )
+    if token.startswith("`") or token.endswith("`"):
+        if len(token) < 2 or not token.startswith("`") or not token.endswith("`"):
+            raise CorroborationPolicyError(
+                f"relation-aliases.md:{line_no}: malformed backtick alias"
+            )
+        token = token[1:-1].strip()
+        if "`" in token:
+            raise CorroborationPolicyError(
+                f"relation-aliases.md:{line_no}: malformed backtick alias"
+            )
+    elif "`" in token:
+        raise CorroborationPolicyError(
+            f"relation-aliases.md:{line_no}: malformed backtick alias"
+        )
+    token = unicodedata.normalize("NFC", token)
+    if not token:
+        raise CorroborationPolicyError(
+            f"relation-aliases.md:{line_no}: alias names must not be empty"
+        )
+    return token
 
 
 def store_relation_aliases(store: Store) -> dict[str, str]:

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -11,13 +11,19 @@ in the DB only.
 
 from __future__ import annotations
 
+from itertools import product
 from pathlib import Path
+import unicodedata
 
+from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
+from verinote.engine.terms import Atom, StringLit, render_term
 from verinote.llm.base import LLMClient
+from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
 from verinote.store import Store
 
 # Query draft, relative to the KB root (the db file's directory).
 QUERY_RELPATH = Path("facts") / "query.dl"
+MAX_ALIAS_EXPANDED_RULES_PER_RULE = 64
 
 
 def query_path(root: Path) -> Path:
@@ -64,5 +70,92 @@ def load_query(store: Store) -> str | None:
     """Read the KB's query draft, or None when none has been generated."""
     path = store.db_path.parent / QUERY_RELPATH
     if path.is_file():
-        return path.read_text(encoding="utf-8")
+        return expand_query_relation_aliases(
+            path.read_text(encoding="utf-8"), store_relation_aliases(store)
+        )
     return None
+
+
+def expand_query_relation_aliases(query_dl: str, aliases: dict[str, str]) -> str:
+    """Append alias-expanded answer rules for relation/3 query bodies.
+
+    Relation aliases are user policy, so the engine should honor them even when a
+    query draft was translated before the alias existed. For example, with
+    ``role -> 역할`` this appends a canonical rule for a model-generated
+    ``relation(S, "role", O)`` body without mutating the stored draft.
+    """
+    if not aliases:
+        return query_dl
+    try:
+        program = parse_program(query_dl)
+    except DatalogParseError:
+        return query_dl
+
+    existing = {_render_rule(rule) for rule in program.rules}
+    extra: list[str] = []
+    for rule in program.rules:
+        alternatives: list[list[object]] = []
+        has_alias = False
+        for index, item in enumerate(rule.body):
+            if not (isinstance(item, AtomExpr) and item.predicate == "relation"):
+                alternatives.append([item])
+                continue
+            if len(item.args) != 3:
+                alternatives.append([item])
+                continue
+            raw = _relation_name(item.args[1])
+            if raw is None or raw not in aliases:
+                alternatives.append([item])
+                continue
+            canonical = aliases[raw]
+            alternatives.append(
+                [item, AtomExpr("relation", (item.args[0], StringLit(canonical), item.args[2]))]
+            )
+            has_alias = True
+        if not has_alias:
+            continue
+        expanded_count = 1
+        for choices in alternatives:
+            expanded_count *= len(choices)
+        if expanded_count > MAX_ALIAS_EXPANDED_RULES_PER_RULE:
+            raise CorroborationPolicyError(
+                "relation-aliases.md: query alias expansion exceeds "
+                f"{MAX_ALIAS_EXPANDED_RULES_PER_RULE} rules for {rule.head.predicate}"
+            )
+        for body in product(*alternatives):
+            rendered = _render_rule_with_body(rule.head, body)
+            if rendered not in existing:
+                existing.add(rendered)
+                extra.append(rendered)
+    if not extra:
+        return query_dl
+    suffix = "\n" if query_dl.endswith("\n") else "\n"
+    return query_dl + suffix + "\n".join(extra) + "\n"
+
+
+def _relation_name(term: object) -> str | None:
+    if isinstance(term, StringLit):
+        return unicodedata.normalize("NFC", term.value)
+    if isinstance(term, Atom):
+        return unicodedata.normalize("NFC", term.name)
+    return None
+
+
+def _render_rule(rule) -> str:
+    return _render_rule_with_body(rule.head, rule.body)
+
+
+def _render_rule_with_body(head: AtomExpr, body: tuple[object, ...]) -> str:
+    return _render_atom(head) + " :- " + ", ".join(_render_body_item(item) for item in body) + "."
+
+
+def _render_body_item(item: object) -> str:
+    if isinstance(item, AtomExpr):
+        return _render_atom(item)
+    if isinstance(item, Comparison):
+        return f"{render_term(item.left)} {item.op} {render_term(item.right)}"
+    raise TypeError(f"unsupported body item: {item!r}")
+
+
+def _render_atom(atom: AtomExpr) -> str:
+    return atom.predicate + "(" + ", ".join(render_term(arg) for arg in atom.args) + ")"

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -14,6 +14,7 @@ from verinote.engine.datalog import (
     parse_and_validate_program,
 )
 from verinote.engine.terms import Compound, StringLit, Term, Var, render_term
+from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.trust import fact_trust_summary
 from verinote.store import Store
@@ -51,7 +52,10 @@ def report_trace(store: Store) -> ReportTrace:
     candidates = store.status_counts().get("candidate", 0) + store.status_counts().get(
         "needs_review", 0
     )
-    query = load_query(store)
+    try:
+        query = load_query(store)
+    except CorroborationPolicyError:
+        return ReportTrace(answers=(), excluded_candidate_count=candidates)
     if not query:
         return ReportTrace(answers=(), excluded_candidate_count=candidates)
 

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from verinote.engine import CheckReport
+from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.store import Store
 
 # Per-KB policy location, relative to the KB root (the db file's directory).
@@ -39,6 +40,14 @@ def verify(store: Store) -> CheckReport:
             text=f"backend: DuckDB\n\npolicy/engine error: {exc}",
             findings=[f"ERROR engine error: {exc}"],
         )
-    return store.inference_cache.run_check(
-        rows, policy_dl=load_policy(store), query_dl=load_query(store)
-    )
+    try:
+        query_dl = load_query(store)
+    except CorroborationPolicyError as exc:
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"backend: DuckDB\n\npolicy/error: {exc}",
+            findings=[f"ERROR policy error: {exc}"],
+        )
+    return store.inference_cache.run_check(rows, policy_dl=load_policy(store), query_dl=query_dl)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -45,6 +45,9 @@ from verinote.pipeline.acceptance import (
 )
 from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    RELATION_ALIASES_RELPATH,
+    relation_aliases,
     store_corroboration,
     store_single_valued_conflicts,
 )
@@ -82,6 +85,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if cfg is None:
             raise RuntimeError("no active KB")
         return cfg
+
+    def _relation_aliases_path() -> Path:
+        return _active_cfg().root / RELATION_ALIASES_RELPATH
+
+    def _relation_aliases_text() -> str:
+        path = _relation_aliases_path()
+        if not path.is_file():
+            return ""
+        return path.read_text(encoding="utf-8")
 
     def _open_root(root: Path) -> None:
         """Point this running app at a KB root, creating it if needed."""
@@ -643,10 +655,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if app.state.store is None:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
+        rep = verify(store)
+        page_error = error
+        if page_error is None:
+            page_error = next(
+                (finding for finding in rep.findings if "policy error" in finding),
+                None,
+            )
         return templates.TemplateResponse(
             request,
             "questions.html",
-            {"questions": store.questions(), "answers": verify(store).answers, "error": error},
+            {"questions": store.questions(), "answers": rep.answers, "error": page_error},
             status_code=status_code,
         )
 
@@ -723,6 +742,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "root": c.root,
                 "has_key": bool(c.api_key),  # never render the key itself
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
+                "relation_aliases": _relation_aliases_text(),
                 "test_result": test_result,
                 "error": error,
             },
@@ -757,6 +777,21 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)
+        return RedirectResponse("/settings", status_code=303)
+
+    @app.post("/settings/relation-aliases", response_class=HTMLResponse)
+    def save_relation_aliases(request: Request, relation_aliases_text: str = Form("")):
+        text = relation_aliases_text.strip()
+        try:
+            relation_aliases(text)
+        except CorroborationPolicyError as e:
+            return _settings(request, error=str(e), status_code=400)
+        path = _relation_aliases_path()
+        if text:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text + "\n", encoding="utf-8")
+        elif path.exists():
+            path.unlink()
         return RedirectResponse("/settings", status_code=303)
 
     @app.post("/settings/root", response_class=HTMLResponse)

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -63,4 +63,13 @@
   {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
   {% if test_result %}<p class="ok-note" role="status">✓ {{ test_result }}</p>{% endif %}
 </div>
+
+<h2>Relation aliases</h2>
+<form class="settings" action="/settings/relation-aliases" method="post">
+  <label>Aliases
+    <textarea name="relation_aliases_text" rows="8"
+              placeholder="- `role` -> `역할`">{{ relation_aliases }}</textarea>
+  </label>
+  <button class="btn" type="submit">Save aliases</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add repository guidance prohibiting real customer/source data in committed artifacts
- add Settings UI support for editing `policy/relation-aliases.md`
- apply relation aliases when loading query drafts so existing translated queries can match canonical fact relations
- surface malformed alias policies as policy errors instead of crashing report/questions

## Validation
- `.venv/bin/python -m ruff check verinote tests`
- `.venv/bin/python -m pytest -q`

## Notes
- Query drafts remain unchanged on disk; alias-expanded rules are added only for effective execution.