### PR TITLE
Route questions through schema-aware planning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,3 +57,36 @@ class FakeClient:
 @pytest.fixture
 def fake_client():
     return FakeClient
+
+
+def query_intent_payload(
+    kind,
+    *,
+    subject=None,
+    relation=None,
+    object=None,
+    relation_candidates=(),
+    operator=None,
+    value_type=None,
+    value=None,
+    reason=None,
+):
+    def target(kind, value):
+        return None if value is None else {"kind": kind, "value": value}
+
+    return {
+        "kind": kind,
+        "subject": target("entity", subject),
+        "relation": target("relation", relation),
+        "object": target("entity", object),
+        "relation_candidates": list(relation_candidates),
+        "operator": operator,
+        "value_type": value_type,
+        "value": value,
+        "reason": reason,
+    }
+
+
+@pytest.fixture
+def intent_payload():
+    return query_intent_payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,15 +120,22 @@ def test_sync_surfaces_llm_error(tmp_path, monkeypatch, capsys, fake_client):
     assert "extraction failed: provider down" in capsys.readouterr().err
 
 
-def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client):
+def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client, intent_payload):
     _env(monkeypatch, tmp_path)
-    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: fake_client())
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(
+            intent=intent_payload(
+                "lookup_object", subject="Sample Subject", relation="is_a"
+            )
+        ),
+    )
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
-    s.add_fact("What is Ada?", "is_a", "Synthetic Answer", status="confirmed")
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
     s.close()
 
-    rc = cli.main(["query", "What is Ada?"])
+    rc = cli.main(["query", "What is Sample Subject?"])
 
     assert rc == 0
     out = capsys.readouterr().out
@@ -183,19 +190,25 @@ def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
     assert "no pending questions" in capsys.readouterr().err
 
 
-def test_repair_validates_and_translates(tmp_path, monkeypatch, capsys, fake_client):
+def test_repair_validates_and_translates(
+    tmp_path, monkeypatch, capsys, fake_client, intent_payload
+):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "verinote.llm.get_client",
         lambda cfg: fake_client(
-            query=lambda question, qid: f'answer_q{qid}(O) :- relation("Ada", "born_in", O).'
+            intent=intent_payload(
+                "lookup_object", subject="Sample Person", relation="born_in"
+            )
         ),
     )
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
-    s.add_fact("Ada", "born_in", "London", status="confirmed")
-    qid = s.add_question("Where was Ada born?")
-    s.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    qid = s.add_question("Where was Sample Person born?")
+    s.set_question_query(
+        qid, 'review_required("Where was Sample Person born?")', "review_required"
+    )
     s.close()
 
     rc = cli.main(["repair"])
