### PR TITLE
Expose provide relation aliases as policy

### DIFF
--- a/tests/test_corroboration.py
+++ b/tests/test_corroboration.py
@@ -9,6 +9,7 @@ from verinote.pipeline.corroboration import (
     relation_aliases,
     single_valued_conflicts,
     store_corroboration,
+    store_relation_aliases,
     store_single_valued_conflicts,
     typed_relations,
 )
@@ -32,6 +33,26 @@ functional("quoted \" relation").
         "established_on",
         'quoted " relation',
     }
+
+
+def test_store_relation_aliases_include_default_policy(tmp_path):
+    s = _store(tmp_path)
+
+    aliases = store_relation_aliases(s)
+
+    assert aliases["제공 요소"] == "제공"
+
+
+def test_store_relation_aliases_merge_user_policy_with_defaults(tmp_path):
+    s = _store(tmp_path)
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
+
+    aliases = store_relation_aliases(s)
+
+    assert aliases["role"] == "역할"
+    assert aliases["제공 요소"] == "제공"
 
 
 def test_corroboration_counts_distinct_engine_sources_only():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -115,7 +115,9 @@ def test_translate_korean_provide_question_bypasses_llm(tmp_path):
     ]
     query_dl = s.questions()[0]["query_dl"]
     assert f'answer_q{qid}(O) :- relation("샘플조직", "제공 요소", O).' in query_dl
-    assert load_query(s) == query_dl + "\n"
+    loaded_query = load_query(s)
+    assert f'answer_q{qid}(O) :- relation("샘플조직", "제공 요소", O).' in loaded_query
+    assert f'answer_q{qid}(O) :- relation("샘플조직", "제공", O).' in loaded_query
 
 
 def test_translate_retries_translation_failed_questions(tmp_path, fake_client, intent_payload):
