### PR TITLE
[codex] Add source accept all and Ask provenance

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -62,7 +62,8 @@ def _store(tmp_path) -> Store:
 
 def test_ask_returns_verified_engine_answer_without_persisting(tmp_path):
     store = _store(tmp_path)
-    store.add_fact("샘플인물", "역할", "검토자", status="confirmed")
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플인물", "역할", "검토자", status="confirmed", source_id=source_id)
 
     result = ask_question(
         store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
@@ -71,6 +72,9 @@ def test_ask_returns_verified_engine_answer_without_persisting(tmp_path):
     assert result.route == "engine"
     assert result.label == "VERIFIED — engine"
     assert "검토자" in result.answer
+    assert result.grounding_facts
+    assert result.grounding_facts[0].answer == "검토자"
+    assert result.grounding_facts[0].source == "sources/sample.txt"
     assert store.questions() == []
     assert not query_path(tmp_path).exists()
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1641,13 +1641,16 @@ def test_ask_post_renders_verified_engine_answer_without_persisting(
     monkeypatch.setattr(webapp, "get_client", lambda cfg: DeterministicOnly())
     c = _client(tmp_path)
     store = c.app.state.store
-    store.add_fact("샘플인물", "역할", "검토자", status="confirmed")
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플인물", "역할", "검토자", status="confirmed", source_id=source_id)
 
     r = c.post("/ask", data={"question": "샘플인물의 역할은 무엇인가?"})
 
     assert r.status_code == 200
     assert "VERIFIED — engine" in r.text
     assert "검토자" in r.text
+    assert "Verified source facts" in r.text
+    assert "sources/sample.txt" in r.text
     assert store.questions() == []
     assert not query_path(tmp_path).exists()
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -687,6 +687,58 @@ def test_sources_page_lists_sources(tmp_path):
     assert "extracted_text" in r.text
     assert f'title="{long_artifact_path}"' in r.text
     assert 'class="truncate"' in r.text
+    assert "Accept all" in r.text
+
+
+def test_sources_accept_all_promotes_review_facts_for_that_source(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    source_id = store.add_source("sources/sample.txt", kind="text")
+    other_source_id = store.add_source("sources/other.txt", kind="text")
+    candidate_id = store.add_fact(
+        "Sample Subject",
+        "uses",
+        "Sample Object",
+        status="candidate",
+        source_id=source_id,
+    )
+    needs_review_id = store.add_fact(
+        "Sample Subject",
+        "mentions",
+        "Sample Note",
+        status="needs_review",
+        source_id=source_id,
+    )
+    confirmed_id = store.add_fact(
+        "Already Confirmed",
+        "is_a",
+        "Sample",
+        status="confirmed",
+        source_id=source_id,
+    )
+    other_id = store.add_fact(
+        "Other Subject",
+        "uses",
+        "Other Object",
+        status="candidate",
+        source_id=other_source_id,
+    )
+
+    r = c.post(f"/sources/{source_id}/accept-all", follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/sources"
+    assert store.get_fact(candidate_id)["status"] == "confirmed"
+    assert store.get_fact(needs_review_id)["status"] == "confirmed"
+    assert store.get_fact(confirmed_id)["status"] == "confirmed"
+    assert store.get_fact(other_id)["status"] == "candidate"
+    assert [event["action"] for event in store.fact_log(candidate_id)] == ["accepted"]
+    assert [event["action"] for event in store.fact_log(needs_review_id)] == ["accepted"]
+    assert store.fact_log(confirmed_id) == []
+    assert store.fact_log(other_id) == []
+
+    body = c.get("/sources").text
+    assert "0 candidate(s)" in body
 
 
 def test_sources_page_shows_trust_counts_and_evidence_snippets(tmp_path, monkeypatch):

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -15,6 +15,7 @@ from verinote.pipeline.corroboration import CorroborationPolicyError, store_rela
 from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_query_flow
 from verinote.pipeline.query_candidate_eval import RELATION_DECL
 from verinote.pipeline.query_intent import QueryIntentKind, deterministic_query_intent
+from verinote.pipeline.report_trace import trace_query_answers
 from verinote.store import ENGINE_STATUSES, Store
 
 ASK_QID = 0
@@ -33,10 +34,12 @@ class AskExcerpt:
 
 @dataclass(frozen=True)
 class AskGroundingFact:
+    answer: str
     subject: str
     relation: str
     object: str
     source: str
+    evidence: str = ""
 
 
 @dataclass(frozen=True)
@@ -83,10 +86,11 @@ def ask_question(
         llm_error_status="review_required",
     )
     if status == "translated" and query_dl:
-        report = _run_engine_query(store, query_dl)
+        report, expanded_query = _run_engine_query(store, query_dl)
         if report.engine_available and report.ok and not report.errors:
             answers = tuple(dict.fromkeys(report.answers))
             if answers:
+                source_facts = tuple(_engine_source_facts(store, expanded_query))
                 return AskResult(
                     route="engine",
                     label="VERIFIED — engine",
@@ -96,6 +100,12 @@ def ask_question(
                     query_dl=query_dl,
                     engine_answers=answers,
                     reason="deterministic query matched confirmed/accepted facts",
+                    grounding_facts=source_facts,
+                    warning=(
+                        None
+                        if source_facts
+                        else "source trace unavailable for this verified query shape"
+                    ),
                 )
             return AskResult(
                 route="engine",
@@ -143,30 +153,61 @@ def ask_question(
     )
 
 
-def _run_engine_query(store: Store, query_dl: str) -> CheckReport:
+def _run_engine_query(store: Store, query_dl: str) -> tuple[CheckReport, str]:
     try:
         expanded = expand_query_relation_aliases(query_dl, store_relation_aliases(store))
-        return run_check_duckdb(
-            store.engine_fact_terms(),
-            policy_dl=RELATION_DECL,
-            query_dl=expanded,
+        return (
+            run_check_duckdb(
+                store.engine_fact_terms(),
+                policy_dl=RELATION_DECL,
+                query_dl=expanded,
+            ),
+            expanded,
         )
     except CorroborationPolicyError as exc:
-        return CheckReport(
-            ok=False,
-            errors=1,
-            warnings=0,
-            text=f"policy error: {exc}",
-            findings=[f"ERROR policy error: {exc}"],
+        return (
+            CheckReport(
+                ok=False,
+                errors=1,
+                warnings=0,
+                text=f"policy error: {exc}",
+                findings=[f"ERROR policy error: {exc}"],
+            ),
+            query_dl,
         )
     except Exception as exc:  # noqa: BLE001 - keep Ask from failing closed
-        return CheckReport(
-            ok=False,
-            errors=1,
-            warnings=0,
-            text=f"ask engine error: {exc}",
-            findings=[f"ERROR engine error: {exc}"],
+        return (
+            CheckReport(
+                ok=False,
+                errors=1,
+                warnings=0,
+                text=f"ask engine error: {exc}",
+                findings=[f"ERROR engine error: {exc}"],
+            ),
+            query_dl,
         )
+
+
+def _engine_source_facts(store: Store, query_dl: str) -> list[AskGroundingFact]:
+    facts: list[AskGroundingFact] = []
+    seen: set[tuple[str, int]] = set()
+    for answer in trace_query_answers(store, query_dl):
+        for fact in answer.facts:
+            key = (answer.value, fact.id)
+            if key in seen:
+                continue
+            seen.add(key)
+            facts.append(
+                AskGroundingFact(
+                    answer=answer.value,
+                    subject=fact.subject,
+                    relation=fact.relation,
+                    object=fact.object,
+                    source=fact.source,
+                    evidence=fact.evidence,
+                )
+            )
+    return facts
 
 
 def _fallback_answer(
@@ -248,6 +289,7 @@ def grounding_facts(
             continue
         rows.append(
             AskGroundingFact(
+                answer="",
                 subject=subject,
                 relation=relation,
                 object=obj,

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -59,11 +59,18 @@ def report_trace(store: Store) -> ReportTrace:
     if not query:
         return ReportTrace(answers=(), excluded_candidate_count=candidates)
 
+    return ReportTrace(
+        answers=trace_query_answers(store, query),
+        excluded_candidate_count=candidates,
+    )
+
+
+def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
+    """Trace direct answer_q rules in one query back to engine-input facts."""
     try:
         program = parse_and_validate_program(_RELATION_DECL + query)
     except (DatalogParseError, DatalogValidationError):
-        return ReportTrace(answers=(), excluded_candidate_count=candidates)
-
+        return ()
     facts = store.engine_fact_terms()
     fact_rows = {int(row["id"]): store.get_fact(int(row["id"])) for row in facts}
     traces = []
@@ -94,10 +101,7 @@ def report_trace(store: Store) -> ReportTrace:
                     conflicted=any(fact.conflicted for fact in trace_facts),
                 )
             )
-    return ReportTrace(
-        answers=tuple(sorted(traces, key=lambda trace: (int(trace.qid), trace.value))),
-        excluded_candidate_count=candidates,
-    )
+    return tuple(sorted(traces, key=lambda trace: (int(trace.qid), trace.value)))
 
 
 def _answer_qid(predicate: str) -> str | None:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -935,6 +935,36 @@ class Store:
             self._log(fact_id, action, before, after, actor=actor, rule_name=rule_name)
             return after
 
+    def accept_review_facts_for_source(self, source_id: int) -> list[sqlite3.Row]:
+        """Promote all review-queue facts for one source to confirmed."""
+        with self._lock:
+            self._conn.execute("BEGIN")
+            try:
+                facts = list(
+                    self._conn.execute(
+                        "SELECT * FROM facts WHERE source_id = ? "
+                        "AND status IN ('candidate','needs_review') ORDER BY id",
+                        (source_id,),
+                    )
+                )
+                accepted: list[sqlite3.Row] = []
+                for before in facts:
+                    fact_id = int(before["id"])
+                    self._conn.execute(
+                        "UPDATE facts SET status = 'confirmed', updated_at = datetime('now') "
+                        "WHERE id = ?",
+                        (fact_id,),
+                    )
+                    after = self.get_fact(fact_id)
+                    self._log(fact_id, "accepted", before, after)
+                    if after is not None:
+                        accepted.append(after)
+                self._conn.execute("COMMIT")
+                return accepted
+            except Exception:
+                self._rollback_quietly()
+                raise
+
     def toggle_review(self, fact_id: int) -> sqlite3.Row | None:
         """needs_review/candidate -> confirmed, and confirmed -> needs_review."""
         row = self.get_fact(fact_id)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -772,6 +772,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         _start_source_extraction(job_id, cfg)
         return RedirectResponse("/sources", status_code=303)
 
+    @app.post("/sources/{source_id}/accept-all", response_class=HTMLResponse)
+    def accept_all_source_facts(request: Request, source_id: int):
+        _active_store().accept_review_facts_for_source(source_id)
+        return RedirectResponse("/sources", status_code=303)
+
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
     def delete_source(request: Request, source_id: int):
         store = _active_store()

--- a/verinote/web/templates/ask.html
+++ b/verinote/web/templates/ask.html
@@ -19,7 +19,7 @@
   <h2>{{ result.label }}</h2>
   <p class="muted">{{ result.reason }}</p>
   {% if result.warning %}
-  <div class="warn">LLM fallback warning: {{ result.warning }}</div>
+  <div class="warn">{{ result.warning }}</div>
   {% endif %}
   <div class="answer-box">
     <pre>{{ result.answer }}</pre>
@@ -33,16 +33,23 @@
   {% endif %}
 
   {% if result.grounding_facts %}
-  <h2>Verified grounding facts</h2>
+  <h2>{{ "Verified source facts" if result.route == "engine" else "Verified grounding facts" }}</h2>
   <table>
-    <thead><tr><th>Subject</th><th>Relation</th><th>Object</th><th>Source</th></tr></thead>
+    <thead>
+      <tr>
+        {% if result.route == "engine" %}<th>Answer</th>{% endif %}
+        <th>Subject</th><th>Relation</th><th>Object</th><th>Source</th><th>Evidence</th>
+      </tr>
+    </thead>
     <tbody>
     {% for fact in result.grounding_facts %}
       <tr>
+        {% if result.route == "engine" %}<td>{{ fact.answer }}</td>{% endif %}
         <td>{{ fact.subject }}</td>
         <td><code>{{ fact.relation }}</code></td>
         <td>{{ fact.object }}</td>
         <td class="src">{{ fact.source }}</td>
+        <td class="src">{{ fact.evidence }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -97,6 +97,11 @@
         <form action="/sources/{{ s["id"] }}/reanalyze" method="post">
           <button class="btn ghost" type="submit">Re-analyze</button>
         </form>
+        {% if s["candidate_count"] or s["needs_review_count"] %}
+        <form action="/sources/{{ s["id"] }}/accept-all" method="post">
+          <button class="btn ghost" type="submit">Accept all</button>
+        </form>
+        {% endif %}
         <form action="/sources/{{ s["id"] }}/delete" method="post">
           <button class="danger" type="submit">Delete</button>
         </form>


### PR DESCRIPTION
## Summary
- Add a source-level Accept all action that promotes that source's candidate and needs_review facts to confirmed with accept audit logs.
- Show verified source facts for Ask engine answers so VERIFIED results include their supporting source provenance.
- Reuse direct query answer tracing for Ask provenance where the engine answer is traceable to relation/3 facts.

## Validation
- `uv run python -m pytest -q`
- `uv run ruff check verinote/store/db.py verinote/web/app.py tests/test_web.py`
- `uv run ruff check verinote/pipeline/ask.py verinote/pipeline/report_trace.py tests/test_ask.py tests/test_web.py`
- `git diff --check`