### PR TITLE
[codex] Add structured query intent extraction

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 import pytest
 
 from verinote.llm.base import ExtractedFact, LLMError
+from verinote.pipeline.query_intent import parse_query_intent
 
 
 class FakeClient:
@@ -11,11 +12,12 @@ class FakeClient:
 
     name = "fake"
 
-    def __init__(self, facts=(), *, error: LLMError | None = None, query=None):
+    def __init__(self, facts=(), *, error: LLMError | None = None, query=None, intent=None):
         self._facts = list(facts)
         self._error = error
         # query: callable(question, qid) -> Datalog line; default answers an is_a.
         self._query = query
+        self._intent = intent
         self.calls = 0
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
@@ -31,6 +33,25 @@ class FakeClient:
         if self._query is not None:
             return self._query(question, qid)
         return f'answer_q{qid}(O) :- relation("{question}", "is_a", O).'
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        raw = self._intent(question) if callable(self._intent) else self._intent
+        if raw is None:
+            raw = {
+                "kind": "unknown_or_unsupported",
+                "subject": None,
+                "relation": None,
+                "object": None,
+                "relation_candidates": None,
+                "operator": None,
+                "value_type": None,
+                "value": None,
+                "reason": "not configured",
+            }
+        return parse_query_intent(raw)
 
 
 @pytest.fixture

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -2,11 +2,194 @@
 import pytest
 
 from verinote.llm import LLMError
-from verinote.llm.schema import EXTRACTION_SYSTEM, FACT_OBJECT_SCHEMA, parse_facts
+from verinote.llm.schema import (
+    EXTRACTION_SYSTEM,
+    FACT_OBJECT_SCHEMA,
+    QUERY_INTENT_SCHEMA,
+    parse_facts,
+)
+from verinote.pipeline.query_intent import IntentTarget, QueryIntentKind, parse_query_intent
+
+
+def _intent_payload(**overrides):
+    payload = {
+        "kind": "unknown_or_unsupported",
+        "subject": None,
+        "relation": None,
+        "object": None,
+        "relation_candidates": None,
+        "operator": None,
+        "value_type": None,
+        "value": None,
+        "reason": "unsupported",
+    }
+    payload.update(overrides)
+    return payload
 
 
 def test_fact_schema_requires_every_property_for_strict_outputs():
     assert set(FACT_OBJECT_SCHEMA["required"]) == set(FACT_OBJECT_SCHEMA["properties"])
