### PR TITLE
[codex] Handle Korean role questions deterministically

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -36,12 +36,31 @@ def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
     assert f"answer_q{qid}" in load_query(s)
 
 
+def test_translate_korean_role_question_bypasses_llm(tmp_path):
+    class FailingClient:
+        def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+            raise AssertionError("deterministic role questions must not call the LLM")
+
+    s = _store(tmp_path)
+    qid = s.add_question("샘플인물의 역할은 무엇인가?")
+    results = translate_questions(s, FailingClient(), root=tmp_path)
+
+    assert results == [
+        {"id": qid, "status": "translated", "query_dl": s.questions()[0]["query_dl"]}
+    ]
+    query_dl = s.questions()[0]["query_dl"]
+    assert f'answer_q{qid}(O) :- relation("샘플인물", "역할", O).' in query_dl
+    assert f'answer_q{qid}(R) :- relation(S, R, "샘플인물").' in query_dl
+    assert f'answer_q{qid}(R) :- relation(S, R, person("샘플인물")).' in query_dl
+    assert load_query(s) == query_dl + "\n"
+
+
 def test_load_query_expands_relation_aliases(tmp_path, fake_client):
     s = _store(tmp_path)
     policy = tmp_path / "policy"
     policy.mkdir()
     (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
-    qid = s.add_question("샘플인물의 역할은 무엇인가")
+    qid = s.add_question("Find the sample person's role")
     client = fake_client(
         query=lambda question, qid: f'answer_q{qid}(V) :- relation("샘플인물", "role", V).'
     )

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,7 +3,7 @@ import builtins
 
 import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.engine.terms import Compound, StringLit
-from verinote.pipeline.query import query_path
+from verinote.pipeline.query import deterministic_query_dl, query_path
 from verinote.pipeline.verify import policy_path, verify
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
@@ -93,6 +93,21 @@ def test_verify_answers_query_through_relation_alias(tmp_path):
 
     assert rep.ok is True
     assert rep.answers == ["q1: 샘플역할"]
+
+
+def test_verify_answers_korean_role_question_across_role_fact_shapes(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("샘플인물", "역할", "샘플역할", status="confirmed")
+    s.add_fact("샘플인물", "대표", "샘플조직", status="confirmed")
+    s.add_fact("샘플기관", "발표자", "샘플인물", status="confirmed")
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(deterministic_query_dl("샘플인물의 역할은 무엇인가?", 1) + "\n", encoding="utf-8")
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.answers == ["q1: 대표, 발표자, 샘플역할"]
 
 
 def test_verify_answers_query_through_multiple_relation_aliases(tmp_path):

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from itertools import product
 from pathlib import Path
+import re
 import unicodedata
 
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
@@ -24,6 +25,12 @@ from verinote.store import Store
 # Query draft, relative to the KB root (the db file's directory).
 QUERY_RELPATH = Path("facts") / "query.dl"
 MAX_ALIAS_EXPANDED_RULES_PER_RULE = 64
+_ESCAPE = re.compile(r'(["\\])')
+_ROLE_QUESTION = re.compile(
+    r'["“”\']?(?P<person>[^"“”\'?？\n]{1,80}?)["“”\']?\s*'
+    r"(?:의|에\s*대한)\s*(?:역할|직책|직위)"
+)
+_GENERIC_ROLE_RELATIONS = ("역할", "직책", "직위", "role", "has_role")
 
 
 def query_path(root: Path) -> Path:
@@ -34,6 +41,40 @@ def _is_review_required(line: str) -> bool:
     return line.lstrip().startswith("review_required")
 
 
+def _lit(value: str) -> str:
+    return '"' + _ESCAPE.sub(r"\\\1", value) + '"'
+
+
+def deterministic_query_dl(question: str, qid: int) -> str | None:
+    """Return deterministic query drafts for common shapes LLMs mistranslate."""
+    match = _ROLE_QUESTION.search(question.strip())
+    if not match:
+        return None
+    person = match.group("person").strip()
+    if not person:
+        return None
+
+    person_lit = _lit(person)
+    person_term = f"person({person_lit})"
+    person_term_lit = _lit(f'person("{person}")')
+    excluded = ", ".join(f"R != {_lit(rel)}" for rel in _GENERIC_ROLE_RELATIONS)
+    role_object_rules = "\n".join(
+        f"answer_q{qid}(O) :- relation({person_lit}, {_lit(rel)}, O)."
+        for rel in _GENERIC_ROLE_RELATIONS
+    )
+    return "\n".join(
+        [
+            f".decl answer_q{qid}(value: symbol)",
+            role_object_rules,
+            f"answer_q{qid}(O) :- relation({person_term}, has_role, O).",
+            f"answer_q{qid}(R) :- relation({person_lit}, R, O), {excluded}.",
+            f"answer_q{qid}(R) :- relation(S, R, {person_lit}).",
+            f"answer_q{qid}(R) :- relation(S, R, {person_term}).",
+            f"answer_q{qid}(R) :- relation(S, R, {person_term_lit}).",
+        ]
+    )
+
+
 def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
     """Translate every pending question, persist drafts, rewrite `query.dl`.
 
@@ -41,12 +82,16 @@ def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[
     """
     results: list[dict] = []
     for q in store.questions(pending_only=True):
-        line = client.translate_query(question=q["text"], qid=q["id"])
-        if _is_review_required(line):
-            status, query_dl = "review_required", line
-        else:
+        query_dl = deterministic_query_dl(q["text"], q["id"])
+        if query_dl is not None:
             status = "translated"
-            query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
+        else:
+            line = client.translate_query(question=q["text"], qid=q["id"])
+            if _is_review_required(line):
+                status, query_dl = "review_required", line
+            else:
+                status = "translated"
+                query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
         store.set_question_query(q["id"], query_dl, status)
         results.append({"id": q["id"], "status": status, "query_dl": query_dl})
     write_query_file(store, root)

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from verinote.engine import validate_query
 from verinote.llm.base import LLMClient, LLMError
-from verinote.pipeline.query import write_query_file
+from verinote.pipeline.query import deterministic_query_dl, write_query_file
 from verinote.store import Store
 
 _log = logging.getLogger("verinote.repair")
@@ -29,6 +29,12 @@ def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dic
         if q["status"] != "review_required":
             continue
         qid = q["id"]
+        deterministic = deterministic_query_dl(q["text"], qid)
+        if deterministic:
+            store.set_question_query(qid, deterministic, "translated")
+            results.append({"id": qid, "accepted": True, "reason": ""})
+            continue
+
         try:
             line = client.translate_query(question=q["text"], qid=qid)
         except LLMError as exc:


### PR DESCRIPTION
## Summary

- Add deterministic translation for Korean person-role questions before falling back to the LLM.
- Query common role fact shapes, including person-role-object, person-role-predicate-organization, and organization-role-predicate-person.
- Reuse the deterministic translation path during question repair.

## Root Cause

Pending questions were selected correctly, but translation could abort before updating the row when the LLM returned non-JSON or schema-invalid output. Korean role questions are also a recurring shape where the model can invent an English relation such as `role` instead of querying the source-language relations already present in the KB.

## Validation

- `.venv/bin/python -m pytest tests/test_query.py tests/test_verify.py::test_verify_answers_korean_role_question_across_role_fact_shapes -q`
- `.venv/bin/python -m ruff check verinote tests`
- Verified the local pending question moved from `pending` to `translated` with a generated query.