@@ -205,19 +218,33 @@ def test_repair_validates_and_translates(tmp_path, monkeypatch, capsys, fake_cli
     assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "translated"
 
 
-def test_repair_reports_durable_rejected_status(tmp_path, monkeypatch, capsys, fake_client):
+def test_repair_reports_durable_rejected_status(
+    tmp_path, monkeypatch, capsys, fake_client, intent_payload
+):
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "verinote.llm.get_client",
         lambda cfg: fake_client(
-            query=lambda q, i: 'no_answer("no confirmed facts match")'
+            intent=intent_payload(
+                "lookup_object", subject="Sample Person", relation="born_in"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "verinote.pipeline.query.evaluate_query_candidate_plan",
+        lambda store, plan: QueryCandidateSetEvaluation(
+            plan=plan, outcome=QueryCandidateSetOutcome.NO_ANSWER
         ),
     )
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
-    qid = s.add_question("What is the sample answer?")
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    qid = s.add_question("Where was Sample Person born?")
     s.set_question_query(
-        qid, 'review_required("What is the sample answer?")', "review_required"
+        qid, 'review_required("Where was Sample Person born?")', "review_required"
     )
     s.close()
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,6 +9,7 @@ from verinote.pipeline.query import (
     expand_query_relation_aliases,
     load_query,
     query_path,
+    query_schema_hint,
     translate_questions,
 )
 from verinote.pipeline.corroboration import CorroborationPolicyError
@@ -22,11 +23,20 @@ def _store(tmp_path) -> Store:
     return s
 
 
-def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
+def test_translate_persists_query_and_writes_file(tmp_path, fake_client, intent_payload):
     s = _store(tmp_path)
-    s.add_fact("What is Ada?", "is_a", "Synthetic Answer", status="confirmed")
-    qid = s.add_question("What is Ada?")
-    results = translate_questions(s, fake_client(), root=tmp_path)
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    qid = s.add_question("What is Sample Subject?")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Subject", relation="is_a"
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("schema-aware translation must not call direct Datalog")
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
 
     assert results[0]["id"] == qid
     assert results[0]["status"] == "translated"
@@ -34,7 +44,10 @@ def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
     q = s.questions()[0]
     assert q["status"] == "translated"
     assert f".decl answer_q{qid}" in q["query_dl"]
-    assert "answer_q%d(O) :- relation(" % qid in q["query_dl"]
+    assert (
+        f'answer_q{qid}(O) :- relation("Sample Subject", "is_a", O).'
+        in q["query_dl"]
+    )
     # and the engine draft file was written
     draft = query_path(tmp_path)
     assert draft.is_file()
@@ -44,8 +57,11 @@ def test_translate_persists_query_and_writes_file(tmp_path, fake_client):
 
 def test_translate_korean_role_question_bypasses_llm(tmp_path):
     class FailingClient:
+        def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+            raise AssertionError("deterministic role questions must not call intent LLM")
+
         def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
-            raise AssertionError("deterministic role questions must not call the LLM")
+            raise AssertionError("deterministic role questions must not call direct Datalog")
 
     s = _store(tmp_path)
     s.add_fact("샘플인물", "역할", "검토자", status="confirmed")
@@ -62,8 +78,6 @@ def test_translate_korean_role_question_bypasses_llm(tmp_path):
     ]
     query_dl = s.questions()[0]["query_dl"]
     assert f'answer_q{qid}(O) :- relation("샘플인물", "역할", O).' in query_dl
-    assert f'answer_q{qid}(R) :- relation(S, R, "샘플인물").' in query_dl
-    assert f'answer_q{qid}(R) :- relation(S, R, person("샘플인물")).' in query_dl
     assert load_query(s) == query_dl + "\n"
 
 
@@ -78,18 +92,22 @@ def test_korean_role_query_datalog_is_derived_from_intent():
     assert 'answer_q7(R) :- relation(S, R, "샘플인물").' in query_dl
 
 
-def test_load_query_expands_relation_aliases(tmp_path, fake_client):
+def test_load_query_expands_relation_aliases(tmp_path):
     s = _store(tmp_path)
     policy = tmp_path / "policy"
     policy.mkdir()
     (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
-    s.add_fact("샘플인물", "역할", "검토자", status="confirmed")
     qid = s.add_question("Find the sample person's role")
-    client = fake_client(
-        query=lambda question, qid: f'answer_q{qid}(V) :- relation("샘플인물", "role", V).'
+    s.set_question_query(
+        qid,
+        f'.decl answer_q{qid}(value: symbol)\n'
+        f'answer_q{qid}(V) :- relation("샘플인물", "role", V).',
+        "translated",
     )
 
-    translate_questions(s, client, root=tmp_path)
+    from verinote.pipeline.query import write_query_file
+
+    write_query_file(s, tmp_path)
 
     stored_query = s.questions()[0]["query_dl"]
     assert f'answer_q{qid}(V) :- relation("샘플인물", "role", V).' in stored_query
@@ -174,11 +192,13 @@ def test_expand_query_relation_aliases_caps_combinations():
         raise AssertionError("expected CorroborationPolicyError")
 
 
-def test_review_required_question_is_flagged_not_in_draft(tmp_path, fake_client):
+def test_review_required_question_is_flagged_not_in_draft(tmp_path, fake_client, intent_payload):
     s = _store(tmp_path)
     qid = s.add_question("What is the meaning of life?")
     client = fake_client(
-        query=lambda question, qid: 'review_required("requires a synthetic relation")'
+        intent=intent_payload(
+            "unknown_or_unsupported", reason="requires a synthetic relation"
+        )
     )
     translate_questions(s, client, root=tmp_path)
 
@@ -191,21 +211,20 @@ def test_review_required_question_is_flagged_not_in_draft(tmp_path, fake_client)
     assert "review_required" not in (load_query(s) or "")
 
 
-def test_invalid_generated_query_requires_review_and_skips_draft(tmp_path, fake_client):
+def test_invalid_intent_output_fails_translation_and_skips_draft(tmp_path, fake_client):
     s = _store(tmp_path)
     qid = s.add_question("What is the sample answer?")
-    client = fake_client(query=lambda question, qid: "this is not datalog")
+    client = fake_client(intent={"kind": "lookup_object"})
 
     results = translate_questions(s, client, root=tmp_path)
 
     q = s.questions()[0]
-    assert results[0]["status"] == "review_required"
-    assert results[0]["query_dl"].startswith("review_required(")
-    assert "invalid query:" in results[0]["reason"]
-    assert q["status"] == "review_required"
+    assert results[0]["status"] == "translation_failed"
+    assert results[0]["query_dl"] is None
+    assert "query intent output did not match schema:" in results[0]["reason"]
+    assert q["status"] == "translation_failed"
     assert q["reason"] == results[0]["reason"]
-    assert q["query_dl"].startswith("review_required(")
-    assert "this is not datalog" not in q["query_dl"]
+    assert q["query_dl"] is None
     assert f"answer_q{qid}" not in (load_query(s) or "")
     assert load_query(s) == ""
 
@@ -221,47 +240,81 @@ def test_query_intent_errors_are_catchable_and_separate_from_datalog_translation
     qid = s.add_question("What is the sample answer?")
     datalog_client = fake_client(query=lambda question, qid: "this is not datalog")
 
-    results = translate_questions(s, datalog_client, root=tmp_path)
+    results = translate_questions(
+        s, datalog_client, root=tmp_path, allow_direct_datalog_fallback=True
+    )
 
     assert results[0]["id"] == qid
     assert results[0]["status"] == "review_required"
     assert "invalid query:" in results[0]["reason"]
 
 
-def test_non_executable_question_states_store_reasons_and_skip_draft(tmp_path, fake_client):
+def test_planner_no_candidates_requires_review(tmp_path, fake_client, intent_payload):
     s = _store(tmp_path)
-    no_answer_id = s.add_question("What is the sample answer?")
-    ambiguous_id = s.add_question("Which sample item is current?")
-    responses = iter(
-        [
-            'no_answer("no confirmed facts match")',
-            'ambiguous("multiple sample entities match")',
-        ]
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    qid = s.add_question("What is the sample answer?")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Missing Subject", relation="is_a"
+        )
     )
-    client = fake_client(query=lambda question, qid: next(responses))
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results[0]["id"] == qid
+    assert results[0]["status"] == "review_required"
+    assert results[0]["reason"] == "no query candidates matched the schema"
+    assert load_query(s) == ""
+
+
+def test_planned_executable_without_rows_becomes_no_answer(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    s = _store(tmp_path)
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    qid = s.add_question("What is Sample Subject?")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Subject", relation="is_a"
+        )
+    )
+
+    def no_rows(store, plan):
+        assert plan.candidates
+        return QueryCandidateSetEvaluation(
+            plan=plan, outcome=QueryCandidateSetOutcome.NO_ANSWER
+        )
+
+    monkeypatch.setattr("verinote.pipeline.query.evaluate_query_candidate_plan", no_rows)
 
     results = translate_questions(s, client, root=tmp_path)
 
     assert results == [
         {
-            "id": no_answer_id,
+            "id": qid,
             "status": "no_answer",
             "query_dl": 'no_answer("no confirmed facts match")',
             "reason": "no confirmed facts match",
-        },
-        {
-            "id": ambiguous_id,
-            "status": "ambiguous",
-            "query_dl": 'ambiguous("multiple sample entities match")',
-            "reason": "multiple sample entities match",
-        },
-    ]
-    rows = s.questions()
-    assert [(q["status"], q["reason"]) for q in rows] == [
-        ("no_answer", "no confirmed facts match"),
-        ("ambiguous", "multiple sample entities match"),
+        }
     ]
     assert load_query(s) == ""
