### PR TITLE
Generate relation discovery candidates

### DIFF
--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -147,18 +147,225 @@ def test_lookup_object_uses_observed_relation_and_subject_side():
     assert plan.truncated is False
 
 
-def test_entity_relation_discovery_intent_is_recognized_but_not_planned_yet():
+def test_entity_relation_discovery_generates_subject_side_candidates():
     plan = plan_query_candidates(
         QueryIntent(
             kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
             subject=IntentTarget("entity", "Sample Entity"),
         ),
-        _snapshot(),
+        _snapshot(
+            _relation(
+                "provides",
+                '"provides"',
+                subjects=(_entity("Sample Entity", '"Sample Entity"'),),
+                objects=(_entity("Sample Value", '"Sample Value"'),),
+            )
+        ),
         qid=9,
     )
 
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q9(value: symbol)\n'
+        'answer_q9("provides") :- relation("Sample Entity", "provides", O).'
+    ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.SUBJECT_RELATION_DISCOVERY
+    ]
+    assert [candidate.direction for candidate in plan.candidates] == [
+        QueryCandidateDirection.SUBJECT_TO_RELATION
+    ]
+    assert plan.reason is None
+
+
+def test_entity_relation_discovery_generates_object_side_candidates_from_exact_facts():
+    snapshot = _snapshot_with_exact(
+        _relation(
+            "mentions",
+            '"mentions"',
+            subjects=(_entity("Other Entity", '"Other Entity"'),),
+            objects=(_entity("Other Value", '"Other Value"'),),
+        ),
+        exact_facts=(
+            _fact(
+                _term("Sample Source", '"Sample Source"'),
+                _term("mentions", '"mentions"'),
+                _term("Sample Entity", '"Sample Entity"'),
+                matched_entity="Sample Entity",
+                matched_side="object",
+            ),
+        ),
+    )
+
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+        ),
+        snapshot,
+        qid=10,
+    )
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q10(value: symbol)\n'
+        'answer_q10("mentions") :- relation(S, "mentions", "Sample Entity").'
+    ]
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.OBJECT_RELATION_DISCOVERY
+    ]
+    assert [candidate.direction for candidate in plan.candidates] == [
+        QueryCandidateDirection.OBJECT_TO_RELATION
+    ]
+
+
+def test_entity_relation_discovery_keeps_direct_lookup_before_discovery():
+    snapshot = _snapshot(
+        _relation(
+            "provides",
+            '"provides"',
+            subjects=(_entity("Sample Entity", '"Sample Entity"'),),
+            objects=(_entity("Sample Value", '"Sample Value"'),),
+        ),
+        _relation(
+            "owns",
+            '"owns"',
+            subjects=(_entity("Sample Entity", '"Sample Entity"'),),
+            objects=(_entity("Other Value", '"Other Value"'),),
+        ),
+    )
+
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+            relation=IntentTarget("relation", "provides"),
+        ),
+        snapshot,
+        qid=11,
+    )
+
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.DIRECT_OBJECT_LOOKUP
+    ]
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q11(value: symbol)\n'
+        'answer_q11(O) :- relation("Sample Entity", "provides", O).',
+    ]
+
+
+def test_entity_relation_discovery_uses_relation_hint_when_direct_lookup_missing():
+    snapshot = _snapshot_with_exact(
+        _relation(
+            "provides",
+            '"provides"',
+            subjects=(_entity("Displayed Entity", '"Displayed Entity"'),),
+            objects=(_entity("Displayed Value", '"Displayed Value"'),),
+        ),
+        exact_facts=(
+            _fact(
+                _term("Hidden Entity", '"Hidden Entity"'),
+                _term("provides", '"provides"'),
+                _term("Sample Value", '"Sample Value"'),
+                matched_entity="Hidden Entity",
+                matched_side="subject",
+            ),
+        ),
+    )
+
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Hidden Entity"),
+            relation=IntentTarget("relation", "provides"),
+        ),
+        snapshot,
+        qid=35,
+    )
+
+    assert [candidate.family for candidate in plan.candidates] == [
+        QueryCandidateFamily.EXACT_FACT_FALLBACK
+    ]
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q35(value: symbol)\n'
+        'answer_q35(O) :- relation("Hidden Entity", "provides", O).',
+    ]
+
+
+def test_entity_relation_discovery_no_match_reason():
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Missing Entity"),
+        ),
+        _snapshot(),
+        qid=32,
+    )
+
     assert plan.candidates == ()
