### PR TITLE
[codex] Add read-only Ask tab

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,12 +12,21 @@ class FakeClient:
 
     name = "fake"
 
-    def __init__(self, facts=(), *, error: LLMError | None = None, query=None, intent=None):
+    def __init__(
+        self,
+        facts=(),
+        *,
+        error: LLMError | None = None,
+        query=None,
+        intent=None,
+        answer: str = "Synthetic fallback answer",
+    ):
         self._facts = list(facts)
         self._error = error
         # query: callable(question, qid) -> Datalog line; default answers an is_a.
         self._query = query
         self._intent = intent
+        self._answer = answer
         self.calls = 0
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
@@ -52,6 +61,12 @@ class FakeClient:
                 "reason": "not configured",
             }
         return parse_query_intent(raw)
+
+    def answer_question(self, *, question: str, context: str) -> str:
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        return self._answer
 
 
 @pytest.fixture

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: MPL-2.0
+
+from verinote.llm.base import LLMError
+from verinote.pipeline.ask import ask_question, search_source_excerpts
+from verinote.pipeline.query import query_path
+from verinote.store import Store
+
+
+class DeterministicOnlyClient:
+    name = "deterministic-only"
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        raise AssertionError("deterministic Ask path must not call intent LLM")
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        raise AssertionError("Ask must not call persistent direct Datalog translation")
+
+    def answer_question(self, *, question: str, context: str) -> str:
+        raise AssertionError("verified engine Ask path must not call fallback LLM")
+
+
+class FallbackClient:
+    name = "fallback"
+
+    def __init__(self, *, answer: str = "UNVERIFIED synthetic answer", error=None):
+        self.answer = answer
+        self.error = error
+        self.context = ""
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        from verinote.pipeline.query_intent import parse_query_intent
+
+        return parse_query_intent(
+            {
+                "kind": "unknown_or_unsupported",
+                "subject": None,
+                "relation": None,
+                "object": None,
+                "relation_candidates": None,
+                "operator": None,
+                "value_type": None,
+                "value": None,
+                "reason": "unsupported synthetic question",
+            }
+        )
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        raise AssertionError("Ask fallback must not persist direct Datalog")
+
+    def answer_question(self, *, question: str, context: str) -> str:
+        self.context = context
+        if self.error is not None:
+            raise self.error
+        return self.answer
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def test_ask_returns_verified_engine_answer_without_persisting(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("샘플인물", "역할", "검토자", status="confirmed")
+
+    result = ask_question(
+        store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
+    )
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "검토자" in result.answer
+    assert store.questions() == []
+    assert not query_path(tmp_path).exists()
+
+
+def test_ask_verified_negative_does_not_fallback_to_candidates(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("샘플인물", "is_a", "person", status="confirmed")
+    store.add_fact("다른샘플인물", "역할", "검토자", status="confirmed")
+    store.add_fact("샘플인물", "역할", "후보역할", status="candidate")
+
+    result = ask_question(
+        store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
+    )
+
+    assert result.route == "engine"
+    assert result.status == "no_answer"
+    assert result.answer == "No confirmed facts match."
+    assert "후보역할" not in result.answer
+
+
+def test_ask_fallback_uses_source_excerpts_and_grounding(tmp_path):
+    source = tmp_path / "sources" / "sample.txt"
+    source.parent.mkdir()
+    source.write_text("샘플조직은 샘플서비스를 제공한다.", encoding="utf-8")
+    store = _store(tmp_path)
+    sid = store.add_source("sources/sample.txt")
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed", source_id=sid)
+    client = FallbackClient(answer="샘플조직은 샘플서비스를 제공한다고 볼 수 있습니다.")
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직 설명해줘")
+
+    assert result.route == "fallback"
+    assert result.label == "UNVERIFIED — source exploration"
+    assert "샘플서비스" in result.answer
+    assert "sources/sample.txt" in client.context
+    assert "샘플조직 | is_a | 조직" in client.context
+    assert result.excerpts
+
+
+def test_ask_fallback_survives_llm_answer_error(tmp_path):
+    store = _store(tmp_path)
+    client = FallbackClient(error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert result.route == "fallback"
+    assert result.warning == "synthetic outage"
+    assert "deterministic engine could not answer" in result.answer
+
+
+def test_search_source_excerpts_reads_latest_text_artifact(tmp_path):
+    store = _store(tmp_path)
+    sid = store.add_source("sources/sample.pdf", kind="binary")
+    artifact_path = tmp_path / "artifacts" / "sources" / str(sid) / "text.txt"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("샘플문서는 샘플항목을 포함한다.", encoding="utf-8")
+    store.add_source_artifact(
+        source_id=sid,
+        kind="extracted_text",
+        path=f"artifacts/sources/{sid}/text.txt",
+        checksum="sha",
+    )
+
+    excerpts = search_source_excerpts(store, root=tmp_path, question="샘플항목")
+
+    assert [item.path for item in excerpts] == [f"artifacts/sources/{sid}/text.txt"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1559,6 +1559,88 @@ def test_add_question_persists(tmp_path):
     assert [q["text"] for q in c.app.state.store.questions()] == ["Where was Ada born?"]
 
 
+def test_ask_page_renders_and_is_linked(tmp_path):
+    c = _client(tmp_path)
+
+    home = c.get("/")
+    page = c.get("/ask")
+
+    assert home.status_code == 200
+    assert 'href="/ask"' in home.text
+    assert page.status_code == 200
+    assert "<h1>Ask</h1>" in page.text
+
+
+def test_ask_post_renders_verified_engine_answer_without_persisting(
+    tmp_path, monkeypatch
+):
+    class DeterministicOnly:
+        name = "deterministic-only"
+
+        def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+            raise AssertionError("deterministic question must bypass LLM")
+
+        def translate_query(self, *, question: str, qid: int, schema_hint: str = ""):
+            raise AssertionError("Ask must not call direct Datalog fallback")
+
+        def answer_question(self, *, question: str, context: str):
+            raise AssertionError("verified engine answer must not call fallback")
+
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: DeterministicOnly())
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact("샘플인물", "역할", "검토자", status="confirmed")
+
+    r = c.post("/ask", data={"question": "샘플인물의 역할은 무엇인가?"})
+
+    assert r.status_code == 200
+    assert "VERIFIED — engine" in r.text
+    assert "검토자" in r.text
+    assert store.questions() == []
+    assert not query_path(tmp_path).exists()
+
+
+def test_ask_post_renders_unverified_llm_fallback(tmp_path, monkeypatch):
+    class Fallback:
+        name = "fallback"
+
+        def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+            return parse_query_intent(
+                {
+                    "kind": "unknown_or_unsupported",
+                    "subject": None,
+                    "relation": None,
+                    "object": None,
+                    "relation_candidates": None,
+                    "operator": None,
+                    "value_type": None,
+                    "value": None,
+                    "reason": "unsupported synthetic question",
+                }
+            )
+
+        def translate_query(self, *, question: str, qid: int, schema_hint: str = ""):
+            raise AssertionError("Ask fallback must not call direct Datalog")
+
+        def answer_question(self, *, question: str, context: str):
+            assert "sources/sample.txt" in context
+            return "Synthetic answer from excerpts."
+
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: Fallback())
+    c = _client(tmp_path)
+    source = tmp_path / "sources" / "sample.txt"
+    source.parent.mkdir()
+    source.write_text("Sample Entity provides Sample Service.", encoding="utf-8")
+    c.app.state.store.add_source("sources/sample.txt")
+
+    r = c.post("/ask", data={"question": "Sample Entity overview"})
+
+    assert r.status_code == 200
+    assert "UNVERIFIED — source exploration" in r.text
+    assert "Synthetic answer from excerpts." in r.text
+    assert "sources/sample.txt" in r.text
+
+
 def test_delete_question_removes_query_file_entry(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -116,6 +116,35 @@ class AnthropicAdapter:
                 return parse_query_intent(block.input)
         raise LLMError("anthropic response contained no tool_use block")
 
+    def answer_question(self, *, question: str, context: str) -> str:
+        try:
+            import anthropic
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
+
+        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        try:
+            msg = client.messages.create(
+                model=self.cfg.model,
+                max_tokens=1200,
+                system=_render_prompt(self.cfg.root, "ask-fallback"),
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"Question:\n{question}\n\nContext:\n{context}",
+                    }
+                ],
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise provider errors
+            raise LLMError(f"anthropic request failed: {exc}") from exc
+
+        parts = [
+            str(getattr(block, "text", "")).strip()
+            for block in msg.content
+            if getattr(block, "type", None) == "text"
+        ]
+        return "\n".join(part for part in parts if part).strip()
+
 
 def _with_schema_hint(prompt: str, schema_hint: str) -> str:
     return prompt + ("\n" + schema_hint if schema_hint else "")

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -74,3 +74,12 @@ class LLMClient(Protocol):
         Adapters raise `LLMError` for malformed or schema-invalid intent output.
         """
         ...
+
+    def answer_question(self, *, question: str, context: str) -> str:
+        """Answer a free-form question from caller-provided context only.
+
+        This is used by the read-only Ask workflow after deterministic engine
+        routing cannot produce an executable answer. Adapters return plain text
+        and raise `LLMError` for provider failures.
+        """
+        ...

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -69,6 +69,13 @@ class ClaudeCliAdapter:
         )
         return parse_query_intent(self._run(prompt, schema=QUERY_INTENT_SCHEMA))
 
+    def answer_question(self, *, question: str, context: str) -> str:
+        prompt = _Prompt(
+            system=_render_prompt(self.cfg.root, "ask-fallback"),
+            user=f"Question:\n{question}\n\nContext:\n{context}",
+        )
+        return self._run_text(prompt)
+
     def _run(self, prompt: "_Prompt", *, schema: dict[str, Any]) -> str:
         schema_json = json.dumps(schema, ensure_ascii=False)
         cmd = [
@@ -79,6 +86,41 @@ class ClaudeCliAdapter:
             prompt.system,
             "--json-schema",
             schema_json,
+            "-p",
+            prompt.user,
+        ]
+        model = _cli_model(self.cfg.model)
+        if model:
+            cmd = ["claude", "--model", model, *cmd[1:]]
+        try:
+            with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    check=False,
+                    cwd=tmpdir,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                    timeout=180,
+                )
+        except FileNotFoundError as exc:
+            raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise LLMError("claude CLI request timed out") from exc
+        except OSError as exc:
+            raise LLMError(f"claude CLI request failed: {exc}") from exc
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()
+            raise LLMError(f"claude CLI exited with {proc.returncode}: {detail}")
+        return proc.stdout.strip()
+
+    def _run_text(self, prompt: "_Prompt") -> str:
+        cmd = [
+            "claude",
+            "--safe-mode",
+            "--no-session-persistence",
+            "--system-prompt",
+            prompt.system,
             "-p",
             prompt.user,
         ]

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -150,6 +150,34 @@ class OllamaAdapter:
 
         return parse_query_intent(body.get("message", {}).get("content", ""))
 
+    def answer_question(self, *, question: str, context: str) -> str:
+        payload = {
+            "model": self.cfg.model,
+            "stream": False,
+            "think": False,
+            "options": {"temperature": 0, "num_predict": 1200},
+            "messages": [
+                {"role": "system", "content": _render_prompt(self.cfg.root, "ask-fallback")},
+                {
+                    "role": "user",
+                    "content": f"Question:\n{question}\n\nContext:\n{context}",
+                },
+            ],
+        }
+        req = urllib.request.Request(
+            f"{self.base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+                req, timeout=self.cfg.llm_timeout_seconds
+            ) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+            raise LLMError(f"ollama request failed: {exc}") from exc
+        return str(body.get("message", {}).get("content", "")).strip()
+
 
 def _with_schema_hint(prompt: str, schema_hint: str) -> str:
     return prompt + ("\n" + schema_hint if schema_hint else "")

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -118,6 +118,33 @@ class OpenAIAdapter:
 
         return parse_query_intent(resp.choices[0].message.content or "")
 
+    def answer_question(self, *, question: str, context: str) -> str:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
+
+        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        try:
+            resp = client.chat.completions.create(
+                model=self.cfg.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": _render_prompt(self.cfg.root, "ask-fallback"),
+                    },
+                    {
+                        "role": "user",
+                        "content": f"Question:\n{question}\n\nContext:\n{context}",
+                    },
+                ],
+                temperature=0,
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise provider errors
+            raise LLMError(f"openai request failed: {exc}") from exc
+
+        return (resp.choices[0].message.content or "").strip()
+
 
 def _with_schema_hint(prompt: str, schema_hint: str) -> str:
     return prompt + ("\n" + schema_hint if schema_hint else "")

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Read-only factlog-style Ask routing for free-form questions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import unicodedata
+
+from verinote.engine import CheckReport
+from verinote.engine.duckdb_backend import run_check_duckdb
+from verinote.llm.base import LLMClient, LLMError
+from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
+from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_query_flow
+from verinote.pipeline.query_candidate_eval import RELATION_DECL
+from verinote.pipeline.query_intent import QueryIntentKind, deterministic_query_intent
+from verinote.store import ENGINE_STATUSES, Store
+
+ASK_QID = 0
+MAX_CONTEXT_CHARS = 12000
+MAX_EXCERPTS = 8
+MAX_GROUNDING_FACTS = 8
+_TOKEN = re.compile(r"[A-Za-z0-9_]{2,}|[가-힣一-龥ぁ-んァ-ン]{1,}")
+
+
+@dataclass(frozen=True)
+class AskExcerpt:
+    path: str
+    excerpt: str
+    score: int
+
+
+@dataclass(frozen=True)
+class AskGroundingFact:
+    subject: str
+    relation: str
+    object: str
+    source: str
+
+
+@dataclass(frozen=True)
+class AskResult:
+    route: str
+    label: str
+    question: str
+    status: str
+    answer: str
+    query_dl: str | None
+    engine_answers: tuple[str, ...]
+    reason: str
+    excerpts: tuple[AskExcerpt, ...] = ()
+    grounding_facts: tuple[AskGroundingFact, ...] = ()
+    warning: str | None = None
+
+
+def ask_question(
+    store: Store,
+    client: LLMClient,
+    *,
+    root: Path,
+    question: str,
+) -> AskResult:
+    """Answer one question without persisting query state or mutating questions."""
+    question = " ".join(question.split())
+    if not question:
+        return AskResult(
+            route="fallback",
+            label="UNVERIFIED — source exploration",
+            question=question,
+            status="empty",
+            answer="Question is required.",
+            query_dl=None,
+            engine_answers=(),
+            reason="empty question",
+        )
+
+    status, query_dl, reason = schema_aware_query_flow(
+        store,
+        client,
+        qid=ASK_QID,
+        question=question,
+        llm_error_status="review_required",
+    )
+    if status == "translated" and query_dl:
+        report = _run_engine_query(store, query_dl)
+        if report.engine_available and report.ok and not report.errors:
+            answers = tuple(dict.fromkeys(report.answers))
+            if answers:
+                return AskResult(
+                    route="engine",
+                    label="VERIFIED — engine",
+                    question=question,
+                    status=status,
+                    answer="\n".join(answers),
+                    query_dl=query_dl,
+                    engine_answers=answers,
+                    reason="deterministic query matched confirmed/accepted facts",
+                )
+            return AskResult(
+                route="engine",
+                label="VERIFIED — engine (negative)",
+                question=question,
+                status="no_answer",
+                answer="No confirmed facts match.",
+                query_dl=query_dl,
+                engine_answers=(),
+                reason="no confirmed facts match",
+            )
+        reason = _short_reason("; ".join(report.findings) or report.text)
+        return _fallback_answer(store, client, root=root, question=question, reason=reason)
+
+    if status == "no_answer":
+        return AskResult(
+            route="engine",
+            label="VERIFIED — engine (negative)",
+            question=question,
+            status=status,
+            answer="No confirmed facts match.",
+            query_dl=query_dl,
+            engine_answers=(),
+            reason=reason or "no confirmed facts match",
+        )
+
+    if status == "review_required" and _known_scope_without_candidate(store, question):
+        return AskResult(
+            route="engine",
+            label="VERIFIED — engine (negative)",
+            question=question,
+            status="no_answer",
+            answer="No confirmed facts match.",
+            query_dl='no_answer("no confirmed facts match")',
+            engine_answers=(),
+            reason="no confirmed facts match",
+        )
+
+    return _fallback_answer(
+        store,
+        client,
+        root=root,
+        question=question,
+        reason=reason or f"deterministic query status: {status}",
+    )
+
+
+def _run_engine_query(store: Store, query_dl: str) -> CheckReport:
+    try:
+        expanded = expand_query_relation_aliases(query_dl, store_relation_aliases(store))
+        return run_check_duckdb(
+            store.engine_fact_terms(),
+            policy_dl=RELATION_DECL,
+            query_dl=expanded,
+        )
+    except CorroborationPolicyError as exc:
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"policy error: {exc}",
+            findings=[f"ERROR policy error: {exc}"],
+        )
+    except Exception as exc:  # noqa: BLE001 - keep Ask from failing closed
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"ask engine error: {exc}",
+            findings=[f"ERROR engine error: {exc}"],
+        )
+
+
+def _fallback_answer(
+    store: Store,
+    client: LLMClient,
+    *,
+    root: Path,
+    question: str,
+    reason: str,
+) -> AskResult:
+    excerpts = tuple(search_source_excerpts(store, root=root, question=question))
+    grounding = tuple(grounding_facts(store, question=question))
+    context = _fallback_context(excerpts, grounding)
+    warning = None
+    try:
+        answer = client.answer_question(question=question, context=context)
+    except LLMError as exc:
+        warning = _short_reason(exc)
+        answer = "The deterministic engine could not answer. Source excerpts are shown below."
+    if not answer:
+        answer = "The deterministic engine could not answer. Source excerpts are shown below."
+    return AskResult(
+        route="fallback",
+        label="UNVERIFIED — source exploration",
+        question=question,
+        status="fallback",
+        answer=answer,
+        query_dl=None,
+        engine_answers=(),
+        reason=reason,
+        excerpts=excerpts,
+        grounding_facts=grounding,
+        warning=warning,
+    )
+
+
+def search_source_excerpts(
+    store: Store,
+    *,
+    root: Path,
+    question: str,
+    limit: int = MAX_EXCERPTS,
+) -> list[AskExcerpt]:
+    patterns = _question_patterns(question)
+    if not patterns:
+        return []
+    matches: list[AskExcerpt] = []
+    seen_paths: set[Path] = set()
+    for label, path in _source_text_paths(store, root):
+        resolved = path.expanduser().resolve()
+        if resolved in seen_paths or not resolved.is_file():
+            continue
+        seen_paths.add(resolved)
+        try:
+            text = resolved.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        except OSError:
+            continue
+        excerpt, score = _best_excerpt(text, patterns)
+        if score:
+            matches.append(AskExcerpt(path=label, excerpt=excerpt, score=score))
+    return sorted(matches, key=lambda item: (-item.score, item.path))[:limit]
+
+
+def grounding_facts(
+    store: Store,
+    *,
+    question: str,
+    limit: int = MAX_GROUNDING_FACTS,
+) -> list[AskGroundingFact]:
+    normalized_question = _fold(question)
+    rows: list[AskGroundingFact] = []
+    for fact in store.facts(statuses=ENGINE_STATUSES):
+        subject = str(fact["subject"])
+        relation = str(fact["relation"])
+        obj = str(fact["object"])
+        if _fold(subject) not in normalized_question and _fold(obj) not in normalized_question:
+            continue
+        rows.append(
+            AskGroundingFact(
+                subject=subject,
+                relation=relation,
+                object=obj,
+                source=str(fact["source_path"] or ""),
+            )
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _known_scope_without_candidate(store: Store, question: str) -> bool:
+    """Classify deterministic known-entity misses as verified negative answers."""
+    intent = deterministic_query_intent(question)
+    if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED or intent.subject is None:
+        return False
+    subject = _fold(intent.subject.value)
+    if not subject:
+        return False
+    return any(
+        _fold(str(fact["subject"])) == subject or _fold(str(fact["object"])) == subject
+        for fact in store.facts(statuses=ENGINE_STATUSES)
+    )
+
+
+def _source_text_paths(store: Store, root: Path) -> list[tuple[str, Path]]:
+    paths: list[tuple[str, Path]] = []
+    for row in store.source_text_inputs():
+        artifact = str(row["artifact_path"])
+        paths.append((artifact, root / artifact))
+    for row in store.sources():
+        source = str(row["path"])
+        path = Path(source)
+        paths.append((source, path if path.is_absolute() else root / path))
+    return paths
+
+
+def _question_patterns(question: str) -> tuple[str, ...]:
+    tokens = [_fold(match.group(0)) for match in _TOKEN.finditer(question)]
+    return tuple(dict.fromkeys(token for token in tokens if token))
+
+
+def _best_excerpt(text: str, patterns: tuple[str, ...]) -> tuple[str, int]:
+    folded = _fold(text)
+    best_pos = -1
+    best_score = 0
+    for pattern in patterns:
+        pos = folded.find(pattern)
+        if pos < 0:
+            continue
+        score = sum(1 for item in patterns if item in folded[max(0, pos - 300) : pos + 300])
+        if score > best_score:
+            best_score = score
+            best_pos = pos
+    if best_pos < 0:
+        return "", 0
+    start = max(0, best_pos - 240)
+    end = min(len(text), best_pos + 420)
+    excerpt = " ".join(text[start:end].split())
+    if start:
+        excerpt = "..." + excerpt
+    if end < len(text):
+        excerpt += "..."
+    return excerpt, best_score
+
+
+def _fallback_context(
+    excerpts: tuple[AskExcerpt, ...],
+    grounding: tuple[AskGroundingFact, ...],
+) -> str:
+    parts: list[str] = []
+    if grounding:
+        parts.append("Verified grounding facts:")
+        for fact in grounding:
+            source = f" ({fact.source})" if fact.source else ""
+            parts.append(f"- {fact.subject} | {fact.relation} | {fact.object}{source}")
+    if excerpts:
+        parts.append("Source excerpts:")
+        for excerpt in excerpts:
+            parts.append(f"- Source: {excerpt.path}\n  Excerpt: {excerpt.excerpt}")
+    if not parts:
+        return "No source excerpts or verified grounding facts matched the question."
+    context = "\n".join(parts)
+    return context[:MAX_CONTEXT_CHARS]
+
+
+def _fold(value: str) -> str:
+    return unicodedata.normalize("NFC", value).casefold()
+
+
+def _short_reason(value: object) -> str:
+    return " ".join(str(value).split())[:240]

--- a/verinote/prompts/defaults/ask-fallback.md
+++ b/verinote/prompts/defaults/ask-fallback.md
@@ -1,0 +1,12 @@
+You answer free-form questions for the Verinote Ask tab after the deterministic
+engine cannot produce an answer.
+
+Use only the provided context. The context may include verified grounding facts
+and source excerpts. Do not use outside knowledge. Do not invent facts, names,
+roles, dates, amounts, or relationships that are not present in the context.
+
+If the context is insufficient, say that the deterministic engine could not
+answer and the available excerpts are insufficient.
+
+Keep the answer concise. Mention the source path when it directly supports a
+sentence. Do not present this answer as a verified engine fact.

--- a/verinote/prompts/library.py
+++ b/verinote/prompts/library.py
@@ -14,6 +14,7 @@ PromptId = Literal[
     "query-translation",
     "query-intent",
     "focused-role-extraction",
+    "ask-fallback",
     "extraction-limit-hint",
     "claude-json-wrapper",
 ]
@@ -69,6 +70,7 @@ _DEFINITIONS: tuple[PromptDefinition, ...] = (
         "Focused role extraction",
         "focused-role-extraction.md",
     ),
+    PromptDefinition("ask-fallback", "Ask fallback answer", "ask-fallback.md"),
     PromptDefinition(
         "extraction-limit-hint",
         "Extraction limit hint",

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -43,6 +43,7 @@ from verinote.pipeline import (
     write_query_file,
 )
 from verinote.pipeline.question_outcome import question_outcome_view
+from verinote.pipeline.ask import ask_question
 from verinote.pipeline.acceptance import (
     accept_recommendations,
     accept_recommendations_for,
@@ -936,6 +937,38 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.get("/questions", response_class=HTMLResponse)
     def questions_page(request: Request):
         return _questions(request)
+
+    def _ask(
+        request: Request,
+        *,
+        question: str = "",
+        result=None,
+        error: str | None = None,
+        status_code: int = 200,
+    ):
+        if app.state.store is None:
+            return _kb_select(request, error=error, status_code=status_code)
+        return templates.TemplateResponse(
+            request,
+            "ask.html",
+            {"question": question, "result": result, "error": error},
+            status_code=status_code,
+        )
+
+    @app.get("/ask", response_class=HTMLResponse)
+    def ask_page(request: Request):
+        return _ask(request)
+
+    @app.post("/ask", response_class=HTMLResponse)
+    def ask_submit(request: Request, question: str = Form(...)):
+        store = _active_store()
+        cfg = _active_cfg()
+        try:
+            client = get_client(app.state.cfg)
+        except LLMError as e:
+            return _ask(request, question=question, error=f"ask failed: {e}", status_code=502)
+        result = ask_question(store, client, root=cfg.root, question=question)
+        return _ask(request, question=question, result=result)
 
     @app.post("/questions", response_class=HTMLResponse)
     def add_question(request: Request, text: str = Form(...)):

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -100,6 +100,14 @@ tr.editing td { background: rgba(91, 157, 255, .06); }
 .settings .inline-setting { flex-direction: row; align-items: center; color: var(--fg); }
 .settings .inline-setting input { width: auto; }
 .settings .btn { align-self: flex-start; }
+.ask-form { display: flex; flex-direction: column; gap: .7rem; margin: 1.2rem 0; }
+.ask-form label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); }
+.ask-form textarea { min-height: 7rem; resize: vertical; background: var(--bg); color: var(--fg);
+  border: 1px solid var(--line); border-radius: 6px; padding: .55rem .65rem; }
+.ask-form .btn { align-self: flex-start; }
+.ask-result { margin-top: 1.4rem; }
+.answer-box pre { margin: .6rem 0 1rem; white-space: pre-wrap; overflow: auto;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: .85rem; }
 .prompt-selector { display: flex; align-items: end; gap: .7rem; margin: 1rem 0; }
 .prompt-selector label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); }
 .prompt-selector select { background: var(--bg); color: var(--fg);

--- a/verinote/web/templates/ask.html
+++ b/verinote/web/templates/ask.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% block title %}Ask · verinote{% endblock %}
+{% block content %}
+<h1>Ask</h1>
+<form class="ask-form" method="post" action="/ask">
+  <label>
+    Question
+    <textarea name="question" required>{{ question or "" }}</textarea>
+  </label>
+  <button class="btn" type="submit">Ask</button>
+</form>
+
+{% if error %}
+<div class="error">{{ error }}</div>
+{% endif %}
+
+{% if result %}
+<section class="ask-result ask-{{ result.route }}">
+  <h2>{{ result.label }}</h2>
+  <p class="muted">{{ result.reason }}</p>
+  {% if result.warning %}
+  <div class="warn">LLM fallback warning: {{ result.warning }}</div>
+  {% endif %}
+  <div class="answer-box">
+    <pre>{{ result.answer }}</pre>
+  </div>
+
+  {% if result.query_dl %}
+  <details>
+    <summary>Engine query</summary>
+    <pre class="report">{{ result.query_dl }}</pre>
+  </details>
+  {% endif %}
+
+  {% if result.grounding_facts %}
+  <h2>Verified grounding facts</h2>
+  <table>
+    <thead><tr><th>Subject</th><th>Relation</th><th>Object</th><th>Source</th></tr></thead>
+    <tbody>
+    {% for fact in result.grounding_facts %}
+      <tr>
+        <td>{{ fact.subject }}</td>
+        <td><code>{{ fact.relation }}</code></td>
+        <td>{{ fact.object }}</td>
+        <td class="src">{{ fact.source }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+
+  {% if result.excerpts %}
+  <h2>Source excerpts</h2>
+  {% for excerpt in result.excerpts %}
+  <article class="evidence">
+    <div class="src">{{ excerpt.path }}</div>
+    <pre>{{ excerpt.excerpt }}</pre>
+  </article>
+  {% endfor %}
+  {% endif %}
+</section>
+{% endif %}
+{% endblock %}

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -15,6 +15,7 @@
       <a href="/sources">Sources</a>
       <a href="/review">Review</a>
       <a href="/workbench">Workbench</a>
+      <a href="/ask">Ask</a>
       <a href="/questions">Questions</a>
       <a href="/report">Report</a>
       <a href="/analytics">Analytics</a>


### PR DESCRIPTION
## Summary
- Add a read-only Ask tab for free-form questions.
- Route deterministic answers through the confirmed/accepted fact engine first.
- Fall back to source-excerpt-grounded LLM answers labelled as unverified when deterministic routing cannot answer.
- Add an editable ask fallback prompt and provider adapter support for plain-text answers.

## Validation
- `uv run python -m pytest -q`
- `uv run ruff check verinote tests/test_ask.py tests/test_web.py`
- `git diff --check`