+
+
+def test_query_schema_hint_is_bounded_schema_only(tmp_path):
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+
+    hint = query_schema_hint(build_query_schema_snapshot(s))
+
+    assert "Observed relations:" in hint
+    assert "is_a" in hint
+    assert "Sample Subject" not in hint
+    assert "Synthetic Answer" not in hint
 
 
 def test_translate_persists_llm_error_as_translation_failed(tmp_path, fake_client):

--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -12,6 +12,7 @@ from verinote.pipeline.query_schema import (
     QuerySchemaSnapshot,
     RelationAliasEntry,
     RelationSchema,
+    SnapshotFact,
     TermRef,
     TypedRelationEntry,
 )
@@ -71,6 +72,39 @@ def _snapshot(*relations: RelationSchema) -> QuerySchemaSnapshot:
         exact_entity_facts=(),
         exact_entity_facts_truncated=False,
         fact_count=len(relations),
+    )
+
+
+def _snapshot_with_exact(
+    *relations: RelationSchema, exact_facts: tuple[SnapshotFact, ...]
+) -> QuerySchemaSnapshot:
+    return QuerySchemaSnapshot(
+        relations=relations,
+        relations_truncated=False,
+        relation_aliases=(),
+        typed_relations=(),
+        exact_entity_facts=exact_facts,
+        exact_entity_facts_truncated=False,
+        fact_count=len(relations) + len(exact_facts),
+    )
+
+
+def _fact(
+    subject: TermRef,
+    relation: TermRef,
+    obj: TermRef,
+    *,
+    matched_entity: str,
+    matched_side: str,
+) -> SnapshotFact:
+    return SnapshotFact(
+        fact_id=1,
+        subject=subject,
+        relation=relation,
+        object=obj,
+        status="confirmed",
+        matched_entity=matched_entity,
+        matched_side=matched_side,
     )
 
 
@@ -331,6 +365,38 @@ def test_candidate_cap_truncates_alias_backed_matches_deterministically():
     assert [candidate.relation_display for candidate in plan.candidates] == [
         "표시0",
         "표시1",
+    ]
+
+
+def test_lookup_object_uses_exact_entity_facts_when_subject_examples_are_bounded():
+    snapshot = _snapshot_with_exact(
+        _relation(
+            "role",
+            '"role"',
+            subjects=(_entity("Other Subject", '"Other Subject"'),),
+            objects=(_entity("Other Value", '"Other Value"'),),
+        ),
+        exact_facts=(
+            _fact(
+                _term("Needle Subject", '"Needle Subject"'),
+                _term("role", '"role"'),
+                _term("Reviewer", '"Reviewer"'),
+                matched_entity="Needle Subject",
+                matched_side="subject",
+            ),
+        ),
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Needle Subject"),
+        relation=IntentTarget("relation", "role"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=24)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q24(value: symbol)\n'
+        'answer_q24(O) :- relation("Needle Subject", "role", O).'
     ]
 
 

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -11,16 +11,25 @@ from verinote.store import Store
 def _store_with_review_required(tmp_path):
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
-    qid = s.add_question("Where was Ada born?")
-    s.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
+    qid = s.add_question("Where was Sample Person born?")
+    s.set_question_query(
+        qid, 'review_required("Where was Sample Person born?")', "review_required"
+    )
     return s, qid
 
 
-def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
+def test_repair_accepts_engine_valid_planned_query(tmp_path, fake_client, intent_payload):
     s, qid = _store_with_review_required(tmp_path)
-    s.add_fact("Ada", "born_in", "London", status="confirmed")
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
     s.set_question_query(qid, s.questions()[0]["query_dl"], "review_required", "stale")
-    client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="born_in"
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("repair must not call direct Datalog before the planner")
+    )
     results = repair_questions(s, client, root=tmp_path)
 
     assert results == [{"id": qid, "accepted": True, "reason": ""}]
