### PR TITLE
Show visible question outcomes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,7 @@ def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client, i
 
     assert rc == 0
     out = capsys.readouterr().out
+    assert "q1: translated - Executable query is ready." in out
     assert "translated 1 question(s)" in out
     assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "translated"
     assert (tmp_path / "facts" / "query.dl").is_file()
@@ -155,7 +156,7 @@ def test_query_persists_translation_failure_reason(tmp_path, monkeypatch, capsys
 
     assert rc == 0
     out = capsys.readouterr().out
-    assert "q1: translation_failed (provider unavailable)" in out
+    assert "q1: translation_failed - provider unavailable" in out
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
     assert q["status"] == "translation_failed"
@@ -175,7 +176,7 @@ def test_query_persists_get_client_failure_reason(tmp_path, monkeypatch, capsys)
 
     assert rc == 0
     out = capsys.readouterr().out
-    assert "q1: translation_failed (missing provider credentials)" in out
+    assert "q1: translation_failed - missing provider credentials" in out
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
     assert q["status"] == "translation_failed"
@@ -214,7 +215,9 @@ def test_repair_validates_and_translates(
     rc = cli.main(["repair"])
 
     assert rc == 0
-    assert "repaired 1/1" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "q1: translated - Executable query is ready." in out
+    assert "repaired 1/1" in out
     assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "translated"
 
 
@@ -252,9 +255,68 @@ def test_repair_reports_durable_rejected_status(
 
     assert rc == 0
     out = capsys.readouterr().out
-    assert "q1: kept no_answer (no confirmed facts match)" in out
+    assert "q1: no_answer - no confirmed facts match" in out
     assert "repaired 0/1" in out
     assert Store(tmp_path / "kb.sqlite").questions()[0]["status"] == "no_answer"
+
+
+def test_query_prints_review_required_outcome(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
+
+    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+        q = store.questions(pending_only=True)[0]
+        reason = "unsupported synthetic question"
+        store.set_question_query(
+            q["id"], f'review_required("{reason}")', "review_required", reason
+        )
+        return [{"id": q["id"], "status": "review_required", "reason": reason}]
+
+    monkeypatch.setattr("verinote.pipeline.translate_questions", translate)
+
+    rc = cli.main(["query", "What synthetic relation is missing?"])
+
+    assert rc == 0
+    assert (
+        "q1: review_required - unsupported synthetic question"
+        in capsys.readouterr().out
+    )
+
+
+def test_query_prints_no_answer_outcome(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
+
+    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+        q = store.questions(pending_only=True)[0]
+        reason = "no confirmed facts match"
+        store.set_question_query(q["id"], f'no_answer("{reason}")', "no_answer", reason)
+        return [{"id": q["id"], "status": "no_answer", "reason": reason}]
+
+    monkeypatch.setattr("verinote.pipeline.translate_questions", translate)
+
+    rc = cli.main(["query", "Which synthetic answer exists?"])
+
+    assert rc == 0
+    assert "q1: no_answer - no confirmed facts match" in capsys.readouterr().out
+
+
+def test_query_prints_ambiguous_outcome(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
+
+    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+        q = store.questions(pending_only=True)[0]
+        reason = "multiple synthetic candidates matched"
+        store.set_question_query(q["id"], f'ambiguous("{reason}")', "ambiguous", reason)
+        return [{"id": q["id"], "status": "ambiguous", "reason": reason}]
+
+    monkeypatch.setattr("verinote.pipeline.translate_questions", translate)
+
+    rc = cli.main(["query", "Which synthetic candidate matches?"])
+
+    assert rc == 0
+    assert "q1: ambiguous - multiple synthetic candidates matched" in capsys.readouterr().out
 
 
 def test_repair_no_review_required_errors(tmp_path, monkeypatch, capsys):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1605,6 +1605,31 @@ def test_translate_persists_get_client_failure_reason(tmp_path, monkeypatch):
     assert "missing provider credentials" in page
 
 
+def test_translate_shows_invalid_model_output_reason_in_question_row(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: object())
+
+    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+        q = store.questions(pending_only=True)[0]
+        reason = "invalid model output: missing answer rule"
+        store.set_question_query(
+            q["id"], f'review_required("{reason}")', "review_required", reason
+        )
+        return [{"id": q["id"], "status": "review_required", "reason": reason}]
+
+    monkeypatch.setattr(webapp, "translate_questions", translate)
+    c = _client(tmp_path)
+    c.app.state.store.add_question("Which synthetic result is available?")
+
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    assert r.status_code == 303
+    body = unescape(c.get("/questions").text)
+    assert "Review required" in body
+    assert "invalid model output: missing answer rule" in body
+
+
 def test_questions_page_shows_non_executable_reason(tmp_path):
     c = _client(tmp_path)
     qid = c.app.state.store.add_question("Which sample item is current?")
@@ -1620,6 +1645,76 @@ def test_questions_page_shows_non_executable_reason(tmp_path):
     assert r.status_code == 200
     assert "ambiguous" in r.text
     assert "multiple sample entities match" in r.text
+
+
+def test_questions_page_shows_all_visible_outcomes(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    rows = [
+        (
+            "Translated synthetic question?",
+            '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("S", "r", O).',
+            "translated",
+            "",
+        ),
+        (
+            "Review synthetic question?",
+            'review_required("unsupported synthetic question")',
+            "review_required",
+            "unsupported synthetic question",
+        ),
+        (
+            "No synthetic answer?",
+            'no_answer("no confirmed facts match")',
+            "no_answer",
+            "no confirmed facts match",
+        ),
+        (
+            "Failed synthetic translation?",
+            None,
+            "translation_failed",
+            "provider returned invalid schema",
+        ),
+        (
+            "Ambiguous synthetic question?",
+            'ambiguous("multiple synthetic candidates matched")',
+            "ambiguous",
+            "multiple synthetic candidates matched",
+        ),
+    ]
+    for text, query_dl, status, reason in rows:
+        qid = store.add_question(text)
+        store.set_question_query(qid, query_dl, status, reason)
+
+    body = unescape(c.get("/questions").text)
+
+    assert "Translated" in body
+    assert "Review required" in body
+    assert "No answer" in body
+    assert "Translation failed" in body
+    assert "Ambiguous" in body
+    assert "badge-question-no-answer" in body
+    assert "badge-question-translation-failed" in body
+    assert "unsupported synthetic question" in body
+    assert "provider returned invalid schema" in body
+    assert "multiple synthetic candidates matched" in body
+    assert "No engine answers yet" in body
+    assert "Check each question outcome above" in body
+
+
+def test_questions_page_recovers_reason_from_non_executable_query(tmp_path):
+    c = _client(tmp_path)
+    qid = c.app.state.store.add_question("Which synthetic item matches?")
+    c.app.state.store.set_question_query(
+        qid,
+        'ambiguous("legacy synthetic ambiguity")',
+        "ambiguous",
+        "",
+    )
+
+    body = unescape(c.get("/questions").text)
+
+    assert "legacy synthetic ambiguity" in body
 
 
 def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client, intent_payload):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from verinote import __version__
 from verinote.config import Config
+from verinote.pipeline.question_outcome import format_question_outcome
 from verinote.store import Store
 
 _DEMO_FACTS = [
@@ -232,8 +233,7 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     else:
         results = translate_questions(store, client, root=cfg.root)
     for r in results:
-        reason = f" ({r['reason']})" if r.get("reason") else ""
-        print(f"  q{r['id']}: {r['status']}{reason}")
+        print(f"  {format_question_outcome(r)}")
     print(f"translated {len(results)} question(s) -> {cfg.root / 'facts' / 'query.dl'}")
     print("run the check to see answers (`verinote ui` → Report)")
     store.close()
@@ -265,8 +265,13 @@ def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
     repaired = sum(1 for r in results if r["accepted"])
     for r in results:
         status = r.get("status") or statuses.get(r["id"], "review_required")
-        mark = "repaired" if r["accepted"] else f"kept {status} ({r['reason']})"
-        print(f"  q{r['id']}: {mark}")
+        reason = "" if r["accepted"] else r.get("reason", "")
+        print(
+            "  "
+            + format_question_outcome(
+                {"id": r["id"], "text": "", "status": status, "reason": reason}
+            )
+        )
     print(f"repaired {repaired}/{len(results)} question(s) (engine-validated)")
     store.close()
     return 0

--- a/verinote/pipeline/question_outcome.py
+++ b/verinote/pipeline/question_outcome.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Display helpers for durable question lifecycle states."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class QuestionOutcomeView:
+    id: int
+    text: str
+    status: str
+    label: str
+    message: str
+    action: str
+    query_dl: str | None
+    badge_class: str
+
+
+_STATUS_META = {
+    "pending": (
+        "Pending",
+        "Waiting for translation.",
+        "Translate to generate a query candidate.",
+    ),
+    "translated": (
+        "Translated",
+        "Executable query is ready.",
+        "Run the report to inspect answers.",
+    ),
+    "review_required": (
+        "Review required",
+        "The question needs manual review before it can run.",
+        "Repair can retry after facts or schema improve.",
+    ),
+    "translation_failed": (
+        "Translation failed",
+        "The provider output could not be used.",
+        "Check the message, provider, and model settings, then translate again.",
+    ),
+    "no_answer": (
+        "No answer",
+        "No confirmed or accepted facts matched the generated query.",
+        "Confirm relevant facts or add sources, then re-analyze and translate again.",
+    ),
+    "ambiguous": (
+        "Ambiguous",
+        "Multiple query candidates produced conflicting answers.",
+        "Narrow the question or review the candidate facts before retrying.",
+    ),
+}
+_NON_EXECUTABLE_RE = re.compile(
+    r"^\s*(review_required|no_answer|ambiguous|translation_failed)\((?P<reason>.*)\)\s*\.?\s*$"
+)
+
+
+def question_outcome_view(question: Mapping[str, object]) -> QuestionOutcomeView:
+    status = str(question["status"])
+    label, default_message, action = _STATUS_META.get(
+        status,
+        (status.replace("_", " ").title(), "Unknown question state.", ""),
+    )
+    reason = str(_question_value(question, "reason") or "").strip()
+    query_dl = _question_value(question, "query_dl")
+    if not reason and query_dl:
+        reason = _reason_from_query_dl(str(query_dl))
+    return QuestionOutcomeView(
+        id=int(question["id"]),
+        text=str(_question_value(question, "text") or ""),
+        status=status,
+        label=label,
+        message=reason or default_message,
+        action=action,
+        query_dl=str(query_dl) if query_dl else None,
+        badge_class=f"badge-question-{status.replace('_', '-')}",
+    )
+
+
+def format_question_outcome(question: Mapping[str, object]) -> str:
+    view = question_outcome_view(question)
+    return f"q{view.id}: {view.status} - {view.message}"
+
+
+def _reason_from_query_dl(query_dl: str) -> str:
+    match = _NON_EXECUTABLE_RE.match(query_dl)
+    if match is None:
+        return ""
+    raw = match.group("reason").strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] == '"':
+        return raw[1:-1].replace(r"\"", '"').replace(r"\\", "\\")
+    return raw
+
+
+def _question_value(question: Mapping[str, object], key: str) -> object | None:
+    try:
+        return question[key]
+    except (IndexError, KeyError):
+        return None

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -41,6 +41,7 @@ from verinote.pipeline import (
     verify,
     write_query_file,
 )
+from verinote.pipeline.question_outcome import question_outcome_view
 from verinote.pipeline.acceptance import (
     accept_recommendations,
     accept_recommendations_for,
@@ -850,7 +851,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return templates.TemplateResponse(
             request,
             "questions.html",
-            {"questions": store.questions(), "answers": rep.answers, "error": page_error},
+            {
+                "questions": [question_outcome_view(q) for q in store.questions()],
+                "answers": rep.answers,
+                "error": page_error,
+            },
             status_code=status_code,
         )
 

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -35,6 +35,13 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .badge-needs_review { color: var(--warn); border-color: var(--warn); }
 .badge-confirmed, .badge-accepted { color: var(--ok); border-color: var(--ok); }
 .badge-superseded { color: var(--danger); border-color: var(--danger); text-decoration: line-through; }
+.badge-question-pending { color: var(--muted); }
+.badge-question-translated { color: var(--ok); border-color: var(--ok); }
+.badge-question-review-required, .badge-question-ambiguous { color: var(--warn); border-color: var(--warn); }
+.badge-question-translation-failed { color: var(--danger); border-color: var(--danger); }
+.badge-question-no-answer { color: var(--accent); border-color: var(--accent); }
+.question-message { margin-top: .25rem; }
+.question-query { max-width: 26rem; max-height: 9rem; }
 
 .actions button { background: var(--panel); color: var(--fg); border: 1px solid var(--line);
   border-radius: 6px; padding: .25rem .5rem; margin-right: .3rem; cursor: pointer; font-size: .82rem; }

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -27,19 +27,20 @@
 
 {% if questions %}
 <table class="counts">
-  <thead><tr><th>#</th><th>Question</th><th>Status</th><th>Query</th><th>Actions</th></tr></thead>
+  <thead><tr><th>#</th><th>Question</th><th>Outcome</th><th>Query</th><th>Actions</th></tr></thead>
   <tbody>
     {% for q in questions %}
-    <tr>
-      <td>{{ q["id"] }}</td>
-      <td>{{ q["text"] }}</td>
+    <tr class="question-row question-{{ q.status }}">
+      <td>{{ q.id }}</td>
+      <td>{{ q.text }}</td>
       <td>
-        <span class="badge">{{ q["status"] }}</span>
-        {% if q["reason"] %}<div class="muted">{{ q["reason"] }}</div>{% endif %}
+        <span class="badge {{ q.badge_class }}">{{ q.label }}</span>
+        <div class="question-message">{{ q.message }}</div>
+        {% if q.action %}<div class="muted">{{ q.action }}</div>{% endif %}
       </td>
-      <td><pre class="report">{{ q["query_dl"] or "—" }}</pre></td>
+      <td><pre class="report question-query">{{ q.query_dl or "—" }}</pre></td>
       <td class="actions">
-        <form action="/questions/{{ q['id'] }}/delete" method="post">
+        <form action="/questions/{{ q.id }}/delete" method="post">
           <button class="danger" type="submit">Delete</button>
         </form>
       </td>
@@ -55,6 +56,6 @@
 {% if answers %}
 <ul class="findings">{% for a in answers %}<li>{{ a }}</li>{% endfor %}</ul>
 {% else %}
-<p class="muted">No answers yet — add a question, translate, and confirm the facts it needs.</p>
+<p class="muted">No engine answers yet. Check each question outcome above for translation, review, ambiguity, or no-answer details.</p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add shared question outcome presentation helpers for UI and CLI
- render per-question labels, messages, action hints, and distinct status badges
- print durable per-question outcomes from query and repair commands
- cover translated, review_required, no_answer, translation_failed, ambiguous, and invalid-output display paths

Closes #118.

## Validation
- uv run pytest -q
- uv run ruff check verinote tests
- git diff --check HEAD~1..HEAD