### PR TITLE
Drop reversed role-designation candidates at extraction

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -477,6 +477,66 @@ def test_extract_source_keeps_non_metric_korean_object_without_local_subject(
     assert fact["object"] == "샘플기능"
 
 
+def test_extract_source_drops_reversed_role_designation(tmp_path, fake_client):
+    # ``org 역할 person`` is the reversed shape of ``person 역할 role``: it names a
+    # person as the OBJECT of a role designation even though that person holds a
+    # role themselves in the same batch. Drop it; keep the correct direction.
+    # (역할 canonicalizes to ``role`` under the default relation aliases.)
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact("샘플인물", "역할", "샘플직책", 0.9),
+            ExtractedFact("샘플조직", "역할", "샘플인물", 0.9),
+        ]
+    )
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="샘플 문서 본문",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    facts = {
+        (str(f["subject"]), str(f["relation"]), str(f["object"])) for f in s.facts()
+    }
+    assert ("샘플인물", "role", "샘플직책") in facts
+    assert ("샘플조직", "role", "샘플인물") not in facts
+
+
+def test_extract_source_keeps_org_representative_role_fact(tmp_path, fake_client):
+    # ``org 대표 person`` (the org's representative) canonicalizes to the same
+    # ``org role person`` shape as a reversed designation, but the person here does
+    # NOT hold a role elsewhere in the batch, so it is a legitimate fact and must
+    # survive — an org-subject check alone would wrongly drop it.
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client([ExtractedFact("샘플조직주식회사", "대표", "샘플인물", 0.9)])
+
+    assert (
+        extract_source(
+            s,
+            client,
+            source_path="sources/x.txt",
+            source_text="샘플 문서 본문",
+            run_id=run_id,
+        )
+        == 1
+    )
+
+    fact = s.facts()[0]
+    assert (fact["subject"], fact["relation"], fact["object"]) == (
+        "샘플조직주식회사",
+        "role",
+        "샘플인물",
+    )
+
+
 def test_extract_source_canonicalizes_generic_value_relation(tmp_path, fake_client):
     s = _store(tmp_path)
     run_id = s.add_run(provider="fake", model="m")

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -50,6 +50,17 @@ _METRIC_OBJECT_RE = re.compile(
 )
 _RECORD_SPLIT_RE = re.compile(r"[\n\r]+|[。.!?;；]")
 _ROLE_CUE_RE = re.compile(r"원문:|대표|대표이사|CTO|CEO|CFO|담당자|발표자|총괄|소속")