@@ -29,26 +38,34 @@ def test_repair_accepts_engine_valid_proposal(tmp_path, fake_client):
     assert f"answer_q{qid}" in (load_query(s) or "")
 
 
-def test_repair_accepts_duckdb_supported_compound_query(tmp_path, fake_client):
+def test_repair_fallback_accepts_duckdb_supported_compound_query(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
     s.add_fact(
-        "Ada",
+        "Sample Person",
         "has_role",
-        Compound("role", (Compound("person", (StringLit("Ada"),)), StringLit("PI"))),
+        Compound(
+            "role",
+            (Compound("person", (StringLit("Sample Person"),)), StringLit("Lead")),
+        ),
         status="confirmed",
     )
     client = fake_client(
         query=lambda q, i: (
-            f'answer_q{i}(S) :- relation(S, "has_role", role(person("Ada"), "PI")).'
+            f'answer_q{i}(S) :- relation(S, "has_role", '
+            'role(person("Sample Person"), "Lead")).'
         )
     )
-    results = repair_questions(s, client, root=tmp_path)
+    results = repair_questions(
+        s, client, root=tmp_path, allow_direct_datalog_fallback=True
+    )
 
     assert results == [{"id": qid, "accepted": True, "reason": ""}]
     assert s.questions()[0]["status"] == "translated"
 
 
-def test_repair_accepts_valid_proposal_without_pyrewire(tmp_path, monkeypatch, fake_client):
+def test_repair_fallback_accepts_valid_proposal_without_pyrewire(
+    tmp_path, monkeypatch, fake_client
+):
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
@@ -58,10 +75,14 @@ def test_repair_accepts_valid_proposal_without_pyrewire(tmp_path, monkeypatch, f
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     s, qid = _store_with_review_required(tmp_path)
-    s.add_fact("Ada", "born_in", "London", status="confirmed")
-    client = fake_client(query=lambda q, i: f'answer_q{i}(O) :- relation("Ada", "born_in", O).')
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        query=lambda q, i: f'answer_q{i}(O) :- relation("Sample Person", "born_in", O).'
+    )
 
-    results = repair_questions(s, client, root=tmp_path)
+    results = repair_questions(
+        s, client, root=tmp_path, allow_direct_datalog_fallback=True
+    )
 
     assert results == [{"id": qid, "accepted": True, "reason": ""}]
     assert s.questions()[0]["status"] == "translated"
@@ -71,7 +92,9 @@ def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
     # references an undeclared predicate -> engine rejects, question untouched
     client = fake_client(query=lambda q, i: f"answer_q{i}(O) :- bogus(O).")
-    results = repair_questions(s, client, root=tmp_path)
+    results = repair_questions(
+        s, client, root=tmp_path, allow_direct_datalog_fallback=True
+    )
 
     assert results[0]["accepted"] is False
     assert "bogus" in results[0]["reason"]
@@ -84,9 +107,13 @@ def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
 def test_repair_rejects_duckdb_unsupported_compound_query(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
     client = fake_client(
-        query=lambda q, i: f'answer_q{i}(person(O)) :- relation("Ada", "born_in", O).'
+        query=lambda q, i: (
+            f'answer_q{i}(person(O)) :- relation("Sample Person", "born_in", O).'
+        )
     )
-    results = repair_questions(s, client, root=tmp_path)
+    results = repair_questions(
+        s, client, root=tmp_path, allow_direct_datalog_fallback=True
+    )
 
     assert results[0]["accepted"] is False
     assert "variable-bearing compound" in results[0]["reason"]
@@ -96,22 +123,42 @@ def test_repair_rejects_duckdb_unsupported_compound_query(tmp_path, fake_client)
     assert f"answer_q{qid}" not in (load_query(s) or "")
 
 
-def test_repair_rejects_still_unanswerable(tmp_path, fake_client):
+def test_repair_rejects_unsupported_intent(tmp_path, fake_client, intent_payload):
     s, qid = _store_with_review_required(tmp_path)
-    client = fake_client(query=lambda q, i: 'review_required("still nope")')
+    client = fake_client(
+        intent=intent_payload("unknown_or_unsupported", reason="still unsupported")
+    )
     results = repair_questions(s, client, root=tmp_path)
 
-    assert results == [{"id": qid, "accepted": False, "reason": "still nope"}]
+    assert results == [{"id": qid, "accepted": False, "reason": "still unsupported"}]
     q = s.questions()[0]
     assert q["status"] == "review_required"
-    assert q["query_dl"] == 'review_required("still nope")'
-    assert q["reason"] == "still nope"
+    assert q["query_dl"] == 'review_required("still unsupported")'
+    assert q["reason"] == "still unsupported"
     assert "review_required" not in (load_query(s) or "")
 
 
-def test_repair_persists_no_answer_lifecycle_outcome(tmp_path, fake_client):
+def test_repair_persists_no_answer_lifecycle_outcome(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
     s, qid = _store_with_review_required(tmp_path)
-    client = fake_client(query=lambda q, i: 'no_answer("no confirmed facts match")')
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="born_in"
+        )
+    )
+
+    def no_rows(store, plan):
+        assert plan.candidates
+        return QueryCandidateSetEvaluation(
+            plan=plan, outcome=QueryCandidateSetOutcome.NO_ANSWER
+        )
+
+    monkeypatch.setattr("verinote.pipeline.query.evaluate_query_candidate_plan", no_rows)
     results = repair_questions(s, client, root=tmp_path)
 
     assert results == [
@@ -124,18 +171,43 @@ def test_repair_persists_no_answer_lifecycle_outcome(tmp_path, fake_client):
     assert "no_answer" not in (load_query(s) or "")
 
 
-def test_repair_persists_ambiguous_lifecycle_outcome(tmp_path, fake_client):
+def test_repair_persists_ambiguous_lifecycle_outcome(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
     s, qid = _store_with_review_required(tmp_path)
-    client = fake_client(query=lambda q, i: 'ambiguous("multiple sample entities match")')
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="born_in"
+        )
+    )
+
+    def ambiguous(store, plan):
+        assert plan.candidates
+        return QueryCandidateSetEvaluation(
+            plan=plan, outcome=QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING
+        )
+
+    monkeypatch.setattr("verinote.pipeline.query.evaluate_query_candidate_plan", ambiguous)
     results = repair_questions(s, client, root=tmp_path)
 
     assert results == [
-        {"id": qid, "accepted": False, "reason": "multiple sample entities match"}
+        {
+            "id": qid,
+            "accepted": False,
+            "reason": "multiple query candidates returned conflicting answers",
+        }
     ]
     q = s.questions()[0]
     assert q["status"] == "ambiguous"
-    assert q["query_dl"] == 'ambiguous("multiple sample entities match")'
-    assert q["reason"] == "multiple sample entities match"
+    assert (
+        q["query_dl"]
+        == 'ambiguous("multiple query candidates returned conflicting answers")'
+    )
+    assert q["reason"] == "multiple query candidates returned conflicting answers"
     assert "ambiguous" not in (load_query(s) or "")
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1544,26 +1544,27 @@ def test_delete_question_removes_query_file_entry(tmp_path):
     assert "No questions yet" in c.get("/questions").text
 
 
-def test_translate_and_report_answers(tmp_path, monkeypatch, fake_client):
-    # canned translator: answer_q<id>(O) :- relation("Ada","born_in",O)
+def test_translate_and_report_answers(tmp_path, monkeypatch, fake_client, intent_payload):
     monkeypatch.setattr(
         webapp,
         "get_client",
         lambda cfg: fake_client(
-            query=lambda question, qid: f'answer_q{qid}(O) :- relation("Ada", "born_in", O).'
+            intent=intent_payload(
+                "lookup_object", subject="Sample Person", relation="born_in"
+            )
         ),
     )
     c = _client(tmp_path)
     store = c.app.state.store
-    store.add_fact("Ada", "born_in", "London", status="confirmed")
-    store.add_question("Where was Ada born?")
+    store.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    store.add_question("Where was Sample Person born?")
 
     r = c.post("/questions/translate", follow_redirects=False)
     assert r.status_code == 303
     assert store.questions()[0]["status"] == "translated"
     # the report and questions page now surface the engine-evaluated answer
-    assert "London" in c.get("/report").text
-    assert "London" in c.get("/questions").text
+    assert "Sample Place" in c.get("/report").text
+    assert "Sample Place" in c.get("/questions").text
 
 
 def test_translate_persists_llm_error_reason(tmp_path, monkeypatch, fake_client):
@@ -1621,19 +1622,23 @@ def test_questions_page_shows_non_executable_reason(tmp_path):
     assert "multiple sample entities match" in r.text
 
 
-def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client):
+def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client, intent_payload):
     monkeypatch.setattr(
         webapp,
         "get_client",
         lambda cfg: fake_client(
-            query=lambda question, qid: f'answer_q{qid}(O) :- relation("Ada", "born_in", O).'
+            intent=intent_payload(
+                "lookup_object", subject="Sample Person", relation="born_in"
+            )
         ),
     )
     c = _client(tmp_path)
     store = c.app.state.store