@@ -149,7 +151,7 @@ def test_translate_retries_translation_failed_questions(tmp_path, fake_client, i
 def test_load_query_expands_relation_aliases(tmp_path):
     s = _store(tmp_path)
     policy = tmp_path / "policy"
-    policy.mkdir()
+    policy.mkdir(exist_ok=True)
     (policy / "relation-aliases.md").write_text("- `role` -> `역할`\n", encoding="utf-8")
     qid = s.add_question("Find the sample person's role")
     s.set_question_query(

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -200,15 +200,8 @@ def test_deterministic_entity_relation_discovery_questions_are_generic():
     assert korean.subject == IntentTarget("entity", "샘플엔티티")
     assert korean_direct_hint.kind == QueryIntentKind.DISCOVER_ENTITY_RELATIONS
     assert korean_direct_hint.subject == IntentTarget("entity", "샘플엔티티")
-    assert korean_direct_hint.relation_candidates == (
-        "제공",
-        "제공기능",
-        "제공 기능",
-        "제공서비스",
-        "제공 서비스",
-        "제공요소",
-        "제공 요소",
-    )
+    assert korean_direct_hint.relation == IntentTarget("relation", "제공")
+    assert korean_direct_hint.relation_candidates == ()
 
 
 def test_deterministic_entity_relation_discovery_rejects_generic_what_does_shapes():

--- a/tests/test_query_schema.py
+++ b/tests/test_query_schema.py
@@ -91,10 +91,9 @@ def test_aliases_preserve_observed_nfd_relation_and_attach_canonical_metadata(tm
         "published_year",
         "published_year",
     ]
-    assert [(a.alias, a.canonical) for a in snapshot.relation_aliases] == [
-        ("게재연도", "published_year"),
-        ("발행년도", "published_year"),
-    ]
+    snapshot_aliases = [(a.alias, a.canonical) for a in snapshot.relation_aliases]
+    assert ("게재연도", "published_year") in snapshot_aliases
+    assert ("발행년도", "published_year") in snapshot_aliases
     assert [
         [(alias.alias, alias.canonical) for alias in relation.aliases]
         for relation in snapshot.relations

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1891,6 +1891,9 @@ def test_settings_page_renders(tmp_path):
 def test_settings_saves_relation_aliases(tmp_path):
     c = _client(tmp_path)
 
+    initial_body = c.get("/settings").text
+    assert "- `제공 요소` -&gt; `제공`" in initial_body
+
     r = c.post(
         "/settings/relation-aliases",
         data={"relation_aliases_text": "- `role` -> `역할`"},
@@ -1902,6 +1905,7 @@ def test_settings_saves_relation_aliases(tmp_path):
     assert alias_path.read_text(encoding="utf-8") == "- `role` -> `역할`\n"
     body = c.get("/settings").text
     assert "- `role` -&gt; `역할`" in body
+    assert "- `제공 요소` -&gt; `제공`" in body
 
 
 def test_settings_saves_plain_relation_aliases(tmp_path):

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -17,6 +17,11 @@ import unicodedata
 from typing import Any, Iterable, Mapping
 
 from verinote.engine import DEFAULT_POLICY
+from verinote.policy_defaults import (
+    DEFAULT_RELATION_ALIASES,
+    RELATION_ALIASES_RELPATH,
+    TYPED_RELATIONS_RELPATH,
+)
 from verinote.store import ENGINE_STATUSES, Store
 
 _FUNCTIONAL_RE = re.compile(r'functional\("((?:\\.|[^"\\])*)"\)\.')
@@ -55,9 +60,6 @@ _DEFAULT_AMOUNT_UNITS = {
     "억": 10**8,
     "조": 10**12,
 }
-RELATION_ALIASES_RELPATH = "policy/relation-aliases.md"
-TYPED_RELATIONS_RELPATH = "policy/typed-relations.md"
-
 
 class CorroborationPolicyError(ValueError):
     """Raised when optional corroboration policy files are malformed."""
@@ -174,10 +176,12 @@ def _relation_alias_token(text: str, *, line_no: int) -> str:
 
 
 def store_relation_aliases(store: Store) -> dict[str, str]:
+    aliases = relation_aliases(DEFAULT_RELATION_ALIASES)
     path = store.db_path.parent / RELATION_ALIASES_RELPATH
     if not path.is_file():
-        return {}
-    return relation_aliases(path.read_text(encoding="utf-8"))
+        return aliases
+    aliases.update(relation_aliases(path.read_text(encoding="utf-8")))
+    return aliases
 
 
 def typed_relations(text: str) -> dict[str, TypedRelationSpec]:

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -211,15 +211,6 @@ _KOREAN_ENTITY_DIRECT_RELATION_DISCOVERY_QUESTION = re.compile(
 )
 KOREAN_ROLE_RELATION_CANDIDATES = ("역할", "직책", "직위")
 ENGLISH_ROLE_RELATION_CANDIDATES = ("role", "title", "position", "has_role")
-KOREAN_PROVIDE_RELATION_CANDIDATES = (
-    "제공",
-    "제공기능",
-    "제공 기능",
-    "제공서비스",
-    "제공 서비스",
-    "제공요소",
-    "제공 요소",
-)
 _GENERIC_ENTITY_ANCHORS = {
     "anything",
     "it",
@@ -279,7 +270,7 @@ def deterministic_query_intent(question: str) -> QueryIntent:
             return QueryIntent(
                 kind=QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
                 subject=IntentTarget("entity", entity),
-                relation_candidates=KOREAN_PROVIDE_RELATION_CANDIDATES,
+                relation=IntentTarget("relation", "제공"),
             )
 
     match = _KOREAN_ENTITY_RELATION_DISCOVERY_QUESTION.match(text)

--- a/verinote/policy_defaults.py
+++ b/verinote/policy_defaults.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Default user-visible policy files for new knowledge bases."""
+
+RELATION_ALIASES_RELPATH = "policy/relation-aliases.md"
+TYPED_RELATIONS_RELPATH = "policy/typed-relations.md"
+
+DEFAULT_RELATION_ALIASES = """# Relation aliases map alternate labels to the canonical relation label.
+# Format: - `raw relation` -> `canonical relation`
+#
+# These defaults keep common Korean provide-related labels configurable instead
+# of hard-coding them into query intent parsing.
+- `제공기능` -> `제공`
+- `제공 기능` -> `제공`
+- `제공서비스` -> `제공`
+- `제공 서비스` -> `제공`
+- `제공요소` -> `제공`
+- `제공 요소` -> `제공`
+"""

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -28,6 +28,7 @@ from verinote.config import (
     save_settings,
 )
 from verinote.llm import LLMError, get_client
+from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
     create_chunked_extraction_job,
     fact_trust_summary,
@@ -115,8 +116,25 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _relation_aliases_text() -> str:
         path = _relation_aliases_path()
         if not path.is_file():
-            return ""
-        return path.read_text(encoding="utf-8")
+            return DEFAULT_RELATION_ALIASES
+        text = path.read_text(encoding="utf-8")
+        defaults = relation_aliases(DEFAULT_RELATION_ALIASES)
+        try:
+            existing = relation_aliases(text)
+        except CorroborationPolicyError:
+            return text
+        missing_defaults = {
+            alias: canonical
+            for alias, canonical in defaults.items()
+            if alias not in existing
+        }
+        if not missing_defaults:
+            return text
+        missing_text = "\n".join(
+            f"- `{alias}` -> `{canonical}`"
+            for alias, canonical in sorted(missing_defaults.items())
+        )
+        return f"{text.rstrip()}\n\n# Default aliases not yet saved in this KB\n{missing_text}\n"
 
     def _open_root(root: Path) -> None:
         """Point this running app at a KB root, creating it if needed."""


### PR DESCRIPTION
## Summary
- move Korean provide compound labels out of query intent hardcoding and into relation alias defaults
- merge default relation aliases through the existing relation alias policy loader
- show missing default aliases in Settings so users can review and save them in `policy/relation-aliases.md`

## Validation
- uv run pytest tests/test_query_intent.py tests/test_query.py tests/test_cli.py tests/test_corroboration.py tests/test_web.py -q
- uv run ruff check verinote/policy_defaults.py verinote/pipeline/corroboration.py verinote/pipeline/query_intent.py verinote/web/app.py tests/test_corroboration.py tests/test_query.py tests/test_query_intent.py tests/test_query_schema.py tests/test_web.py
- uv run pytest -q

## Local check
- verified Settings exposes the default provide aliases alongside the existing KB alias file
- verified the reported Korean provide question plans as `translated` via relation aliases