+# Generic role-designation relations (``샘플인물 역할 샘플직책`` — the SUBJECT holds a
+# role, the OBJECT is the role/title). The default policy canonicalizes 역할/직책/
+# 직위/대표/대표이사 all to ``role``, so the raw labels and the canonical label are
+# both listed; matching is done on the canonicalized relation so an aliased KB and
+# a bare KB behave the same. Role-*named* relations (``샘플조직 샘플직책 샘플인물``, where
+# the title itself is the relation, not an alias of role) are a different, valid
+# shape and are deliberately NOT matched here.
+_ROLE_DESIGNATION_RELATIONS = {
+    "역할", "직책", "직위", "직함", "대표", "대표이사", "role", "title", "position"
+}
+_ROLE_DESIGNATION_RELATIONS_CF = {relation.casefold() for relation in _ROLE_DESIGNATION_RELATIONS}
 
 
 def extract_source(
@@ -299,12 +310,15 @@ def _candidate_rows(
 ) -> list[tuple[object, object, object, ExtractedFact]]:
     rows = []
     aliases = relation_aliases or {}
+    role_bearers = _role_bearer_subjects(facts, aliases)
     try:
         for f in facts:
             f = _canonical_fact(f, aliases)
             if f is None:
                 continue
             if _is_normalization_bridge(f):
+                continue
+            if _is_reversed_role_designation(f, role_bearers, aliases):
                 continue
             if _has_unbacked_han_translation(f, source_text):
                 continue
@@ -370,6 +384,57 @@ def _is_normalization_bridge(f: ExtractedFact) -> bool:
     if relation_kind != "string" or relation not in _NORMALIZATION_BRIDGE_RELATIONS:
         return False
     return f.subject_kind == "term" or f.object_kind == "term"
+
+
+def _norm_entity(value: str) -> str:
+    return unicodedata.normalize("NFC", value).strip()
+
+
+def _is_role_designation_relation(
+    relation: str, relation_kind: str, aliases: dict[str, str]
+) -> bool:
+    """True when ``relation`` canonicalizes to a generic role-designation label."""
+    if relation_kind != "string":
+        return False
+    canonical = canonical_relation(_norm_entity(relation), aliases)
+    return canonical.strip().casefold() in _ROLE_DESIGNATION_RELATIONS_CF
+
+
+def _role_bearer_subjects(
+    facts: list[ExtractedFact], aliases: dict[str, str]
+) -> set[str]:
+    """Entities extracted as the SUBJECT of a role designation in this batch.
+
+    Such an entity holds a role, so it is a person/role-bearer — it must not also
+    appear as the OBJECT of a role designation. This co-occurrence signal is what
+    distinguishes ``샘플조직 역할 샘플인물`` (reversed) from ``샘플인물 역할 샘플직책``
+    (correct); it depends on both facts landing in the same extraction batch.
+    """
+    return {
+        _norm_entity(f.subject)
+        for f in facts
+        if f.subject_kind == "string"
+        and _is_role_designation_relation(f.relation, f.relation_kind, aliases)
+    }
+
+
+def _is_reversed_role_designation(
+    f: ExtractedFact, role_bearers: set[str], aliases: dict[str, str]
+) -> bool:
+    """Drop a role designation whose direction is reversed (``org role person``).
+
+    The single, low-false-positive signal is that the OBJECT is itself a
+    role-bearer — it appears as the SUBJECT of a role designation in this batch, so
+    it is a person who holds a role and cannot also BE the role value of something
+    else. This is the only signal that stays correct once the policy collapses
+    대표/역할/직책 into one ``role`` relation: a plain org-subject check would also
+    drop the valid ``조직 대표 사람`` (org's representative), which shares the same
+    canonical shape. Role-*named* relations such as ``샘플조직 샘플직책 샘플인물`` are a
+    valid shape and are not matched here — only the generic role designations are.
+    """
+    if not _is_role_designation_relation(f.relation, f.relation_kind, aliases):
+        return False
+    return f.object_kind == "string" and _norm_entity(f.object) in role_bearers
 
 
 def _has_unbacked_han_translation(f: ExtractedFact, source_text: str) -> bool:


### PR DESCRIPTION
## Problem

Asking "X의 역할은?" could return a **person** as the answer. The engine faithfully restated a stored fact whose direction is reversed: `조직 역할 사람` is the mirror image of the correct `사람 역할 직책` (`샘플인물 역할 샘플직책`). The reversed triple conflates affiliation with role and drops the actual title, so it is pure noise.

## Fix

Add a deterministic filter at the candidate gate (`_candidate_rows` in `verinote/pipeline/extract.py`): a role-designation triple whose **OBJECT is itself a role-bearer** — it appears as the SUBJECT of a role designation elsewhere in the same extraction batch — is reversed and gets dropped.

- `샘플조직 역할 샘플인물` → `샘플인물` holds a role (`샘플인물 역할 샘플직책`) → **dropped**
- `샘플인물 역할 샘플직책` → kept

### Why only this signal

The default relation aliases canonicalize `역할`/`직책`/`대표`/`대표이사` all to `role`. So the valid `조직 대표 사람` (an org's representative) and the reversed `조직 역할 사람` share the exact same canonical shape `org role person`. A naive "org-subject" check would wrongly drop the valid `조직 대표 사람`. The role-bearer cross-reference is the only signal that distinguishes the two without false positives.

## Scope

Applies to future extraction/sync only; existing confirmed facts are untouched.

## Test

- `test_extract_source_drops_reversed_role_designation` — reversed dropped, correct direction kept
- `test_extract_source_keeps_org_representative_role_fact` — valid `조직 대표 사람` survives (no false positive)
- `ruff` clean; full suite 669 passed / 7 skipped