### PR TITLE
Track query candidate metadata

### DIFF
--- a/tests/test_query_candidate_eval.py
+++ b/tests/test_query_candidate_eval.py
@@ -9,6 +9,7 @@ from verinote.pipeline.query_candidate_eval import (
     evaluate_query_candidate_plan,
 )
 from verinote.pipeline.query_planner import QueryCandidate, QueryCandidatePlan
+from verinote.pipeline.query_planner import QueryCandidateDirection, QueryCandidateFamily
 from verinote.store import Store
 
 
@@ -18,9 +19,16 @@ def _store(tmp_path) -> Store:
     return store
 
 
-def _candidate(query_dl: str) -> QueryCandidate:
+def _candidate(
+    query_dl: str,
+    *,
+    family: QueryCandidateFamily = QueryCandidateFamily.MANUAL_DRAFT,
+    direction: QueryCandidateDirection | None = None,
+) -> QueryCandidate:
     return QueryCandidate(
         query_dl=query_dl,
+        family=family,
+        direction=direction,
         relation_display=None,
         relation_executable=None,
         subject_executable=None,
@@ -31,7 +39,9 @@ def _candidate(query_dl: str) -> QueryCandidate:
 def _lookup(qid: int, subject: str, relation: str) -> QueryCandidate:
     return _candidate(
         f'.decl answer_q{qid}(value: symbol)\n'
-        f'answer_q{qid}(O) :- relation("{subject}", "{relation}", O).'
+        f'answer_q{qid}(O) :- relation("{subject}", "{relation}", O).',
+        family=QueryCandidateFamily.DIRECT_OBJECT_LOOKUP,
+        direction=QueryCandidateDirection.SUBJECT_TO_OBJECT,
     )
 
 
@@ -278,6 +288,26 @@ def test_evaluate_query_candidate_plan_selects_first_same_answer_candidate(tmp_p
     assert evaluation.outcome == QueryCandidateSetOutcome.VALID
     assert evaluation.selected == first
     assert evaluation.answers == ("q1: Reviewer",)
+
+
+def test_evaluate_query_candidate_plan_preserves_candidate_metadata(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "role", "Reviewer", status="confirmed")
+    candidate = _lookup(1, "Sample Person", "role")
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert evaluation.evaluations[0].candidate is candidate
+    assert evaluation.evaluations[0].candidate.family == (
+        QueryCandidateFamily.DIRECT_OBJECT_LOOKUP
+    )
+    assert evaluation.evaluations[0].candidate.direction == (
+        QueryCandidateDirection.SUBJECT_TO_OBJECT
+    )
+    assert evaluation.selected is candidate
+    assert evaluation.selected.family == QueryCandidateFamily.DIRECT_OBJECT_LOOKUP
+    assert evaluation.selected.direction == QueryCandidateDirection.SUBJECT_TO_OBJECT
 
 
 def test_evaluate_query_candidate_plan_marks_conflicting_answer_sets_ambiguous(tmp_path):

--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -4,6 +4,8 @@ import unicodedata
 
 from verinote.pipeline.query_intent import IntentTarget, QueryIntent, QueryIntentKind
 from verinote.pipeline.query_planner import (
+    QueryCandidateDirection,
+    QueryCandidateFamily,
     QueryPlannerBounds,
     plan_query_candidates,
 )
@@ -136,6 +138,12 @@ def test_lookup_object_uses_observed_relation_and_subject_side():
         '.decl answer_q12(value: symbol)\n'
         'answer_q12(O) :- relation("Sample Person", "역할", O).'
     ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.DIRECT_OBJECT_LOOKUP
+    ]
+    assert [candidate.direction for candidate in plan.candidates] == [
+        QueryCandidateDirection.SUBJECT_TO_OBJECT
+    ]
     assert plan.truncated is False
 
 
@@ -180,6 +188,12 @@ def test_lookup_subject_uses_object_side_directionality():
         '.decl answer_q13(value: symbol)\n'
         'answer_q13(S) :- relation(S, "역할", "Reviewer").'
     ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.DIRECT_SUBJECT_LOOKUP
+    ]
+    assert [candidate.direction for candidate in plan.candidates] == [
+        QueryCandidateDirection.OBJECT_TO_SUBJECT
+    ]
 
 
 def test_lookup_relation_uses_intentional_variable_relation_only_for_relation_lookup():
