### PR TITLE
[codex] Avoid false verified negative Ask answers

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -100,11 +100,21 @@ def test_ask_answers_generic_korean_attribute_question_from_engine(tmp_path):
     assert result.grounding_facts[0].source == "sources/sample-project.txt"
 
 
-def test_ask_verified_negative_does_not_fallback_to_candidates(tmp_path):
+def test_ask_verified_negative_only_for_explicit_no_answer_flow(tmp_path, monkeypatch):
+    import verinote.pipeline.ask as ask_module
+
     store = _store(tmp_path)
     store.add_fact("샘플인물", "is_a", "person", status="confirmed")
-    store.add_fact("다른샘플인물", "역할", "검토자", status="confirmed")
     store.add_fact("샘플인물", "역할", "후보역할", status="candidate")
+    monkeypatch.setattr(
+        ask_module,
+        "schema_aware_query_flow",
+        lambda *args, **kwargs: (
+            "no_answer",
+            'no_answer("no confirmed facts match")',
+            "no confirmed facts match",
+        ),
+    )
 
     result = ask_question(
         store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
@@ -114,6 +124,19 @@ def test_ask_verified_negative_does_not_fallback_to_candidates(tmp_path):
     assert result.status == "no_answer"
     assert result.answer == "No confirmed facts match."
     assert "후보역할" not in result.answer
+
+
+def test_ask_does_not_verify_negative_when_relation_candidate_is_missing(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed")
+    client = FallbackClient(answer="출처 탐색 결과를 확인해야 합니다.")
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직의 임직원 수는?")
+
+    assert result.route == "fallback"
+    assert result.label == "UNVERIFIED — source exploration"
+    assert result.status == "fallback"
+    assert "No confirmed facts match." not in result.answer
 
 
 def test_ask_fallback_uses_source_excerpts_and_grounding(tmp_path):

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -14,7 +14,6 @@ from verinote.llm.base import LLMClient, LLMError
 from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
 from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_query_flow
 from verinote.pipeline.query_candidate_eval import RELATION_DECL
-from verinote.pipeline.query_intent import QueryIntentKind, deterministic_query_intent
 from verinote.pipeline.report_trace import trace_query_answers
 from verinote.store import ENGINE_STATUSES, Store
 
@@ -130,18 +129,6 @@ def ask_question(
             query_dl=query_dl,
             engine_answers=(),
             reason=reason or "no confirmed facts match",
-        )
-
-    if status == "review_required" and _known_scope_without_candidate(store, question):
-        return AskResult(
-            route="engine",
-            label="VERIFIED — engine (negative)",
-            question=question,
-            status="no_answer",
-            answer="No confirmed facts match.",
-            query_dl='no_answer("no confirmed facts match")',
-            engine_answers=(),
-            reason="no confirmed facts match",
         )
 
     return _fallback_answer(
@@ -299,20 +286,6 @@ def grounding_facts(
         if len(rows) >= limit:
             break
     return rows
-
-
-def _known_scope_without_candidate(store: Store, question: str) -> bool:
-    """Classify deterministic known-entity misses as verified negative answers."""
-    intent = deterministic_query_intent(question)
-    if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED or intent.subject is None:
-        return False
-    subject = _fold(intent.subject.value)
-    if not subject:
-        return False
-    return any(
-        _fold(str(fact["subject"])) == subject or _fold(str(fact["object"])) == subject
-        for fact in store.facts(statuses=ENGINE_STATUSES)
-    )
 
 
 def _source_text_paths(store: Store, root: Path) -> list[tuple[str, Path]]:


### PR DESCRIPTION
## Summary
- Remove the Ask shortcut that converted known-entity relation-planning misses into verified negative answers.
- Keep verified negative results only for explicit no_answer outcomes from the schema-aware query flow.
- Add regression coverage for relation-candidate misses such as employee-count questions so they fall back to unverified source exploration instead of claiming a verified absence.

## Validation
- `uv run python -m pytest -q`
- `uv run ruff check verinote/pipeline/ask.py tests/test_ask.py`
- `git diff --check`