### PR TITLE
Add deterministic query candidate planner

### DIFF
--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: MPL-2.0
+
+from verinote.pipeline.query_intent import IntentTarget, QueryIntent, QueryIntentKind
+from verinote.pipeline.query_planner import (
+    QueryPlannerBounds,
+    plan_query_candidates,
+)
+from verinote.pipeline.query_schema import (
+    EntityRef,
+    QuerySchemaSnapshot,
+    RelationAliasEntry,
+    RelationSchema,
+    TermRef,
+    TypedRelationEntry,
+)
+
+
+def _term(display: str, executable: str, kind: str = "StringLit") -> TermRef:
+    return TermRef(
+        display=display,
+        executable=executable,
+        kind=kind,
+        key=f"{kind}:{executable}",
+    )
+
+
+def _entity(display: str, executable: str, kind: str = "StringLit") -> EntityRef:
+    return EntityRef(
+        display=display,
+        executable=executable,
+        kind=kind,
+        key=f"{kind}:{executable}",
+        fact_count=1,
+    )
+
+
+def _relation(
+    display: str,
+    executable: str,
+    *,
+    subjects: tuple[EntityRef, ...],
+    objects: tuple[EntityRef, ...],
+    canonical: str | None = None,
+    aliases: tuple[RelationAliasEntry, ...] = (),
+    typed: TypedRelationEntry | None = None,
+    kind: str = "StringLit",
+) -> RelationSchema:
+    return RelationSchema(
+        relation=_term(display, executable, kind),
+        canonical_relation=canonical or display,
+        aliases=aliases,
+        typed=typed,
+        fact_count=1,
+        distinct_subject_count=len(subjects),
+        distinct_object_count=len(objects),
+        subjects=subjects,
+        objects=objects,
+        subjects_truncated=False,
+        objects_truncated=False,
+    )
+
+
+def _snapshot(*relations: RelationSchema) -> QuerySchemaSnapshot:
+    return QuerySchemaSnapshot(
+        relations=relations,
+        relations_truncated=False,
+        relation_aliases=(),
+        typed_relations=(),
+        exact_entity_facts=(),
+        exact_entity_facts_truncated=False,
+        fact_count=len(relations),
+    )
+
+
+def test_lookup_object_uses_observed_relation_and_subject_side():
+    sample_person = _entity("Sample Person", '"Sample Person"')
+    snapshot = _snapshot(
+        _relation(
+            "역할",
+            '"역할"',
+            subjects=(sample_person,),
+            objects=(_entity("Reviewer", '"Reviewer"'),),
+        ),
+        _relation(
+            "역할",
+            '"역할"',
+            subjects=(_entity("Other Subject", '"Other Subject"'),),
+            objects=(sample_person,),
+        ),
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Person"),
+        relation=IntentTarget("relation", "역할"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=12)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q12(value: symbol)\n'
+        'answer_q12(O) :- relation("Sample Person", "역할", O).'
+    ]
+    assert plan.truncated is False
+
+
+def test_lookup_subject_uses_object_side_directionality():
+    snapshot = _snapshot(
+        _relation(
+            "역할",
+            '"역할"',
+            subjects=(_entity("Sample Person", '"Sample Person"'),),
+            objects=(_entity("Reviewer", '"Reviewer"'),),
+        ),
+        _relation(
+            "역할",
+            '"역할"',
+            subjects=(_entity("Reviewer", '"Reviewer"'),),
+            objects=(_entity("Other Value", '"Other Value"'),),
+        ),
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_SUBJECT,
+        relation=IntentTarget("relation", "역할"),
+        object=IntentTarget("entity", "Reviewer"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=13)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q13(value: symbol)\n'
+        'answer_q13(S) :- relation(S, "역할", "Reviewer").'
+    ]
+
+
+def test_lookup_relation_uses_intentional_variable_relation_only_for_relation_lookup():
+    snapshot = _snapshot(
+        _relation(
+            "authored",
+            '"authored"',
+            subjects=(_entity("Sample Person", '"Sample Person"'),),
+            objects=(_entity("Sample Document", '"Sample Document"'),),
+        ),
+        _relation(
+            "reviewed",
+            '"reviewed"',
+            subjects=(_entity("Sample Person", '"Sample Person"'),),
+            objects=(_entity("Sample Document", '"Sample Document"'),),
+        ),
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_RELATION,
+        subject=IntentTarget("entity", "Sample Person"),
+        object=IntentTarget("entity", "Sample Document"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=14)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q14(value: symbol)\n'
+        'answer_q14(R) :- relation("Sample Person", R, "Sample Document").'
+    ]
+
+
+def test_source_language_relation_is_preserved_for_alias_backed_lookup():
+    snapshot = _snapshot(
+        _relation(
+            "역할",
+            '"역할"',
+            subjects=(_entity("Sample Person", '"Sample Person"'),),
+            objects=(_entity("Reviewer", '"Reviewer"'),),
+            aliases=(RelationAliasEntry(alias="role", canonical="역할"),),
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Person"),
+        relation_candidates=("role", "title"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=15)
+
+    assert [candidate.relation_display for candidate in plan.candidates] == ["역할"]
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q15(value: symbol)\n'
+        'answer_q15(O) :- relation("Sample Person", "역할", O).'
+    ]
+
+
+def test_typed_relation_metadata_can_match_without_inventing_relation_terms():
+    snapshot = _snapshot(
+        _relation(
+            "매출액",
+            '"매출액"',
+            subjects=(_entity("Synthetic Company", '"Synthetic Company"'),),
+            objects=(_entity("amount(5, \"억\")", 'amount(5, "억")', "Compound"),),
+            canonical="revenue",
+            typed=TypedRelationEntry(
+                relation="revenue",
+                type="amount",
+                alias="revenue_scalar",
+            ),
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Synthetic Company"),
+        relation=IntentTarget("relation", "revenue_scalar"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=16)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q16(value: symbol)\n'
+        'answer_q16(O) :- relation("Synthetic Company", "매출액", O).'
+    ]
+
+
+def test_role_title_lookup_uses_observed_schema_without_inventing_relations():
+    snapshot = _snapshot(
+        _relation(
+            "직책",
+            '"직책"',
+            subjects=(_entity("Sample Person", '"Sample Person"'),),
+            objects=(_entity("Editor", '"Editor"'),),
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Person"),
+        relation_candidates=("역할", "직책", "직위", "has_role"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=17)
+
+    assert [candidate.relation_display for candidate in plan.candidates] == ["직책"]
+    assert "has_role" not in "\n".join(
+        candidate.query_dl for candidate in plan.candidates
+    )
+
+
+def test_candidate_cap_truncates_deterministically():
+    snapshot = _snapshot(
+        *(
+            _relation(
+                relation,
+                f'"{relation}"',
+                subjects=(_entity("Sample Person", '"Sample Person"'),),
+                objects=(_entity(f"Value {relation}", f'"Value {relation}"'),),
+            )
+            for relation in ("r0", "r1", "r2")
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Person"),
+        relation_candidates=("r0", "r1", "r2"),
+    )
+
+    plan = plan_query_candidates(
+        intent,
+        snapshot,
+        qid=18,
+        bounds=QueryPlannerBounds(max_candidates=2),
+    )
+
+    assert plan.truncated is True
+    assert [candidate.relation_display for candidate in plan.candidates] == ["r0", "r1"]
+
+
+def test_structural_endpoint_terms_render_with_executable_identity():
+    snapshot = _snapshot(
+        _relation(
+            "has_role",
+            "has_role",
+            kind="Atom",
+            subjects=(_entity('person("Ada")', 'person("Ada")', "Compound"),),
+            objects=(
+                _entity(
+                    'role(person("Ada"), "PI")',
+                    'role(person("Ada"), "PI")',
+                    "Compound",
+                ),
+            ),
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", 'person("Ada")'),
+        relation=IntentTarget("relation", "has_role"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=19)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q19(value: symbol)\n'
+        'answer_q19(O) :- relation(person("Ada"), has_role, O).'
+    ]

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Deterministic schema-aware query candidate planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import unicodedata
+
+from verinote.pipeline.query_intent import QueryIntent, QueryIntentKind
+from verinote.pipeline.query_schema import (
+    EntityRef,
+    QuerySchemaSnapshot,
+    RelationSchema,
+)
+
+
+@dataclass(frozen=True)
+class QueryPlannerBounds:
+    max_candidates: int = 32
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.max_candidates, bool)
+            or not isinstance(self.max_candidates, int)
+            or self.max_candidates < 0
+        ):
+            raise ValueError("max_candidates must be a non-negative integer")
+
+
+@dataclass(frozen=True)
+class QueryCandidate:
+    query_dl: str
+    relation_display: str | None
+    relation_executable: str | None
+    subject_executable: str | None
+    object_executable: str | None
+
+
+@dataclass(frozen=True)
+class QueryCandidatePlan:
+    qid: int
+    candidates: tuple[QueryCandidate, ...]
+    truncated: bool = False
+    reason: str | None = None
+
+
+def plan_query_candidates(
+    intent: QueryIntent,
+    snapshot: QuerySchemaSnapshot,
+    *,
+    qid: int,
+    bounds: QueryPlannerBounds = QueryPlannerBounds(),
+) -> QueryCandidatePlan:
+    """Return bounded deterministic Datalog candidates for a structured intent."""
+    if isinstance(qid, bool) or not isinstance(qid, int) or qid < 0:
+        raise ValueError("qid must be a non-negative integer")
+
+    if intent.kind == QueryIntentKind.LOOKUP_OBJECT:
+        candidates = _lookup_object_candidates(intent, snapshot, qid)
+        reason = None
+    elif intent.kind == QueryIntentKind.LOOKUP_SUBJECT:
+        candidates = _lookup_subject_candidates(intent, snapshot, qid)
+        reason = None
+    elif intent.kind == QueryIntentKind.LOOKUP_RELATION:
+        candidates = _lookup_relation_candidates(intent, snapshot, qid)
+        reason = None
+    else:
+        candidates = ()
+        reason = f"unsupported intent kind: {intent.kind.value}"
+
+    return _bounded_plan(qid, candidates, bounds, reason=reason)
+
+
+def _lookup_object_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> tuple[QueryCandidate, ...]:
+    if intent.subject is None:
+        return ()
+    candidates: list[QueryCandidate] = []
+    for relation in _matching_relations(intent, snapshot):
+        for subject in _matching_entities(relation.subjects, intent.subject.value):
+            query_dl = _query_dl(
+                qid,
+                "O",
+                f"relation({subject.executable}, {relation.relation.executable}, O)",
+            )
+            candidates.append(
+                QueryCandidate(
+                    query_dl=query_dl,
+                    relation_display=relation.relation.display,
+                    relation_executable=relation.relation.executable,
+                    subject_executable=subject.executable,
+                    object_executable=None,
+                )
+            )
+    return _dedupe_candidates(candidates)
+
+
+def _lookup_subject_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> tuple[QueryCandidate, ...]:
+    if intent.object is None:
+        return ()
+    candidates: list[QueryCandidate] = []
+    for relation in _matching_relations(intent, snapshot):
+        for obj in _matching_entities(relation.objects, intent.object.value):
+            query_dl = _query_dl(
+                qid,
+                "S",
+                f"relation(S, {relation.relation.executable}, {obj.executable})",
+            )
+            candidates.append(
+                QueryCandidate(
+                    query_dl=query_dl,
+                    relation_display=relation.relation.display,
+                    relation_executable=relation.relation.executable,
+                    subject_executable=None,
+                    object_executable=obj.executable,
+                )
+            )
+    return _dedupe_candidates(candidates)
+
+
+def _lookup_relation_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> tuple[QueryCandidate, ...]:
+    subject_value = intent.subject.value if intent.subject is not None else None
+    object_value = intent.object.value if intent.object is not None else None
+    candidates: list[QueryCandidate] = []
+
+    for relation in snapshot.relations:
+        subjects = (
+            _matching_entities(relation.subjects, subject_value)
+            if subject_value is not None
+            else (None,)
+        )
+        objects = (
+            _matching_entities(relation.objects, object_value)
+            if object_value is not None
+            else (None,)
+        )
+        for subject in subjects:
+            for obj in objects:
+                body = _lookup_relation_body(subject, obj)
+                candidates.append(
+                    QueryCandidate(
+                        query_dl=_query_dl(qid, "R", body),
+                        relation_display=None,
+                        relation_executable=None,
+                        subject_executable=(
+                            subject.executable if subject is not None else None
+                        ),
+                        object_executable=(
+                            obj.executable if obj is not None else None
+                        ),
+                    )
+                )
+    return _dedupe_candidates(candidates)
+
+
+def _lookup_relation_body(subject: EntityRef | None, obj: EntityRef | None) -> str:
+    if subject is not None and obj is not None:
+        return f"relation({subject.executable}, R, {obj.executable})"
+    if subject is not None:
+        return f"relation({subject.executable}, R, O)"
+    if obj is not None:
+        return f"relation(S, R, {obj.executable})"
+    raise ValueError("lookup_relation requires at least one endpoint")
+
+
+def _matching_relations(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot
+) -> tuple[RelationSchema, ...]:
+    wanted = _relation_requests(intent)
+    if not wanted:
+        return ()
+    return tuple(
+        relation
+        for relation in snapshot.relations
+        if _relation_matches_any(relation, wanted)
+    )
+
+
+def _relation_requests(intent: QueryIntent) -> tuple[str, ...]:
+    values: list[str] = []
+    if intent.relation is not None:
+        values.append(intent.relation.value)
+    values.extend(intent.relation_candidates)
+    return tuple(dict.fromkeys(_nfc(value) for value in values))
+
+
+def _relation_matches_any(relation: RelationSchema, wanted: tuple[str, ...]) -> bool:
+    observed = {
+        _nfc(relation.relation.display),
+        _nfc(relation.relation.executable),
+        _nfc(relation.canonical_relation),
+    }
+    for alias in relation.aliases:
+        observed.add(_nfc(alias.alias))
+        observed.add(_nfc(alias.canonical))
+    if relation.typed is not None:
+        observed.add(_nfc(relation.typed.relation))
+        observed.add(_nfc(relation.typed.alias))
+        observed.add(_nfc(relation.typed.type))
+    return any(value in observed for value in wanted)
+
+
+def _matching_entities(
+    entities: tuple[EntityRef, ...], value: str | None
+) -> tuple[EntityRef, ...]:
+    if value is None:
+        return entities
+    wanted = _nfc(value)
+    return tuple(
+        entity
+        for entity in entities
+        if wanted in {
+            _nfc(entity.display),
+            _nfc(entity.executable),
+            _nfc(entity.key),
+        }
+    )
+
+
+def _query_dl(qid: int, head_value: str, body: str) -> str:
+    return f".decl answer_q{qid}(value: symbol)\nanswer_q{qid}({head_value}) :- {body}."
+
+
+def _bounded_plan(
+    qid: int,
+    candidates: tuple[QueryCandidate, ...],
+    bounds: QueryPlannerBounds,
+    *,
+    reason: str | None,
+) -> QueryCandidatePlan:
+    bounded = candidates[: bounds.max_candidates]
+    return QueryCandidatePlan(
+        qid=qid,
+        candidates=bounded,
+        truncated=len(candidates) > bounds.max_candidates,
+        reason=reason,
+    )
+
+
+def _dedupe_candidates(candidates: list[QueryCandidate]) -> tuple[QueryCandidate, ...]:
+    return tuple(dict.fromkeys(candidates))
+
+
+def _nfc(value: str) -> str:
+    return unicodedata.normalize("NFC", value)


### PR DESCRIPTION
## Summary
- add a pure schema-aware query candidate planner for structured lookup intents
- preserve observed executable relation terms while matching aliases, canonical names, and typed metadata
- add synthetic coverage for source-language preservation, directionality, structural term rendering, and bounded output

## Validation
- uv run pytest -q
- uv run ruff check verinote tests
- git diff --check HEAD~1..HEAD

Closes #114