-    assert plan.reason == "entity relation discovery planning is not implemented yet"
+    assert plan.reason == "no relation discovery candidates matched the schema"
+
+
+def test_entity_relation_discovery_uses_exact_facts_when_schema_examples_omit_anchor():
+    snapshot = _snapshot_with_exact(
+        _relation(
+            "supports",
+            '"supports"',
+            subjects=(_entity("Displayed Subject", '"Displayed Subject"'),),
+            objects=(_entity("Displayed Value", '"Displayed Value"'),),
+        ),
+        exact_facts=(
+            _fact(
+                _term("Hidden Subject", '"Hidden Subject"'),
+                _term("supports", '"supports"'),
+                _term("Sample Value", '"Sample Value"'),
+                matched_entity="Hidden Subject",
+                matched_side="subject",
+            ),
+        ),
+    )
+
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Hidden Subject"),
+        ),
+        snapshot,
+        qid=33,
+    )
+
+    assert [candidate.query_dl for candidate in plan.candidates] == [
+        '.decl answer_q33(value: symbol)\n'
+        'answer_q33("supports") :- relation("Hidden Subject", "supports", O).'
+    ]
+
+
+def test_entity_relation_discovery_candidate_cap_truncates_deterministically():
+    snapshot = _snapshot(
+        *(
+            _relation(
+                relation,
+                f'"{relation}"',
+                subjects=(_entity("Sample Entity", '"Sample Entity"'),),
+                objects=(_entity(f"Value {relation}", f'"Value {relation}"'),),
+            )
+            for relation in ("alpha", "beta", "gamma")
+        )
+    )
+
+    plan = plan_query_candidates(
+        QueryIntent(
+            kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+            subject=IntentTarget("entity", "Sample Entity"),
+        ),
+        snapshot,
+        qid=34,
+        bounds=QueryPlannerBounds(max_candidates=2),
+    )
+
+    assert plan.truncated is True
+    assert [candidate.relation_display for candidate in plan.candidates] == [
+        "alpha",
+        "beta",
+    ]
 
 
 def test_lookup_subject_uses_object_side_directionality():

--- a/tests/test_query_planning_e2e.py
+++ b/tests/test_query_planning_e2e.py
@@ -100,6 +100,98 @@ def test_translate_planner_persists_query_file_and_verify_answers(tmp_path):
     assert report.answers == ["q1: 샘플역할"]
 
 