-    store.add_fact("Ada", "born_in", "London", status="confirmed")
-    qid = store.add_question("Where was Ada born?")
-    store.set_question_query(qid, 'review_required("Where was Ada born?")', "review_required")
+    store.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    qid = store.add_question("Where was Sample Person born?")
+    store.set_question_query(
+        qid, 'review_required("Where was Sample Person born?")', "review_required"
+    )
 
     r = c.post("/questions/repair", follow_redirects=False)
     assert r.status_code == 303

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -30,6 +30,11 @@ from verinote.pipeline.query_intent import (
     QueryIntentKind,
     deterministic_query_intent,
 )
+from verinote.pipeline.query_planner import plan_query_candidates
+from verinote.pipeline.query_schema import (
+    QuerySchemaSnapshot,
+    build_query_schema_snapshot,
+)
 from verinote.store import Store
 
 # Query draft, relative to the KB root (the db file's directory).
@@ -68,6 +73,30 @@ def _short_reason(value: object) -> str:
 
 def _lit(value: str) -> str:
     return '"' + _ESCAPE.sub(r"\\\1", value) + '"'
+
+
+def query_schema_hint(snapshot: QuerySchemaSnapshot) -> str:
+    """Render a bounded schema-only hint for structured intent extraction."""
+    lines = [f"Confirmed relation/3 schema snapshot: {snapshot.fact_count} fact(s)."]
+    if snapshot.relations:
+        lines.append("Observed relations:")
+    for relation in snapshot.relations:
+        labels = [relation.relation.display]
+        if relation.canonical_relation != relation.relation.display:
+            labels.append(relation.canonical_relation)
+        labels.extend(alias.alias for alias in relation.aliases)
+        labels.extend(alias.canonical for alias in relation.aliases)
+        if relation.typed is not None:
+            labels.extend((relation.typed.relation, relation.typed.alias))
+        label_text = ", ".join(dict.fromkeys(labels))
+        lines.append(
+            f"- {label_text} "
+            f"(subjects={relation.distinct_subject_count}, "
+            f"objects={relation.distinct_object_count})"
+        )
+    if snapshot.relations_truncated:
+        lines.append("- relation list truncated")
+    return "\n".join(lines)
 
 
 def deterministic_query_dl(question: str, qid: int) -> str | None:
