### PR TITLE
Share relation alias semantics in query planning

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -131,6 +131,36 @@ def test_expand_query_relation_aliases_normalizes_query_relation_names():
     assert 'answer_q1(O) :- relation("샘플인물", "role", O).' in expanded
 
 
+def test_expand_query_relation_aliases_does_not_duplicate_existing_canonical_rule():
+    query_dl = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Sample Person", "role", O).\n'
+        'answer_q1(O) :- relation("Sample Person", "역할", O).\n'
+    )
+
+    expanded = expand_query_relation_aliases(query_dl, {"role": "역할"})
+
+    assert (
+        expanded.count('answer_q1(O) :- relation("Sample Person", "역할", O).')
+        == 1
+    )
+    assert (
+        expanded.count('answer_q1(O) :- relation("Sample Person", "role", O).')
+        == 1
+    )
+
+
+def test_expand_query_relation_aliases_does_not_expand_canonical_back_to_raw():
+    query_dl = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Sample Person", "역할", O).\n'
+    )
+
+    expanded = expand_query_relation_aliases(query_dl, {"role": "역할"})
+
+    assert expanded == query_dl
+
+
 def test_expand_query_relation_aliases_caps_combinations():
     body = ", ".join(f'relation(X{i}, "r{i}", X{i + 1})' for i in range(7))
     query_dl = ".decl answer_q1(value: symbol)\n" f"answer_q1(O) :- {body}.\n"

--- a/tests/test_query_candidate_eval.py
+++ b/tests/test_query_candidate_eval.py
@@ -213,6 +213,47 @@ def test_evaluate_query_candidate_plan_reports_alias_policy_error(tmp_path):
     assert "relation-aliases.md" in evaluation.evaluations[0].report.text
 
 
