### PR TITLE
Define entity-centric relation discovery intent

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -35,6 +35,10 @@ def test_query_intent_schema_is_separate_from_datalog_query_schema():
     assert QUERY_INTENT_SCHEMA["required"] == list(QUERY_INTENT_SCHEMA["properties"])
     assert "datalog" not in QUERY_INTENT_SCHEMA["properties"]
     assert QUERY_INTENT_SCHEMA["additionalProperties"] is False
+    assert (
+        "discover_entity_relations"
+        in QUERY_INTENT_SCHEMA["properties"]["kind"]["enum"]
+    )
     for field in ("subject", "relation", "object"):
         schema = QUERY_INTENT_SCHEMA["properties"][field]
         assert schema["type"] == ["object", "null"]
@@ -118,6 +122,40 @@ def test_parse_query_intent_accepts_valid_compare_typed_value():
     assert intent.value == "10"
 
 
+def test_parse_query_intent_accepts_entity_relation_discovery():
+    broad = parse_query_intent(
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            reason=None,
+        )
+    )
+    direct_first = parse_query_intent(
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            relation={"kind": "relation", "value": "provides"},
+            reason=None,
+        )
+    )
+    candidate_first = parse_query_intent(
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            relation_candidates=["provides", "connects"],
+            reason=None,
+        )
+    )
+
+    assert broad.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert broad.subject == IntentTarget("entity", "Sample Entity")
+    assert broad.relation_candidates == ()
+    assert direct_first.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert direct_first.relation == IntentTarget("relation", "provides")
+    assert candidate_first.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert candidate_first.relation_candidates == ("provides", "connects")
+
+
 def test_parse_query_intent_accepts_unsupported_with_reason():
     intent = parse_query_intent(
         _intent_payload(reason="requires planning")
@@ -174,6 +212,40 @@ def test_parse_query_intent_accepts_unsupported_with_reason():
             kind="lookup_relation",
             relation={"kind": "relation", "value": "역할"},
             subject={"kind": "entity", "value": "샘플인물"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject=None,
+            reason=None,
+        ),
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "relation", "value": "provides"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            object={"kind": "entity", "value": "Sample Object"},
+            reason=None,
+        ),
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            operator=">",
+            reason=None,
+        ),
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            reason="unsupported",
+        ),
+        _intent_payload(
+            kind="discover_entity_relations",
+            subject={"kind": "entity", "value": "Sample Entity"},
+            relation={"kind": "relation", "value": "provides"},
+            relation_candidates=["offers"],
             reason=None,
         ),
         _intent_payload(

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -52,6 +52,29 @@ def test_valid_lookup_subject_lookup_relation_count_and_compare_intents():
     ).kind == QueryIntentKind.COMPARE_TYPED_VALUE
 
 
+def test_valid_entity_relation_discovery_intents():
+    broad = QueryIntent(
+        kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+        subject=IntentTarget("entity", "Sample Entity"),
+    )
+    direct_first = QueryIntent(
+        kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+        subject=IntentTarget("entity", "Sample Entity"),
+        relation=IntentTarget("relation", "provides"),
+    )
+    candidate_first = QueryIntent(
+        kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+        subject=IntentTarget("entity", "샘플엔티티"),
+        relation_candidates=("제공", "연결"),
+    )
+
+    assert broad.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert broad.subject == IntentTarget("entity", "Sample Entity")
+    assert broad.relation is None
+    assert direct_first.relation == IntentTarget("relation", "provides")
+    assert candidate_first.relation_candidates == ("제공", "연결")
+
+
 def test_intent_rejects_invalid_combinations():
     with pytest.raises(ValueError, match="lookup_object"):
         QueryIntent(
@@ -94,6 +117,38 @@ def test_intent_rejects_swapped_target_kinds_and_bad_value_type():
             value_type="duration",
             value="10",
         )
+    with pytest.raises(ValueError, match="discover_entity_relations"):
+        QueryIntent(kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS)
+    with pytest.raises(ValueError, match="discover_entity_relations subject"):
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("relation", "제공"),
+        )
+    with pytest.raises(ValueError, match="discover_entity_relations"):
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+            object=IntentTarget("entity", "Sample Object"),
+        )
+    with pytest.raises(ValueError, match="does not accept comparison fields"):
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+            operator=">",
+        )
+    with pytest.raises(ValueError, match="does not accept reason"):
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+            reason="unsupported",
+        )
+    with pytest.raises(ValueError, match="relation or relation_candidates"):
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+            relation=IntentTarget("relation", "provides"),
+            relation_candidates=("offers",),
+        )
 
 
 def test_unsupported_deterministic_question_returns_unknown_intent():