+def test_translate_relation_discovery_persists_relation_answer(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact(
+        "Sample Entity",
+        "synthetic_relation",
+        "Sample Value",
+        status="confirmed",
+    )
+    qid = store.add_question("How is Sample Entity related?")
+    client = IntentOnlyClient(
+        _intent(
+            "discover_entity_relations",
+            subject="Sample Entity",
+        )
+    )
+
+    results = translate_questions(store, client, root=tmp_path)
+    report = verify(store)
+
+    assert results[0]["status"] == "translated"
+    question = store.questions()[0]
+    assert question["status"] == "translated"
+    assert (
+        f'answer_q{qid}("synthetic_relation") :- '
+        'relation("Sample Entity", "synthetic_relation", O).'
+    ) in question["query_dl"]
+    assert report.ok is True
+    assert report.answers == ["q1: synthetic_relation"]
+
+
+def test_translate_relation_discovery_relation_hint_prefers_direct_lookup(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact(
+        "Sample Entity",
+        "provides",
+        "Sample Value",
+        status="confirmed",
+    )
+    store.add_fact(
+        "Sample Entity",
+        "owns",
+        "Other Value",
+        status="confirmed",
+    )
+    qid = store.add_question("Synthetic relation hint coverage?")
+    client = IntentOnlyClient(
+        _intent(
+            "discover_entity_relations",
+            subject="Sample Entity",
+            relation="provides",
+        )
+    )
+
+    results = translate_questions(store, client, root=tmp_path)
+    report = verify(store)
+
+    assert results[0]["status"] == "translated"
+    question = store.questions()[0]
+    assert (
+        f'answer_q{qid}(O) :- relation("Sample Entity", "provides", O).'
+    ) in question["query_dl"]
+    assert "ambiguous" not in question["query_dl"]
+    assert report.ok is True
+    assert report.answers == ["q1: Sample Value"]
+
+
+def test_translate_relation_discovery_low_signal_relation_requires_review(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact(
+        "Sample Entity",
+        "source",
+        "Sample Value",
+        status="confirmed",
+    )
+    store.add_question("How is Sample Entity related?")
+    client = IntentOnlyClient(
+        _intent(
+            "discover_entity_relations",
+            subject="Sample Entity",
+        )
+    )
+
+    results = translate_questions(store, client, root=tmp_path)
+
+    assert results[0]["status"] == "review_required"
+    assert results[0]["reason"] == "relation label requires review: source"
+    question = store.questions()[0]
+    assert question["status"] == "review_required"
+    assert question["query_dl"] == 'review_required("relation label requires review: source")'
+    assert load_query(store) == ""
+
+
 def test_cli_query_uses_planner_and_reports_stable_row_outcome(
     tmp_path, monkeypatch, capsys
 ):

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -89,13 +89,126 @@ def plan_query_candidates(
         candidates = _lookup_relation_candidates(intent, snapshot, qid)
         reason = None
     elif intent.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS:
-        candidates = ()
-        reason = "entity relation discovery planning is not implemented yet"
+        candidates = _discover_entity_relation_candidates(intent, snapshot, qid)
+        reason = None if candidates else "no relation discovery candidates matched the schema"
     else:
         candidates = ()
         reason = f"unsupported intent kind: {intent.kind.value}"
 
     return _bounded_plan(qid, candidates, bounds, reason=reason)
+
+
+def _discover_entity_relation_candidates(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot, qid: int
+) -> tuple[QueryCandidate, ...]:
+    if intent.subject is None:
+        return ()
+    candidates: list[QueryCandidate] = []
+    requested = _relation_requests(intent)
+    if requested:
+        direct_candidates = list(_lookup_object_candidates(intent, snapshot, qid))
+        if direct_candidates:
+            return tuple(direct_candidates)
+        candidates.extend(_discover_from_relation_examples(intent, snapshot, qid, requested))
+        candidates.extend(_discover_from_exact_facts(intent, snapshot, qid, requested))
+        return _dedupe_candidates(candidates)
+    candidates.extend(_discover_from_relation_examples(intent, snapshot, qid, requested))
+    candidates.extend(_discover_from_exact_facts(intent, snapshot, qid, requested))
+    return _dedupe_candidates(candidates)
+
+
+def _discover_from_relation_examples(
+    intent: QueryIntent,
+    snapshot: QuerySchemaSnapshot,
+    qid: int,
+    requested: tuple[str, ...],
+) -> list[QueryCandidate]:
+    if intent.subject is None:
+        return []
+    candidates: list[QueryCandidate] = []
+    for relation in snapshot.relations:
+        if requested and not _relation_matches_any(relation, requested):
+            continue
+        for subject in _matching_entities(relation.subjects, intent.subject.value):
+            candidates.append(
+                _subject_relation_discovery_candidate(qid, relation.relation, subject)
+            )
+        for obj in _matching_entities(relation.objects, intent.subject.value):
+            candidates.append(
+                _object_relation_discovery_candidate(qid, relation.relation, obj)
+            )
+    return candidates
+
+
+def _discover_from_exact_facts(
+    intent: QueryIntent,
+    snapshot: QuerySchemaSnapshot,
+    qid: int,
+    requested: tuple[str, ...],
+) -> list[QueryCandidate]:
+    if intent.subject is None:
+        return []
+    candidates: list[QueryCandidate] = []
+    for fact in snapshot.exact_entity_facts:
+        if requested and not _fact_relation_matches_any_requested(fact, requested, snapshot):
+            continue
+        if fact.matched_side in {"subject", "both"} and _entity_ref_matches(
+            fact.subject, intent.subject.value
+        ):
+            candidates.append(
+                _subject_relation_discovery_candidate(
+                    qid,
+                    fact.relation,
+                    _entity_from_term_ref(fact.subject),
+                )
+            )
+        if fact.matched_side in {"object", "both"} and _entity_ref_matches(
+            fact.object, intent.subject.value
+        ):
+            candidates.append(
+                _object_relation_discovery_candidate(
+                    qid,
+                    fact.relation,
+                    _entity_from_term_ref(fact.object),
+                )
+            )
+    return candidates
+
+
+def _subject_relation_discovery_candidate(
+    qid: int, relation: TermRef, subject: EntityRef
+) -> QueryCandidate:
+    return QueryCandidate(
+        query_dl=_query_dl(
+            qid,
+            _answer_label(relation),
+            f"relation({subject.executable}, {relation.executable}, O)",
+        ),
+        family=QueryCandidateFamily.SUBJECT_RELATION_DISCOVERY,
+        direction=QueryCandidateDirection.SUBJECT_TO_RELATION,
+        relation_display=relation.display,
+        relation_executable=relation.executable,
+        subject_executable=subject.executable,
+        object_executable=None,
+    )
+
+
+def _object_relation_discovery_candidate(
+    qid: int, relation: TermRef, obj: EntityRef
+) -> QueryCandidate:
+    return QueryCandidate(
+        query_dl=_query_dl(
+            qid,
+            _answer_label(relation),
+            f"relation(S, {relation.executable}, {obj.executable})",
+        ),
+        family=QueryCandidateFamily.OBJECT_RELATION_DISCOVERY,
+        direction=QueryCandidateDirection.OBJECT_TO_RELATION,
+        relation_display=relation.display,
+        relation_executable=relation.executable,
+        subject_executable=None,
+        object_executable=obj.executable,
+    )
 
 
 def _lookup_object_candidates(
@@ -388,6 +501,12 @@ def _fact_relation_matches_any(
     wanted = _relation_requests(intent)
     if not wanted:
         return False
+    return _fact_relation_matches_any_requested(fact, wanted, snapshot)
+
+
+def _fact_relation_matches_any_requested(
+    fact: SnapshotFact, wanted: tuple[str, ...], snapshot: QuerySchemaSnapshot
+) -> bool:
     aliases = {entry.alias: entry.canonical for entry in snapshot.relation_aliases}
     observed = (_nfc(fact.relation.display), _nfc(fact.relation.executable))
     return any(
@@ -409,6 +528,10 @@ def _entity_from_term_ref(ref: TermRef) -> EntityRef:
 
 def _query_dl(qid: int, head_value: str, body: str) -> str:
     return f".decl answer_q{qid}(value: symbol)\nanswer_q{qid}({head_value}) :- {body}."
+
+
+def _answer_label(relation: TermRef) -> str:
+    return relation.executable if relation.kind != "StringLit" else relation.executable
 
 
 def _bounded_plan(


### PR DESCRIPTION
## Summary
- generate schema-backed relation-discovery candidates for entity-centric discovery intents
- preserve direct lookup behavior when a relation hint can produce object-answer candidates
- add subject-side and object-side discovery candidates with family/direction metadata
- use exact entity facts so bounded schema examples do not hide anchor facts
- cover deterministic bounds, exact-fact discovery, direct preference, e2e translation, and low-signal quality policy integration

## Validation
- `uv run pytest tests/test_query_planner.py tests/test_query_planning_e2e.py -q`
- `uv run pytest -q`
- `uv run ruff check verinote/pipeline/query_planner.py tests/test_query_planner.py tests/test_query_planning_e2e.py`
- `git diff --check`

Closes #133