### PR TITLE
[codex] Add durable question lifecycle outcomes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,6 +134,45 @@ def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client):
     assert (tmp_path / "facts" / "query.dl").is_file()
 
 
+def test_query_persists_translation_failure_reason(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(error=LLMError("provider unavailable")),
+    )
+
+    rc = cli.main(["query", "What is the sample answer?"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "q1: translation_failed (provider unavailable)" in out
+    s = Store(tmp_path / "kb.sqlite")
+    q = s.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == "provider unavailable"
+    assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
+
+
+def test_query_persists_get_client_failure_reason(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+
+    def raise_client_error(cfg):
+        raise LLMError("missing provider credentials")
+
+    monkeypatch.setattr("verinote.llm.get_client", raise_client_error)
+
+    rc = cli.main(["query", "What is the sample answer?"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "q1: translation_failed (missing provider credentials)" in out
+    s = Store(tmp_path / "kb.sqlite")
+    q = s.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == "missing provider credentials"
+    assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
+
+
 def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     rc = cli.main(["query"])
@@ -160,6 +199,31 @@ def test_repair_validates_and_translates(tmp_path, monkeypatch, capsys, fake_cli
     assert rc == 0
     assert "repaired 1/1" in capsys.readouterr().out
     assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "translated"
+
+
+def test_repair_reports_durable_rejected_status(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(
+            query=lambda q, i: 'no_answer("no confirmed facts match")'
+        ),
+    )
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    qid = s.add_question("What is the sample answer?")
+    s.set_question_query(
+        qid, 'review_required("What is the sample answer?")', "review_required"
+    )
+    s.close()
+
+    rc = cli.main(["repair"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "q1: kept no_answer (no confirmed facts match)" in out
+    assert "repaired 0/1" in out
+    assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "no_answer"
 
 
 def test_repair_no_review_required_errors(tmp_path, monkeypatch, capsys):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import unicodedata
 
+from verinote.llm.base import LLMError
 from verinote.pipeline.query import (
     expand_query_relation_aliases,
     load_query,
@@ -46,7 +47,12 @@ def test_translate_korean_role_question_bypasses_llm(tmp_path):
     results = translate_questions(s, FailingClient(), root=tmp_path)
 
     assert results == [
-        {"id": qid, "status": "translated", "query_dl": s.questions()[0]["query_dl"]}
+        {
+            "id": qid,
+            "status": "translated",
+            "query_dl": s.questions()[0]["query_dl"],
+            "reason": "",
+        }
     ]
     query_dl = s.questions()[0]["query_dl"]
     assert f'answer_q{qid}(O) :- relation("샘플인물", "역할", O).' in query_dl
@@ -123,15 +129,96 @@ def test_expand_query_relation_aliases_caps_combinations():
 def test_review_required_question_is_flagged_not_in_draft(tmp_path, fake_client):
     s = _store(tmp_path)
     qid = s.add_question("What is the meaning of life?")
-    client = fake_client(query=lambda question, qid: f'review_required("{question}")')
+    client = fake_client(
+        query=lambda question, qid: 'review_required("requires a synthetic relation")'
+    )
     translate_questions(s, client, root=tmp_path)
 
     q = s.questions()[0]
     assert q["status"] == "review_required"
+    assert q["reason"] == "requires a synthetic relation"
     assert q["query_dl"].startswith("review_required(")
     # review_required lines are tracked in the DB, not fed to the engine
     assert f"answer_q{qid}" not in (load_query(s) or "")
     assert "review_required" not in (load_query(s) or "")
+
+
+def test_invalid_generated_query_requires_review_and_skips_draft(tmp_path, fake_client):
+    s = _store(tmp_path)
+    qid = s.add_question("What is the sample answer?")
+    client = fake_client(query=lambda question, qid: "this is not datalog")
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    q = s.questions()[0]
+    assert results[0]["status"] == "review_required"
+    assert results[0]["query_dl"].startswith("review_required(")
+    assert "invalid query:" in results[0]["reason"]
+    assert q["status"] == "review_required"
+    assert q["reason"] == results[0]["reason"]
+    assert q["query_dl"].startswith("review_required(")
+    assert "this is not datalog" not in q["query_dl"]
+    assert f"answer_q{qid}" not in (load_query(s) or "")
+    assert load_query(s) == ""
+
+
+def test_non_executable_question_states_store_reasons_and_skip_draft(tmp_path, fake_client):
+    s = _store(tmp_path)
+    no_answer_id = s.add_question("What is the sample answer?")
+    ambiguous_id = s.add_question("Which sample item is current?")
+    responses = iter(
+        [
+            'no_answer("no confirmed facts match")',
+            'ambiguous("multiple sample entities match")',
+        ]
+    )
+    client = fake_client(query=lambda question, qid: next(responses))
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {
+            "id": no_answer_id,
+            "status": "no_answer",
+            "query_dl": 'no_answer("no confirmed facts match")',
+            "reason": "no confirmed facts match",
+        },
+        {
+            "id": ambiguous_id,
+            "status": "ambiguous",
+            "query_dl": 'ambiguous("multiple sample entities match")',
+            "reason": "multiple sample entities match",
+        },
+    ]
+    rows = s.questions()
+    assert [(q["status"], q["reason"]) for q in rows] == [
+        ("no_answer", "no confirmed facts match"),
+        ("ambiguous", "multiple sample entities match"),
+    ]
+    assert load_query(s) == ""
+
+
+def test_translate_persists_llm_error_as_translation_failed(tmp_path, fake_client):
+    s = _store(tmp_path)
+    qid = s.add_question("What is the sample answer?")
+
+    results = translate_questions(
+        s, fake_client(error=LLMError("provider unavailable")), root=tmp_path
+    )
+
+    assert results == [
+        {
+            "id": qid,
+            "status": "translation_failed",
+            "query_dl": None,
+            "reason": "provider unavailable",
+        }
+    ]
+    q = s.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == "provider unavailable"
+    assert q["query_dl"] is None
+    assert load_query(s) == ""
 
 
 def test_translate_only_touches_pending(tmp_path, fake_client):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
 
+from verinote.llm.base import LLMError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.repair import repair_questions
 from verinote.store import Store
@@ -16,11 +17,13 @@ def _store_with_review_required(tmp_path):
 
 def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
+    s.set_question_query(qid, s.questions()[0]["query_dl"], "review_required", "stale")
     client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
     results = repair_questions(s, client, root=tmp_path)
 
     assert results == [{"id": qid, "accepted": True, "reason": ""}]
     assert s.questions()[0]["status"] == "translated"
+    assert s.questions()[0]["reason"] == ""
     assert f"answer_q{qid}" in (load_query(s) or "")
 
 
@@ -63,7 +66,9 @@ def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
 
     assert results[0]["accepted"] is False
     assert "bogus" in results[0]["reason"]
-    assert s.questions()[0]["status"] == "review_required"
+    q = s.questions()[0]
+    assert q["status"] == "review_required"
+    assert q["reason"] == results[0]["reason"]
     assert f"answer_q{qid}" not in (load_query(s) or "")
 
 
@@ -76,15 +81,65 @@ def test_repair_rejects_duckdb_unsupported_compound_query(tmp_path, fake_client)
 
     assert results[0]["accepted"] is False
     assert "variable-bearing compound" in results[0]["reason"]
-    assert s.questions()[0]["status"] == "review_required"
+    q = s.questions()[0]
+    assert q["status"] == "review_required"
+    assert q["reason"] == results[0]["reason"]
     assert f"answer_q{qid}" not in (load_query(s) or "")
 
 
 def test_repair_rejects_still_unanswerable(tmp_path, fake_client):
-    s, _qid = _store_with_review_required(tmp_path)
+    s, qid = _store_with_review_required(tmp_path)
     client = fake_client(query=lambda q, i: 'review_required("still nope")')
     results = repair_questions(s, client, root=tmp_path)
 
-    assert results[0]["accepted"] is False
-    assert "cannot express" in results[0]["reason"]
-    assert s.questions()[0]["status"] == "review_required"
+    assert results == [{"id": qid, "accepted": False, "reason": "still nope"}]
+    q = s.questions()[0]
+    assert q["status"] == "review_required"
+    assert q["query_dl"] == 'review_required("still nope")'
+    assert q["reason"] == "still nope"
+    assert "review_required" not in (load_query(s) or "")
+
+
+def test_repair_persists_no_answer_lifecycle_outcome(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    client = fake_client(query=lambda q, i: 'no_answer("no confirmed facts match")')
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {"id": qid, "accepted": False, "reason": "no confirmed facts match"}
+    ]
+    q = s.questions()[0]
+    assert q["status"] == "no_answer"
+    assert q["query_dl"] == 'no_answer("no confirmed facts match")'
+    assert q["reason"] == "no confirmed facts match"
+    assert "no_answer" not in (load_query(s) or "")
+
+
+def test_repair_persists_ambiguous_lifecycle_outcome(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    client = fake_client(query=lambda q, i: 'ambiguous("multiple sample entities match")')
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {"id": qid, "accepted": False, "reason": "multiple sample entities match"}
+    ]
+    q = s.questions()[0]
+    assert q["status"] == "ambiguous"
+    assert q["query_dl"] == 'ambiguous("multiple sample entities match")'
+    assert q["reason"] == "multiple sample entities match"
+    assert "ambiguous" not in (load_query(s) or "")
+
+
+def test_repair_persists_llm_error_reason(tmp_path, fake_client):
+    s, qid = _store_with_review_required(tmp_path)
+    original_query = s.questions()[0]["query_dl"]
+    client = fake_client(error=LLMError("provider unavailable"))
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {"id": qid, "accepted": False, "reason": "llm error: provider unavailable"}
+    ]
+    q = s.questions()[0]
+    assert q["status"] == "review_required"
+    assert q["query_dl"] == original_query
+    assert q["reason"] == "llm error: provider unavailable"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -697,12 +697,47 @@ def test_extraction_job_records_lifecycle_events(tmp_path):
 def test_questions_add_list_and_translate(tmp_path):
     s = _store(tmp_path)
     qid = s.add_question("Where was Ada born?")
-    assert [(q["id"], q["status"]) for q in s.questions()] == [(qid, "pending")]
+    assert [(q["id"], q["status"], q["reason"]) for q in s.questions()] == [
+        (qid, "pending", "")
+    ]
     assert [q["id"] for q in s.questions(pending_only=True)] == [qid]
 
     s.set_question_query(qid, ".decl answer_q1(value: symbol)", "translated")
     assert s.questions(pending_only=True) == []
     assert s.questions()[0]["status"] == "translated"
+    assert s.questions()[0]["reason"] == ""
 
     s.delete_question(qid)
     assert s.questions() == []
+
+
+def test_question_schema_migration_preserves_legacy_rows_and_adds_reason(tmp_path):
+    db_path = tmp_path / "kb.sqlite"
+    s = Store(db_path)
+    s._conn.executescript(
+        """
+        CREATE TABLE questions (
+            id         INTEGER PRIMARY KEY,
+            text       TEXT NOT NULL,
+            query_dl   TEXT,
+            status     TEXT NOT NULL DEFAULT 'pending'
+                         CHECK (status IN ('pending','translated','review_required')),
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO questions(id, text, query_dl, status, created_at)
+        VALUES(7, 'Synthetic question?', 'review_required("needs sample policy")',
+               'review_required', '2026-01-01 00:00:00');
+        """
+    )
+    s.init_schema()
+
+    row = s.questions()[0]
+    assert row["id"] == 7
+    assert row["text"] == "Synthetic question?"
+    assert row["status"] == "review_required"
+    assert row["reason"] == ""
+
+    s.set_question_query(7, None, "translation_failed", "provider unavailable")
+    row = s.questions()[0]
+    assert row["status"] == "translation_failed"
+    assert row["reason"] == "provider unavailable"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1565,15 +1565,59 @@ def test_translate_and_report_answers(tmp_path, monkeypatch, fake_client):
     assert "London" in c.get("/questions").text
 
 
-def test_translate_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
+def test_translate_persists_llm_error_reason(tmp_path, monkeypatch, fake_client):
     monkeypatch.setattr(
-        webapp, "get_client", lambda cfg: fake_client(error=LLMError("provider down"))
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(error=LLMError("provider unavailable")),
     )
     c = _client(tmp_path)
-    c.app.state.store.add_question("q?")
-    r = c.post("/questions/translate")
-    assert r.status_code == 502
-    assert "translation failed: provider down" in r.text
+    c.app.state.store.add_question("What is the sample answer?")
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    assert r.status_code == 303
+    q = c.app.state.store.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == "provider unavailable"
+    page = c.get("/questions").text
+    assert "translation_failed" in page
+    assert "provider unavailable" in page
+
+
+def test_translate_persists_get_client_failure_reason(tmp_path, monkeypatch):
+    def raise_client_error(cfg):
+        raise LLMError("missing provider credentials")
+
+    monkeypatch.setattr(webapp, "get_client", raise_client_error)
+    c = _client(tmp_path)
+    c.app.state.store.add_question("What is the sample answer?")
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    assert r.status_code == 303
+    q = c.app.state.store.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == "missing provider credentials"
+    assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
+    page = c.get("/questions").text
+    assert "translation_failed" in page
+    assert "missing provider credentials" in page
+
+
+def test_questions_page_shows_non_executable_reason(tmp_path):
+    c = _client(tmp_path)
+    qid = c.app.state.store.add_question("Which sample item is current?")
+    c.app.state.store.set_question_query(
+        qid,
+        'ambiguous("multiple sample entities match")',
+        "ambiguous",
+        "multiple sample entities match",
+    )
+
+    r = c.get("/questions")
+
+    assert r.status_code == 200
+    assert "ambiguous" in r.text
+    assert "multiple sample entities match" in r.text
 
 
 def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -208,7 +208,7 @@ def cmd_ingest(cfg: Config, args: argparse.Namespace) -> int:
 
 def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
-    from verinote.pipeline import translate_questions
+    from verinote.pipeline import translate_questions, write_query_file
 
     store = _store(cfg)
     if args.question:
@@ -220,17 +220,28 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     try:
         client = get_client(cfg)
-        results = translate_questions(store, client, root=cfg.root)
     except LLMError as e:
-        print(f"translation failed: {e}", file=sys.stderr)
-        store.close()
-        return 1
+        reason = _short_error(e)
+        results = []
+        for q in pending:
+            store.set_question_query(q["id"], None, "translation_failed", reason)
+            results.append(
+                {"id": q["id"], "status": "translation_failed", "reason": reason}
+            )
+        write_query_file(store, cfg.root)
+    else:
+        results = translate_questions(store, client, root=cfg.root)
     for r in results:
-        print(f"  q{r['id']}: {r['status']}")
+        reason = f" ({r['reason']})" if r.get("reason") else ""
+        print(f"  q{r['id']}: {r['status']}{reason}")
     print(f"translated {len(results)} question(s) -> {cfg.root / 'facts' / 'query.dl'}")
     print("run the check to see answers (`verinote ui` → Report)")
     store.close()
     return 0
+
+
+def _short_error(exc: BaseException) -> str:
+    return " ".join(str(exc).split())[:240]
 
 
 def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
@@ -250,9 +261,11 @@ def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
         store.close()
         return 1
     results = repair_questions(store, client, root=cfg.root)
+    statuses = {q["id"]: q["status"] for q in store.questions()}
     repaired = sum(1 for r in results if r["accepted"])
     for r in results:
-        mark = "repaired" if r["accepted"] else f"kept review_required ({r['reason']})"
+        status = r.get("status") or statuses.get(r["id"], "review_required")
+        mark = "repaired" if r["accepted"] else f"kept {status} ({r['reason']})"
         print(f"  q{r['id']}: {mark}")
     print(f"repaired {repaired}/{len(results)} question(s) (engine-validated)")
     store.close()

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -57,7 +57,9 @@ class LLMClient(Protocol):
         """Translate an NL `question` into a single Datalog query line.
 
         Return a rule whose head is ``answer_q<qid>(V)`` binding one answer
-        variable over ``relation/3``, or ``review_required("<question>")`` when
-        the question can't be expressed. Raise `LLMError` on provider/parse error.
+        variable over ``relation/3``. When no executable rule is appropriate,
+        return a durable non-executable outcome:
+        ``review_required("reason")``, ``no_answer("reason")``, or
+        ``ambiguous("reason")``. Raise `LLMError` on provider/parse error.
         """
         ...

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -114,8 +114,8 @@ EXTRACTION_SYSTEM = (
 
 
 # --- query translation (#3) ------------------------------------------------
-# A single Datalog query line: a rule deriving the question's answer relation,
-# or a review_required(...) fallback when the question can't be expressed.
+# A single Datalog query line: either a rule deriving the question's answer
+# relation, or a durable non-executable outcome with a concise reason.
 QUERY_SCHEMA: dict[str, Any] = {
     "type": "object",
     "required": ["datalog"],
@@ -135,8 +135,11 @@ def query_system(qid: int) -> str:
         "Use only the relation/3 predicate in rule bodies. Terms may be variables, "
         "string literals, integer literals, atoms, or fully ground compound terms; "
         "do not construct compound terms from variables in the answer head or body. "
-        "If the question cannot be expressed this way, return exactly "
-        'review_required("<the original question>"). Emit JSON matching the schema.'
+        "If no executable rule is appropriate, return a durable status line "
+        "with a concise reason instead: review_required(\"reason\") when a human "
+        "must clarify or model the query, no_answer(\"reason\") when confirmed "
+        "facts cannot answer it, or ambiguous(\"reason\") when multiple meanings "
+        "or entities fit. Emit JSON matching the schema."
     )
 
 

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -2,11 +2,11 @@
 """Translate NL questions to Datalog query drafts and persist them for the engine.
 
 Each pending question is translated by the `LLMClient` into either an
-`answer_q<id>` rule (status `translated`) or a `review_required(...)` line
-(status `review_required`). The translated rules are written to
-`<root>/facts/query.dl`, which `verify()` feeds to the DuckDB backend so
-`/report` shows each query's evaluation. `review_required` questions are tracked
-in the DB only.
+`answer_q<id>` rule (status `translated`) or a durable non-executable lifecycle
+state such as `review_required`, `no_answer`, `ambiguous`, or
+`translation_failed`. The translated rules are written to `<root>/facts/query.dl`,
+which `verify()` feeds to the DuckDB backend so `/report` shows each query's
+evaluation. Non-executable outcomes are tracked in the DB only.
 """
 
 from __future__ import annotations
@@ -16,9 +16,10 @@ from pathlib import Path
 import re
 import unicodedata
 
+from verinote.engine import validate_query
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
 from verinote.engine.terms import Atom, StringLit, render_term
-from verinote.llm.base import LLMClient
+from verinote.llm.base import LLMClient, LLMError
 from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
 from verinote.store import Store
 
@@ -31,6 +32,10 @@ _ROLE_QUESTION = re.compile(
     r"(?:의|에\s*대한)\s*(?:역할|직책|직위)"
 )
 _GENERIC_ROLE_RELATIONS = ("역할", "직책", "직위", "role", "has_role")
+_STATUS_LINE = re.compile(
+    r"^\s*(?P<status>review_required|no_answer|ambiguous)\s*\((?P<reason>.*)\)\s*\.?\s*$",
+    re.DOTALL,
+)
 
 
 def query_path(root: Path) -> Path:
@@ -39,6 +44,21 @@ def query_path(root: Path) -> Path:
 
 def _is_review_required(line: str) -> bool:
     return line.lstrip().startswith("review_required")
+
+
+def _non_executable_outcome(line: str) -> tuple[str, str] | None:
+    match = _STATUS_LINE.match(line)
+    if not match:
+        return None
+    return match.group("status"), _short_reason(match.group("reason"))
+
+
+def _short_reason(value: object) -> str:
+    text = str(value).strip()
+    if len(text) >= 2 and text[0] == text[-1] == '"':
+        text = text[1:-1]
+    text = text.replace('\\"', '"').replace("\\\\", "\\")
+    return " ".join(text.split())[:240]
 
 
 def _lit(value: str) -> str:
@@ -78,22 +98,42 @@ def deterministic_query_dl(question: str, qid: int) -> str | None:
 def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
     """Translate every pending question, persist drafts, rewrite `query.dl`.
 
-    Returns one dict per translated question: {id, status, query_dl}.
+    Returns one dict per processed question: {id, status, query_dl, reason}.
     """
     results: list[dict] = []
     for q in store.questions(pending_only=True):
+        reason = ""
         query_dl = deterministic_query_dl(q["text"], q["id"])
         if query_dl is not None:
             status = "translated"
         else:
-            line = client.translate_query(question=q["text"], qid=q["id"])
-            if _is_review_required(line):
-                status, query_dl = "review_required", line
+            try:
+                line = client.translate_query(question=q["text"], qid=q["id"])
+            except LLMError as exc:
+                status = "translation_failed"
+                query_dl = None
+                reason = _short_reason(exc)
             else:
-                status = "translated"
-                query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
-        store.set_question_query(q["id"], query_dl, status)
-        results.append({"id": q["id"], "status": status, "query_dl": query_dl})
+                outcome = _non_executable_outcome(line)
+                if outcome is not None:
+                    status, reason = outcome
+                    query_dl = line
+                elif _is_review_required(line):
+                    status, query_dl = "review_required", line
+                    reason = _short_reason(line.removeprefix("review_required"))
+                else:
+                    query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
+                    ok, validation_reason = validate_query(query_dl)
+                    if ok:
+                        status = "translated"
+                    else:
+                        status = "review_required"
+                        reason = _short_reason(f"invalid query: {validation_reason}")
+                        query_dl = f"review_required({_lit(reason)})"
+        store.set_question_query(q["id"], query_dl, status, reason)
+        results.append(
+            {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}
+        )
     write_query_file(store, root)
     return results
 

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -14,7 +14,11 @@ from pathlib import Path
 
 from verinote.engine import validate_query
 from verinote.llm.base import LLMClient, LLMError
-from verinote.pipeline.query import deterministic_query_dl, write_query_file
+from verinote.pipeline.query import (
+    _non_executable_outcome,
+    deterministic_query_dl,
+    write_query_file,
+)
 from verinote.store import Store
 
 _log = logging.getLogger("verinote.repair")
@@ -38,12 +42,24 @@ def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dic
         try:
             line = client.translate_query(question=q["text"], qid=qid)
         except LLMError as exc:
-            results.append({"id": qid, "accepted": False, "reason": f"llm error: {exc}"})
+            reason = f"llm error: {exc}"
+            store.set_question_query(qid, q["query_dl"], "review_required", reason)
+            results.append({"id": qid, "accepted": False, "reason": reason})
             _log.warning("repair q%d: llm error: %s", qid, exc)
             continue
 
+        outcome = _non_executable_outcome(line)
+        if outcome is not None:
+            status, reason = outcome
+            store.set_question_query(qid, line, status, reason)
+            results.append({"id": qid, "accepted": False, "reason": reason})
+            _log.warning("repair q%d: model returned %s: %s", qid, status, reason)
+            continue
+
         if line.lstrip().startswith("review_required"):
-            results.append({"id": qid, "accepted": False, "reason": "model still cannot express it"})
+            reason = "model still cannot express it"
+            store.set_question_query(qid, line, "review_required", reason)
+            results.append({"id": qid, "accepted": False, "reason": reason})
             _log.warning("repair q%d: still review_required", qid)
             continue
 
@@ -53,6 +69,7 @@ def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dic
             store.set_question_query(qid, proposal, "translated")
             results.append({"id": qid, "accepted": True, "reason": ""})
         else:
+            store.set_question_query(qid, q["query_dl"], "review_required", reason)
             results.append({"id": qid, "accepted": False, "reason": reason})
             _log.warning("repair q%d rejected by engine: %s", qid, reason)
 

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -24,6 +24,16 @@ MAX_EVIDENCE_SNIPPET_CHARS = 1000
 REVIEW_PAGE_SIZES = (25, 50, 100)
 DEFAULT_REVIEW_PAGE_SIZE = 50
 DEFAULT_REVIEW_SORT = "newest"
+QUESTION_STATUSES = frozenset(
+    {
+        "pending",
+        "translated",
+        "review_required",
+        "translation_failed",
+        "no_answer",
+        "ambiguous",
+    }
+)
 REVIEW_SORT_SQL = {
     "newest": "f.id DESC",
     "oldest": "f.id ASC",
@@ -988,11 +998,15 @@ class Store:
             sql += " WHERE status = 'pending'"
         return list(self._conn.execute(sql + " ORDER BY id"))
 
-    def set_question_query(self, question_id: int, query_dl: str, status: str) -> None:
+    def set_question_query(
+        self, question_id: int, query_dl: str | None, status: str, reason: str = ""
+    ) -> None:
+        if status not in QUESTION_STATUSES:
+            raise ValueError(f"unknown question status: {status}")
         with self._lock:
             self._conn.execute(
-                "UPDATE questions SET query_dl = ?, status = ? WHERE id = ?",
-                (query_dl, status, question_id),
+                "UPDATE questions SET query_dl = ?, status = ?, reason = ? WHERE id = ?",
+                (query_dl, status, reason, question_id),
             )
 
     def delete_question(self, question_id: int) -> None:
@@ -1289,6 +1303,59 @@ class Store:
                 ON fact_events(job_id);
             """
         )
+        self._ensure_question_schema()
+
+    def _ensure_question_schema(self) -> None:
+        columns = {
+            row["name"] for row in self._conn.execute("PRAGMA table_info(questions)")
+        }
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'questions'"
+        ).fetchone()
+        create_sql = row["sql"] if row is not None and row["sql"] is not None else ""
+        needs_rebuild = "reason" not in columns or any(
+            status not in create_sql for status in QUESTION_STATUSES
+        )
+        if not needs_rebuild:
+            return
+
+        select_reason = "reason" if "reason" in columns else "''"
+        self._conn.execute("BEGIN")
+        try:
+            self._conn.execute("DROP TABLE IF EXISTS questions_new")
+            self._conn.execute(
+                """
+                CREATE TABLE questions_new (
+                    id         INTEGER PRIMARY KEY,
+                    text       TEXT NOT NULL,
+                    query_dl   TEXT,
+                    status     TEXT NOT NULL DEFAULT 'pending'
+                                 CHECK (
+                                     status IN (
+                                         'pending',
+                                         'translated',
+                                         'review_required',
+                                         'translation_failed',
+                                         'no_answer',
+                                         'ambiguous'
+                                     )
+                                 ),
+                    reason     TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+                """
+            )
+            self._conn.execute(
+                "INSERT INTO questions_new(id, text, query_dl, status, reason, created_at) "
+                f"SELECT id, text, query_dl, status, {select_reason}, created_at "
+                "FROM questions"
+            )
+            self._conn.execute("DROP TABLE questions")
+            self._conn.execute("ALTER TABLE questions_new RENAME TO questions")
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._rollback_quietly()
+            raise
 
     def _refresh_extraction_job(self, job_id: int, *, final: bool = False) -> None:
         counts = self._conn.execute(

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -131,13 +131,24 @@ CREATE INDEX IF NOT EXISTS idx_fact_evidence_source ON fact_evidence(source_id);
 CREATE INDEX IF NOT EXISTS idx_fact_evidence_chunk ON fact_evidence(chunk_id);
 
 -- Natural-language questions translated to a Datalog query draft (#3). status:
--- pending -> translated (an `answer_q<id>` rule) | review_required (untranslatable).
+-- pending -> translated (an `answer_q<id>` rule) | review_required/no_answer/
+-- translation_failed/ambiguous (visible non-executable outcomes).
 CREATE TABLE IF NOT EXISTS questions (
     id         INTEGER PRIMARY KEY,
     text       TEXT NOT NULL,
     query_dl   TEXT,
     status     TEXT NOT NULL DEFAULT 'pending'
-                 CHECK (status IN ('pending','translated','review_required')),
+                 CHECK (
+                     status IN (
+                         'pending',
+                         'translated',
+                         'review_required',
+                         'translation_failed',
+                         'no_answer',
+                         'ambiguous'
+                     )
+                 ),
+    reason     TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -99,6 +99,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             raise RuntimeError("no active KB")
         return cfg
 
+    def _short_error(exc: BaseException) -> str:
+        return " ".join(str(exc).split())[:240]
+
+    def _fail_pending_translations(store: Store, cfg: Config, exc: LLMError) -> None:
+        reason = _short_error(exc)
+        for q in store.questions(pending_only=True):
+            store.set_question_query(q["id"], None, "translation_failed", reason)
+        write_query_file(store, cfg.root)
+
     def _relation_aliases_path() -> Path:
         return _active_cfg().root / RELATION_ALIASES_RELPATH
 
@@ -866,9 +875,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         store = _active_store()
         cfg = _active_cfg()
         try:
-            translate_questions(store, get_client(app.state.cfg), root=cfg.root)
+            client = get_client(app.state.cfg)
         except LLMError as e:
-            return _questions(request, error=f"translation failed: {e}", status_code=502)
+            _fail_pending_translations(store, cfg, e)
+            return RedirectResponse("/questions", status_code=303)
+        translate_questions(store, client, root=cfg.root)
         return RedirectResponse("/questions", status_code=303)
 
     @app.post("/questions/repair", response_class=HTMLResponse)

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -4,13 +4,14 @@
 <h1>Questions</h1>
 <p class="muted">Natural-language questions are translated to a Datalog query the
   engine evaluates over confirmed facts. Untranslatable ones are flagged
-  <code>review_required</code>.</p>
+  <code>review_required</code>, <code>no_answer</code>, <code>ambiguous</code>, or
+  <code>translation_failed</code>.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 
 <form class="upload" action="/questions" method="post">
   <label>Ask a question
-    <input type="text" name="text" size="48" placeholder="Where was Ada Lovelace born?" required>
+    <input type="text" name="text" size="48" placeholder="Where was Example Person born?" required>
   </label>
   <button class="btn" type="submit">Add</button>
 </form>
@@ -32,7 +33,10 @@
     <tr>
       <td>{{ q["id"] }}</td>
       <td>{{ q["text"] }}</td>
-      <td><span class="badge">{{ q["status"] }}</span></td>
+      <td>
+        <span class="badge">{{ q["status"] }}</span>
+        {% if q["reason"] %}<div class="muted">{{ q["reason"] }}</div>{% endif %}
+      </td>
       <td><pre class="report">{{ q["query_dl"] or "—" }}</pre></td>
       <td class="actions">
         <form action="/questions/{{ q['id'] }}/delete" method="post">


### PR DESCRIPTION
## Summary
- Add durable question lifecycle statuses and stored reasons for query translation outcomes.
- Persist provider/client failures, per-question LLM failures, invalid generated Datalog, and non-executable outcomes instead of leaving questions pending or emitting them to `query.dl`.
- Surface lifecycle status/reason in CLI and web Questions UI, and update the LLM query contract for `review_required`, `no_answer`, and `ambiguous` outcomes.
- Persist repair rejection reasons and durable repair outcomes, including CLI output for non-`review_required` rejected statuses.

Fixes #111.

## Implementation Skill Checks
- Architect pass: validated the design boundary across store schema, query/repair pipeline, CLI/web, and LLM contract.
- Critic pass: required provider-failure persistence, generated-Datalog validation, repair reason persistence, and CLI repair visibility.
- Implementer pass: completed as one atomic issue-scoped commit.
- Reviewer pass: no blocking findings after final CLI repair status fix.

## Validation
- `uv run pytest tests/test_query.py tests/test_repair.py tests/test_store.py tests/test_cli.py tests/test_web.py -q` -> 141 passed
- `uv run ruff check verinote tests` -> passed
- `git diff --check` -> passed
- Sensitive sample data scan for previously disallowed real names/organizations -> no matches

## Notes
- Untracked local `.omc/` files and `uv.lock` were not included.