@@ -208,6 +222,49 @@ def test_lookup_relation_uses_intentional_variable_relation_only_for_relation_lo
     assert [candidate.query_dl for candidate in plan.candidates] == [
         '.decl answer_q14(value: symbol)\n'
         'answer_q14(R) :- relation("Sample Person", R, "Sample Document").'
+    ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.DIRECT_RELATION_LOOKUP
+    ]
+    assert [candidate.direction for candidate in plan.candidates] == [
+        QueryCandidateDirection.SUBJECT_OBJECT_TO_RELATION
+    ]
+
+
+def test_lookup_relation_metadata_tracks_one_sided_direction():
+    sample_person = _entity("Sample Person", '"Sample Person"')
+    sample_document = _entity("Sample Document", '"Sample Document"')
+    snapshot = _snapshot(
+        _relation(
+            "authored",
+            '"authored"',
+            subjects=(sample_person,),
+            objects=(sample_document,),
+        )
+    )
+
+    subject_plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.LOOKUP_RELATION,
+            subject=IntentTarget("entity", "Sample Person"),
+        ),
+        snapshot,
+        qid=30,
+    )
+    object_plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.LOOKUP_RELATION,
+            object=IntentTarget("entity", "Sample Document"),
+        ),
+        snapshot,
+        qid=31,
+    )
+
+    assert [candidate.direction for candidate in subject_plan.candidates] == [
+        QueryCandidateDirection.SUBJECT_TO_RELATION
+    ]
+    assert [candidate.direction for candidate in object_plan.candidates] == [
+        QueryCandidateDirection.OBJECT_TO_RELATION
     ]
 
 
@@ -411,6 +468,48 @@ def test_lookup_object_uses_exact_entity_facts_when_subject_examples_are_bounded
     assert [candidate.query_dl for candidate in plan.candidates] == [
         '.decl answer_q24(value: symbol)\n'
         'answer_q24(O) :- relation("Needle Subject", "role", O).'
+    ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.EXACT_FACT_FALLBACK
+    ]
+    assert [candidate.direction for candidate in plan.candidates] == [
+        QueryCandidateDirection.SUBJECT_TO_OBJECT
+    ]
+
+
+def test_dedupe_keeps_pre_metadata_candidate_identity_for_same_query():
+    sample_subject = _entity("Sample Subject", '"Sample Subject"')
+    snapshot = _snapshot_with_exact(
+        _relation(
+            "role",
+            '"role"',
+            subjects=(sample_subject,),
+            objects=(_entity("Reviewer", '"Reviewer"'),),
+        ),
+        exact_facts=(
+            _fact(
+                _term("Sample Subject", '"Sample Subject"'),
+                _term("role", '"role"'),
+                _term("Reviewer", '"Reviewer"'),
+                matched_entity="Sample Subject",
+                matched_side="subject",
+            ),
+        ),
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "Sample Subject"),
+        relation=IntentTarget("relation", "role"),
+    )
+
+    plan = plan_query_candidates(intent, snapshot, qid=25)
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q25(value: symbol)\n'
+        'answer_q25(O) :- relation("Sample Subject", "role", O).'
+    ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.DIRECT_OBJECT_LOOKUP
     ]
 
 

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -145,10 +145,16 @@ def classify_query_draft(store: Store, qid: int, query_dl: str) -> tuple[str, st
         QueryCandidateSetOutcome,
         evaluate_query_candidate_plan,
     )