@@ -144,6 +173,103 @@ def classify_query_draft(store: Store, qid: int, query_dl: str) -> tuple[str, st
     return "review_required", f"review_required({_lit(reason)})", reason
 
 
+def schema_aware_query_flow(
+    store: Store,
+    client: LLMClient,
+    *,
+    qid: int,
+    question: str,
+    llm_error_status: str,
+) -> tuple[str, str | None, str]:
+    """Translate one question through intent extraction, planning, and dry-run evaluation."""
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    snapshot = build_query_schema_snapshot(store)
+    intent = deterministic_query_intent(question)
+    if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
+        try:
+            intent = client.extract_query_intent(
+                question=question,
+                schema_hint=query_schema_hint(snapshot),
+            )
+        except LLMError as exc:
+            reason = _short_reason(exc)
+            if llm_error_status == "translation_failed":
+                return "translation_failed", None, reason
+            reason = _short_reason(f"llm error: {exc}")
+            return "review_required", f"review_required({_lit(reason)})", reason
+
+    if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
+        reason = _short_reason(intent.reason or "unsupported query intent")
+        return "review_required", f"review_required({_lit(reason)})", reason
+
+    exact_entities = _intent_exact_entities(intent)
+    if exact_entities:
+        snapshot = build_query_schema_snapshot(store, exact_entities=exact_entities)
+    plan = plan_query_candidates(intent, snapshot, qid=qid)
+    evaluation = evaluate_query_candidate_plan(store, plan)
+
+    if evaluation.outcome == QueryCandidateSetOutcome.VALID and evaluation.selected:
+        return "translated", evaluation.selected.query_dl, ""
+    if evaluation.outcome == QueryCandidateSetOutcome.NO_ANSWER:
+        reason = "no confirmed facts match"
+        return "no_answer", f"no_answer({_lit(reason)})", reason
+    if evaluation.outcome == QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING:
+        reason = "multiple query candidates returned conflicting answers"
+        return "ambiguous", f"ambiguous({_lit(reason)})", reason
+    if evaluation.outcome == QueryCandidateSetOutcome.EMPTY:
+        reason = _short_reason(plan.reason or "no query candidates matched the schema")
+    elif evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR:
+        reason = _short_reason("engine/policy error: " + _evaluation_reason(evaluation))
+    else:
+        reason = _short_reason("invalid query: " + _evaluation_reason(evaluation))
+    return "review_required", f"review_required({_lit(reason)})", reason
+
+
+def _intent_exact_entities(intent: QueryIntent) -> tuple[str, ...]:
+    values = []
+    for target in (intent.subject, intent.object):
+        if target is not None and target.kind in {"entity", "value", "typed_value"}:
+            values.append(target.value)
+    return tuple(dict.fromkeys(values))
+
+
+def evaluate_query_candidate_plan(store: Store, plan):
+    from verinote.pipeline.query_candidate_eval import (
+        evaluate_query_candidate_plan as _evaluate_query_candidate_plan,
+    )
+
+    return _evaluate_query_candidate_plan(store, plan)
+
+
+def _translate_direct_datalog_fallback(
+    store: Store,
+    client: LLMClient,
+    *,
+    qid: int,
+    question: str,
+    llm_error_status: str,
+) -> tuple[str, str | None, str]:
+    try:
+        line = client.translate_query(question=question, qid=qid)
+    except LLMError as exc:
+        reason = _short_reason(exc)
+        if llm_error_status == "translation_failed":
+            return "translation_failed", None, reason
+        reason = _short_reason(f"llm error: {exc}")
+        return "review_required", f"review_required({_lit(reason)})", reason
+
+    outcome = _non_executable_outcome(line)
+    if outcome is not None:
+        status, reason = outcome
+        return status, line, reason
+    if _is_review_required(line):
+        reason = _short_reason(line.removeprefix("review_required"))
+        return "review_required", line, reason
+    proposal = f".decl answer_q{qid}(value: symbol)\n{line}"
+    return classify_query_draft(store, qid, proposal)
+
+
 def _evaluation_reason(evaluation) -> str:
     for item in evaluation.evaluations:
         if item.validation_reason:
@@ -155,37 +281,34 @@ def _evaluation_reason(evaluation) -> str:
     return evaluation.outcome.value
 
 
-def translate_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
+def translate_questions(
+    store: Store,
+    client: LLMClient,
+    *,
+    root: Path,
+    allow_direct_datalog_fallback: bool = False,
+) -> list[dict]:
     """Translate every pending question, persist drafts, rewrite `query.dl`.
 
     Returns one dict per processed question: {id, status, query_dl, reason}.
     """
     results: list[dict] = []
     for q in store.questions(pending_only=True):
-        reason = ""
-        query_dl = deterministic_query_dl(q["text"], q["id"])
-        if query_dl is not None:
-            status, query_dl, reason = classify_query_draft(store, q["id"], query_dl)
-        else:
-            try:
-                line = client.translate_query(question=q["text"], qid=q["id"])
-            except LLMError as exc:
-                status = "translation_failed"
-                query_dl = None
-                reason = _short_reason(exc)
-            else:
-                outcome = _non_executable_outcome(line)
-                if outcome is not None:
-                    status, reason = outcome
-                    query_dl = line
-                elif _is_review_required(line):
-                    status, query_dl = "review_required", line
-                    reason = _short_reason(line.removeprefix("review_required"))
-                else:
-                    query_dl = f".decl answer_q{q['id']}(value: symbol)\n{line}"
-                    status, query_dl, reason = classify_query_draft(
-                        store, q["id"], query_dl
-                    )
+        status, query_dl, reason = schema_aware_query_flow(
+            store,
+            client,
+            qid=q["id"],
+            question=q["text"],
+            llm_error_status="translation_failed",
+        )
+        if allow_direct_datalog_fallback and status == "review_required":
+            status, query_dl, reason = _translate_direct_datalog_fallback(
+                store,
+                client,
+                qid=q["id"],
+                question=q["text"],
+                llm_error_status="translation_failed",
+            )
         store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
             {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -12,6 +12,8 @@ from verinote.pipeline.query_schema import (
     EntityRef,
     QuerySchemaSnapshot,
     RelationSchema,
+    SnapshotFact,
+    TermRef,
 )
 
 
@@ -94,6 +96,9 @@ def _lookup_object_candidates(
                     object_executable=None,
                 )
             )
+    candidates.extend(
+        _lookup_object_exact_fact_candidates(intent, snapshot, qid)
+    )
     return _dedupe_candidates(candidates)
 
 
@@ -119,6 +124,9 @@ def _lookup_subject_candidates(
                     object_executable=obj.executable,
                 )
             )
