### PR TITLE
Handle Korean provide questions deterministically

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -343,7 +343,36 @@ def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     rc = cli.main(["query"])
     assert rc == 1
-    assert "no pending questions" in capsys.readouterr().err
+    assert "no pending or failed questions" in capsys.readouterr().err
+
+
+def test_query_retries_translation_failed_questions(
+    tmp_path, monkeypatch, capsys, fake_client, intent_payload
+):
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    qid = store.add_question("What is Sample Subject?")
+    store.set_question_query(qid, None, "translation_failed", "provider returned invalid schema")
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(
+            intent=intent_payload(
+                "lookup_object", subject="Sample Subject", relation="is_a"
+            )
+        ),
+    )
+
+    rc = cli.main(["query"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "q1: translated - Executable query is ready." in out
+    assert "translated 1 question(s)" in out
+    q = Store(tmp_path / "kb.sqlite").questions()[0]
+    assert q["status"] == "translated"
+    assert q["reason"] == ""
 
 
 def test_repair_validates_and_translates(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -91,6 +91,61 @@ def test_korean_role_question_is_parsed_as_structured_intent():
     assert intent.relation_candidates == ("역할", "직책", "직위")
 
 
+def test_translate_korean_provide_question_bypasses_llm(tmp_path):
+    class FailingClient:
+        def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+            raise AssertionError("deterministic provide questions must not call intent LLM")
+
+        def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+            raise AssertionError("deterministic provide questions must not call direct Datalog")
+
+    s = _store(tmp_path)
+    s.add_fact("샘플조직", "제공 요소", "샘플서비스", status="confirmed")
+    qid = s.add_question("샘플조직이 제공하는 것은?")
+
+    results = translate_questions(s, FailingClient(), root=tmp_path)
+
+    assert results == [
+        {
+            "id": qid,
+            "status": "translated",
+            "query_dl": s.questions()[0]["query_dl"],
+            "reason": "",
+        }
+    ]
+    query_dl = s.questions()[0]["query_dl"]
+    assert f'answer_q{qid}(O) :- relation("샘플조직", "제공 요소", O).' in query_dl
+    assert load_query(s) == query_dl + "\n"
+
+
+def test_translate_retries_translation_failed_questions(tmp_path, fake_client, intent_payload):
+    s = _store(tmp_path)
+    s.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    qid = s.add_question("What is Sample Subject?")
+    s.set_question_query(qid, None, "translation_failed", "provider returned invalid schema")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Subject", relation="is_a"
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("schema-aware retry must not call direct Datalog")
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {
+            "id": qid,
+            "status": "translated",
+            "query_dl": s.questions()[0]["query_dl"],
+            "reason": "",
+        }
+    ]
+    assert s.questions()[0]["status"] == "translated"
+    assert "provider returned invalid schema" not in s.questions()[0]["reason"]
+
+
 def test_load_query_expands_relation_aliases(tmp_path):
     s = _store(tmp_path)
     policy = tmp_path / "policy"

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -183,6 +183,7 @@ def test_deterministic_entity_relation_discovery_questions_are_generic():
     )
     direct_hint = deterministic_query_intent("What does Sample Entity provide?")
     korean = deterministic_query_intent("샘플엔티티는 어떤 관계인가?")
+    korean_direct_hint = deterministic_query_intent("샘플엔티티가 제공하는 것은?")
 
     assert english.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
     assert english.subject == IntentTarget("entity", "Sample Entity")
@@ -197,6 +198,17 @@ def test_deterministic_entity_relation_discovery_questions_are_generic():
     assert lower_direct_hint.relation == IntentTarget("relation", "provide")
     assert korean.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
     assert korean.subject == IntentTarget("entity", "샘플엔티티")
+    assert korean_direct_hint.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
+    assert korean_direct_hint.subject == IntentTarget("entity", "샘플엔티티")
+    assert korean_direct_hint.relation_candidates == (
+        "제공",
+        "제공기능",
+        "제공 기능",
+        "제공서비스",
+        "제공 서비스",
+        "제공요소",
+        "제공 요소",
+    )
 
 
 def test_deterministic_entity_relation_discovery_rejects_generic_what_does_shapes():

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -214,9 +214,14 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     store = _store(cfg)
     if args.question:
         store.add_question(args.question)
-    pending = store.questions(pending_only=True)
-    if not pending:
-        print("no pending questions (add one: `verinote query \"...\"`)", file=sys.stderr)
+    translatable = [
+        q for q in store.questions() if q["status"] in {"pending", "translation_failed"}
+    ]
+    if not translatable:
+        print(
+            "no pending or failed questions (add one: `verinote query \"...\"`)",
+            file=sys.stderr,
+        )
         store.close()
         return 1
     try:
@@ -224,7 +229,7 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     except LLMError as e:
         reason = _short_error(e)
         results = []
-        for q in pending:
+        for q in translatable:
             store.set_question_query(q["id"], None, "translation_failed", reason)
             results.append(
                 {"id": q["id"], "status": "translation_failed", "reason": reason}

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -299,12 +299,14 @@ def translate_questions(
     root: Path,
     allow_direct_datalog_fallback: bool = False,
 ) -> list[dict]:
-    """Translate every pending question, persist drafts, rewrite `query.dl`.
+    """Translate pending and previously failed questions, persist drafts, rewrite `query.dl`.
 
     Returns one dict per processed question: {id, status, query_dl, reason}.
     """
     results: list[dict] = []
-    for q in store.questions(pending_only=True):
+    for q in store.questions():
+        if q["status"] not in {"pending", "translation_failed"}:
+            continue
         flow = _schema_aware_query_flow_result(
             store,
             client,

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -205,8 +205,21 @@ _KOREAN_ENTITY_RELATION_DISCOVERY_QUESTION = re.compile(
     r'["“”\']?(?P<entity>[^"“”\'?？\n]{1,80}?)["“”\']?\s*'
     r"(?:는|은|이|가)\s*어떤\s*관계(?:인가|입니까|야)?\s*\??\s*$"
 )
+_KOREAN_ENTITY_DIRECT_RELATION_DISCOVERY_QUESTION = re.compile(
+    r'["“”\']?(?P<entity>[^"“”\'?？\n]{1,80}?)["“”\']?\s*'
+    r"(?:는|은|이|가)\s*(?P<relation>제공)하는\s*것(?:은|이|인가|입니까)?\s*\??\s*$"
+)
 KOREAN_ROLE_RELATION_CANDIDATES = ("역할", "직책", "직위")
 ENGLISH_ROLE_RELATION_CANDIDATES = ("role", "title", "position", "has_role")
+KOREAN_PROVIDE_RELATION_CANDIDATES = (
+    "제공",
+    "제공기능",
+    "제공 기능",
+    "제공서비스",
+    "제공 서비스",
+    "제공요소",
+    "제공 요소",
+)
 _GENERIC_ENTITY_ANCHORS = {
     "anything",
     "it",
@@ -257,6 +270,16 @@ def deterministic_query_intent(question: str) -> QueryIntent:
                 kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
                 subject=IntentTarget("entity", entity),
                 relation=IntentTarget("relation", relation),
+            )
+
+    match = _KOREAN_ENTITY_DIRECT_RELATION_DISCOVERY_QUESTION.match(text)
+    if match:
+        entity = match.group("entity").strip()
+        if entity:
+            return QueryIntent(
+                kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+                subject=IntentTarget("entity", entity),
+                relation_candidates=KOREAN_PROVIDE_RELATION_CANDIDATES,
             )
 
     match = _KOREAN_ENTITY_RELATION_DISCOVERY_QUESTION.match(text)


### PR DESCRIPTION
## Summary
- parse Korean “entity provides what?” questions as deterministic relation-discovery intents
- include Korean provide-related compound relation candidates such as provide feature/service/element forms
- retry previously `translation_failed` questions from the translate flow and CLI so fixed/transient failures can recover

## Validation
- uv run pytest tests/test_query_intent.py tests/test_query.py tests/test_cli.py -q
- uv run ruff check verinote/pipeline/query_intent.py verinote/pipeline/query.py verinote/cli.py tests/test_query_intent.py tests/test_query.py tests/test_cli.py
- uv run pytest -q

## Local check
- verified the reported question now plans as `translated` without requiring LLM intent extraction or direct Datalog fallback