-    from verinote.pipeline.query_planner import QueryCandidate, QueryCandidatePlan
+    from verinote.pipeline.query_planner import (
+        QueryCandidate,
+        QueryCandidateFamily,
+        QueryCandidatePlan,
+    )
 
     candidate = QueryCandidate(
         query_dl=query_dl,
+        family=QueryCandidateFamily.MANUAL_DRAFT,
+        direction=None,
         relation_display=None,
         relation_executable=None,
         subject_executable=None,

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 import unicodedata
 
 from verinote.pipeline.corroboration import relation_label_matches
@@ -30,9 +31,29 @@ class QueryPlannerBounds:
             raise ValueError("max_candidates must be a non-negative integer")
 
 
+class QueryCandidateFamily(StrEnum):
+    DIRECT_OBJECT_LOOKUP = "direct_object_lookup"
+    DIRECT_SUBJECT_LOOKUP = "direct_subject_lookup"
+    DIRECT_RELATION_LOOKUP = "direct_relation_lookup"
+    SUBJECT_RELATION_DISCOVERY = "subject_relation_discovery"
+    OBJECT_RELATION_DISCOVERY = "object_relation_discovery"
+    EXACT_FACT_FALLBACK = "exact_fact_fallback"
+    MANUAL_DRAFT = "manual_draft"
+
+
+class QueryCandidateDirection(StrEnum):
+    SUBJECT_TO_OBJECT = "subject_to_object"
+    OBJECT_TO_SUBJECT = "object_to_subject"
+    SUBJECT_TO_RELATION = "subject_to_relation"
+    OBJECT_TO_RELATION = "object_to_relation"
+    SUBJECT_OBJECT_TO_RELATION = "subject_object_to_relation"
+
+
 @dataclass(frozen=True)
 class QueryCandidate:
     query_dl: str
+    family: QueryCandidateFamily
+    direction: QueryCandidateDirection | None
     relation_display: str | None
     relation_executable: str | None
     subject_executable: str | None
@@ -93,6 +114,8 @@ def _lookup_object_candidates(
             candidates.append(
                 QueryCandidate(
                     query_dl=query_dl,
+                    family=QueryCandidateFamily.DIRECT_OBJECT_LOOKUP,
+                    direction=QueryCandidateDirection.SUBJECT_TO_OBJECT,
                     relation_display=relation.relation.display,
                     relation_executable=relation.relation.executable,
                     subject_executable=subject.executable,
@@ -121,6 +144,8 @@ def _lookup_subject_candidates(
             candidates.append(
                 QueryCandidate(
                     query_dl=query_dl,
+                    family=QueryCandidateFamily.DIRECT_SUBJECT_LOOKUP,
+                    direction=QueryCandidateDirection.OBJECT_TO_SUBJECT,
                     relation_display=relation.relation.display,
                     relation_executable=relation.relation.executable,
                     subject_executable=None,
@@ -157,6 +182,8 @@ def _lookup_relation_candidates(
                 candidates.append(
                     QueryCandidate(
                         query_dl=_query_dl(qid, "R", body),
+                        family=QueryCandidateFamily.DIRECT_RELATION_LOOKUP,
+                        direction=_lookup_relation_direction(subject, obj),
                         relation_display=None,
                         relation_executable=None,
                         subject_executable=(
@@ -191,6 +218,8 @@ def _lookup_object_exact_fact_candidates(
                     "O",
                     f"relation({fact.subject.executable}, {fact.relation.executable}, O)",
                 ),
+                family=QueryCandidateFamily.EXACT_FACT_FALLBACK,
+                direction=QueryCandidateDirection.SUBJECT_TO_OBJECT,
                 relation_display=fact.relation.display,
                 relation_executable=fact.relation.executable,
                 subject_executable=fact.subject.executable,
@@ -220,6 +249,8 @@ def _lookup_subject_exact_fact_candidates(
                     "S",
                     f"relation(S, {fact.relation.executable}, {fact.object.executable})",
                 ),
+                family=QueryCandidateFamily.EXACT_FACT_FALLBACK,
+                direction=QueryCandidateDirection.OBJECT_TO_SUBJECT,
                 relation_display=fact.relation.display,
                 relation_executable=fact.relation.executable,
                 subject_executable=None,
@@ -255,6 +286,8 @@ def _lookup_relation_exact_fact_candidates(
         candidates.append(
             QueryCandidate(
                 query_dl=_query_dl(qid, "R", _lookup_relation_body(subject, obj)),
+                family=QueryCandidateFamily.EXACT_FACT_FALLBACK,
+                direction=_lookup_relation_direction(subject, obj),
                 relation_display=None,
                 relation_executable=None,
                 subject_executable=subject.executable if subject is not None else None,
@@ -262,6 +295,18 @@ def _lookup_relation_exact_fact_candidates(
             )
         )
     return candidates
+
+
+def _lookup_relation_direction(
+    subject: EntityRef | None, obj: EntityRef | None
+) -> QueryCandidateDirection:
+    if subject is not None and obj is not None:
+        return QueryCandidateDirection.SUBJECT_OBJECT_TO_RELATION
+    if subject is not None:
+        return QueryCandidateDirection.SUBJECT_TO_RELATION
+    if obj is not None:
+        return QueryCandidateDirection.OBJECT_TO_RELATION
+    raise ValueError("lookup_relation requires at least one endpoint")
 
 
 def _lookup_relation_body(subject: EntityRef | None, obj: EntityRef | None) -> str:
@@ -383,7 +428,17 @@ def _bounded_plan(
 
 
 def _dedupe_candidates(candidates: list[QueryCandidate]) -> tuple[QueryCandidate, ...]:
-    return tuple(dict.fromkeys(candidates))
+    deduped: dict[tuple[str, str | None, str | None, str | None, str | None], QueryCandidate] = {}
+    for candidate in candidates:
+        key = (
+            candidate.query_dl,
+            candidate.relation_display,
+            candidate.relation_executable,
+            candidate.subject_executable,
+            candidate.object_executable,
+        )
+        deduped.setdefault(key, candidate)
+    return tuple(deduped.values())
 
 
 def _nfc(value: str) -> str:


### PR DESCRIPTION
## Summary
- add stable query candidate family and direction metadata enums
- populate metadata for direct lookup, relation lookup, exact-fact fallback, and manual draft validation candidates
- preserve pre-existing Datalog/rendering dedupe semantics when metadata differs
- assert metadata survives candidate evaluation without changing selection behavior

## Validation
- `uv run pytest tests/test_query_planner.py tests/test_query_candidate_eval.py -q`
- `uv run pytest -q`
- `uv run ruff check verinote/pipeline/query_planner.py verinote/pipeline/query.py tests/test_query_planner.py tests/test_query_candidate_eval.py`
- `git diff --check`

Closes #131