### PR TITLE
Wire relation discovery through question flow

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,7 +5,6 @@ import pytest
 
 from verinote.llm.base import LLMError
 from verinote.pipeline.query import (
-    deterministic_query_intent_dl,
     expand_query_relation_aliases,
     load_query,
     query_path,
@@ -78,18 +77,18 @@ def test_translate_korean_role_question_bypasses_llm(tmp_path):
     ]
     query_dl = s.questions()[0]["query_dl"]
     assert f'answer_q{qid}(O) :- relation("샘플인물", "역할", O).' in query_dl
+    assert "has_role" not in query_dl
+    assert "person(" not in query_dl
     assert load_query(s) == query_dl + "\n"
 
 
-def test_korean_role_query_datalog_is_derived_from_intent():
+def test_korean_role_question_is_parsed_as_structured_intent():
     intent = deterministic_query_intent("샘플인물의 역할은 무엇인가?")
 
-    query_dl = deterministic_query_intent_dl(intent, 7)
-
-    assert query_dl is not None
-    assert 'answer_q7(O) :- relation("샘플인물", "역할", O).' in query_dl
-    assert 'answer_q7(O) :- relation(person("샘플인물"), has_role, O).' in query_dl
-    assert 'answer_q7(R) :- relation(S, R, "샘플인물").' in query_dl
+    assert intent.kind.value == "lookup_object"
+    assert intent.subject is not None
+    assert intent.subject.value == "샘플인물"
+    assert intent.relation_candidates == ("역할", "직책", "직위")
 
 
 def test_load_query_expands_relation_aliases(tmp_path):