+def test_evaluate_query_candidate_plan_reports_alias_expansion_cap_as_policy_error(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text(
+        "\n".join(f"- `r{i}` -> `canonical_{i}`" for i in range(7)) + "\n",
+        encoding="utf-8",
+    )
+    body = ", ".join(f'relation(X{i}, "r{i}", X{i + 1})' for i in range(7))
+    candidate = _candidate(
+        ".decl answer_q1(value: symbol)\n" f"answer_q1(X7) :- {body}."
+    )
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR
+    assert evaluation.evaluations[0].outcome == QueryCandidateOutcome.ENGINE_POLICY_ERROR
+    assert evaluation.evaluations[0].report is not None
+    assert "query alias expansion exceeds" in evaluation.evaluations[0].report.text
+
+
+def test_evaluate_query_candidate_plan_dedupes_mixed_raw_and_canonical_answers(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
+    store.add_fact("Sample Person", "role", "Reviewer", status="confirmed")
+    store.add_fact("Sample Person", "역할", "Reviewer", status="confirmed")
+
+    evaluation = evaluate_query_candidate_plan(
+        store, _plan(_lookup(1, "Sample Person", "role"))
+    )
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert evaluation.answers == ("q1: Reviewer",)
+
+
 def test_evaluate_query_candidate_plan_empty(tmp_path):
     store = _store(tmp_path)
 

--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
+import unicodedata
+
 from verinote.pipeline.query_intent import IntentTarget, QueryIntent, QueryIntentKind
 from verinote.pipeline.query_planner import (
     QueryPlannerBounds,
@@ -186,6 +188,54 @@ def test_source_language_relation_is_preserved_for_alias_backed_lookup():
     ]
 
 
+def test_canonical_observed_relation_matches_raw_alias_without_rewrite():
+    snapshot = _snapshot(
+        _relation(
+            "revenue",
+            '"revenue"',
+            subjects=(_entity("Synthetic Company", '"Synthetic Company"'),),
+            objects=(_entity("100", '"100"'),),
+            aliases=(RelationAliasEntry(alias="매출", canonical="revenue"),),
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Synthetic Company"),
+        relation=IntentTarget("relation", "매출"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=20)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q20(value: symbol)\n'
+        'answer_q20(O) :- relation("Synthetic Company", "revenue", O).'
+    ]
+
+
+def test_unicode_nfd_observed_relation_matches_nfc_alias_policy():
+    nfd_role = unicodedata.normalize("NFD", "역할")
+    snapshot = _snapshot(
+        _relation(
+            nfd_role,
+            f'"{nfd_role}"',
+            subjects=(_entity("Sample Person", '"Sample Person"'),),
+            objects=(_entity("Reviewer", '"Reviewer"'),),
+            aliases=(RelationAliasEntry(alias="role", canonical="역할"),),
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Person"),
+        relation=IntentTarget("relation", "role"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=21)
+
+    assert [candidate.relation_executable for candidate in plan.candidates] == [
+        f'"{nfd_role}"'
+    ]
+
+
 def test_typed_relation_metadata_can_match_without_inventing_relation_terms():
     snapshot = _snapshot(
         _relation(
@@ -212,6 +262,75 @@ def test_typed_relation_metadata_can_match_without_inventing_relation_terms():
     assert [candidate.query_dl for candidate in plan.candidates] == [
         '.decl answer_q16(value: symbol)\n'
         'answer_q16(O) :- relation("Synthetic Company", "매출액", O).'
+    ]
+
+
+def test_generic_typed_type_does_not_match_all_typed_amount_relations():
+    snapshot = _snapshot(
+        _relation(
+            "매출액",
+            '"매출액"',
+            subjects=(_entity("Synthetic Company", '"Synthetic Company"'),),
+            objects=(_entity("amount(5, \"억\")", 'amount(5, "억")', "Compound"),),
+            typed=TypedRelationEntry(
+                relation="매출액",
+                type="amount",
+                alias="revenue_scalar",
+            ),
+        ),
+        _relation(
+            "비용",
+            '"비용"',
+            subjects=(_entity("Synthetic Company", '"Synthetic Company"'),),
+            objects=(_entity("amount(2, \"억\")", 'amount(2, "억")', "Compound"),),
+            typed=TypedRelationEntry(
+                relation="비용",
+                type="amount",
+                alias="cost_scalar",
+            ),
+        ),
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Synthetic Company"),
+        relation=IntentTarget("relation", "amount"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=22)
+
+    assert plan.candidates == ()
+
+
+def test_candidate_cap_truncates_alias_backed_matches_deterministically():
+    snapshot = _snapshot(
+        *(
+            _relation(
+                display,
+                f'"{display}"',
+                subjects=(_entity("Sample Person", '"Sample Person"'),),
+                objects=(_entity(f"Value {index}", f'"Value {index}"'),),
+                aliases=(RelationAliasEntry(alias=f"raw_{index}", canonical=display),),
+            )
+            for index, display in enumerate(("표시0", "표시1", "표시2"))
+        )
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Person"),
+        relation_candidates=("raw_0", "raw_1", "raw_2"),
+    )
+
+    plan = plan_query_candidates(
+        intent,
+        snapshot,
+        qid=23,
+        bounds=QueryPlannerBounds(max_candidates=2),
+    )
+
+    assert plan.truncated is True
+    assert [candidate.relation_display for candidate in plan.candidates] == [
+        "표시0",
+        "표시1",
     ]
 
 

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -315,14 +315,60 @@ def _canonical_relation(relation: str, aliases: dict[str, str]) -> str:
 
 def canonical_relation(relation: str, aliases: dict[str, str]) -> str:
     """Return the relation name used for alias-aware trust comparisons."""
+    return relation_canonical_variant(relation, aliases)
+
+
+def relation_canonical_variant(relation: str, aliases: Mapping[str, str]) -> str:
+    """Return the alias canonical label for ``relation`` when policy defines one."""
     if not aliases:
         return relation
     normalized = unicodedata.normalize("NFC", relation)
-    if normalized in aliases:
-        return aliases[normalized]
-    if normalized in set(aliases.values()):
+    normalized_aliases = {
+        unicodedata.normalize("NFC", raw): unicodedata.normalize("NFC", canonical)
+        for raw, canonical in aliases.items()
+    }
+    if normalized in normalized_aliases:
+        return normalized_aliases[normalized]
+    if normalized in set(normalized_aliases.values()):
         return normalized
     return relation
+
+
+def relation_label_variants(relation: str, aliases: Mapping[str, str]) -> tuple[str, ...]:
+    """Return deterministic alias-equivalent labels for a relation label.
+
+    The input label is preserved as the first variant after NFC normalization so
+    callers that render queries keep observed labels ahead of policy-derived
+    alternatives.
+    """
+    normalized = unicodedata.normalize("NFC", relation)
+    variants = [normalized]
+    canonical = relation_canonical_variant(normalized, aliases)
+    if canonical != normalized:
+        variants.append(canonical)
+    normalized_aliases = {
+        unicodedata.normalize("NFC", raw): unicodedata.normalize("NFC", target)
+        for raw, target in aliases.items()
+    }
+    for alias, target in sorted(
+        normalized_aliases.items(),
+        key=lambda item: (
+            item[1],
+            item[0],
+        ),
+    ):
+        if target == canonical and alias not in variants:
+            variants.append(alias)
+    return tuple(variants)
+
+
+def relation_label_matches(
+    observed: str, wanted: str, aliases: Mapping[str, str]
+) -> bool:
+    """Return whether two relation labels match under alias/canonical semantics."""
+    observed_variants = set(relation_label_variants(observed, aliases))
+    wanted_variants = set(relation_label_variants(wanted, aliases))
+    return not observed_variants.isdisjoint(wanted_variants)
 
 
 def _value(row: Mapping[str, object], key: str, default: object = None) -> Any:

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -19,7 +19,11 @@ import unicodedata
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
 from verinote.engine.terms import Atom, StringLit, render_term
 from verinote.llm.base import LLMClient, LLMError
-from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
+from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    relation_canonical_variant,
+    store_relation_aliases,
+)
 from verinote.pipeline.query_intent import (
     KOREAN_ROLE_RELATION_CANDIDATES,
     QueryIntent,
@@ -233,7 +237,7 @@ def expand_query_relation_aliases(query_dl: str, aliases: dict[str, str]) -> str
     for rule in program.rules:
         alternatives: list[list[object]] = []
         has_alias = False
-        for index, item in enumerate(rule.body):
+        for item in rule.body:
             if not (isinstance(item, AtomExpr) and item.predicate == "relation"):
                 alternatives.append([item])
                 continue
@@ -241,12 +245,21 @@ def expand_query_relation_aliases(query_dl: str, aliases: dict[str, str]) -> str
                 alternatives.append([item])
                 continue
             raw = _relation_name(item.args[1])
-            if raw is None or raw not in aliases:
+            if raw is None:
                 alternatives.append([item])
                 continue
-            canonical = aliases[raw]
+            canonical = relation_canonical_variant(raw, aliases)
+            if canonical == unicodedata.normalize("NFC", raw):
+                alternatives.append([item])
+                continue
             alternatives.append(
-                [item, AtomExpr("relation", (item.args[0], StringLit(canonical), item.args[2]))]
+                [
+                    item,
+                    AtomExpr(
+                        "relation",
+                        (item.args[0], StringLit(canonical), item.args[2]),
+                    ),
+                ]
             )
             has_alias = True
         if not has_alias:

--- a/verinote/pipeline/query_candidate_eval.py
+++ b/verinote/pipeline/query_candidate_eval.py
@@ -96,7 +96,7 @@ def evaluate_query_candidate(
             outcome=QueryCandidateOutcome.ENGINE_POLICY_ERROR,
             report=report,
         )
-    answers = tuple(report.answers)
+    answers = tuple(dict.fromkeys(report.answers))
     if not answers:
         return QueryCandidateEvaluation(
             candidate=candidate,

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import unicodedata
 
+from verinote.pipeline.corroboration import relation_label_matches
 from verinote.pipeline.query_intent import QueryIntent, QueryIntentKind
 from verinote.pipeline.query_schema import (
     EntityRef,
@@ -190,19 +191,23 @@ def _relation_requests(intent: QueryIntent) -> tuple[str, ...]:
 
 
 def _relation_matches_any(relation: RelationSchema, wanted: tuple[str, ...]) -> bool:
-    observed = {
+    aliases = {entry.alias: entry.canonical for entry in relation.aliases}
+    observed = [
         _nfc(relation.relation.display),
         _nfc(relation.relation.executable),
         _nfc(relation.canonical_relation),
-    }
+    ]
     for alias in relation.aliases:
-        observed.add(_nfc(alias.alias))
-        observed.add(_nfc(alias.canonical))
+        observed.append(_nfc(alias.alias))
+        observed.append(_nfc(alias.canonical))
     if relation.typed is not None:
-        observed.add(_nfc(relation.typed.relation))
-        observed.add(_nfc(relation.typed.alias))
-        observed.add(_nfc(relation.typed.type))
-    return any(value in observed for value in wanted)
+        observed.append(_nfc(relation.typed.relation))
+        observed.append(_nfc(relation.typed.alias))
+    return any(
+        relation_label_matches(observed_value, wanted_value, aliases)
+        for observed_value in observed
+        for wanted_value in wanted
+    )
 
 
 def _matching_entities(


### PR DESCRIPTION
## Summary
- centralize alias/canonical relation matching helpers in corroboration
- use shared semantics in query alias expansion and planner relation matching while preserving observed executable labels
- prevent broad typed-type matches and de-duplicate dry-run answers deterministically

## Validation
- uv run pytest -q
- uv run ruff check verinote tests
- git diff --check HEAD~1..HEAD

Closes #116