+    candidates.extend(
+        _lookup_subject_exact_fact_candidates(intent, snapshot, qid)
+    )
     return _dedupe_candidates(candidates)
 
 
@@ -156,7 +164,101 @@ def _lookup_relation_candidates(
                         ),
                     )
                 )
+    candidates.extend(_lookup_relation_exact_fact_candidates(intent, snapshot, qid))
     return _dedupe_candidates(candidates)
+
+
+def _lookup_object_exact_fact_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> list[QueryCandidate]:
+    if intent.subject is None:
+        return []
+    candidates: list[QueryCandidate] = []
+    for fact in snapshot.exact_entity_facts:
+        if fact.matched_side not in {"subject", "both"}:
+            continue
+        if not _entity_ref_matches(fact.subject, intent.subject.value):
+            continue
+        if not _fact_relation_matches_any(fact, intent, snapshot):
+            continue
+        candidates.append(
+            QueryCandidate(
+                query_dl=_query_dl(
+                    qid,
+                    "O",
+                    f"relation({fact.subject.executable}, {fact.relation.executable}, O)",
+                ),
+                relation_display=fact.relation.display,
+                relation_executable=fact.relation.executable,
+                subject_executable=fact.subject.executable,
+                object_executable=None,
+            )
+        )
+    return candidates
+
+
+def _lookup_subject_exact_fact_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> list[QueryCandidate]:
+    if intent.object is None:
+        return []
+    candidates: list[QueryCandidate] = []
+    for fact in snapshot.exact_entity_facts:
+        if fact.matched_side not in {"object", "both"}:
+            continue
+        if not _entity_ref_matches(fact.object, intent.object.value):
+            continue
+        if not _fact_relation_matches_any(fact, intent, snapshot):
+            continue
+        candidates.append(
+            QueryCandidate(
+                query_dl=_query_dl(
+                    qid,
+                    "S",
+                    f"relation(S, {fact.relation.executable}, {fact.object.executable})",
+                ),
+                relation_display=fact.relation.display,
+                relation_executable=fact.relation.executable,
+                subject_executable=None,
+                object_executable=fact.object.executable,
+            )
+        )
+    return candidates
+
+
+def _lookup_relation_exact_fact_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> list[QueryCandidate]:
+    subject_value = intent.subject.value if intent.subject is not None else None
+    object_value = intent.object.value if intent.object is not None else None
+    candidates: list[QueryCandidate] = []
+    for fact in snapshot.exact_entity_facts:
+        subject = (
+            _entity_from_term_ref(fact.subject)
+            if subject_value is not None
+            and _entity_ref_matches(fact.subject, subject_value)
+            else None
+        )
+        obj = (
+            _entity_from_term_ref(fact.object)
+            if object_value is not None
+            and _entity_ref_matches(fact.object, object_value)
+            else None
+        )
+        if subject_value is not None and subject is None:
+            continue
+        if object_value is not None and obj is None:
+            continue
+        candidates.append(
+            QueryCandidate(
+                query_dl=_query_dl(qid, "R", _lookup_relation_body(subject, obj)),
+                relation_display=None,
+                relation_executable=None,
+                subject_executable=subject.executable if subject is not None else None,
+                object_executable=obj.executable if obj is not None else None,
+            )
+        )
+    return candidates
 
 
 def _lookup_relation_body(subject: EntityRef | None, obj: EntityRef | None) -> str:
@@ -224,6 +326,36 @@ def _matching_entities(
             _nfc(entity.executable),
             _nfc(entity.key),
         }
+    )
+
+
+def _entity_ref_matches(ref: TermRef, value: str) -> bool:
+    wanted = _nfc(value)
+    return wanted in {_nfc(ref.display), _nfc(ref.executable), _nfc(ref.key)}
+
+
+def _fact_relation_matches_any(
+    fact: SnapshotFact, intent: QueryIntent, snapshot: QuerySchemaSnapshot
+) -> bool:
+    wanted = _relation_requests(intent)
+    if not wanted:
+        return False
+    aliases = {entry.alias: entry.canonical for entry in snapshot.relation_aliases}
+    observed = (_nfc(fact.relation.display), _nfc(fact.relation.executable))
+    return any(
+        relation_label_matches(observed_value, wanted_value, aliases)
+        for observed_value in observed
+        for wanted_value in wanted
+    )
+
+
+def _entity_from_term_ref(ref: TermRef) -> EntityRef:
+    return EntityRef(
+        display=ref.display,
+        executable=ref.executable,
+        kind=ref.kind,
+        key=ref.key,
+        fact_count=1,
     )
 
 

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from verinote.llm.base import LLMClient, LLMError
+from verinote.llm.base import LLMClient
 from verinote.pipeline.query import (
-    _non_executable_outcome,
-    classify_query_draft,
-    deterministic_query_dl,
+    _translate_direct_datalog_fallback,
+    schema_aware_query_flow,
     write_query_file,
 )
 from verinote.store import Store
@@ -24,7 +23,13 @@ from verinote.store import Store
 _log = logging.getLogger("verinote.repair")
 
 
-def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dict]:
+def repair_questions(
+    store: Store,
+    client: LLMClient,
+    *,
+    root: Path,
+    allow_direct_datalog_fallback: bool = False,
+) -> list[dict]:
     """Attempt to repair every `review_required` question. Returns per-question
     results: {id, accepted, reason}. Only engine-validated proposals are applied.
     """
@@ -33,48 +38,34 @@ def repair_questions(store: Store, client: LLMClient, *, root: Path) -> list[dic
         if q["status"] != "review_required":
             continue
         qid = q["id"]
-        deterministic = deterministic_query_dl(q["text"], qid)
-        if deterministic:
-            status, query_dl, reason = classify_query_draft(store, qid, deterministic)
-            store.set_question_query(qid, query_dl, status, reason)
-            results.append(
-                {"id": qid, "accepted": status == "translated", "reason": reason}
+        status, query_dl, reason = schema_aware_query_flow(
+            store,
+            client,
+            qid=qid,
+            question=q["text"],
+            llm_error_status="review_required",
+        )
+        if allow_direct_datalog_fallback and status == "review_required":
+            status, query_dl, reason = _translate_direct_datalog_fallback(
+                store,
+                client,
+                qid=qid,
+                question=q["text"],
+                llm_error_status="review_required",
             )
-            continue
-
-        try:
-            line = client.translate_query(question=q["text"], qid=qid)
-        except LLMError as exc:
-            reason = f"llm error: {exc}"
-            store.set_question_query(qid, q["query_dl"], "review_required", reason)
-            results.append({"id": qid, "accepted": False, "reason": reason})
-            _log.warning("repair q%d: llm error: %s", qid, exc)
-            continue
-
-        outcome = _non_executable_outcome(line)
-        if outcome is not None:
-            status, reason = outcome
-            store.set_question_query(qid, line, status, reason)
-            results.append({"id": qid, "accepted": False, "reason": reason})
-            _log.warning("repair q%d: model returned %s: %s", qid, status, reason)
-            continue
-
-        if line.lstrip().startswith("review_required"):
-            reason = "model still cannot express it"
-            store.set_question_query(qid, line, "review_required", reason)
-            results.append({"id": qid, "accepted": False, "reason": reason})
-            _log.warning("repair q%d: still review_required", qid)
-            continue
-
-        proposal = f".decl answer_q{qid}(value: symbol)\n{line}"
-        status, query_dl, reason = classify_query_draft(store, qid, proposal)
-        if status == "translated":
-            store.set_question_query(qid, query_dl, status, reason)
-            results.append({"id": qid, "accepted": True, "reason": ""})
-        else:
-            store.set_question_query(qid, query_dl, status, reason)
-            results.append({"id": qid, "accepted": False, "reason": reason})
-            _log.warning("repair q%d rejected by dry-run: %s", qid, reason)
+        if (
+            status == "review_required"
+            and query_dl is not None
+            and reason.startswith("llm error:")
+        ):
+            query_dl = q["query_dl"]
+        store.set_question_query(qid, query_dl, status, reason)
+        accepted = status == "translated"
+        results.append(
+            {"id": qid, "accepted": accepted, "reason": "" if accepted else reason}
+        )
+        if not accepted:
+            _log.warning("repair q%d kept %s: %s", qid, status, reason)
 
     write_query_file(store, root)
     return results


### PR DESCRIPTION
## Summary
- route translation and repair through schema snapshot, structured intent, candidate planning, and dry-run evaluation
- keep direct Datalog fallback false by default and gated through existing validation/dry-run classification
- use exact-entity snapshots to recover planned candidates when relation examples are bounded

## Validation
- uv run pytest -q
- uv run ruff check verinote tests
- git diff --check HEAD~1..HEAD

Closes #117