### PR TITLE
Dry-run query candidates before persistence

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,14 +123,17 @@ def test_sync_surfaces_llm_error(tmp_path, monkeypatch, capsys, fake_client):
 def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr("verinote.llm.get_client", lambda cfg: fake_client())
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    s.add_fact("What is Ada?", "is_a", "Synthetic Answer", status="confirmed")
+    s.close()
 
     rc = cli.main(["query", "What is Ada?"])
 
     assert rc == 0
     out = capsys.readouterr().out
     assert "translated 1 question(s)" in out
-    s = Store(tmp_path / "kb.sqlite")
-    assert s.questions()[0]["status"] == "translated"
+    assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "translated"
     assert (tmp_path / "facts" / "query.dl").is_file()
 
 
@@ -190,6 +193,7 @@ def test_repair_validates_and_translates(tmp_path, monkeypatch, capsys, fake_cli
     )
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
+    s.add_fact("Ada", "born_in", "London", status="confirmed")
     qid = s.add_question("Where was Ada born?")
     s.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
     s.close()

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -100,6 +100,19 @@ def test_duckdb_backend_answer_query_format_matches_check_report():
     assert "q1: London" in rep.text
 
 
+def test_duckdb_backend_omits_answer_bucket_when_query_has_no_rows():
+    _duckdb()
+    query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Other", "born_in", O).\n'
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "born_in", "object": "London"}],
+        query_dl=query,
+    )
+
+    assert rep.ok is True
+    assert rep.answers == []
+    assert "--- answers ---" not in rep.text
+
+
 def test_duckdb_backend_supports_joins_projection_and_duplicates_are_set_semantics():
     _duckdb()
     policy = (

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -24,6 +24,7 @@ def _store(tmp_path) -> Store:
 
 def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
     s = _store(tmp_path)
+    s.add_fact("What is Ada?", "is_a", "Synthetic Answer", status="confirmed")
     qid = s.add_question("What is Ada?")
     results = translate_questions(s, fake_client(), root=tmp_path)
 
@@ -47,6 +48,7 @@ def test_translate_korean_role_question_bypasses_llm(tmp_path):
             raise AssertionError("deterministic role questions must not call the LLM")
 
     s = _store(tmp_path)
+    s.add_fact("샘플인물", "역할", "검토자", status="confirmed")
     qid = s.add_question("샘플인물의 역할은 무엇인가?")
     results = translate_questions(s, FailingClient(), root=tmp_path)
 
@@ -81,6 +83,7 @@ def test_load_query_expands_relation_aliases(tmp_path, fake_client):
     policy = tmp_path / "policy"
     policy.mkdir()
     (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
+    s.add_fact("샘플인물", "역할", "검토자", status="confirmed")
     qid = s.add_question("Find the sample person's role")
     client = fake_client(
         query=lambda question, qid: f'answer_q{qid}(V) :- relation("샘플인물", "role", V).'

--- a/tests/test_query_candidate_eval.py
+++ b/tests/test_query_candidate_eval.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: MPL-2.0
+
+import verinote.pipeline.query_candidate_eval as query_candidate_eval
+from verinote.engine import CheckReport
+from verinote.pipeline.query_candidate_eval import (
+    QueryCandidateOutcome,
+    QueryCandidateSetOutcome,
+    evaluate_query_candidate,
+    evaluate_query_candidate_plan,
+)
+from verinote.pipeline.query_planner import QueryCandidate, QueryCandidatePlan
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def _candidate(query_dl: str) -> QueryCandidate:
+    return QueryCandidate(
+        query_dl=query_dl,
+        relation_display=None,
+        relation_executable=None,
+        subject_executable=None,
+        object_executable=None,
+    )
+
+
+def _lookup(qid: int, subject: str, relation: str) -> QueryCandidate:
+    return _candidate(
+        f'.decl answer_q{qid}(value: symbol)\n'
+        f'answer_q{qid}(O) :- relation("{subject}", "{relation}", O).'
+    )
+
+
+def _plan(*candidates: QueryCandidate, qid: int = 1) -> QueryCandidatePlan:
+    return QueryCandidatePlan(qid=qid, candidates=tuple(candidates))
+
+
+def test_evaluate_query_candidate_rejects_invalid_syntax(tmp_path):
+    store = _store(tmp_path)
+
+    evaluation = evaluate_query_candidate(store, _candidate("this is not datalog"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.INVALID
+    assert evaluation.validation_reason
+    assert evaluation.report is None
+
+
+def test_evaluate_query_candidate_rejects_unsupported_predicate(tmp_path):
+    store = _store(tmp_path)
+    candidate = _candidate(".decl answer_q1(value: symbol)\nanswer_q1(O) :- bogus(O).")
+
+    evaluation = evaluate_query_candidate(store, candidate)
+
+    assert evaluation.outcome == QueryCandidateOutcome.INVALID
+    assert "bogus" in evaluation.validation_reason
+
+
+def test_evaluate_query_candidate_no_rows_is_no_answer(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "born_in", "Sample City", status="confirmed")
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Other Person", "born_in"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.NO_ANSWER
+    assert evaluation.answers == ()
+    assert evaluation.report is not None
+    assert evaluation.report.ok is True
+
+
+def test_evaluate_query_candidate_answers_from_confirmed_and_accepted(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "role", "Confirmed Role", status="confirmed")
+    store.add_fact("Sample Person", "role", "Accepted Role", status="accepted")
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "role"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.VALID_WITH_ANSWERS
+    assert evaluation.answers == ("q1: Accepted Role, Confirmed Role",)
+
+
+def test_evaluate_query_candidate_keeps_empty_string_answer(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "note", "", status="confirmed")
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "note"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.VALID_WITH_ANSWERS
+    assert evaluation.answers == ("q1: ",)
+
+
+def test_evaluate_query_candidate_ignores_candidate_and_needs_review_facts(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "role", "Candidate Role", status="candidate")
+    store.add_fact("Sample Person", "role", "Needs Review Role", status="needs_review")
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "role"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.NO_ANSWER
+
+
+def test_evaluate_query_candidate_reports_engine_unavailable(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+
+    def fake_run_check(*args, **kwargs):
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text="DuckDB is not installed",
+            findings=["ERROR engine error: DuckDB is not installed"],
+            engine_available=False,
+        )
+
+    monkeypatch.setattr(query_candidate_eval, "run_check_duckdb", fake_run_check)
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "role"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.ENGINE_POLICY_ERROR
+    assert evaluation.report is not None
+    assert evaluation.report.engine_available is False
+
+
+def test_evaluate_query_candidate_reports_validation_engine_unavailable(
+    tmp_path, monkeypatch
+):
+    store = _store(tmp_path)
+    monkeypatch.setattr(
+        query_candidate_eval,
+        "validate_query",
+        lambda query_dl: (False, "ERROR engine error: DuckDB is not installed"),
+    )
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "role"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.ENGINE_POLICY_ERROR
+    assert evaluation.report is not None
+    assert evaluation.report.engine_available is False
+
+
+def test_evaluate_query_candidate_reports_backend_error(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+
+    def fake_run_check(*args, **kwargs):
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text="backend error",
+            findings=["ERROR engine error: backend error"],
+        )
+
+    monkeypatch.setattr(query_candidate_eval, "run_check_duckdb", fake_run_check)
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "role"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.ENGINE_POLICY_ERROR
+    assert evaluation.report is not None
+    assert evaluation.report.findings == ["ERROR engine error: backend error"]
+
+
+def test_evaluate_query_candidate_uses_minimal_relation_policy(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Sample Org", "established_on", "2021", status="confirmed")
+    store.add_fact("Sample Person", "role", "Reviewer", status="confirmed")
+
+    evaluation = evaluate_query_candidate(store, _lookup(1, "Sample Person", "role"))
+
+    assert evaluation.outcome == QueryCandidateOutcome.VALID_WITH_ANSWERS
+    assert evaluation.answers == ("q1: Reviewer",)
+    assert evaluation.report is not None
+    assert evaluation.report.findings == []
+
+
+def test_evaluate_query_candidate_plan_expands_relation_aliases_without_mutating_selected(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
+    store.add_fact("Sample Person", "역할", "Reviewer", status="confirmed")
+    candidate = _lookup(1, "Sample Person", "role")
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert evaluation.answers == ("q1: Reviewer",)
+    assert evaluation.selected == candidate
+    assert evaluation.selected.query_dl == candidate.query_dl
+    assert '"역할"' not in evaluation.selected.query_dl
+
+
+def test_evaluate_query_candidate_plan_reports_alias_policy_error(tmp_path):
+    store = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("not a valid alias entry\n", encoding="utf-8")
+
+    evaluation = evaluate_query_candidate_plan(
+        store,
+        _plan(_lookup(1, "Sample Person", "role")),
+    )
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR
+    assert len(evaluation.evaluations) == 1
+    assert evaluation.evaluations[0].outcome == QueryCandidateOutcome.ENGINE_POLICY_ERROR
+    assert evaluation.evaluations[0].report is not None
+    assert "relation-aliases.md" in evaluation.evaluations[0].report.text
+
+
+def test_evaluate_query_candidate_plan_empty(tmp_path):
+    store = _store(tmp_path)
+
+    evaluation = evaluate_query_candidate_plan(store, _plan())
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.EMPTY
+    assert evaluation.evaluations == ()
+    assert evaluation.selected is None
+
+
+def test_evaluate_query_candidate_plan_selects_first_same_answer_candidate(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "role", "Reviewer", status="confirmed")
+    first = _lookup(1, "Sample Person", "role")
+    second = _candidate(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("Sample Person", "role", O), O != "Other".'
+    )
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(first, second))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert evaluation.selected == first
+    assert evaluation.answers == ("q1: Reviewer",)
+
+
+def test_evaluate_query_candidate_plan_marks_conflicting_answer_sets_ambiguous(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "role", "Reviewer", status="confirmed")
+    store.add_fact("Sample Person", "title", "Editor", status="confirmed")
+    role = _lookup(1, "Sample Person", "role")
+    title = _lookup(1, "Sample Person", "title")
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(role, title))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING
+    assert evaluation.selected == role
+    assert evaluation.answers == ("q1: Reviewer",)
+
+
+def test_evaluate_query_candidate_plan_invalid_and_no_answer_rollups(tmp_path):
+    store = _store(tmp_path)
+    invalid = _candidate(".decl answer_q1(value: symbol)\nanswer_q1(O) :- bogus(O).")
+
+    invalid_evaluation = evaluate_query_candidate_plan(store, _plan(invalid))
+    mixed_evaluation = evaluate_query_candidate_plan(
+        store, _plan(invalid, _lookup(1, "Sample Person", "role"))
+    )
+
+    assert invalid_evaluation.outcome == QueryCandidateSetOutcome.INVALID
+    assert mixed_evaluation.outcome == QueryCandidateSetOutcome.NO_ANSWER
+
+
+def test_evaluate_query_candidate_has_no_persistence_side_effects(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "role", "Reviewer", status="confirmed")
+    before_facts = [dict(row) for row in store.facts()]
+    before_questions = [dict(row) for row in store.questions()]
+
+    evaluation = evaluate_query_candidate_plan(
+        store, _plan(_lookup(1, "Sample Person", "role"))
+    )
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert [dict(row) for row in store.facts()] == before_facts
+    assert [dict(row) for row in store.questions()] == before_questions
+    assert not (tmp_path / "facts" / "query.dl").exists()

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
 
+from verinote.engine.terms import Compound, StringLit
 from verinote.llm.base import LLMError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.repair import repair_questions
@@ -17,6 +18,7 @@ def _store_with_review_required(tmp_path):
 
 def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
+    s.add_fact("Ada", "born_in", "London", status="confirmed")
     s.set_question_query(qid, s.questions()[0]["query_dl"], "review_required", "stale")
     client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
     results = repair_questions(s, client, root=tmp_path)
@@ -29,6 +31,12 @@ def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
 
 def test_repair_accepts_duckdb_supported_compound_query(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
+    s.add_fact(
+        "Ada",
+        "has_role",
+        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+        status="confirmed",
+    )
     client = fake_client(
         query=lambda q, i: (
             f'answer_q{i}(S) :- relation(S, "has_role", role(person("Ada"), "PI")).'
@@ -50,6 +58,7 @@ def test_repair_accepts_valid_proposal_without_pyrewire(tmp_path, monkeypatch, f
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     s, qid = _store_with_review_required(tmp_path)
+    s.add_fact("Ada", "born_in", "London", status="confirmed")
     client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
 
     results = repair_questions(s, client, root=tmp_path)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1525,6 +1525,7 @@ def test_add_question_persists(tmp_path):
 def test_delete_question_removes_query_file_entry(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store
+    store.add_fact("Ada", "born_in", "London", status="confirmed")
     qid = store.add_question("Where was Ada born?")
     store.set_question_query(
         qid,
@@ -1630,6 +1631,7 @@ def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client):
     )
     c = _client(tmp_path)
     store = c.app.state.store
+    store.add_fact("Ada", "born_in", "London", status="confirmed")
     qid = store.add_question("Where was Ada born?")
     store.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
 

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -378,8 +378,9 @@ def _collect_report(
                 f"{name[len(_WARN_PREFIX) :]}: {row}" for row in rendered_rows
             )
         elif name.startswith(_ANSWER_PREFIX):
-            qid = name[len(_ANSWER_PREFIX) :]
-            answers_by_q.setdefault(qid, []).extend(rendered_rows)
+            if rendered_rows:
+                qid = name[len(_ANSWER_PREFIX) :]
+                answers_by_q.setdefault(qid, []).extend(rendered_rows)
 
     errors = sorted(set(errors))
     warnings = sorted(set(warnings))

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import re
 import unicodedata
 
-from verinote.engine import validate_query
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
 from verinote.engine.terms import Atom, StringLit, render_term
 from verinote.llm.base import LLMClient, LLMError
@@ -104,6 +103,54 @@ def deterministic_query_intent_dl(intent: QueryIntent, qid: int) -> str | None:
     )
 
 
+def classify_query_draft(store: Store, qid: int, query_dl: str) -> tuple[str, str, str]:
+    """Validate and dry-run one query draft before it can be persisted.
+
+    Returns ``(status, query_dl, reason)`` using question lifecycle states.
+    """
+    from verinote.pipeline.query_candidate_eval import (
+        QueryCandidateSetOutcome,
+        evaluate_query_candidate_plan,
+    )
+    from verinote.pipeline.query_planner import QueryCandidate, QueryCandidatePlan
+
+    candidate = QueryCandidate(
+        query_dl=query_dl,
+        relation_display=None,
+        relation_executable=None,
+        subject_executable=None,
+        object_executable=None,
+    )
+    evaluation = evaluate_query_candidate_plan(
+        store,
+        QueryCandidatePlan(qid=qid, candidates=(candidate,)),
+    )
+    if evaluation.outcome == QueryCandidateSetOutcome.VALID:
+        return "translated", query_dl, ""
+    if evaluation.outcome == QueryCandidateSetOutcome.NO_ANSWER:
+        reason = "no confirmed facts match"
+        return "no_answer", f"no_answer({_lit(reason)})", reason
+    if evaluation.outcome == QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING:
+        reason = "multiple query candidates returned conflicting answers"
+        return "ambiguous", f"ambiguous({_lit(reason)})", reason
+    if evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR:
+        reason = _short_reason("engine/policy error: " + _evaluation_reason(evaluation))
+    else:
+        reason = _short_reason("invalid query: " + _evaluation_reason(evaluation))
+    return "review_required", f"review_required({_lit(reason)})", reason
+
+
+def _evaluation_reason(evaluation) -> str:
+    for item in evaluation.evaluations:
+        if item.validation_reason:
+            return item.validation_reason
+        if item.report is not None:
+            if item.report.findings:
+                return item.report.findings[0]
+            return item.report.text
+    return evaluation.outcome.value
+
+
 def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
     """Translate every pending question, persist drafts, rewrite `query.dl`.
 
@@ -114,7 +161,7 @@ def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[
         reason = ""
         query_dl = deterministic_query_dl(q["text"], q["id"])
         if query_dl is not None:
-            status = "translated"
+            status, query_dl, reason = classify_query_draft(store, q["id"], query_dl)
         else:
             try:
                 line = client.translate_query(question=q["text"], qid=q["id"])
@@ -132,13 +179,9 @@ def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[
                     reason = _short_reason(line.removeprefix("review_required"))
                 else:
                     query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
-                    ok, validation_reason = validate_query(query_dl)
-                    if ok:
-                        status = "translated"
-                    else:
-                        status = "review_required"
-                        reason = _short_reason(f"invalid query: {validation_reason}")
-                        query_dl = f"review_required({_lit(reason)})"
+                    status, query_dl, reason = classify_query_draft(
+                        store, q["id"], query_dl
+                    )
         store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
             {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}

--- a/verinote/pipeline/query_candidate_eval.py
+++ b/verinote/pipeline/query_candidate_eval.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Dry-run evaluation for deterministic query planner candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+from verinote.engine import CheckReport, validate_query
+from verinote.engine.duckdb_backend import run_check_duckdb
+from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
+from verinote.pipeline.query import expand_query_relation_aliases
+from verinote.pipeline.query_planner import QueryCandidate, QueryCandidatePlan
+
+RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+
+
+class QueryCandidateOutcome(Enum):
+    INVALID = "invalid"
+    ENGINE_POLICY_ERROR = "engine_policy_error"
+    NO_ANSWER = "no_answer"
+    VALID_WITH_ANSWERS = "valid_with_answers"
+
+
+class QueryCandidateSetOutcome(Enum):
+    EMPTY = "empty"
+    INVALID = "invalid"
+    ENGINE_POLICY_ERROR = "engine_policy_error"
+    NO_ANSWER = "no_answer"
+    VALID = "valid"
+    AMBIGUOUS_CONFLICTING = "ambiguous_conflicting"
+
+
+@dataclass(frozen=True)
+class QueryCandidateEvaluation:
+    candidate: QueryCandidate
+    outcome: QueryCandidateOutcome
+    answers: tuple[str, ...] = ()
+    validation_reason: str | None = None
+    report: CheckReport | None = None
+
+
+@dataclass(frozen=True)
+class QueryCandidateSetEvaluation:
+    plan: QueryCandidatePlan
+    outcome: QueryCandidateSetOutcome
+    evaluations: tuple[QueryCandidateEvaluation, ...] = ()
+    selected: QueryCandidate | None = None
+    answers: tuple[str, ...] = ()
+
+
+def evaluate_query_candidate(
+    store,
+    candidate: QueryCandidate,
+    *,
+    aliases: Mapping[str, str] | None = None,
+) -> QueryCandidateEvaluation:
+    """Validate and dry-run one planner candidate without mutating stored query state."""
+    ok, reason = validate_query(candidate.query_dl)
+    if not ok:
+        if _validation_engine_error(reason):
+            return QueryCandidateEvaluation(
+                candidate=candidate,
+                outcome=QueryCandidateOutcome.ENGINE_POLICY_ERROR,
+                validation_reason=reason,
+                report=_engine_error_report(reason),
+            )
+        return QueryCandidateEvaluation(
+            candidate=candidate,
+            outcome=QueryCandidateOutcome.INVALID,
+            validation_reason=reason,
+        )
+
+    try:
+        query_dl = expand_query_relation_aliases(candidate.query_dl, dict(aliases or {}))
+        report = run_check_duckdb(
+            store.engine_fact_terms(),
+            policy_dl=RELATION_DECL,
+            query_dl=query_dl,
+        )
+    except CorroborationPolicyError as exc:
+        report = _engine_error_report(str(exc))
+    except Exception as exc:
+        report = CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"query candidate dry-run error: {exc}",
+            findings=[f"ERROR engine error: {exc}"],
+        )
+
+    if not report.engine_available or not report.ok or report.errors:
+        return QueryCandidateEvaluation(
+            candidate=candidate,
+            outcome=QueryCandidateOutcome.ENGINE_POLICY_ERROR,
+            report=report,
+        )
+    answers = tuple(report.answers)
+    if not answers:
+        return QueryCandidateEvaluation(
+            candidate=candidate,
+            outcome=QueryCandidateOutcome.NO_ANSWER,
+            report=report,
+        )
+    return QueryCandidateEvaluation(
+        candidate=candidate,
+        outcome=QueryCandidateOutcome.VALID_WITH_ANSWERS,
+        answers=answers,
+        report=report,
+    )
+
+
+def evaluate_query_candidate_plan(store, plan: QueryCandidatePlan) -> QueryCandidateSetEvaluation:
+    """Evaluate a candidate plan and choose a deterministic non-ambiguous candidate."""
+    if not plan.candidates:
+        return QueryCandidateSetEvaluation(plan=plan, outcome=QueryCandidateSetOutcome.EMPTY)
+
+    try:
+        aliases = store_relation_aliases(store)
+    except CorroborationPolicyError as exc:
+        report = _engine_error_report(str(exc))
+        evaluations = tuple(
+            QueryCandidateEvaluation(
+                candidate=candidate,
+                outcome=QueryCandidateOutcome.ENGINE_POLICY_ERROR,
+                report=report,
+            )
+            for candidate in plan.candidates
+        )
+        return QueryCandidateSetEvaluation(
+            plan=plan,
+            outcome=QueryCandidateSetOutcome.ENGINE_POLICY_ERROR,
+            evaluations=evaluations,
+        )
+    evaluations = tuple(
+        evaluate_query_candidate(store, candidate, aliases=aliases)
+        for candidate in plan.candidates
+    )
+
+    if any(
+        evaluation.outcome == QueryCandidateOutcome.ENGINE_POLICY_ERROR
+        for evaluation in evaluations
+    ):
+        return QueryCandidateSetEvaluation(
+            plan=plan,
+            outcome=QueryCandidateSetOutcome.ENGINE_POLICY_ERROR,
+            evaluations=evaluations,
+        )
+
+    answering = tuple(
+        evaluation
+        for evaluation in evaluations
+        if evaluation.outcome == QueryCandidateOutcome.VALID_WITH_ANSWERS
+    )
+    if not answering:
+        if all(
+            evaluation.outcome == QueryCandidateOutcome.INVALID
+            for evaluation in evaluations
+        ):
+            outcome = QueryCandidateSetOutcome.INVALID
+        else:
+            outcome = QueryCandidateSetOutcome.NO_ANSWER
+        return QueryCandidateSetEvaluation(
+            plan=plan,
+            outcome=outcome,
+            evaluations=evaluations,
+        )
+
+    answer_sets = {evaluation.answers for evaluation in answering}
+    selected = answering[0]
+    if len(answer_sets) > 1:
+        return QueryCandidateSetEvaluation(
+            plan=plan,
+            outcome=QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING,
+            evaluations=evaluations,
+            selected=selected.candidate,
+            answers=selected.answers,
+        )
+    return QueryCandidateSetEvaluation(
+        plan=plan,
+        outcome=QueryCandidateSetOutcome.VALID,
+        evaluations=evaluations,
+        selected=selected.candidate,
+        answers=selected.answers,
+    )
+
+def _validation_engine_error(reason: str) -> bool:
+    normalized = reason.lower()
+    return "duckdb is not installed" in normalized or "engine error" in normalized
+
+
+def _engine_error_report(reason: str) -> CheckReport:
+    engine_available = "duckdb is not installed" not in reason.lower()
+    return CheckReport(
+        ok=False,
+        errors=1,
+        warnings=0,
+        text=f"query candidate validation error: {reason}",
+        findings=[f"ERROR engine error: {reason}"],
+        engine_available=engine_available,
+    )

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from verinote.engine import validate_query
 from verinote.llm.base import LLMClient, LLMError
 from verinote.pipeline.query import (
     _non_executable_outcome,
+    classify_query_draft,
     deterministic_query_dl,
     write_query_file,
 )
@@ -35,8 +35,11 @@ def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dic
         qid = q["id"]
         deterministic = deterministic_query_dl(q["text"], qid)
         if deterministic:
-            store.set_question_query(qid, deterministic, "translated")
-            results.append({"id": qid, "accepted": True, "reason": ""})
+            status, query_dl, reason = classify_query_draft(store, qid, deterministic)
+            store.set_question_query(qid, query_dl, status, reason)
+            results.append(
+                {"id": qid, "accepted": status == "translated", "reason": reason}
+            )
             continue
 
         try:
@@ -64,14 +67,14 @@ def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dic
             continue
 
         proposal = f".decl answer_q{qid}(value: symbol)\n{line}"
-        ok, reason = validate_query(proposal)
-        if ok:
-            store.set_question_query(qid, proposal, "translated")
+        status, query_dl, reason = classify_query_draft(store, qid, proposal)
+        if status == "translated":
+            store.set_question_query(qid, query_dl, status, reason)
             results.append({"id": qid, "accepted": True, "reason": ""})
         else:
-            store.set_question_query(qid, q["query_dl"], "review_required", reason)
+            store.set_question_query(qid, query_dl, status, reason)
             results.append({"id": qid, "accepted": False, "reason": reason})
-            _log.warning("repair q%d rejected by engine: %s", qid, reason)
+            _log.warning("repair q%d rejected by dry-run: %s", qid, reason)
 
     write_query_file(store, root)
     return results


### PR DESCRIPTION
## Summary
- add a reusable query candidate evaluator with explicit valid, no-answer, invalid, engine-error, and ambiguous outcomes
- gate translation and repair query drafts through validation plus dry-run before persisting translated queries
- fix DuckDB answer collection so zero-row query tables do not produce synthetic empty answers

## Validation
- uv run pytest -q
- uv run ruff check verinote tests
- git diff --check HEAD~1..HEAD

Closes #115