+
+
+def test_query_intent_schema_is_separate_from_datalog_query_schema():
+    assert QUERY_INTENT_SCHEMA["required"] == list(QUERY_INTENT_SCHEMA["properties"])
+    assert "datalog" not in QUERY_INTENT_SCHEMA["properties"]
+    assert QUERY_INTENT_SCHEMA["additionalProperties"] is False
+    for field in ("subject", "relation", "object"):
+        schema = QUERY_INTENT_SCHEMA["properties"][field]
+        assert schema["type"] == ["object", "null"]
+        assert schema["required"] == list(schema["properties"])
+        assert schema["additionalProperties"] is False
+    assert QUERY_INTENT_SCHEMA["properties"]["value_type"]["enum"] == [
+        "date",
+        "number",
+        "amount",
+        "ordinal",
+        None,
+    ]
+
+
+def test_parse_query_intent_accepts_valid_lookup_object():
+    intent = parse_query_intent(
+        _intent_payload(
+            kind="lookup_object",
+            subject={"kind": "entity", "value": "샘플인물"},
+            relation_candidates=["역할", "직책", "직위"],
+            reason=None,
+        )
+    )
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "샘플인물")
+    assert intent.relation_candidates == ("역할", "직책", "직위")
+
+
+def test_parse_query_intent_accepts_valid_lookup_subject_lookup_relation_and_count():
+    assert (
+        parse_query_intent(
+            _intent_payload(
+                kind="lookup_subject",
+                relation={"kind": "relation", "value": "역할"},
+                object={"kind": "entity", "value": "검토자"},
+                reason=None,
+            )
+        ).kind
+        == QueryIntentKind.LOOKUP_SUBJECT
+    )
+    assert (
+        parse_query_intent(
+            _intent_payload(
+                kind="lookup_relation",
+                subject={"kind": "entity", "value": "샘플인물"},
+                object={"kind": "entity", "value": "샘플문서"},
+                reason=None,
+            )
+        ).kind
+        == QueryIntentKind.LOOKUP_RELATION
+    )
+    assert (
+        parse_query_intent(
+            _intent_payload(
+                kind="count",
+                relation={"kind": "relation", "value": "참여"},
+                reason=None,
+            )
+        ).kind
+        == QueryIntentKind.COUNT
+    )
+
+
+def test_parse_query_intent_accepts_valid_compare_typed_value():
+    intent = parse_query_intent(
+        _intent_payload(
+            kind="compare_typed_value",
+            subject={"kind": "entity", "value": "샘플항목"},
+            relation={"kind": "relation", "value": "수량"},
+            operator=">",
+            value_type="number",
+            value="10",
+            reason=None,
+        )
+    )
+
+    assert intent.kind == QueryIntentKind.COMPARE_TYPED_VALUE
+    assert intent.operator == ">"
+    assert intent.value_type == "number"
+    assert intent.value == "10"
+
+
+def test_parse_query_intent_accepts_unsupported_with_reason():
+    intent = parse_query_intent(
+        _intent_payload(reason="requires planning")
+    )
+
+    assert intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    assert intent.reason == "requires planning"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json",
+        {"subject": {"kind": "entity", "value": "샘플인물"}},
+        _intent_payload(kind="not_a_kind"),
+        _intent_payload(kind="lookup_object", unexpected="field"),
+        _intent_payload(
+            kind="lookup_object",
+            subject={"kind": "entity", "value": "샘플인물", "extra": "x"},
+            relation={"kind": "relation", "value": "역할"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="lookup_object",
+            subject={"kind": "entity", "value": ""},
+            relation={"kind": "relation", "value": "역할"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="lookup_object",
+            subject={"kind": "entity", "value": "샘플인물"},
+            relation_candidates=["역할", 3],
+            reason=None,
+        ),
+        _intent_payload(
+            kind="lookup_object",
+            subject={"kind": "entity", "value": "샘플인물"},
+            reason=None,
+        ),
+        _intent_payload(reason=""),
+        _intent_payload(
+            kind="lookup_object",
+            subject={"kind": "relation", "value": "역할"},
+            relation={"kind": "entity", "value": "샘플인물"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="lookup_subject",
+            relation={"kind": "entity", "value": "샘플인물"},
+            object={"kind": "relation", "value": "역할"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="lookup_relation",
+            relation={"kind": "relation", "value": "역할"},
+            subject={"kind": "entity", "value": "샘플인물"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="compare_typed_value",
+            subject={"kind": "entity", "value": "샘플항목"},
+            relation={"kind": "relation", "value": "수량"},
+            operator=">",
+            value_type="duration",
+            value="10",
+            reason=None,
+        ),
+    ],
+)
+def test_parse_query_intent_rejects_malformed_or_invalid_output(raw):
+    with pytest.raises(LLMError):
+        parse_query_intent(raw)
 
 
 def test_extraction_prompt_prioritizes_semantic_spo_facts():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: MPL-2.0
 import unicodedata
 
+import pytest
+
 from verinote.llm.base import LLMError
 from verinote.pipeline.query import (
+    deterministic_query_intent_dl,
     expand_query_relation_aliases,
     load_query,
     query_path,
     translate_questions,
 )
 from verinote.pipeline.corroboration import CorroborationPolicyError
+from verinote.pipeline.query_intent import deterministic_query_intent
 from verinote.store import Store
 
 
@@ -59,6 +63,17 @@ def test_translate_korean_role_question_bypasses_llm(tmp_path):
     assert f'answer_q{qid}(R) :- relation(S, R, "샘플인물").' in query_dl
     assert f'answer_q{qid}(R) :- relation(S, R, person("샘플인물")).' in query_dl
     assert load_query(s) == query_dl + "\n"
+
+
+def test_korean_role_query_datalog_is_derived_from_intent():
+    intent = deterministic_query_intent("샘플인물의 역할은 무엇인가?")
+
+    query_dl = deterministic_query_intent_dl(intent, 7)
+
+    assert query_dl is not None
+    assert 'answer_q7(O) :- relation("샘플인물", "역할", O).' in query_dl
+    assert 'answer_q7(O) :- relation(person("샘플인물"), has_role, O).' in query_dl
+    assert 'answer_q7(R) :- relation(S, R, "샘플인물").' in query_dl
 
 
 def test_load_query_expands_relation_aliases(tmp_path, fake_client):
@@ -160,6 +175,24 @@ def test_invalid_generated_query_requires_review_and_skips_draft(tmp_path, fake_
     assert "this is not datalog" not in q["query_dl"]
     assert f"answer_q{qid}" not in (load_query(s) or "")
     assert load_query(s) == ""
+
+
+def test_query_intent_errors_are_catchable_and_separate_from_datalog_translation(
+    tmp_path, fake_client
+):
+    intent_client = fake_client(intent="not json")
+    with pytest.raises(LLMError, match="query intent output was not JSON"):
+        intent_client.extract_query_intent(question="What is the sample answer?")
+
+    s = _store(tmp_path)
+    qid = s.add_question("What is the sample answer?")
+    datalog_client = fake_client(query=lambda question, qid: "this is not datalog")
+
+    results = translate_questions(s, datalog_client, root=tmp_path)
+
+    assert results[0]["id"] == qid
+    assert results[0]["status"] == "review_required"
+    assert "invalid query:" in results[0]["reason"]
 
 
 def test_non_executable_question_states_store_reasons_and_skip_draft(tmp_path, fake_client):

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MPL-2.0
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from verinote.pipeline.query_intent import (
+    ENGLISH_ROLE_RELATION_CANDIDATES,
+    KOREAN_ROLE_RELATION_CANDIDATES,
+    IntentTarget,
+    QueryIntent,
+    QueryIntentKind,
+    deterministic_query_intent,
+)
+
+
+def test_lookup_object_intent_is_frozen_and_typed():
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "샘플인물"),
+        relation_candidates=("역할", "직책"),
+    )
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "샘플인물")
+    assert intent.relation_candidates == ("역할", "직책")
+    with pytest.raises(FrozenInstanceError):
+        intent.relation_candidates = ("role",)
+
+
+def test_valid_lookup_subject_lookup_relation_count_and_compare_intents():
+    assert QueryIntent(
+        kind=QueryIntentKind.LOOKUP_SUBJECT,
+        relation=IntentTarget("relation", "역할"),
+        object=IntentTarget("entity", "검토자"),
+    ).kind == QueryIntentKind.LOOKUP_SUBJECT
+    assert QueryIntent(
+        kind=QueryIntentKind.LOOKUP_RELATION,
+        subject=IntentTarget("entity", "샘플인물"),
+        object=IntentTarget("entity", "샘플문서"),
+    ).kind == QueryIntentKind.LOOKUP_RELATION
+    assert QueryIntent(
+        kind=QueryIntentKind.COUNT,
+        relation=IntentTarget("relation", "참여"),
+    ).kind == QueryIntentKind.COUNT
+    assert QueryIntent(
+        kind=QueryIntentKind.COMPARE_TYPED_VALUE,
+        subject=IntentTarget("entity", "샘플항목"),
+        relation=IntentTarget("relation", "수량"),
+        operator=">=",
+        value_type="number",
+        value="3",
+    ).kind == QueryIntentKind.COMPARE_TYPED_VALUE
+
+
+def test_intent_rejects_invalid_combinations():
+    with pytest.raises(ValueError, match="lookup_object"):
+        QueryIntent(
+            kind=QueryIntentKind.LOOKUP_OBJECT,
+            subject=IntentTarget("entity", "샘플인물"),
+        )
+    with pytest.raises(ValueError, match="unknown_or_unsupported"):
+        QueryIntent(
+            kind=QueryIntentKind.UNKNOWN_OR_UNSUPPORTED,
+            subject=IntentTarget("entity", "샘플인물"),
+            reason="unsupported",
+        )
+
+
+def test_intent_rejects_swapped_target_kinds_and_bad_value_type():
+    with pytest.raises(ValueError, match="lookup_object subject"):
+        QueryIntent(
+            kind=QueryIntentKind.LOOKUP_OBJECT,
+            subject=IntentTarget("relation", "역할"),
+            relation=IntentTarget("relation", "역할"),
+        )
+    with pytest.raises(ValueError, match="lookup_subject relation"):
+        QueryIntent(
+            kind=QueryIntentKind.LOOKUP_SUBJECT,
+            relation=IntentTarget("entity", "샘플인물"),
+            object=IntentTarget("entity", "검토자"),
+        )
+    with pytest.raises(ValueError, match="lookup_relation does not accept a relation"):
+        QueryIntent(
+            kind=QueryIntentKind.LOOKUP_RELATION,
+            subject=IntentTarget("entity", "샘플인물"),
+            relation=IntentTarget("relation", "역할"),
+        )
+    with pytest.raises(ValueError, match="value_type"):
+        QueryIntent(
+            kind=QueryIntentKind.COMPARE_TYPED_VALUE,
+            subject=IntentTarget("entity", "샘플항목"),
+            relation=IntentTarget("relation", "수량"),
+            operator=">",
+            value_type="duration",
+            value="10",
+        )
+
+
+def test_unsupported_deterministic_question_returns_unknown_intent():
+    intent = deterministic_query_intent("이 질문은 합성이지만 지원하지 않는 형태입니다.")
+
+    assert intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    assert intent.reason == "unsupported deterministic query shape"
+
+
+def test_korean_role_title_questions_preserve_source_language_candidates():
+    for label in ("역할", "직책", "직위"):
+        intent = deterministic_query_intent(f"샘플인물의 {label}은 무엇인가?")
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+        assert intent.subject == IntentTarget("entity", "샘플인물")
+        assert intent.relation_candidates == KOREAN_ROLE_RELATION_CANDIDATES
+        assert "role" not in intent.relation_candidates
+
+
+def test_english_role_title_questions_use_english_candidates():
+    intent = deterministic_query_intent("What is Sample Person's role?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "Sample Person")
+    assert intent.relation_candidates == ENGLISH_ROLE_RELATION_CANDIDATES

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -8,11 +8,14 @@ from verinote.llm.base import ExtractedFact, LLMError
 from verinote.llm.schema import (
     EXTRACTION_SYSTEM,
     FACT_ARRAY_SCHEMA,
+    QUERY_INTENT_SCHEMA,
+    QUERY_INTENT_SYSTEM,
     QUERY_SCHEMA,
     parse_facts,
     parse_query,
     query_system,
 )
+from verinote.pipeline.query_intent import QueryIntent, parse_query_intent
 
 
 class AnthropicAdapter:
@@ -77,4 +80,33 @@ class AnthropicAdapter:
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
                 return parse_query(block.input)
+        raise LLMError("anthropic response contained no tool_use block")
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
+        try:
+            import anthropic
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
+
+        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        tool = {
+            "name": "emit_query_intent",
+            "description": "Return the structured query intent.",
+            "input_schema": QUERY_INTENT_SCHEMA,
+        }
+        try:
+            msg = client.messages.create(
+                model=self.cfg.model,
+                max_tokens=1024,
+                system=QUERY_INTENT_SYSTEM + ("\n" + schema_hint if schema_hint else ""),
+                tools=[tool],
+                tool_choice={"type": "tool", "name": "emit_query_intent"},
+                messages=[{"role": "user", "content": question}],
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise provider errors
+            raise LLMError(f"anthropic request failed: {exc}") from exc
+
+        for block in msg.content:
+            if getattr(block, "type", None) == "tool_use":
+                return parse_query_intent(block.input)
         raise LLMError("anthropic response contained no tool_use block")

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 from dataclasses import KW_ONLY, dataclass
-from typing import Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from verinote.pipeline.query_intent import QueryIntent
 
 FactSlotKind = Literal["string", "term"]
 
@@ -61,5 +64,13 @@ class LLMClient(Protocol):
         return a durable non-executable outcome:
         ``review_required("reason")``, ``no_answer("reason")``, or
         ``ambiguous("reason")``. Raise `LLMError` on provider/parse error.
+        """
+        ...
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = "") -> "QueryIntent":
+        """Extract a constrained query intent from `question`.
+
+        This structured-output boundary is separate from Datalog translation.
+        Adapters raise `LLMError` for malformed or schema-invalid intent output.
         """
         ...

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -14,11 +14,14 @@ from verinote.llm.base import ExtractedFact, LLMError
 from verinote.llm.schema import (
     EXTRACTION_SYSTEM,
     FACT_ARRAY_SCHEMA,
+    QUERY_INTENT_SCHEMA,
+    QUERY_INTENT_SYSTEM,
     QUERY_SCHEMA,
     parse_facts,
     parse_query,
     query_system,
 )
+from verinote.pipeline.query_intent import QueryIntent, parse_query_intent
 
 _MODEL_ALIASES = {
     "fable": "fable",
@@ -48,6 +51,14 @@ class ClaudeCliAdapter:
             user=question,
         )
         return parse_query(self._run(prompt, schema=QUERY_SCHEMA))
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
+        prompt = _prompt(
+            system=QUERY_INTENT_SYSTEM + ("\n" + schema_hint if schema_hint else ""),
+            schema=QUERY_INTENT_SCHEMA,
+            user=question,
+        )
+        return parse_query_intent(self._run(prompt, schema=QUERY_INTENT_SCHEMA))
 
     def _run(self, prompt: "_Prompt", *, schema: dict[str, Any]) -> str:
         schema_json = json.dumps(schema, ensure_ascii=False)

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -13,11 +13,14 @@ import urllib.request
 from verinote.config import Config
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.llm.schema import (
+    QUERY_INTENT_SCHEMA,
+    QUERY_INTENT_SYSTEM,
     QUERY_SCHEMA,
     parse_facts,
     parse_query,
     query_system,
 )
+from verinote.pipeline.query_intent import QueryIntent, parse_query_intent
 
 
 OLLAMA_FACT_ARRAY_SCHEMA = {
@@ -136,3 +139,31 @@ class OllamaAdapter:
             raise LLMError(f"ollama request failed: {exc}") from exc
 
         return parse_query(body.get("message", {}).get("content", ""))
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
+        system = QUERY_INTENT_SYSTEM + ("\n" + schema_hint if schema_hint else "")
+        payload = {
+            "model": self.cfg.model,
+            "stream": False,
+            "think": False,
+            "format": QUERY_INTENT_SCHEMA,
+            "options": {"temperature": 0, "num_predict": 512},
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": question},
+            ],
+        }
+        req = urllib.request.Request(
+            f"{self.base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+                req, timeout=self.cfg.llm_timeout_seconds
+            ) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+            raise LLMError(f"ollama request failed: {exc}") from exc
+
+        return parse_query_intent(body.get("message", {}).get("content", ""))

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -8,11 +8,14 @@ from verinote.llm.base import ExtractedFact, LLMError
 from verinote.llm.schema import (
     EXTRACTION_SYSTEM,
     FACT_ARRAY_SCHEMA,
+    QUERY_INTENT_SCHEMA,
+    QUERY_INTENT_SYSTEM,
     QUERY_SCHEMA,
     parse_facts,
     parse_query,
     query_system,
 )
+from verinote.pipeline.query_intent import QueryIntent, parse_query_intent
 
 
 class OpenAIAdapter:
@@ -69,3 +72,34 @@ class OpenAIAdapter:
             raise LLMError(f"openai request failed: {exc}") from exc
 
         return parse_query(resp.choices[0].message.content or "")
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
+
+        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        try:
+            resp = client.chat.completions.create(
+                model=self.cfg.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": QUERY_INTENT_SYSTEM + ("\n" + schema_hint if schema_hint else ""),
+                    },
+                    {"role": "user", "content": question},
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "query_intent",
+                        "schema": QUERY_INTENT_SCHEMA,
+                        "strict": True,
+                    },
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise provider errors
+            raise LLMError(f"openai request failed: {exc}") from exc
+
+        return parse_query_intent(resp.choices[0].message.content or "")

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -155,6 +155,59 @@ def parse_query(raw: str | dict[str, Any]) -> str:
     return line
 
 
+# --- query intent extraction (#113) ---------------------------------------
+
+QUERY_INTENT_TARGET_SCHEMA: dict[str, Any] = {
+    "type": ["object", "null"],
+    "required": ["kind", "value"],
+    "additionalProperties": False,
+    "properties": {
+        "kind": {"type": "string", "enum": ["entity", "relation", "value", "typed_value"]},
+        "value": {"type": "string", "minLength": 1},
+    },
+}
+
+QUERY_INTENT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "kind": {
+            "type": "string",
+            "enum": [
+                "lookup_object",
+                "lookup_subject",
+                "lookup_relation",
+                "count",
+                "compare_typed_value",
+                "unknown_or_unsupported",
+            ],
+        },
+        "subject": QUERY_INTENT_TARGET_SCHEMA,
+        "relation": QUERY_INTENT_TARGET_SCHEMA,
+        "object": QUERY_INTENT_TARGET_SCHEMA,
+        "relation_candidates": {
+            "type": ["array", "null"],
+            "items": {"type": "string", "minLength": 1},
+        },
+        "operator": {"type": ["string", "null"], "enum": ["=", "!=", "<", "<=", ">", ">=", None]},
+        "value_type": {
+            "type": ["string", "null"],
+            "enum": ["date", "number", "amount", "ordinal", None],
+        },
+        "value": {"type": ["string", "null"], "minLength": 1},
+        "reason": {"type": ["string", "null"], "minLength": 1},
+    },
+}
+QUERY_INTENT_SCHEMA["required"] = list(QUERY_INTENT_SCHEMA["properties"])
+
+
+QUERY_INTENT_SYSTEM = (
+    "Classify one natural-language question into a constrained query intent. "
+    "Return only JSON matching the schema. Use null for fields that do not apply. "
+    "Do not emit Datalog, relation/3 rules, answer_q predicates, or execution plans."
+)
+
+
 def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
     """Parse provider output (a JSON string or already-decoded dict) into facts."""
     try:

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -21,16 +21,18 @@ from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, par
 from verinote.engine.terms import Atom, StringLit, render_term
 from verinote.llm.base import LLMClient, LLMError
 from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
+from verinote.pipeline.query_intent import (
+    KOREAN_ROLE_RELATION_CANDIDATES,
+    QueryIntent,
+    QueryIntentKind,
+    deterministic_query_intent,
+)
 from verinote.store import Store
 
 # Query draft, relative to the KB root (the db file's directory).
 QUERY_RELPATH = Path("facts") / "query.dl"
 MAX_ALIAS_EXPANDED_RULES_PER_RULE = 64
 _ESCAPE = re.compile(r'(["\\])')
-_ROLE_QUESTION = re.compile(
-    r'["“”\']?(?P<person>[^"“”\'?？\n]{1,80}?)["“”\']?\s*'
-    r"(?:의|에\s*대한)\s*(?:역할|직책|직위)"
-)
 _GENERIC_ROLE_RELATIONS = ("역할", "직책", "직위", "role", "has_role")
 _STATUS_LINE = re.compile(
     r"^\s*(?P<status>review_required|no_answer|ambiguous)\s*\((?P<reason>.*)\)\s*\.?\s*$",
@@ -67,12 +69,19 @@ def _lit(value: str) -> str:
 
 def deterministic_query_dl(question: str, qid: int) -> str | None:
     """Return deterministic query drafts for common shapes LLMs mistranslate."""
-    match = _ROLE_QUESTION.search(question.strip())
-    if not match:
+    intent = deterministic_query_intent(question)
+    return deterministic_query_intent_dl(intent, qid)
+
+
+def deterministic_query_intent_dl(intent: QueryIntent, qid: int) -> str | None:
+    """Bridge supported deterministic intents to the legacy query draft shape."""
+    if (
+        intent.kind != QueryIntentKind.LOOKUP_OBJECT
+        or intent.subject is None
+        or intent.relation_candidates != KOREAN_ROLE_RELATION_CANDIDATES
+    ):
         return None
-    person = match.group("person").strip()
-    if not person:
-        return None
+    person = intent.subject.value
 
     person_lit = _lit(person)
     person_term = f"person({person_lit})"

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Structured query intent objects and deterministic intent parsing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+import json
+import re
+from typing import Any
+
+from verinote.llm.base import LLMError
+
+
+class QueryIntentKind(StrEnum):
+    LOOKUP_OBJECT = "lookup_object"
+    LOOKUP_SUBJECT = "lookup_subject"
+    LOOKUP_RELATION = "lookup_relation"
+    COUNT = "count"
+    COMPARE_TYPED_VALUE = "compare_typed_value"
+    UNKNOWN_OR_UNSUPPORTED = "unknown_or_unsupported"
+
+
+@dataclass(frozen=True)
+class IntentTarget:
+    """A normalized query target without execution-language rendering."""
+
+    kind: str
+    value: str
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"entity", "relation", "value", "typed_value"}:
+            raise ValueError(f"unsupported target kind: {self.kind}")
+        if not isinstance(self.value, str) or not self.value.strip():
+            raise ValueError("target value must be a non-empty string")
+        object.__setattr__(self, "value", self.value.strip())
+
+
+@dataclass(frozen=True)
+class QueryIntent:
+    """Internal structured representation of a natural-language question."""
+
+    kind: QueryIntentKind
+    subject: IntentTarget | None = None
+    relation: IntentTarget | None = None
+    object: IntentTarget | None = None
+    relation_candidates: tuple[str, ...] = field(default_factory=tuple)
+    operator: str | None = None
+    value_type: str | None = None
+    value: str | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, QueryIntentKind):
+            object.__setattr__(self, "kind", QueryIntentKind(self.kind))
+        if not isinstance(self.relation_candidates, tuple):
+            raise ValueError("relation_candidates must be a tuple")
+        object.__setattr__(
+            self,
+            "relation_candidates",
+            tuple(_clean_required_string(item, "relation candidate") for item in self.relation_candidates),
+        )
+        if self.operator is not None:
+            object.__setattr__(self, "operator", _clean_required_string(self.operator, "operator"))
+        if self.value_type is not None:
+            object.__setattr__(self, "value_type", _clean_required_string(self.value_type, "value_type"))
+        if self.value is not None:
+            object.__setattr__(self, "value", _clean_required_string(self.value, "value"))
+        if self.reason is not None:
+            object.__setattr__(self, "reason", _clean_required_string(self.reason, "reason"))
+        self._validate_combination()
+
+    def _validate_combination(self) -> None:
+        kind = self.kind
+        has_relation = self.relation is not None or bool(self.relation_candidates)
+        if kind == QueryIntentKind.LOOKUP_OBJECT:
+            if self.subject is None or not has_relation or self.object is not None:
+                raise ValueError("lookup_object requires subject and relation, and no object")
+            self._require_target_kind("subject", self.subject, {"entity"})
+            self._require_relation_field()
+            self._forbid_compare_fields()
+            self._forbid_reason()
+        elif kind == QueryIntentKind.LOOKUP_SUBJECT:
+            if self.subject is not None or not has_relation or self.object is None:
+                raise ValueError("lookup_subject requires relation and object, and no subject")
+            self._require_relation_field()
+            self._require_target_kind("object", self.object, {"entity", "value", "typed_value"})
+            self._forbid_compare_fields()
+            self._forbid_reason()
+        elif kind == QueryIntentKind.LOOKUP_RELATION:
+            if self.relation is not None or self.relation_candidates:
+                raise ValueError("lookup_relation does not accept a relation")
+            if self.subject is None and self.object is None:
+                raise ValueError("lookup_relation requires subject or object")
+            self._require_optional_lookup_endpoint("subject", self.subject)
+            self._require_optional_lookup_endpoint("object", self.object)
+            self._forbid_compare_fields()
+            self._forbid_reason()
+        elif kind == QueryIntentKind.COUNT:
+            if self.subject is None and self.object is None and not has_relation:
+                raise ValueError("count requires at least one target or relation")
+            self._require_optional_lookup_endpoint("subject", self.subject)
+            if self.relation is not None:
+                self._require_target_kind("relation", self.relation, {"relation"})
+            self._require_optional_lookup_endpoint("object", self.object)
+            self._forbid_compare_fields()
+            self._forbid_reason()
+        elif kind == QueryIntentKind.COMPARE_TYPED_VALUE:
+            if (
+                self.subject is None
+                or not has_relation
+                or self.operator is None
+                or self.value_type is None
+                or self.value is None
+            ):
+                raise ValueError(
+                    "compare_typed_value requires subject, relation, operator, value_type, and value"
+                )
+            self._require_target_kind("subject", self.subject, {"entity"})
+            self._require_relation_field()
+            if self.operator not in {"=", "!=", "<", "<=", ">", ">="}:
+                raise ValueError("compare_typed_value operator is invalid")
+            if self.value_type not in {"date", "number", "amount", "ordinal"}:
+                raise ValueError("compare_typed_value value_type is invalid")
+            if self.object is not None:
+                self._require_target_kind("object", self.object, {"typed_value", "value"})
+            self._forbid_reason()
+        elif kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
+            if not self.reason:
+                raise ValueError("unknown_or_unsupported requires a reason")
+            if any(
+                item is not None
+                for item in (
+                    self.subject,
+                    self.relation,
+                    self.object,
+                    self.operator,
+                    self.value_type,
+                    self.value,
+                )
+            ) or self.relation_candidates:
+                raise ValueError("unknown_or_unsupported accepts only kind and reason")
+
+    def _forbid_compare_fields(self) -> None:
+        if self.operator is not None or self.value_type is not None or self.value is not None:
+            raise ValueError(f"{self.kind.value} does not accept comparison fields")
+
+    def _forbid_reason(self) -> None:
+        if self.reason is not None:
+            raise ValueError(f"{self.kind.value} does not accept reason")
+
+    def _require_relation_field(self) -> None:
+        if self.relation is not None:
+            self._require_target_kind("relation", self.relation, {"relation"})
+
+    def _require_optional_lookup_endpoint(self, field_name: str, target: IntentTarget | None) -> None:
+        if target is not None:
+            self._require_target_kind(field_name, target, {"entity", "value", "typed_value"})
+
+    def _require_target_kind(
+        self, field_name: str, target: IntentTarget | None, allowed: set[str]
+    ) -> None:
+        if target is None:
+            return
+        if target.kind not in allowed:
+            allowed_text = ", ".join(sorted(allowed))
+            raise ValueError(f"{self.kind.value} {field_name} must be {allowed_text}")
+
+
+_ROLE_TITLE_QUESTION = re.compile(
+    r'["“”\']?(?P<person>[^"“”\'?？\n]{1,80}?)["“”\']?\s*'
+    r"(?:의|에\s*대한)\s*(?P<label>역할|직책|직위)"
+)
+_ENGLISH_ROLE_TITLE_QUESTION = re.compile(
+    r"^\s*(?:what\s+is|what\s+was|find|show)\s+"
+    r"(?:the\s+)?(?P<person>[A-Z][^?]{0,80}?)"
+    r"(?:'s|\s+)?\s+(?P<label>role|title|position)\s*\??\s*$",
+    re.IGNORECASE,
+)
+KOREAN_ROLE_RELATION_CANDIDATES = ("역할", "직책", "직위")
+ENGLISH_ROLE_RELATION_CANDIDATES = ("role", "title", "position", "has_role")
+
+
+def deterministic_query_intent(question: str) -> QueryIntent:
+    """Return a structured intent for deterministic synthetic question shapes."""
+    text = question.strip()
+    match = _ROLE_TITLE_QUESTION.search(text)
+    if match:
+        person = match.group("person").strip()
+        if person:
+            return QueryIntent(
+                kind=QueryIntentKind.LOOKUP_OBJECT,
+                subject=IntentTarget("entity", person),
+                relation_candidates=KOREAN_ROLE_RELATION_CANDIDATES,
+            )
+
+    match = _ENGLISH_ROLE_TITLE_QUESTION.match(text)
+    if match:
+        person = match.group("person").strip()
+        if person:
+            return QueryIntent(
+                kind=QueryIntentKind.LOOKUP_OBJECT,
+                subject=IntentTarget("entity", person),
+                relation_candidates=ENGLISH_ROLE_RELATION_CANDIDATES,
+            )
+
+    return QueryIntent(
+        kind=QueryIntentKind.UNKNOWN_OR_UNSUPPORTED,
+        reason="unsupported deterministic query shape",
+    )
+
+
+QUERY_INTENT_FIELDS = (
+    "kind",
+    "subject",
+    "relation",
+    "object",
+    "relation_candidates",
+    "operator",
+    "value_type",
+    "value",
+    "reason",
+)
+
+
+def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
+    """Parse constrained JSON provider output into an internal query intent."""
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+        raise LLMError(f"query intent output was not JSON: {exc}") from exc
+    try:
+        return _parse_query_intent_object(data)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LLMError(f"query intent output did not match schema: {exc}") from exc
+
+
+def _parse_query_intent_object(data: Any) -> QueryIntent:
+    if not isinstance(data, dict):
+        raise TypeError("query intent output must be an object")
+    allowed = set(QUERY_INTENT_FIELDS)
+    extra = set(data) - allowed
+    if extra:
+        raise ValueError(f"unexpected fields: {', '.join(sorted(extra))}")
+    missing = allowed - set(data)
+    if missing:
+        raise KeyError(", ".join(sorted(missing)))
+    raw_kind = data["kind"]
+    if not isinstance(raw_kind, str):
+        raise TypeError("kind must be a string")
+    try:
+        kind = QueryIntentKind(raw_kind)
+    except ValueError as exc:
+        raise ValueError(f"unknown query intent kind: {raw_kind}") from exc
+    return QueryIntent(
+        kind=kind,
+        subject=_parse_intent_target(data, "subject"),
+        relation=_parse_intent_target(data, "relation"),
+        object=_parse_intent_target(data, "object"),
+        relation_candidates=_parse_relation_candidates(data),
+        operator=_parse_optional_string(data, "operator"),
+        value_type=_parse_optional_string(data, "value_type"),
+        value=_parse_optional_string(data, "value"),
+        reason=_parse_optional_string(data, "reason"),
+    )
+
+
+def _parse_intent_target(data: dict[str, Any], field_name: str) -> IntentTarget | None:
+    raw = data[field_name]
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise TypeError(f"{field_name} must be an object or null")
+    extra = set(raw) - {"kind", "value"}
+    if extra:
+        raise ValueError(f"{field_name} has unexpected fields: {', '.join(sorted(extra))}")
+    if set(raw) != {"kind", "value"}:
+        missing = sorted({"kind", "value"} - set(raw))
+        raise KeyError(f"{field_name}.{missing[0]}")
+    if not isinstance(raw["kind"], str):
+        raise TypeError(f"{field_name}.kind must be a string")
+    if not isinstance(raw["value"], str):
+        raise TypeError(f"{field_name}.value must be a string")
+    return IntentTarget(raw["kind"], raw["value"])
+
+
+def _parse_relation_candidates(data: dict[str, Any]) -> tuple[str, ...]:
+    raw = data["relation_candidates"]
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise TypeError("relation_candidates must be an array or null")
+    if not all(isinstance(item, str) for item in raw):
+        raise TypeError("relation_candidates items must be strings")
+    return tuple(raw)
+
+
+def _parse_optional_string(data: dict[str, Any], field_name: str) -> str | None:
+    value = data[field_name]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string or null")
+    if not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _clean_required_string(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return text


### PR DESCRIPTION
## Summary
- Add frozen structured query intent objects and deterministic intent parsing.
- Add a strict query-intent JSON schema and parser boundary for future LLM-assisted intent extraction.
- Add `LLMClient.extract_query_intent(...)` and provider adapter implementations separate from Datalog translation.
- Represent the existing deterministic Korean role/title query path as an intent before bridging to the legacy Datalog draft.

Fixes #113.

## Implementation Skill Checks
- Architect pass defined the intent API, deterministic role/title scope, strict schema/parser, and non-goals.
- Critic pass required no Datalog in the intent layer, catchable malformed output, explicit unsupported intents, source-language relation preservation, and meaningful tests.
- Reviewer pass caught strict-schema, target-kind validation, layering, and intent-client-boundary gaps; those were fixed.
- Final Architect/Critic validation found no code-design blockers after excluding local tooling state from Git.

## Validation
- `uv run pytest -q` -> 522 passed, 7 skipped
- `uv run ruff check verinote tests` -> passed
- `git diff --check` -> passed
- Sensitive sample data scan for previously disallowed real names/organizations -> no matches

## Notes
- This PR does not implement query candidate planning or replace the full query execution path. That remains for follow-up issues.
- Local `.omc/` and `uv.lock` are excluded locally and not included in this PR.
