### PR TITLE
Add relation discovery quality policy

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -303,6 +303,102 @@ def test_planned_executable_without_rows_becomes_no_answer(
     assert load_query(s) == ""
 
 
+def test_quality_policy_review_required_outcome_is_persisted(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    from verinote.pipeline.query_candidate_eval import QueryCandidateEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateOutcome
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    s = _store(tmp_path)
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    qid = s.add_question("What is Sample Subject?")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Subject", relation="is_a"
+        )
+    )
+
+    def review_required(store, plan):
+        assert plan.candidates
+        return QueryCandidateSetEvaluation(
+            plan=plan,
+            outcome=QueryCandidateSetOutcome.REVIEW_REQUIRED,
+            evaluations=(
+                QueryCandidateEvaluation(
+                    candidate=plan.candidates[0],
+                    outcome=QueryCandidateOutcome.REVIEW_REQUIRED,
+                    review_reason="relation label requires review: source",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "verinote.pipeline.query.evaluate_query_candidate_plan", review_required
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {
+            "id": qid,
+            "status": "review_required",
+            "query_dl": 'review_required("relation label requires review: source")',
+            "reason": "relation label requires review: source",
+        }
+    ]
+    assert load_query(s) == ""
+
+
+def test_quality_policy_review_reason_wins_over_invalid_candidate_reason(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    from verinote.pipeline.query_candidate_eval import QueryCandidateEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateOutcome
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetEvaluation
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    s = _store(tmp_path)
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    s.add_question("What is Sample Subject?")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Subject", relation="is_a"
+        )
+    )
+
+    def review_required(store, plan):
+        assert plan.candidates
+        invalid = QueryCandidateEvaluation(
+            candidate=plan.candidates[0],
+            outcome=QueryCandidateOutcome.INVALID,
+            validation_reason="unsupported predicate: bogus",
+        )
+        denied = QueryCandidateEvaluation(
+            candidate=plan.candidates[0],
+            outcome=QueryCandidateOutcome.REVIEW_REQUIRED,
+            review_reason="relation label requires review: source",
+        )
+        return QueryCandidateSetEvaluation(
+            plan=plan,
+            outcome=QueryCandidateSetOutcome.REVIEW_REQUIRED,
+            evaluations=(invalid, denied),
+        )
+
+    monkeypatch.setattr(
+        "verinote.pipeline.query.evaluate_query_candidate_plan", review_required
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results[0]["status"] == "review_required"
+    assert results[0]["reason"] == "relation label requires review: source"
+    assert results[0]["query_dl"] == (
+        'review_required("relation label requires review: source")'
+    )
+
+
 def test_query_schema_hint_is_bounded_schema_only(tmp_path):
     from verinote.pipeline.query_schema import build_query_schema_snapshot
 

--- a/tests/test_query_candidate_eval.py
+++ b/tests/test_query_candidate_eval.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import verinote.pipeline.query_candidate_eval as query_candidate_eval
+import verinote.pipeline.query_quality_policy as query_quality_policy
 from verinote.engine import CheckReport
 from verinote.pipeline.query_candidate_eval import (
     QueryCandidateOutcome,
@@ -24,13 +25,15 @@ def _candidate(
     *,
     family: QueryCandidateFamily = QueryCandidateFamily.MANUAL_DRAFT,
     direction: QueryCandidateDirection | None = None,
+    relation_display: str | None = None,
+    relation_executable: str | None = None,
 ) -> QueryCandidate:
     return QueryCandidate(
         query_dl=query_dl,
         family=family,
         direction=direction,
-        relation_display=None,
-        relation_executable=None,
+        relation_display=relation_display,
+        relation_executable=relation_executable,
         subject_executable=None,
         object_executable=None,
     )
@@ -42,6 +45,21 @@ def _lookup(qid: int, subject: str, relation: str) -> QueryCandidate:
         f'answer_q{qid}(O) :- relation("{subject}", "{relation}", O).',
         family=QueryCandidateFamily.DIRECT_OBJECT_LOOKUP,
         direction=QueryCandidateDirection.SUBJECT_TO_OBJECT,
+    )
+
+
+def _relation_discovery(
+    qid: int, relation: str, *, display: str | None = None
+) -> QueryCandidate:
+    relation_display = display or relation
+    return _candidate(
+        f'.decl answer_q{qid}(value: symbol)\n'
+        f'answer_q{qid}("{relation}") :- '
+        f'relation("Sample Entity", "{relation}", "Sample Value").',
+        family=QueryCandidateFamily.SUBJECT_RELATION_DISCOVERY,
+        direction=QueryCandidateDirection.SUBJECT_TO_RELATION,
+        relation_display=relation_display,
+        relation_executable=f'"{relation}"',
     )
 
 
@@ -308,6 +326,133 @@ def test_evaluate_query_candidate_plan_preserves_candidate_metadata(tmp_path):
     assert evaluation.selected is candidate
     assert evaluation.selected.family == QueryCandidateFamily.DIRECT_OBJECT_LOOKUP
     assert evaluation.selected.direction == QueryCandidateDirection.SUBJECT_TO_OBJECT
+
+
+def test_relation_discovery_allowed_label_can_translate(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Entity", "synthetic_relation", "Sample Value", status="confirmed")
+    candidate = _relation_discovery(1, "synthetic_relation")
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert evaluation.selected is candidate
+    assert evaluation.answers == ("q1: synthetic_relation",)
+
+
+def test_relation_discovery_denied_label_requires_review(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Entity", "source", "Sample Value", status="confirmed")
+    candidate = _relation_discovery(1, "source")
+
+    candidate_evaluation = evaluate_query_candidate(store, candidate)
+    plan_evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert candidate_evaluation.outcome == QueryCandidateOutcome.REVIEW_REQUIRED
+    assert candidate_evaluation.answers == ()
+    assert candidate_evaluation.review_reason == "relation label requires review: source"
+    assert plan_evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED
+    assert plan_evaluation.outcome != QueryCandidateSetOutcome.NO_ANSWER
+    assert plan_evaluation.answers == ()
+
+
+def test_relation_discovery_denied_label_normalization_requires_review(
+    tmp_path, monkeypatch
+):
+    store = _store(tmp_path)
+    nfd_source = "sourc" + "é"
+    nfc_source = "sourcé"
+    monkeypatch.setattr(
+        query_quality_policy,
+        "LOW_SIGNAL_RELATION_LABELS",
+        frozenset({nfc_source}),
+    )
+    store.add_fact("Sample Entity", nfc_source, "Sample Value", status="confirmed")
+    candidate = _relation_discovery(1, nfc_source, display=f"  {nfd_source.upper()}  ")
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED
+    assert evaluation.evaluations[0].review_reason == (
+        f"relation label requires review: {nfc_source}"
+    )
+
+    store.add_fact("Sample Entity", "SOURCE", "Sample Value", status="confirmed")
+    monkeypatch.setattr(
+        query_quality_policy,
+        "LOW_SIGNAL_RELATION_LABELS",
+        frozenset({"source"}),
+    )
+    source_candidate = _relation_discovery(2, "SOURCE", display="  SOURCE  ")
+    source_evaluation = evaluate_query_candidate_plan(
+        store,
+        QueryCandidatePlan(qid=2, candidates=(source_candidate,)),
+    )
+
+    assert source_evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED
+    assert source_evaluation.evaluations[0].review_reason == (
+        "relation label requires review: source"
+    )
+
+
+def test_relation_discovery_mixed_denied_and_allowed_selects_allowed(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Entity", "source", "Sample Value", status="confirmed")
+    store.add_fact(
+        "Sample Entity", "synthetic_relation", "Sample Value", status="confirmed"
+    )
+    denied = _relation_discovery(1, "source")
+    allowed = _relation_discovery(1, "synthetic_relation")
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(denied, allowed))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert evaluation.selected is allowed
+    assert evaluation.answers == ("q1: synthetic_relation",)
+
+
+def test_relation_discovery_missing_relation_label_requires_review(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Entity", "synthetic_relation", "Sample Value", status="confirmed")
+    candidate = _candidate(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1("synthetic_relation") :- '
+        'relation("Sample Entity", "synthetic_relation", "Sample Value").',
+        family=QueryCandidateFamily.SUBJECT_RELATION_DISCOVERY,
+        direction=QueryCandidateDirection.SUBJECT_TO_RELATION,
+    )
+
+    evaluation = evaluate_query_candidate_plan(store, _plan(candidate))
+
+    assert evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED
+    assert evaluation.evaluations[0].review_reason == (
+        "relation discovery candidate lacks a relation label"
+    )
+
+
+def test_relation_quality_policy_does_not_block_direct_lookups(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "source", "Sample Document", status="confirmed")
+    direct_object = _lookup(1, "Sample Person", "source")
+    direct_relation = _candidate(
+        '.decl answer_q2(value: symbol)\n'
+        'answer_q2(R) :- relation("Sample Person", R, "Sample Document").',
+        family=QueryCandidateFamily.DIRECT_RELATION_LOOKUP,
+        direction=QueryCandidateDirection.SUBJECT_OBJECT_TO_RELATION,
+        relation_display="source",
+        relation_executable='"source"',
+    )
+
+    object_evaluation = evaluate_query_candidate_plan(store, _plan(direct_object))
+    relation_evaluation = evaluate_query_candidate_plan(
+        store,
+        QueryCandidatePlan(qid=2, candidates=(direct_relation,)),
+    )
+
+    assert object_evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert object_evaluation.answers == ("q1: Sample Document",)
+    assert relation_evaluation.outcome == QueryCandidateSetOutcome.VALID
+    assert relation_evaluation.answers == ("q2: source",)
 
 
 def test_evaluate_query_candidate_plan_marks_conflicting_answer_sets_ambiguous(tmp_path):

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -223,6 +223,9 @@ def schema_aware_query_flow(
     if evaluation.outcome == QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING:
         reason = "multiple query candidates returned conflicting answers"
         return "ambiguous", f"ambiguous({_lit(reason)})", reason
+    if evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED:
+        reason = _short_reason(_evaluation_reason(evaluation))
+        return "review_required", f"review_required({_lit(reason)})", reason
     if evaluation.outcome == QueryCandidateSetOutcome.EMPTY:
         reason = _short_reason(plan.reason or "no query candidates matched the schema")
     elif evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR:
@@ -277,6 +280,9 @@ def _translate_direct_datalog_fallback(
 
 
 def _evaluation_reason(evaluation) -> str:
+    for item in evaluation.evaluations:
+        if item.review_reason:
+            return item.review_reason
     for item in evaluation.evaluations:
         if item.validation_reason:
             return item.validation_reason

--- a/verinote/pipeline/query_candidate_eval.py
+++ b/verinote/pipeline/query_candidate_eval.py
@@ -12,6 +12,10 @@ from verinote.engine.duckdb_backend import run_check_duckdb
 from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
 from verinote.pipeline.query import expand_query_relation_aliases
 from verinote.pipeline.query_planner import QueryCandidate, QueryCandidatePlan
+from verinote.pipeline.query_quality_policy import (
+    BROAD_RELATION_DISCOVERY_FAMILIES,
+    evaluate_relation_discovery_label,
+)
 
 RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
 
@@ -20,6 +24,7 @@ class QueryCandidateOutcome(Enum):
     INVALID = "invalid"
     ENGINE_POLICY_ERROR = "engine_policy_error"
     NO_ANSWER = "no_answer"
+    REVIEW_REQUIRED = "review_required"
     VALID_WITH_ANSWERS = "valid_with_answers"
 
 
@@ -28,6 +33,7 @@ class QueryCandidateSetOutcome(Enum):
     INVALID = "invalid"
     ENGINE_POLICY_ERROR = "engine_policy_error"
     NO_ANSWER = "no_answer"
+    REVIEW_REQUIRED = "review_required"
     VALID = "valid"
     AMBIGUOUS_CONFLICTING = "ambiguous_conflicting"
 
@@ -38,6 +44,7 @@ class QueryCandidateEvaluation:
     outcome: QueryCandidateOutcome
     answers: tuple[str, ...] = ()
     validation_reason: str | None = None
+    review_reason: str | None = None
     report: CheckReport | None = None
 
 
@@ -103,6 +110,15 @@ def evaluate_query_candidate(
             outcome=QueryCandidateOutcome.NO_ANSWER,
             report=report,
         )
+    if candidate.family in BROAD_RELATION_DISCOVERY_FAMILIES:
+        decision = evaluate_relation_discovery_label(candidate.relation_display)
+        if not decision.allowed:
+            return QueryCandidateEvaluation(
+                candidate=candidate,
+                outcome=QueryCandidateOutcome.REVIEW_REQUIRED,
+                review_reason=decision.reason,
+                report=report,
+            )
     return QueryCandidateEvaluation(
         candidate=candidate,
         outcome=QueryCandidateOutcome.VALID_WITH_ANSWERS,
@@ -153,7 +169,18 @@ def evaluate_query_candidate_plan(store, plan: QueryCandidatePlan) -> QueryCandi
         for evaluation in evaluations
         if evaluation.outcome == QueryCandidateOutcome.VALID_WITH_ANSWERS
     )
+    review_required = tuple(
+        evaluation
+        for evaluation in evaluations
+        if evaluation.outcome == QueryCandidateOutcome.REVIEW_REQUIRED
+    )
     if not answering:
+        if review_required:
+            return QueryCandidateSetEvaluation(
+                plan=plan,
+                outcome=QueryCandidateSetOutcome.REVIEW_REQUIRED,
+                evaluations=evaluations,
+            )
         if all(
             evaluation.outcome == QueryCandidateOutcome.INVALID
             for evaluation in evaluations

--- a/verinote/pipeline/query_quality_policy.py
+++ b/verinote/pipeline/query_quality_policy.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Deterministic quality policies for query candidate answers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import unicodedata
+
+from verinote.pipeline.query_planner import QueryCandidateFamily
+
+BROAD_RELATION_DISCOVERY_FAMILIES = frozenset(
+    {
+        QueryCandidateFamily.SUBJECT_RELATION_DISCOVERY,
+        QueryCandidateFamily.OBJECT_RELATION_DISCOVERY,
+    }
+)
+
+LOW_SIGNAL_RELATION_LABELS = frozenset(
+    {
+        "column",
+        "field",
+        "metadata",
+        "row",
+        "source",
+        "value",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RelationDiscoveryQualityDecision:
+    allowed: bool
+    reason: str | None = None
+    normalized_label: str | None = None
+
+
+def evaluate_relation_discovery_label(
+    label: str | None,
+) -> RelationDiscoveryQualityDecision:
+    """Return a deterministic broad-discovery quality decision for a relation label."""
+    if label is None or not label.strip():
+        return RelationDiscoveryQualityDecision(
+            allowed=False,
+            reason="relation discovery candidate lacks a relation label",
+        )
+    normalized = normalize_relation_quality_label(label)
+    if normalized in LOW_SIGNAL_RELATION_LABELS:
+        return RelationDiscoveryQualityDecision(
+            allowed=False,
+            reason=f"relation label requires review: {normalized}",
+            normalized_label=normalized,
+        )
+    return RelationDiscoveryQualityDecision(
+        allowed=True,
+        normalized_label=normalized,
+    )
+
+
+def normalize_relation_quality_label(label: str) -> str:
+    return unicodedata.normalize("NFC", label).strip().casefold()


### PR DESCRIPTION
## Summary
- add a deterministic broad relation-discovery quality policy for low-signal relation labels
- apply the policy only to subject/object relation-discovery candidate families
- distinguish policy-denied discovery from true no-answer with review-required evaluator outcomes
- map review-required evaluator outcomes to persisted `review_required(...)` question state
- cover normalization, denied-only, mixed denied/allowed, missing labels, reason precedence, and direct lookup exemption

## Validation
- `uv run pytest tests/test_query_candidate_eval.py tests/test_query.py -q`
- `uv run pytest -q`
- `uv run ruff check verinote/pipeline/query_candidate_eval.py verinote/pipeline/query.py verinote/pipeline/query_quality_policy.py tests/test_query_candidate_eval.py tests/test_query.py`
- `git diff --check`

Closes #132