@@ -119,3 +174,53 @@ def test_english_role_title_questions_use_english_candidates():
     assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
     assert intent.subject == IntentTarget("entity", "Sample Person")
     assert intent.relation_candidates == ENGLISH_ROLE_RELATION_CANDIDATES
+
+
+def test_deterministic_entity_relation_discovery_questions_are_generic():
+    english = deterministic_query_intent("How is Sample Entity related?")
+    connected = deterministic_query_intent(
+        "Which relation connects Sample Entity to other facts?"
+    )
+    direct_hint = deterministic_query_intent("What does Sample Entity provide?")
+    korean = deterministic_query_intent("샘플엔티티는 어떤 관계인가?")
+
+    assert english.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert english.subject == IntentTarget("entity", "Sample Entity")
+    assert english.relation_candidates == ()
+    assert connected.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert connected.subject == IntentTarget("entity", "Sample Entity")
+    assert direct_hint.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert direct_hint.subject == IntentTarget("entity", "Sample Entity")
+    assert direct_hint.relation == IntentTarget("relation", "provide")
+    lower_direct_hint = deterministic_query_intent("what does Sample Entity provide?")
+    assert lower_direct_hint.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert lower_direct_hint.relation == IntentTarget("relation", "provide")
+    assert korean.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert korean.subject == IntentTarget("entity", "샘플엔티티")
+
+
+def test_deterministic_entity_relation_discovery_rejects_generic_what_does_shapes():
+    assert (
+        deterministic_query_intent("how is this related?").kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
+    assert (
+        deterministic_query_intent("How is This related?").kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
+    assert (
+        deterministic_query_intent("What does sample entity provide?").kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
+    assert (
+        deterministic_query_intent("What does This provide?").kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
+    assert (
+        deterministic_query_intent("What does Sample Entity mean?").kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
+    assert (
+        deterministic_query_intent("What does Sample Entity have?").kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )

--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -139,6 +139,20 @@ def test_lookup_object_uses_observed_relation_and_subject_side():
     assert plan.truncated is False
 
 
+def test_entity_relation_discovery_intent_is_recognized_but_not_planned_yet():
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+        ),
+        _snapshot(),
+        qid=9,
+    )
+
+    assert plan.candidates == ()
+    assert plan.reason == "entity relation discovery planning is not implemented yet"
+
+
 def test_lookup_subject_uses_object_side_directionality():
     snapshot = _snapshot(
         _relation(

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -177,6 +177,7 @@ QUERY_INTENT_SCHEMA: dict[str, Any] = {
                 "lookup_object",
                 "lookup_subject",
                 "lookup_relation",
+                "discover_entity_relations",
                 "count",
                 "compare_typed_value",
                 "unknown_or_unsupported",
@@ -204,6 +205,10 @@ QUERY_INTENT_SCHEMA["required"] = list(QUERY_INTENT_SCHEMA["properties"])
 QUERY_INTENT_SYSTEM = (
     "Classify one natural-language question into a constrained query intent. "
     "Return only JSON matching the schema. Use null for fields that do not apply. "
+    "Use discover_entity_relations for broad entity-centric relationship questions "
+    "where the entity is known but the useful KB relation may need schema-backed "
+    "discovery; include an optional relation or relation_candidates only when the "
+    "question also gives a direct relation hint to try first. "
     "Do not emit Datalog, relation/3 rules, answer_q predicates, or execution plans."
 )
 

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -16,6 +16,7 @@ class QueryIntentKind(StrEnum):
     LOOKUP_OBJECT = "lookup_object"
     LOOKUP_SUBJECT = "lookup_subject"
     LOOKUP_RELATION = "lookup_relation"
+    DISCOVER_ENTITY_RELATIONS = "discover_entity_relations"
     COUNT = "count"
     COMPARE_TYPED_VALUE = "compare_typed_value"
     UNKNOWN_OR_UNSUPPORTED = "unknown_or_unsupported"
@@ -94,6 +95,19 @@ class QueryIntent:
                 raise ValueError("lookup_relation requires subject or object")
             self._require_optional_lookup_endpoint("subject", self.subject)
             self._require_optional_lookup_endpoint("object", self.object)
+            self._forbid_compare_fields()
+            self._forbid_reason()
+        elif kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS:
+            if self.subject is None or self.object is not None:
+                raise ValueError(
+                    "discover_entity_relations requires subject and no object"
+                )
+            if self.relation is not None and self.relation_candidates:
+                raise ValueError(
+                    "discover_entity_relations accepts relation or relation_candidates, not both"
+                )
+            self._require_target_kind("subject", self.subject, {"entity"})
+            self._require_relation_field()
             self._forbid_compare_fields()
             self._forbid_reason()
         elif kind == QueryIntentKind.COUNT:
@@ -177,8 +191,29 @@ _ENGLISH_ROLE_TITLE_QUESTION = re.compile(
     r"(?:'s|\s+)?\s+(?P<label>role|title|position)\s*\??\s*$",
     re.IGNORECASE,
 )
+_ENGLISH_ENTITY_RELATION_DISCOVERY_QUESTION = re.compile(
+    r"^\s*(?i:how\s+is|how\s+was)\s+"
+    r"(?P<entity>[A-Z][^?]{0,80}?)\s+related\s*\??\s*$|"
+    r"^\s*(?i:which\s+relation\s+connects)\s+"
+    r"(?P<connected_entity>[A-Z][^?]{0,80}?)\s+to\s+other\s+facts\s*\??\s*$",
+)
+_ENGLISH_ENTITY_DIRECT_RELATION_DISCOVERY_QUESTION = re.compile(
+    r"^\s*(?i:what\s+does)\s+(?P<entity>[A-Z][^?]{0,80}?)\s+"
+    r"(?P<relation>(?i:provide|provides|offer|offers|connect|connects|relate|relates))\s*\?\s*$"
+)
+_KOREAN_ENTITY_RELATION_DISCOVERY_QUESTION = re.compile(
+    r'["“”\']?(?P<entity>[^"“”\'?？\n]{1,80}?)["“”\']?\s*'
+    r"(?:는|은|이|가)\s*어떤\s*관계(?:인가|입니까|야)?\s*\??\s*$"
+)
 KOREAN_ROLE_RELATION_CANDIDATES = ("역할", "직책", "직위")
 ENGLISH_ROLE_RELATION_CANDIDATES = ("role", "title", "position", "has_role")
+_GENERIC_ENTITY_ANCHORS = {
+    "anything",
+    "it",
+    "something",
+    "that",
+    "this",
+}
 
 
 def deterministic_query_intent(question: str) -> QueryIntent:
@@ -204,10 +239,43 @@ def deterministic_query_intent(question: str) -> QueryIntent:
                 relation_candidates=ENGLISH_ROLE_RELATION_CANDIDATES,
             )
 
+    match = _ENGLISH_ENTITY_RELATION_DISCOVERY_QUESTION.match(text)
+    if match:
+        entity = (match.group("entity") or match.group("connected_entity")).strip()
+        if entity and not _is_generic_entity_anchor(entity):
+            return QueryIntent(
+                kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+                subject=IntentTarget("entity", entity),
+            )
+
+    match = _ENGLISH_ENTITY_DIRECT_RELATION_DISCOVERY_QUESTION.match(text)
+    if match:
+        entity = match.group("entity").strip()
+        relation = match.group("relation").strip()
+        if entity and relation and not _is_generic_entity_anchor(entity):
+            return QueryIntent(
+                kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+                subject=IntentTarget("entity", entity),
+                relation=IntentTarget("relation", relation),
+            )
+
+    match = _KOREAN_ENTITY_RELATION_DISCOVERY_QUESTION.match(text)
+    if match:
+        entity = match.group("entity").strip()
+        if entity:
+            return QueryIntent(
+                kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+                subject=IntentTarget("entity", entity),
+            )
+
     return QueryIntent(
         kind=QueryIntentKind.UNKNOWN_OR_UNSUPPORTED,
         reason="unsupported deterministic query shape",
     )
+
+
+def _is_generic_entity_anchor(value: str) -> bool:
+    return value.strip().casefold() in _GENERIC_ENTITY_ANCHORS
 
 
 QUERY_INTENT_FIELDS = (

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -67,6 +67,9 @@ def plan_query_candidates(
     elif intent.kind == QueryIntentKind.LOOKUP_RELATION:
         candidates = _lookup_relation_candidates(intent, snapshot, qid)
         reason = None
+    elif intent.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS:
+        candidates = ()
+        reason = "entity relation discovery planning is not implemented yet"
     else:
         candidates = ()
         reason = f"unsupported intent kind: {intent.kind.value}"


### PR DESCRIPTION
## Summary
- add a dedicated `discover_entity_relations` query intent contract for broad entity-centric relation discovery
- update the LLM schema and prompt guidance so providers can emit the new intent without Datalog
- add deterministic parsing safeguards for synthetic English and Korean relation-discovery questions
- make the planner recognize the new intent while deferring candidate generation to later subissues

## Validation
- `uv run pytest tests/test_query_intent.py tests/test_llm_schema.py tests/test_query_planner.py -q`
- `uv run pytest -q`
- `uv run ruff check verinote tests`
- `git diff --check`

Closes #130