### PR TITLE
Restate verified Ask answers as fact triples

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -79,6 +79,22 @@ def test_ask_returns_verified_engine_answer_without_persisting(tmp_path):
     assert not query_path(tmp_path).exists()
 
 
+def test_ask_engine_answer_restates_triple_with_inline_source(tmp_path):
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플인물", "역할", "샘플역할", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
+    )
+
+    assert result.route == "engine"
+    # factlog-style: the answer restates the verified triple, not a bare object,
+    # and never leaks the internal q<id>: /report prefix.
+    assert result.answer == "샘플인물, 역할, 샘플역할\n    ← sources/sample.txt"
+    assert "q0:" not in result.answer
+
+
 def test_ask_answers_generic_korean_attribute_question_from_engine(tmp_path):
     store = _store(tmp_path)
     source_id = store.add_source("sources/sample-project.txt")

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -22,6 +22,10 @@ MAX_CONTEXT_CHARS = 12000
 MAX_EXCERPTS = 8
 MAX_GROUNDING_FACTS = 8
 _TOKEN = re.compile(r"[A-Za-z0-9_]{2,}|[가-힣一-龥ぁ-んァ-ン]{1,}")
+# The engine formats each answer as ``q<id>: value`` for the /report view. That
+# report prefix is never part of the answer itself, so strip it when it leaks
+# into an Ask answer body.
+_ANSWER_QID_PREFIX = re.compile(r"^q\d+:\s*")
 
 
 @dataclass(frozen=True)
@@ -95,7 +99,7 @@ def ask_question(
                     label="VERIFIED — engine",
                     question=question,
                     status=status,
-                    answer="\n".join(answers),
+                    answer=_render_engine_answer_body(answers, source_facts),
                     query_dl=query_dl,
                     engine_answers=answers,
                     reason="deterministic query matched confirmed/accepted facts",
@@ -195,6 +199,34 @@ def _engine_source_facts(store: Store, query_dl: str) -> list[AskGroundingFact]:
                 )
             )
     return facts
+
+
+def _render_engine_answer_body(
+    answers: tuple[str, ...],
+    source_facts: tuple[AskGroundingFact, ...],
+) -> str:
+    """Render a verified engine answer as factlog-style fact rows.
+
+    Each verified triple is restated as ``subject, relation, object`` with its
+    backing source(s) cited inline beneath (``    ← <source>``), mirroring
+    factlog's ``render_engine_answer`` — so the answer states *which fact* is
+    verified, not a bare object value. When the source trace is unavailable, fall
+    back to the raw engine answer values with the internal ``q<id>:`` report
+    prefix stripped (that prefix is a /report artifact, never part of the answer).
+    """
+    if source_facts:
+        sources_by_triple: dict[tuple[str, str, str], list[str]] = {}
+        for fact in source_facts:
+            triple = (fact.subject, fact.relation, fact.object)
+            sources = sources_by_triple.setdefault(triple, [])
+            if fact.source and fact.source not in sources:
+                sources.append(fact.source)
+        lines: list[str] = []
+        for (subject, relation, obj), sources in sources_by_triple.items():
+            lines.append(f"{subject}, {relation}, {obj}")
+            lines.extend(f"    ← {source}" for source in sources)
+        return "\n".join(lines)
+    return "\n".join(_ANSWER_QID_PREFIX.sub("", line) for line in answers)
 
 
 def _fallback_answer(


### PR DESCRIPTION
## What

Align the verified engine **Ask** answer with factlog's `render_engine_answer` output.

Asking "X의 역할은?" previously answered:

```
q0: 팀장
```

- the internal `q<id>:` `/report` prefix leaked into the user-facing answer
- the body was a bare object value, so the answer alone didn't say *which fact* was verified

Now it restates the verified triple with its backing source cited inline, exactly like factlog:

```
샘플인물, 역할, 샘플역할
    ← sources/sample.txt
```

## How

- Add `_render_engine_answer_body(answers, source_facts)` in `verinote/pipeline/ask.py`: groups verified triples, renders `subject, relation, object` with one `    ← <source>` line per backing source. Falls back to the raw answer values with the `q<id>:` prefix stripped when the source trace is unavailable.
- Use it for the positive engine path instead of reusing the `/report` answer format.

`grounding_facts`, excerpts, and the rest of the web UI are unchanged — only the answer body was realigned.

## Test

- New regression test `test_ask_engine_answer_restates_triple_with_inline_source` (placeholder `샘플~` data).
- `ruff` clean; ask/verify/web suites (120 tests) pass.