@@ -339,6 +338,40 @@ def test_quality_policy_review_required_outcome_is_persisted(
     )
 
     results = translate_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {
+            "id": qid,
+            "status": "review_required",
+            "query_dl": 'review_required("relation label requires review: source")',
+            "reason": "relation label requires review: source",
+        }
+    ]
+    assert load_query(s) == ""
+
+
+def test_supported_planner_review_required_does_not_call_direct_fallback(
+    tmp_path, fake_client, intent_payload
+):
+    s = _store(tmp_path)
+    s.add_fact("Sample Entity", "source", "Sample Value", status="confirmed")
+    qid = s.add_question("Synthetic planner-supported review?")
+    client = fake_client(
+        intent=intent_payload(
+            "discover_entity_relations",
+            subject="Sample Entity",
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("planner-supported review must not call direct Datalog fallback")
+    )
+
+    results = translate_questions(
+        s,
+        client,
+        root=tmp_path,
+        allow_direct_datalog_fallback=True,
+    )
 
     assert results == [
         {

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -38,6 +38,82 @@ def test_repair_accepts_engine_valid_planned_query(tmp_path, fake_client, intent
     assert f"answer_q{qid}" in (load_query(s) or "")
 
 
+def test_repair_accepts_relation_discovery_planned_query(
+    tmp_path, fake_client, intent_payload
+):
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    s.add_fact("Sample Entity", "synthetic_relation", "Sample Value", status="confirmed")
+    qid = s.add_question("Synthetic relation discovery repair?")
+    s.set_question_query(
+        qid,
+        'review_required("Synthetic relation discovery repair?")',
+        "review_required",
+    )
+    client = fake_client(
+        intent=intent_payload(
+            "discover_entity_relations",
+            subject="Sample Entity",
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("repair must not call direct Datalog for planner-supported paths")
+    )
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    question = s.questions()[0]
+    assert question["status"] == "translated"
+    assert (
+        f'answer_q{qid}("synthetic_relation") :- '
+        'relation("Sample Entity", "synthetic_relation", O).'
+    ) in question["query_dl"]
+    assert load_query(s) == question["query_dl"] + "\n"
+
+
+def test_repair_planner_review_required_does_not_call_direct_fallback(
+    tmp_path, fake_client, intent_payload
+):
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    s.add_fact("Sample Entity", "source", "Sample Value", status="confirmed")
+    qid = s.add_question("Synthetic relation discovery repair?")
+    s.set_question_query(
+        qid,
+        'review_required("Synthetic relation discovery repair?")',
+        "review_required",
+    )
+    client = fake_client(
+        intent=intent_payload(
+            "discover_entity_relations",
+            subject="Sample Entity",
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("planner-supported repair must not call direct Datalog fallback")
+    )
+
+    results = repair_questions(
+        s,
+        client,
+        root=tmp_path,
+        allow_direct_datalog_fallback=True,
+    )
+
+    assert results == [
+        {
+            "id": qid,
+            "accepted": False,
+            "reason": "relation label requires review: source",
+        }
+    ]
+    question = s.questions()[0]
+    assert question["status"] == "review_required"
+    assert question["query_dl"] == 'review_required("relation label requires review: source")'
+    assert load_query(s) == ""
+
+
 def test_repair_fallback_accepts_duckdb_supported_compound_query(tmp_path, fake_client):
     s, qid = _store_with_review_required(tmp_path)
     s.add_fact(

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,7 +3,7 @@ import builtins
 
 import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.engine.terms import Compound, StringLit
-from verinote.pipeline.query import deterministic_query_dl, query_path
+from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import policy_path, verify
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
@@ -95,19 +95,23 @@ def test_verify_answers_query_through_relation_alias(tmp_path):
     assert rep.answers == ["q1: 샘플역할"]
 
 
-def test_verify_answers_korean_role_question_across_role_fact_shapes(tmp_path):
+def test_verify_answers_explicit_korean_role_query(tmp_path):
     s = _store(tmp_path)
     s.add_fact("샘플인물", "역할", "샘플역할", status="confirmed")
     s.add_fact("샘플인물", "대표", "샘플조직", status="confirmed")
     s.add_fact("샘플기관", "발표자", "샘플인물", status="confirmed")
     path = query_path(tmp_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(deterministic_query_dl("샘플인물의 역할은 무엇인가?", 1) + "\n", encoding="utf-8")
+    path.write_text(
+        '.decl answer_q1(value: symbol)\n'
+        'answer_q1(O) :- relation("샘플인물", "역할", O).\n',
+        encoding="utf-8",
+    )
 
     rep = verify(s)
 
     assert rep.ok is True
-    assert rep.answers == ["q1: 대표, 발표자, 샘플역할"]
+    assert rep.answers == ["q1: 샘플역할"]
 
 
 def test_verify_answers_query_through_multiple_relation_aliases(tmp_path):

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -11,6 +11,7 @@ evaluation. Non-executable outcomes are tracked in the DB only.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 import re
@@ -25,8 +26,6 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
 )
 from verinote.pipeline.query_intent import (
-    KOREAN_ROLE_RELATION_CANDIDATES,
-    QueryIntent,
     QueryIntentKind,
     deterministic_query_intent,
 )
@@ -41,11 +40,18 @@ from verinote.store import Store
 QUERY_RELPATH = Path("facts") / "query.dl"
 MAX_ALIAS_EXPANDED_RULES_PER_RULE = 64
 _ESCAPE = re.compile(r'(["\\])')
-_GENERIC_ROLE_RELATIONS = ("역할", "직책", "직위", "role", "has_role")
 _STATUS_LINE = re.compile(
     r"^\s*(?P<status>review_required|no_answer|ambiguous)\s*\((?P<reason>.*)\)\s*\.?\s*$",
     re.DOTALL,
 )
+
+
+@dataclass(frozen=True)
+class _QueryFlowResult:
+    status: str
+    query_dl: str | None
+    reason: str
+    allow_direct_datalog_fallback: bool = False
 
 
 def query_path(root: Path) -> Path:
@@ -97,43 +103,6 @@ def query_schema_hint(snapshot: QuerySchemaSnapshot) -> str:
     if snapshot.relations_truncated:
         lines.append("- relation list truncated")
     return "\n".join(lines)
-
-
-def deterministic_query_dl(question: str, qid: int) -> str | None:
-    """Return deterministic query drafts for common shapes LLMs mistranslate."""
-    intent = deterministic_query_intent(question)
-    return deterministic_query_intent_dl(intent, qid)
-
-
-def deterministic_query_intent_dl(intent: QueryIntent, qid: int) -> str | None:
-    """Bridge supported deterministic intents to the legacy query draft shape."""
-    if (
-        intent.kind != QueryIntentKind.LOOKUP_OBJECT
-        or intent.subject is None
-        or intent.relation_candidates != KOREAN_ROLE_RELATION_CANDIDATES
-    ):
-        return None
-    person = intent.subject.value
-
-    person_lit = _lit(person)
-    person_term = f"person({person_lit})"
-    person_term_lit = _lit(f'person("{person}")')
-    excluded = ", ".join(f"R != {_lit(rel)}" for rel in _GENERIC_ROLE_RELATIONS)
-    role_object_rules = "\n".join(
-        f"answer_q{qid}(O) :- relation({person_lit}, {_lit(rel)}, O)."
-        for rel in _GENERIC_ROLE_RELATIONS
-    )
-    return "\n".join(
-        [
-            f".decl answer_q{qid}(value: symbol)",
-            role_object_rules,
-            f"answer_q{qid}(O) :- relation({person_term}, has_role, O).",
-            f"answer_q{qid}(R) :- relation({person_lit}, R, O), {excluded}.",
-            f"answer_q{qid}(R) :- relation(S, R, {person_lit}).",
-            f"answer_q{qid}(R) :- relation(S, R, {person_term}).",
-            f"answer_q{qid}(R) :- relation(S, R, {person_term_lit}).",
-        ]
-    )
 
 
 def classify_query_draft(store: Store, qid: int, query_dl: str) -> tuple[str, str, str]:
@@ -188,6 +157,24 @@ def schema_aware_query_flow(
     llm_error_status: str,
 ) -> tuple[str, str | None, str]:
     """Translate one question through intent extraction, planning, and dry-run evaluation."""
+    result = _schema_aware_query_flow_result(
+        store,
+        client,
+        qid=qid,
+        question=question,
+        llm_error_status=llm_error_status,
+    )
+    return result.status, result.query_dl, result.reason
+
+
+def _schema_aware_query_flow_result(
+    store: Store,
+    client: LLMClient,
+    *,
+    qid: int,
+    question: str,
+    llm_error_status: str,
+) -> _QueryFlowResult:
     from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
 
     snapshot = build_query_schema_snapshot(store)
@@ -201,13 +188,23 @@ def schema_aware_query_flow(
         except LLMError as exc:
             reason = _short_reason(exc)
             if llm_error_status == "translation_failed":
-                return "translation_failed", None, reason
+                return _QueryFlowResult("translation_failed", None, reason)
             reason = _short_reason(f"llm error: {exc}")
-            return "review_required", f"review_required({_lit(reason)})", reason
+            return _QueryFlowResult(
+                "review_required",
+                f"review_required({_lit(reason)})",
+                reason,
+                allow_direct_datalog_fallback=True,
+            )
 
     if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
         reason = _short_reason(intent.reason or "unsupported query intent")
-        return "review_required", f"review_required({_lit(reason)})", reason
+        return _QueryFlowResult(
+            "review_required",
+            f"review_required({_lit(reason)})",
+            reason,
+            allow_direct_datalog_fallback=True,
+        )
 
     exact_entities = _intent_exact_entities(intent)
     if exact_entities:
@@ -216,28 +213,30 @@ def schema_aware_query_flow(
     evaluation = evaluate_query_candidate_plan(store, plan)
 
     if evaluation.outcome == QueryCandidateSetOutcome.VALID and evaluation.selected:
-        return "translated", evaluation.selected.query_dl, ""
+        return _QueryFlowResult("translated", evaluation.selected.query_dl, "")
     if evaluation.outcome == QueryCandidateSetOutcome.NO_ANSWER:
         reason = "no confirmed facts match"
-        return "no_answer", f"no_answer({_lit(reason)})", reason
+        return _QueryFlowResult("no_answer", f"no_answer({_lit(reason)})", reason)
     if evaluation.outcome == QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING:
         reason = "multiple query candidates returned conflicting answers"
-        return "ambiguous", f"ambiguous({_lit(reason)})", reason
+        return _QueryFlowResult("ambiguous", f"ambiguous({_lit(reason)})", reason)
     if evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED:
         reason = _short_reason(_evaluation_reason(evaluation))
-        return "review_required", f"review_required({_lit(reason)})", reason
+        return _QueryFlowResult(
+            "review_required", f"review_required({_lit(reason)})", reason
+        )
     if evaluation.outcome == QueryCandidateSetOutcome.EMPTY:
         reason = _short_reason(plan.reason or "no query candidates matched the schema")
     elif evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR:
         reason = _short_reason("engine/policy error: " + _evaluation_reason(evaluation))
     else:
         reason = _short_reason("invalid query: " + _evaluation_reason(evaluation))
-    return "review_required", f"review_required({_lit(reason)})", reason
+    return _QueryFlowResult("review_required", f"review_required({_lit(reason)})", reason)
 
 
-def _intent_exact_entities(intent: QueryIntent) -> tuple[str, ...]:
+def _intent_exact_entities(intent: object) -> tuple[str, ...]:
     values = []
-    for target in (intent.subject, intent.object):
+    for target in (getattr(intent, "subject", None), getattr(intent, "object", None)):
         if target is not None and target.kind in {"entity", "value", "typed_value"}:
             values.append(target.value)
     return tuple(dict.fromkeys(values))
@@ -306,14 +305,19 @@ def translate_questions(
     """
     results: list[dict] = []
     for q in store.questions(pending_only=True):
-        status, query_dl, reason = schema_aware_query_flow(
+        flow = _schema_aware_query_flow_result(
             store,
             client,
             qid=q["id"],
             question=q["text"],
             llm_error_status="translation_failed",
         )
-        if allow_direct_datalog_fallback and status == "review_required":
+        status, query_dl, reason = flow.status, flow.query_dl, flow.reason
+        if (
+            allow_direct_datalog_fallback
+            and status == "review_required"
+            and flow.allow_direct_datalog_fallback
+        ):
             status, query_dl, reason = _translate_direct_datalog_fallback(
                 store,
                 client,

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 from verinote.llm.base import LLMClient
 from verinote.pipeline.query import (
+    _schema_aware_query_flow_result,
     _translate_direct_datalog_fallback,
-    schema_aware_query_flow,
     write_query_file,
 )
 from verinote.store import Store
@@ -38,14 +38,19 @@ def repair_questions(
         if q["status"] != "review_required":
             continue
         qid = q["id"]
-        status, query_dl, reason = schema_aware_query_flow(
+        flow = _schema_aware_query_flow_result(
             store,
             client,
             qid=qid,
             question=q["text"],
             llm_error_status="review_required",
         )
-        if allow_direct_datalog_fallback and status == "review_required":
+        status, query_dl, reason = flow.status, flow.query_dl, flow.reason
+        if (
+            allow_direct_datalog_fallback
+            and status == "review_required"
+            and flow.allow_direct_datalog_fallback
+        ):
             status, query_dl, reason = _translate_direct_datalog_fallback(
                 store,
                 client,


### PR DESCRIPTION
## Summary
- remove the legacy deterministic role/title Datalog bridge from query translation
- keep deterministic parsing as structured intent that flows through planner/evaluator
- gate optional direct Datalog fallback so planner-supported review/no-answer/ambiguous outcomes do not call `translate_query()`
- apply the same fallback guard to repair
- add repair and translation coverage for relation discovery planner paths and fallback suppression

## Validation
- `uv run pytest tests/test_query.py tests/test_repair.py tests/test_verify.py tests/test_query_planning_e2e.py -q`
- `uv run pytest -q`
- `uv run ruff check verinote/pipeline/query.py verinote/pipeline/repair.py tests/test_query.py tests/test_repair.py tests/test_verify.py`
- `git diff --check`

Closes #135