### PR TITLE
[codex] Paginate and sort review queue

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -32,6 +32,70 @@ def test_review_queue_excludes_confirmed(tmp_path):
     assert [q["subject"] for q in queue] == ["A"]
 
 
+def test_review_queue_page_limits_counts_and_sorts(tmp_path):
+    s = _store(tmp_path)
+    for idx in range(1, 56):
+        s.add_fact(f"Candidate {idx:02d}", "r", "B", status="candidate")
+    s.add_fact("Confirmed", "r", "B", status="confirmed")
+
+    first = s.review_queue_page(page=1, page_size=25, sort="newest")
+    second = s.review_queue_page(page=2, page_size=25, sort="newest")
+
+    assert first.total == 55
+    assert len(first.rows) == 25
+    assert first.start == 1
+    assert first.end == 25
+    assert first.page_count == 3
+    assert first.rows[0]["subject"] == "Candidate 55"
+    assert second.rows[0]["subject"] == "Candidate 30"
+
+
+def test_review_queue_page_clamps_invalid_params(tmp_path):
+    s = _store(tmp_path)
+    for idx in range(3):
+        s.add_fact(f"Candidate {idx}", "r", "B", status="candidate")
+
+    page = s.review_queue_page(page="bad", page_size=999, sort="unsafe")
+
+    assert page.page == 1
+    assert page.page_size == 50
+    assert page.sort == "newest"
+    assert [row["subject"] for row in page.rows] == [
+        "Candidate 2",
+        "Candidate 1",
+        "Candidate 0",
+    ]
+
+
+def test_review_queue_page_sort_source_is_allowlisted(tmp_path):
+    s = _store(tmp_path)
+    b = s.add_source("sources/b.txt")
+    a = s.add_source("sources/a.txt")
+    s.add_fact("No Source", "r", "B", status="candidate")
+    s.add_fact("B Source", "r", "B", status="candidate", source_id=b)
+    s.add_fact("A Source", "r", "B", status="candidate", source_id=a)
+
+    page = s.review_queue_page(page=1, page_size=25, sort="source")
+
+    assert [row["subject"] for row in page.rows] == ["A Source", "B Source", "No Source"]
+
+
+def test_review_queue_ids_and_facts_by_ids_preserve_sort_order(tmp_path):
+    s = _store(tmp_path)
+    ids = [
+        s.add_fact("First", "r", "B", status="candidate"),
+        s.add_fact("Second", "r", "B", status="candidate"),
+        s.add_fact("Third", "r", "B", status="candidate"),
+    ]
+    s.add_fact("Confirmed", "r", "B", status="confirmed")
+
+    newest_ids = s.review_queue_ids(sort="newest")
+    rows = s.facts_by_ids([ids[1], ids[0]])
+
+    assert newest_ids == [ids[2], ids[1], ids[0]]
+    assert [row["subject"] for row in rows] == ["Second", "First"]
+
+
 def test_review_log_records_decision(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("A", "r", "B", status="needs_review")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -204,6 +204,72 @@ def test_review_shows_queue(tmp_path):
     assert "Conf." not in r.text
 
 
+def test_review_paginates_large_queue_and_preserves_controls(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    for idx in range(1200):
+        store.add_fact(f"Bulk {idx:03d}", "uses", "Sample", status="candidate")
+
+    body = unescape(c.get("/review").text)
+
+    assert body.count('<tr id="fact-') == 50
+    assert "Showing 1-50 of 1201 review facts" in body
+    assert "Bulk 1199" in body
+    assert "Bulk 1149" not in body
+    assert 'href="/review?filter=needs-human-decision&sort=newest&page_size=50&page=2"' in body
+
+    page_two = unescape(c.get("/review?page=2").text)
+    assert page_two.count('<tr id="fact-') == 50
+    assert "Showing 51-100 of 1201 review facts" in page_two
+    assert "Bulk 1149" in page_two
+    assert "Bulk 1099" not in page_two
+
+    controls = unescape(c.get("/review?sort=oldest&page_size=25&page=2").text)
+    assert 'href="/review?filter=unsupported&sort=oldest&page_size=25&page=1"' in controls
+    assert '<option value="oldest" selected>Oldest</option>' in controls
+    assert '<option value="25" selected>25</option>' in controls
+
+
+def test_review_clamps_invalid_pagination_params(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    for idx in range(60):
+        store.add_fact(f"Clamp {idx:03d}", "uses", "Sample", status="candidate")
+
+    body = unescape(c.get("/review?page=bad&page_size=1000&sort=subject").text)
+
+    assert body.count('<tr id="fact-') == 50
+    assert "Showing 1-50 of 61 review facts" in body
+    assert '<option value="newest" selected>Newest</option>' in body
+    assert '<option value="50" selected>50</option>' in body
+
+
+def test_review_trust_filter_applies_before_pagination(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    for idx in range(60):
+        source_id = store.add_source(f"sources/support-{idx:03d}.txt")
+        store.add_fact(f"Supported {idx:03d}", "uses", "Sample", status="candidate")
+        store.add_fact(
+            f"Supported {idx:03d}",
+            "uses",
+            "Sample",
+            status="confirmed",
+            source_id=source_id,
+        )
+
+    unfiltered = unescape(c.get("/review").text)
+    assert "is_a" not in unfiltered
+
+    body = unescape(c.get("/review?filter=unsupported").text)
+
+    assert body.count('<tr id="fact-') == 1
+    assert "Showing 1-1 of 1 review facts" in body
+    assert "is_a" in body
+    assert "Supported 059" not in body
+    assert "Trust filter is applied to this page" not in body
+
+
 def test_review_renders_structural_terms_from_duckdb_and_distinguishes_strings(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable
 import unicodedata
 
 from verinote.pipeline.corroboration import (
@@ -41,6 +42,19 @@ def accept_recommendations(store: Store) -> dict[int, AcceptRecommendation]:
     engine = _engine(store)
     recommendations = {}
     for fact in store.facts(statuses=REVIEW_STATUSES):
+        recommendations[int(fact["id"])] = engine.recommend(fact)
+    return recommendations
+
+
+def accept_recommendations_for(
+    store: Store, fact_ids: Iterable[int]
+) -> dict[int, AcceptRecommendation]:
+    engine = _engine(store)
+    recommendations = {}
+    for fact_id in fact_ids:
+        fact = store.get_fact(int(fact_id))
+        if fact is None:
+            continue
         recommendations[int(fact["id"])] = engine.recommend(fact)
     return recommendations
 

--- a/verinote/store/__init__.py
+++ b/verinote/store/__init__.py
@@ -2,9 +2,19 @@
 """SQLite system-of-record for verinote."""
 
 from verinote.store.db import (
-    Store,
-    REVIEW_STATUSES,
+    DEFAULT_REVIEW_PAGE_SIZE,
     ENGINE_STATUSES,
+    REVIEW_PAGE_SIZES,
+    REVIEW_STATUSES,
+    ReviewQueuePage,
+    Store,
 )
 
-__all__ = ["Store", "REVIEW_STATUSES", "ENGINE_STATUSES"]
+__all__ = [
+    "Store",
+    "REVIEW_STATUSES",
+    "ENGINE_STATUSES",
+    "DEFAULT_REVIEW_PAGE_SIZE",
+    "REVIEW_PAGE_SIZES",
+    "ReviewQueuePage",
+]

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -9,6 +9,7 @@ for deterministic inference and attaches this same file read-only for analytics.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import sqlite3
 import threading
@@ -20,10 +21,85 @@ from typing import Any, Iterable
 REVIEW_STATUSES = frozenset({"candidate", "needs_review"})
 ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
+REVIEW_PAGE_SIZES = (25, 50, 100)
+DEFAULT_REVIEW_PAGE_SIZE = 50
+DEFAULT_REVIEW_SORT = "newest"
+REVIEW_SORT_SQL = {
+    "newest": "f.id DESC",
+    "oldest": "f.id ASC",
+    "updated": "f.updated_at DESC, f.id DESC",
+    "confidence": "f.confidence DESC, f.id DESC",
+    "source": "s.path IS NULL ASC, lower(s.path) ASC, f.id DESC",
+}
 
 
 def _load_schema() -> str:
     return resources.files("verinote.store").joinpath("schema.sql").read_text(encoding="utf-8")
+
+
+@dataclass(frozen=True)
+class ReviewQueuePage:
+    rows: list[sqlite3.Row]
+    total: int
+    page: int
+    page_size: int
+    sort: str
+
+    @property
+    def page_count(self) -> int:
+        if self.total == 0:
+            return 1
+        return (self.total + self.page_size - 1) // self.page_size
+
+    @property
+    def start(self) -> int:
+        if self.total == 0:
+            return 0
+        return (self.page - 1) * self.page_size + 1
+
+    @property
+    def end(self) -> int:
+        return min(self.page * self.page_size, self.total)
+
+    @classmethod
+    def from_rows(
+        cls,
+        rows: list[sqlite3.Row],
+        *,
+        total: int,
+        page: object,
+        page_size: object,
+        sort: object,
+    ) -> "ReviewQueuePage":
+        page_size = _review_page_size(page_size)
+        page = _positive_int(page, 1)
+        sort = _review_sort(sort)
+        page_count = max(1, (total + page_size - 1) // page_size)
+        return cls(
+            rows=rows,
+            total=total,
+            page=min(page, page_count),
+            page_size=page_size,
+            sort=sort,
+        )
+
+
+def _positive_int(value: object, default: int) -> int:
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _review_page_size(value: object) -> int:
+    parsed = _positive_int(value, DEFAULT_REVIEW_PAGE_SIZE)
+    return parsed if parsed in REVIEW_PAGE_SIZES else DEFAULT_REVIEW_PAGE_SIZE
+
+
+def _review_sort(value: object) -> str:
+    sort = str(value)
+    return sort if sort in REVIEW_SORT_SQL else DEFAULT_REVIEW_SORT
 
 
 class Store:
@@ -742,6 +818,75 @@ class Store:
 
     def review_queue(self) -> list[sqlite3.Row]:
         return self.facts(statuses=REVIEW_STATUSES)
+
+    def review_queue_ids(self, *, sort: object = DEFAULT_REVIEW_SORT) -> list[int]:
+        sort = _review_sort(sort)
+        statuses = tuple(sorted(REVIEW_STATUSES))
+        placeholders = ",".join("?" * len(statuses))
+        rows = self._conn.execute(
+            "SELECT f.id FROM facts f "
+            "LEFT JOIN sources s ON s.id = f.source_id "
+            f"WHERE f.status IN ({placeholders}) "
+            f"ORDER BY {REVIEW_SORT_SQL[sort]}",
+            statuses,
+        )
+        return [int(row["id"]) for row in rows]
+
+    def facts_by_ids(self, fact_ids: Iterable[int]) -> list[sqlite3.Row]:
+        ids = [int(fact_id) for fact_id in fact_ids]
+        if not ids:
+            return []
+        placeholders = ",".join("?" * len(ids))
+        rows = list(
+            self._conn.execute(
+                "SELECT f.*, s.path AS source_path FROM facts f "
+                "LEFT JOIN sources s ON s.id = f.source_id "
+                f"WHERE f.id IN ({placeholders})",
+                tuple(ids),
+            )
+        )
+        by_id = {int(row["id"]): row for row in rows}
+        return [by_id[fact_id] for fact_id in ids if fact_id in by_id]
+
+    def review_queue_page(
+        self,
+        *,
+        page: object = 1,
+        page_size: object = DEFAULT_REVIEW_PAGE_SIZE,
+        sort: object = DEFAULT_REVIEW_SORT,
+    ) -> ReviewQueuePage:
+        page_size = _review_page_size(page_size)
+        page = _positive_int(page, 1)
+        sort = _review_sort(sort)
+        statuses = tuple(sorted(REVIEW_STATUSES))
+        placeholders = ",".join("?" * len(statuses))
+        where = f"f.status IN ({placeholders})"
+        total = int(
+            self._conn.execute(
+                f"SELECT COUNT(*) AS c FROM facts f WHERE {where}",
+                statuses,
+            ).fetchone()["c"]
+        )
+        page_count = max(1, (total + page_size - 1) // page_size)
+        page = min(page, page_count)
+        offset = (page - 1) * page_size
+        rows = list(
+            self._conn.execute(
+                "SELECT f.*, s.path AS source_path FROM facts f "
+                "LEFT JOIN sources s ON s.id = f.source_id "
+                f"WHERE {where} "
+                f"ORDER BY {REVIEW_SORT_SQL[sort]} "
+                "LIMIT ? OFFSET ?",
+                (*statuses, page_size, offset),
+            )
+        )
+        return ReviewQueuePage.from_rows(
+            rows=rows,
+            total=total,
+            page=page,
+            page_size=page_size,
+            sort=sort,
+        )
 
     def status_counts(self) -> dict[str, int]:
         rows = self._conn.execute("SELECT status, COUNT(*) c FROM facts GROUP BY status")

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -99,6 +99,7 @@ CREATE TABLE IF NOT EXISTS facts (
 );
 
 CREATE INDEX IF NOT EXISTS idx_facts_status ON facts(status);
+CREATE INDEX IF NOT EXISTS idx_facts_review_status_id ON facts(status, id);
 CREATE INDEX IF NOT EXISTS idx_facts_triple ON facts(subject, relation, object);
 
 -- Source-backed evidence anchors for extracted facts. Chunk-level anchors are

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 import threading
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -41,6 +42,7 @@ from verinote.pipeline import (
 )
 from verinote.pipeline.acceptance import (
     accept_recommendations,
+    accept_recommendations_for,
     apply_auto_accept_recommendations,
 )
 from verinote.pipeline.report_trace import report_trace
@@ -53,7 +55,12 @@ from verinote.pipeline.corroboration import (
 )
 from verinote.pipeline.workbench import trust_workbench
 from verinote.engine.terms import StringLit, render_term
-from verinote.store import Store
+from verinote.store import (
+    DEFAULT_REVIEW_PAGE_SIZE,
+    REVIEW_PAGE_SIZES,
+    ReviewQueuePage,
+    Store,
+)
 from verinote.store.fact_input import structural_term, term_input_kind
 
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
@@ -194,18 +201,137 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             ("conflicted", "Conflicted"),
         ]
 
-    def _filter_review_rows(rows: list[dict[str, object]], active_filter: str):
+    def _active_review_filter(active_filter: str) -> str:
         labels = {key for key, _ in _review_filters()}
-        if active_filter not in labels:
-            active_filter = "needs-human-decision"
-        if active_filter == "needs-human-decision":
-            return rows
-        label = active_filter.replace("-", "_")
+        return active_filter if active_filter in labels else "needs-human-decision"
+
+    def _review_url(
+        *,
+        active_filter: str,
+        sort: str,
+        page_size: int,
+        page: int = 1,
+    ) -> str:
+        return "/review?" + urlencode(
+            {
+                "filter": active_filter,
+                "sort": sort,
+                "page_size": page_size,
+                "page": page,
+            }
+        )
+
+    def _review_filter_links(active_filter: str, sort: str, page_size: int):
         return [
-            row
-            for row in rows
-            if row["trust"] is not None and label in row["trust"].trust_labels
+            {
+                "key": key,
+                "label": label,
+                "href": _review_url(
+                    active_filter=key,
+                    sort=sort,
+                    page_size=page_size,
+                    page=1,
+                ),
+                "active": active_filter == key,
+            }
+            for key, label in _review_filters()
         ]
+
+    def _review_pages(active_filter: str, sort: str, page_size: int, page: int, page_count: int):
+        candidates = {1, page_count}
+        for nearby in range(page - 2, page + 3):
+            if 1 <= nearby <= page_count:
+                candidates.add(nearby)
+        pages = []
+        last = 0
+        for number in sorted(candidates):
+            if last and number > last + 1:
+                pages.append({"ellipsis": True})
+            pages.append(
+                {
+                    "number": number,
+                    "active": number == page,
+                    "href": _review_url(
+                        active_filter=active_filter,
+                        sort=sort,
+                        page_size=page_size,
+                        page=number,
+                    ),
+                }
+            )
+            last = number
+        return pages
+
+    def _review_pager(active_filter: str, page_data):
+        page_count = page_data.page_count
+        page = page_data.page
+        return {
+            "total": page_data.total,
+            "start": page_data.start,
+            "end": page_data.end,
+            "page": page,
+            "page_size": page_data.page_size,
+            "page_count": page_count,
+            "sort": page_data.sort,
+            "page_sizes": REVIEW_PAGE_SIZES,
+            "sort_options": [
+                ("newest", "Newest"),
+                ("oldest", "Oldest"),
+                ("updated", "Recently updated"),
+                ("confidence", "Confidence"),
+                ("source", "Source"),
+            ],
+            "prev_href": (
+                _review_url(
+                    active_filter=active_filter,
+                    sort=page_data.sort,
+                    page_size=page_data.page_size,
+                    page=page - 1,
+                )
+                if page > 1
+                else None
+            ),
+            "next_href": (
+                _review_url(
+                    active_filter=active_filter,
+                    sort=page_data.sort,
+                    page_size=page_data.page_size,
+                    page=page + 1,
+                )
+                if page < page_count
+                else None
+            ),
+            "pages": _review_pages(
+                active_filter, page_data.sort, page_data.page_size, page, page_count
+            ),
+        }
+
+    def _review_page(store: Store, active_filter: str, page: str, page_size: str, sort: str):
+        if active_filter == "needs-human-decision":
+            return store.review_queue_page(page=page, page_size=page_size, sort=sort)
+        label = active_filter.replace("-", "_")
+        matching_ids = [
+            fact_id
+            for fact_id in store.review_queue_ids(sort=sort)
+            if (summary := fact_trust_summary(store, fact_id)) is not None
+            and label in summary.trust_labels
+        ]
+        page_data = ReviewQueuePage.from_rows(
+            rows=[],
+            total=len(matching_ids),
+            page=page,
+            page_size=page_size,
+            sort=sort,
+        )
+        start = (page_data.page - 1) * page_data.page_size
+        rows = store.facts_by_ids(matching_ids[start : start + page_data.page_size])
+        return ReviewQueuePage.from_rows(
+            rows=rows,
+            total=len(matching_ids),
+            page=page_data.page,
+            page_size=page_data.page_size,
+            sort=page_data.sort,
+        )
 
     def _source_inspector_rows(store: Store) -> list[dict[str, object]]:
         facts = store.facts()
@@ -547,19 +673,30 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return RedirectResponse("/sources", status_code=303)
 
     @app.get("/review", response_class=HTMLResponse)
-    def review(request: Request, filter: str = "needs-human-decision"):
+    def review(
+        request: Request,
+        filter: str = "needs-human-decision",
+        page: str = "1",
+        page_size: str = str(DEFAULT_REVIEW_PAGE_SIZE),
+        sort: str = "newest",
+    ):
         store = _active_store()
-        _maybe_apply_auto_accept()
-        recommendations = accept_recommendations(store)
-        rows = [_fact_row_context(f, recommendations) for f in store.review_queue()]
-        rows = _filter_review_rows(rows, filter)
+        active_filter = _active_review_filter(filter)
+        page_data = _review_page(store, active_filter, page, page_size, sort)
+        recommendations = accept_recommendations_for(
+            store, [int(f["id"]) for f in page_data.rows]
+        )
+        rows = [_fact_row_context(f, recommendations) for f in page_data.rows]
         return templates.TemplateResponse(
             request,
             "review.html",
             {
                 "queue": rows,
-                "active_filter": filter,
-                "filters": _review_filters(),
+                "active_filter": active_filter,
+                "filters": _review_filter_links(
+                    active_filter, page_data.sort, page_data.page_size
+                ),
+                "pager": _review_pager(active_filter, page_data),
             },
         )
 

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -46,6 +46,22 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .filters { display: flex; gap: .45rem; flex-wrap: wrap; margin: 1rem 0; }
 .filters a { text-decoration: none; color: var(--muted); }
 .filters a.active { color: var(--accent); border-color: var(--accent); }
+.review-toolbar { display: flex; align-items: end; gap: .8rem; flex-wrap: wrap;
+  margin: .8rem 0; }
+.review-toolbar label { display: flex; flex-direction: column; gap: .25rem;
+  color: var(--muted); font-size: .85rem; }
+.review-toolbar select { background: var(--bg); color: var(--fg);
+  border: 1px solid var(--line); border-radius: 6px; padding: .35rem .5rem; }
+.review-toolbar button { background: var(--accent); color: #06101f; border: 0;
+  border-radius: 6px; padding: .4rem .75rem; cursor: pointer; font-weight: 600; }
+.review-status { color: var(--muted); margin: .65rem 0; }
+.review-status .muted { margin-left: .5rem; }
+.pagination { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap;
+  margin: .8rem 0 1rem; }
+.pagination a { text-decoration: none; }
+.pagination .active { color: var(--accent); border-color: var(--accent); }
+.pagination .disabled { pointer-events: none; }
+.page-ellipsis { color: var(--muted); padding: 0 .2rem; }
 .row-meta { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .35rem; }
 .signals { min-width: 13rem; }
 .signals .badge { display: inline-block; margin: .12rem .1rem; }

--- a/verinote/web/templates/review.html
+++ b/verinote/web/templates/review.html
@@ -6,10 +6,68 @@
   Toggle promotes to <code>confirmed</code>; accept/reject decide directly.</p>
 
 <nav class="filters" aria-label="review filters">
-  {% for key, label in filters %}
-    <a class="badge {% if active_filter == key %}active{% endif %}" href="/review?filter={{ key }}">{{ label }}</a>
+  {% for item in filters %}
+    <a class="badge {% if item.active %}active{% endif %}"
+       href="{{ item.href }}"
+       {% if item.active %}aria-current="page"{% endif %}>{{ item.label }}</a>
   {% endfor %}
 </nav>
+
+<form class="review-toolbar" action="/review" method="get">
+  <input type="hidden" name="filter" value="{{ active_filter }}">
+  <input type="hidden" name="page" value="1">
+  <label>
+    Sort
+    <select name="sort">
+      {% for key, label in pager.sort_options %}
+        <option value="{{ key }}" {% if pager.sort == key %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>
+    Page size
+    <select name="page_size">
+      {% for size in pager.page_sizes %}
+        <option value="{{ size }}" {% if pager.page_size == size %}selected{% endif %}>{{ size }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <button type="submit">Apply</button>
+</form>
+
+<div class="review-status" aria-live="polite">
+  {% if pager.total %}
+    Showing {{ pager.start }}-{{ pager.end }} of {{ pager.total }} review facts
+  {% else %}
+    Showing 0 of 0 review facts
+  {% endif %}
+</div>
+
+{% macro review_pages(pager) -%}
+<nav class="pagination" aria-label="Review pages">
+  {% if pager.prev_href %}
+    <a class="btn ghost" href="{{ pager.prev_href }}">Previous</a>
+  {% else %}
+    <span class="btn ghost disabled" aria-disabled="true">Previous</span>
+  {% endif %}
+  {% for item in pager.pages %}
+    {% if item.ellipsis %}
+      <span class="page-ellipsis">...</span>
+    {% elif item.active %}
+      <span class="badge active" aria-current="page">{{ item.number }}</span>
+    {% else %}
+      <a class="badge" href="{{ item.href }}">{{ item.number }}</a>
+    {% endif %}
+  {% endfor %}
+  {% if pager.next_href %}
+    <a class="btn ghost" href="{{ pager.next_href }}">Next</a>
+  {% else %}
+    <span class="btn ghost disabled" aria-disabled="true">Next</span>
+  {% endif %}
+</nav>
+{%- endmacro %}
+
+{{ review_pages(pager) }}
 
 {% if queue %}
 <table class="facts">
@@ -27,7 +85,15 @@
 </table>
 {% else %}
 <div class="empty">
-  <p>Review queue is empty for this filter.</p>
+  {% if active_filter == "needs-human-decision" %}
+    <p>Review queue is empty.</p>
+    <p>No facts need review.</p>
+    <p>Candidate and needs_review facts will appear here after extraction.</p>
+  {% else %}
+    <p>No facts match this filter.</p>
+    <p>Try another review filter.</p>
+  {% endif %}
 </div>
 {% endif %}
+{{ review_pages(pager) }}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Add review queue pagination metadata and page/window handling in the store.
- Sort review items deterministically and preserve review filters across pagination controls.
- Update the review UI with pager controls and coverage for store/web behavior.

## Validation

- `.venv/bin/python -m pytest tests/test_store.py tests/test_web.py -q`
- `.venv/bin/python -m ruff check verinote tests`
