### PR TITLE
fix(#155): make a lost logic policy loud instead of silently falling back to DEFAULT_POLICY

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -521,3 +521,163 @@ def test_report_of_unrecorded_policy_kb_is_not_ok(tmp_path, monkeypatch):
     assert "WARNINGS" in resp.text
     assert "policy_unrecorded" in resp.text
     assert "knowledge base is consistent" not in resp.text
+
+
+# --- a halted KB takes no writes: CLI, worker, and the recovery paths that must
+# --- keep working (the contract this PR claimed but did not enforce)
+
+
+def _halted_cli_kb(tmp_path, monkeypatch):
+    """A CLI-visible KB whose scaffolded policy file has been deleted."""
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    policy = tmp_path / POLICY_RELPATH
+    policy.unlink()
+    return policy
+
+
+def _kb_rows(tmp_path):
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    try:
+        return (len(store.sources()), len(store.facts()), len(store.questions()))
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["ingest", "<src>"], id="ingest"),
+        pytest.param(["seed"], id="seed"),
+        pytest.param(["query", "who is Ada?"], id="query"),
+        pytest.param(["sync", "<src>"], id="sync"),
+        pytest.param(["repair"], id="repair"),
+    ],
+)
+def test_cli_write_commands_refuse_on_halted_kb(tmp_path, monkeypatch, capsys, argv):
+    """Every write command halts — and writes *nothing* — while the policy is lost."""
+    policy = _halted_cli_kb(tmp_path, monkeypatch)
+    src = tmp_path / "input.txt"
+    src.write_text("Ada is_a engineer\n", encoding="utf-8")
+
+    rc = cli.main([a.replace("<src>", str(src)) for a in argv])
+
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "policy file" in err and "missing" in err
+    # nothing was written: no registered source file, no rows, no query file
+    assert not (tmp_path / "sources" / "input.txt").exists()
+    assert not (tmp_path / "facts" / "query.dl").exists()
+    assert _kb_rows(tmp_path) == (0, 0, 0)
+    assert not policy.exists()  # the evidence of the loss is intact
+
+
+def test_init_refuses_on_halted_kb(tmp_path, monkeypatch, capsys):
+    """`init` is not exempt: re-scaffolding would paper over the lost policy.
+
+    Rewriting the default policy here would turn a KB whose human-written rules
+    are gone into a plausible-looking green KB. Recovery is an explicit human act
+    (`policy reset --force`), so `init` stays a refused write — and `--seed` must
+    not slip demo rows into the halted KB on its way to the refusal either.
+    """
+    policy = _halted_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["init", "--seed"]) == 2
+
+    assert "policy file" in capsys.readouterr().err
+    assert not policy.exists()
+    assert _kb_rows(tmp_path) == (0, 0, 0)
+
+
+def test_status_and_coverage_survive_halt(tmp_path, monkeypatch, capsys):
+    """Read-only diagnosis keeps working — a halt you cannot inspect is a brick."""
+    _halted_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["status"]) == 0
+    assert cli.main(["coverage"]) == 0
+
+    out = capsys.readouterr().out
+    assert "KB:" in out
+    assert "coverage:" in out
+
+
+def test_policy_reset_force_recovers_halted_kb(tmp_path, monkeypatch, capsys):
+    """The recovery path runs *on* a halted KB, and really un-halts it."""
+    policy = _halted_cli_kb(tmp_path, monkeypatch)
+    src = tmp_path / "input.txt"
+    src.write_text("Ada is_a engineer\n", encoding="utf-8")
+    assert cli.main(["ingest", str(src)]) != 0  # halted before recovery
+
+    assert cli.main(["policy", "reset", "--force"]) == 0
+
+    assert policy.read_text(encoding="utf-8") == DEFAULT_POLICY
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    marker = store.policy_marker()
+    store.close()
+    assert marker is not None and marker["origin"] == "reset"
+    # and the KB accepts writes again — recovery that leaves it halted is no recovery
+    capsys.readouterr()
+    assert cli.main(["ingest", str(src)]) == 0
+    assert (tmp_path / "sources" / "input.txt").is_file()
+
+
+class _PolicyDeletingClient:
+    """Deletes the KB's policy file just as the *second* chunk is extracted."""
+
+    name = "fake"
+
+    def __init__(self, policy_path):
+        self.policy_path = policy_path
+        self.calls = 0
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        from verinote.llm.base import ExtractedFact
+
+        self.calls += 1
+        if self.calls == 2:
+            self.policy_path.unlink()
+        return [ExtractedFact(source_text, "is_a", "chunk", 0.9)]
+
+
+def test_extraction_worker_halts_when_policy_disappears_mid_job(tmp_path):
+    """A job started on a healthy KB must stop the moment the policy vanishes.
+
+    The CLI's start-of-command check cannot see this: the job was already running
+    (and the Store already open) when the file was deleted. Only a re-check at the
+    per-chunk write boundary keeps chunk 2 out of a KB with no rules.
+    """
+    from verinote.pipeline.extract import process_extraction_job
+
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    source_id = store.add_source("sources/a.txt")
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=2
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=["alpha", "beta"])
+
+    client = _PolicyDeletingClient(path)
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(store, client, job_id=job_id)
+
+    assert client.calls == 2  # the second chunk was extracted but never persisted
+    facts = store.facts()
+    assert [f["subject"] for f in facts] == ["alpha"]
+    snippets = [e["snippet"] for f in facts for e in store.fact_evidence(f["id"])]
+    assert "beta" not in snippets
+    store.close()
+
+
+def test_store_has_no_public_meta_delete(tmp_path):
+    """No public API may drop a policy marker — that is the silent-fallback bug."""
+    store = _store(tmp_path)
+    public = {name for name in dir(store) if not name.startswith("_")}
+    store.close()
+
+    assert "delete_meta" not in public
+    assert "set_meta" not in public
+    assert "get_meta" not in public
+    assert "clear_policy_marker" not in public

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: MPL-2.0
+"""A lost logic policy must never read as a consistent KB (#155)."""
+
+import pytest
+
+import verinote.cli as cli
+from verinote.engine import DEFAULT_POLICY
+from verinote.pipeline.corroboration import store_functional_relations
+from verinote.pipeline.policy_state import (
+    POLICY_RELPATH,
+    PolicyMissingError,
+    PolicyStatus,
+    policy_sha256,
+    resolve_policy,
+)
+from verinote.pipeline.verify import load_policy, verify
+from verinote.store import Store
+
+# A human-written policy: `employed_by` is single-valued for a subject. This is
+# exactly the rule that evaporates in #155 when the policy file is deleted.
+FUNCTIONAL_POLICY = (
+    ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+    ".decl functional(rel: symbol)\n"
+    ".decl error_functional_conflict(subject: symbol, rel: symbol)\n"
+    'functional("employed_by").\n'
+    "error_functional_conflict(S, R) :-\n"
+    "    relation(S, R, A), relation(S, R, B), functional(R), A != B.\n"
+)
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def _write_policy(tmp_path, text: str = FUNCTIONAL_POLICY):
+    path = tmp_path / POLICY_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _conflicting_facts(store: Store) -> None:
+    source = store.add_source("sources/a.txt")
+    store.add_fact("Ada", "employed_by", "AcmeCorp", status="confirmed", source_id=source)
+    store.add_fact("Ada", "employed_by", "BetaCorp", status="confirmed", source_id=source)
+
+
+def _env(monkeypatch, tmp_path):
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+
+
+# --- 1. the reported bug: deleting a recorded policy used to turn the KB green ---
+
+
+def test_recorded_policy_catches_conflict(tmp_path):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    _conflicting_facts(store)
+
+    rep = verify(store)
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert "functional_conflict" in "\n".join(rep.findings)
+
+
+def test_deleting_a_recorded_policy_is_an_error_not_a_clean_report(tmp_path):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    _conflicting_facts(store)
+    path.unlink()
+
+    rep = verify(store)
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert any("policy_missing" in finding for finding in rep.findings)
+    assert "consistent" not in rep.text
+    # both recovery routes are named, and neither of them is automatic
+    assert "policy reset --force" in rep.text
+    assert "version control" in rep.text
+
+
+def test_resolve_policy_missing_recorded(tmp_path):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    path.unlink()
+
+    state = resolve_policy(store)
+    assert state.status is PolicyStatus.MISSING_RECORDED
+    assert state.marker is not None
+    with pytest.raises(PolicyMissingError):
+        load_policy(store)
+
+
+def test_hash_mismatch_is_not_an_error(tmp_path):
+    """Editing a policy is normal: the sha256 is evidence, never a verdict."""
+    store = _store(tmp_path)
+    _write_policy(tmp_path)
+    store.record_policy_marker("0" * 64, origin="scaffold")
+
+    state = resolve_policy(store)
+    assert state.status is PolicyStatus.PRESENT
+    assert verify(store).ok is True
+
+
+# --- 2. fresh KB: no file, no marker -> default policy, but loudly ---
+
+
+def test_unrecorded_policy_runs_default_with_a_warning(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Ada", "is_a", "engineer", status="confirmed")
+
+    rep = verify(store)
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings >= 1
+    assert any("policy_unrecorded" in finding for finding in rep.findings)
+    assert "shipped default" in rep.text
+    assert resolve_policy(store).status is PolicyStatus.UNRECORDED_DEFAULT
+    assert load_policy(store) is None
+
+
+def test_unrecorded_policy_still_reports_default_policy_errors(tmp_path):
+    store = _store(tmp_path)
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Org", "established_on", "2021", status="confirmed")
+
+    rep = verify(store)
+    assert rep.ok is False
+    assert rep.errors > 0
+    assert any("policy_unrecorded" in finding for finding in rep.findings)
+
+
+# --- 3. init scaffolds a policy file and records the marker ---
+
+
+def test_init_records_a_scaffold_marker(tmp_path, monkeypatch):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+
+    path = tmp_path / POLICY_RELPATH
+    assert path.is_file()
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    marker = store.policy_marker()
+    assert marker is not None
+    assert marker["origin"] == "scaffold"
+    assert marker["sha256"] == policy_sha256(DEFAULT_POLICY)
+    store.close()
+
+
+# --- 4. backwards compatibility: a pre-marker KB adopts its policy on open ---
+
+
+def test_existing_policy_file_is_adopted_on_open(tmp_path, monkeypatch):
+    _env(monkeypatch, tmp_path)
+    path = _write_policy(tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    assert store.policy_marker() is None  # pre-#155 KB
+    store.close()
+
+    assert cli.main(["status"]) == 0
+
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    marker = store.policy_marker()
+    assert marker is not None
+    assert marker["origin"] == "adopted"
+    assert marker["sha256"] == policy_sha256(path.read_text(encoding="utf-8"))
+    store.close()
+
+
+def test_kb_with_no_policy_file_is_not_adopted(tmp_path, monkeypatch):
+    """An upgraded KB that already had no policy has no evidence either way."""
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.close()
+
+    assert cli.main(["status"]) == 0
+
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    assert store.policy_marker() is None
+    assert resolve_policy(store).status is PolicyStatus.UNRECORDED_DEFAULT
+    store.close()
+
+
+# --- 5. a recorded-but-missing policy is never silently re-created ---
+
+
+def test_init_refuses_to_recreate_a_recorded_policy(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    path = tmp_path / POLICY_RELPATH
+    path.unlink()
+
+    rc = cli.main(["init"])
+    assert rc != 0
+    assert not path.exists()  # re-creating it would hide the loss
+    err = capsys.readouterr().err
+    assert "policy reset --force" in err
+
+
+def test_web_open_root_does_not_recreate_a_recorded_policy(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from verinote.config import Config
+    from verinote.web.app import create_app
+
+    # keep the app-level config (active KB root) inside tmp_path
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    root = tmp_path / "kb"
+    root.mkdir()
+    store = Store(Config.for_root(root).db_path)
+    store.init_schema()
+    path = _write_policy(root)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    _conflicting_facts(store)
+    store.close()
+    path.unlink()
+
+    app = create_app(Config.for_root(root))
+    with TestClient(app) as client:
+        resp = client.post("/kb/select", data={"root": str(root)}, follow_redirects=False)
+        assert resp.status_code in (200, 303)
+        assert not path.exists()
+        report = client.get("/report")
+        assert report.status_code == 200
+        assert "policy_missing" in report.text
+        assert "no findings" not in report.text
+
+
+# --- 6. the escape hatch: an explicit human reset ---
+
+
+def test_policy_reset_requires_force(tmp_path, monkeypatch):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    path = tmp_path / POLICY_RELPATH
+    path.unlink()
+
+    assert cli.main(["policy", "reset"]) == 2
+    assert not path.exists()
+
+
+def test_policy_reset_force_restores_the_policy(tmp_path, monkeypatch):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    path = tmp_path / POLICY_RELPATH
+    path.unlink()
+
+    assert cli.main(["policy", "reset", "--force"]) == 0
+    assert path.read_text(encoding="utf-8") == DEFAULT_POLICY
+
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    marker = store.policy_marker()
+    assert marker is not None
+    assert marker["origin"] == "reset"
+    rep = verify(store)
+    assert rep.ok is True
+    assert not any("policy_missing" in finding for finding in rep.findings)
+    assert not any("policy_unrecorded" in finding for finding in rep.findings)
+    store.close()
+
+
+# --- 7. the second consumer: acceptance gating must not silently change ---
+
+
+def test_store_functional_relations_raises_when_policy_is_lost(tmp_path):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    assert store_functional_relations(store) == {"employed_by"}
+
+    path.unlink()
+    with pytest.raises(PolicyMissingError):
+        store_functional_relations(store)
+
+
+def test_store_functional_relations_uses_default_for_unrecorded_kb(tmp_path):
+    store = _store(tmp_path)
+    assert "established_on" in store_functional_relations(store)

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -378,6 +378,28 @@ def _get_paths(app, client) -> list[str]:
     return paths
 
 
+def _mutating_paths(app, client) -> list[str]:
+    """Every POST/PUT/PATCH/DELETE route the app declares, with params filled in."""
+    values = {
+        "fact_id": client.fact_id,
+        "source_id": client.source_id,
+        "question_id": client.question_id,
+        "job_id": client.job_id,
+    }
+    paths = []
+    for route in app.routes:
+        methods = getattr(route, "methods", None) or set()
+        path = getattr(route, "path", "")
+        if not path or not methods & {"POST", "PUT", "PATCH", "DELETE"}:
+            continue
+        for name, value in values.items():
+            path = path.replace("{" + name + "}", str(value))
+        if "{" in path:
+            raise AssertionError(f"route param not covered by this test: {path}")
+        paths.append(path)
+    return paths
+
+
 def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
     """Enumerated so a newly added route is covered automatically."""
     client = _halted_client(tmp_path, monkeypatch)
@@ -414,6 +436,39 @@ def test_halted_kb_refuses_writes_and_leaves_facts_untouched(tmp_path, monkeypat
     # the guard runs before the route, so the autocommitted status change that
     # used to happen before the render blew up cannot happen at all
     assert store.get_fact(client.fact_id)["status"] == "candidate"
+
+
+def test_no_mutating_route_writes_when_the_policy_is_lost(tmp_path, monkeypatch):
+    """Enumerated like the GET test: default-deny stays locked as routes are added.
+
+    The only writes a halted KB accepts are the ones that leave it (switching the
+    active KB root). Everything else — facts *and* human-written policy files such
+    as relation-aliases.md — would be a change made while this KB's rules are not
+    being applied.
+    """
+    client = _halted_client(tmp_path, monkeypatch)
+    app = client.app
+    store = app.state.store
+    # writes that are allowed because they are how a human gets *out* of the halt
+    exempt = {"/kb/select", "/settings/root"}
+
+    paths = _mutating_paths(app, client)
+    assert f"/facts/{client.fact_id}/accept" in paths
+    assert "/settings/relation-aliases" in paths and "/settings" in paths
+
+    before = {int(f["id"]): f["status"] for f in store.facts()}
+    for path in paths:
+        if path in exempt:
+            continue
+        resp = client.post(path, data={"relation_aliases_text": "role -> ROLE"})
+        assert resp.status_code == 409, f"{path} accepted a write on a halted KB"
+        assert "policy reset --force" in resp.text, f"{path} hid the recovery route"
+
+    assert {int(f["id"]): f["status"] for f in store.facts()} == before
+    # no policy or settings file was written behind the halt
+    assert not (tmp_path / "policy" / "relation-aliases.md").exists()
+    assert not (tmp_path / "config.json").exists()
+    assert not client.policy_path.exists()
 
 
 def test_questions_page_exposes_a_lost_policy(tmp_path, monkeypatch):

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -121,6 +121,9 @@ def test_unrecorded_policy_runs_default_with_a_warning(tmp_path):
     assert rep.warnings >= 1
     assert any("policy_unrecorded" in finding for finding in rep.findings)
     assert "shipped default" in rep.text
+    # a run of the default policy is not a statement about this KB's rules, so
+    # the engine's clean-bill sentence must not survive into the report
+    assert "consistent" not in rep.text
     assert resolve_policy(store).status is PolicyStatus.UNRECORDED_DEFAULT
     assert load_policy(store) is None
 
@@ -290,3 +293,176 @@ def test_store_functional_relations_raises_when_policy_is_lost(tmp_path):
 def test_store_functional_relations_uses_default_for_unrecorded_kb(tmp_path):
     store = _store(tmp_path)
     assert "established_on" in store_functional_relations(store)
+
+
+def test_auto_accept_is_fail_closed_when_the_policy_is_lost(tmp_path):
+    """A rule-driven promotion must not run while the rules are missing."""
+    from verinote.pipeline.acceptance import apply_auto_accept_recommendations
+
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    source = store.add_source("sources/a.txt")
+    fact_id = store.add_fact(
+        "Ada", "is_a", "engineer", status="confirmed", confidence=0.99, source_id=source
+    )
+    path.unlink()
+
+    with pytest.raises(PolicyMissingError):
+        apply_auto_accept_recommendations(store)
+    assert store.get_fact(fact_id)["status"] == "confirmed"
+
+
+# --- web: a halted KB reports, it does not crash, and it does not accept writes ---
+
+
+def _halted_client(tmp_path, monkeypatch):
+    """A web client on a KB whose recorded policy file has been deleted."""
+    from fastapi.testclient import TestClient
+
+    from verinote.config import Config
+    from verinote.web.app import create_app
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    store = Store(cfg.db_path)
+    store.init_schema()
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    source_id = store.add_source("sources/a.txt")
+    fact_id = store.add_fact(
+        "Ada", "is_a", "engineer", status="candidate", confidence=0.9, source_id=source_id
+    )
+    question_id = store.add_question("who is Ada?")
+    store.close()
+    path.unlink()
+
+    client = TestClient(create_app(cfg), raise_server_exceptions=False)
+    client.fact_id = fact_id
+    client.source_id = source_id
+    client.question_id = question_id
+    client.job_id = 1
+    client.policy_path = path
+    return client
+
+
+def _get_paths(app, client) -> list[str]:
+    """Every GET route the app declares, with path params filled in."""
+    values = {
+        "fact_id": client.fact_id,
+        "source_id": client.source_id,
+        "question_id": client.question_id,
+        "job_id": client.job_id,
+    }
+    paths = []
+    for route in app.routes:
+        methods = getattr(route, "methods", None) or set()
+        path = getattr(route, "path", "")
+        if "GET" not in methods or not path or path.startswith("/static"):
+            continue
+        for name, value in values.items():
+            path = path.replace("{" + name + "}", str(value))
+        if "{" in path:  # an unknown param: fail loudly rather than skip silently
+            raise AssertionError(f"route param not covered by this test: {path}")
+        paths.append(path)
+    return paths
+
+
+def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
+    """Enumerated so a newly added route is covered automatically."""
+    client = _halted_client(tmp_path, monkeypatch)
+    app = client.app
+    exempt = {"/report", "/settings"}
+
+    paths = _get_paths(app, client)
+    assert "/" in paths and "/review" in paths and "/workbench" in paths
+
+    for path in paths:
+        resp = client.get(path)
+        assert resp.status_code != 500, f"{path} crashed instead of reporting"
+        if path in exempt:
+            continue
+        assert resp.status_code == 409, f"{path} did not halt"
+        assert "policy reset --force" in resp.text, f"{path} hid the recovery route"
+
+    report = client.get("/report")
+    assert report.status_code == 200
+    assert "policy_missing" in report.text
+    # ("inconsistent — promotion stays gated" is the errors banner, not a claim
+    # that the KB checked out clean)
+    assert "knowledge base is consistent" not in report.text
+
+
+def test_halted_kb_refuses_writes_and_leaves_facts_untouched(tmp_path, monkeypatch):
+    client = _halted_client(tmp_path, monkeypatch)
+    store = client.app.state.store
+
+    resp = client.post(f"/facts/{client.fact_id}/accept")
+
+    assert resp.status_code == 409
+    assert "policy reset --force" in resp.text
+    # the guard runs before the route, so the autocommitted status change that
+    # used to happen before the render blew up cannot happen at all
+    assert store.get_fact(client.fact_id)["status"] == "candidate"
+
+
+def test_questions_page_exposes_a_lost_policy(tmp_path, monkeypatch):
+    client = _halted_client(tmp_path, monkeypatch)
+
+    resp = client.get("/questions")
+
+    assert resp.status_code == 409
+    assert "policy_missing" in resp.text or "is missing" in resp.text
+    assert "policy reset --force" in resp.text
+
+
+def test_restoring_the_policy_file_unblocks_the_kb(tmp_path, monkeypatch):
+    client = _halted_client(tmp_path, monkeypatch)
+    assert client.get("/review").status_code == 409
+
+    client.policy_path.parent.mkdir(parents=True, exist_ok=True)
+    client.policy_path.write_text(FUNCTIONAL_POLICY, encoding="utf-8")
+
+    assert client.get("/review").status_code == 200
+
+
+# --- the report of an unrecorded-policy KB never renders as OK ---
+
+
+def test_report_of_unrecorded_policy_kb_is_not_ok(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from verinote.config import Config
+    from verinote.web.app import create_app
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+    client.app.state.store.add_fact("Ada", "is_a", "engineer", status="confirmed")
+
+    resp = client.get("/report")
+
+    assert resp.status_code == 200
+    assert ">\n    OK\n  <" not in resp.text
+    assert "WARNINGS" in resp.text
+    assert "policy_unrecorded" in resp.text
+    assert "knowledge base is consistent" not in resp.text

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -389,17 +389,58 @@ def cmd_ui(cfg: Config | None, args: argparse.Namespace) -> int:
     return 0
 
 
+def _refuse_on_halted_kb(cfg: Config | None) -> int | None:
+    """Exit code to return instead of running a write on a halted KB, or None.
+
+    Asked once, in `main`, for every subcommand that did not declare itself
+    `halt_safe`. The KB's policy state itself is *never* inferred here: that
+    judgement lives in `policy_state.assert_writable` alone. The db-file check is
+    only "is there a KB at all" — with no database there can be no marker, hence
+    nothing that could be halted, and `init` on a fresh root must still work.
+    """
+    from verinote.pipeline.policy_state import PolicyMissingError, assert_writable
+
+    if cfg is None or not cfg.db_path.is_file():
+        return None
+    store = Store(cfg.db_path)
+    store.init_schema()
+    try:
+        assert_writable(store)
+    except PolicyMissingError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        store.close()
+    return None
+
+
 def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI.
+
+    Every subcommand declares `halt_safe`: may it run against a KB whose recorded
+    logic policy file is gone? `halt_safe=True` is for the paths that must survive
+    a halt — read-only diagnosis, and the recovery command itself — because a halt
+    the user cannot diagnose or undo is just a bricked KB. Everything that writes
+    declares False and is refused by `main`.
+
+    `init` is deliberately *not* exempt: re-scaffolding the default policy onto a
+    KB that recorded a policy would overwrite the evidence of the loss with a
+    plausible-looking green KB, which is the exact failure this whole mechanism
+    exists to prevent. Recovery is `policy reset --force` — an explicit human act.
+
+    Fail closed: `main` reads this flag with a default of False, so a new
+    subcommand that forgets to declare one is treated as a write and blocked.
+    """
     p = argparse.ArgumentParser(prog="verinote", description="Honest KB: LLM extracts, DuckDB verifies.")
     p.add_argument("--version", action="version", version=f"verinote {__version__}")
     sub = p.add_subparsers(dest="command", required=True)
 
     init = sub.add_parser("init", help="scaffold a local KB (SQLite) under VERINOTE_ROOT (./data)")
     init.add_argument("--seed", action="store_true", help="insert demo facts")
-    init.set_defaults(func=cmd_init)
+    init.set_defaults(func=cmd_init, halt_safe=False)
 
     seed = sub.add_parser("seed", help="insert demo facts into the KB")
-    seed.set_defaults(func=cmd_seed)
+    seed.set_defaults(func=cmd_seed, halt_safe=False)
 
     sync = sub.add_parser("sync", help="extract candidate facts from sources via the LLM")
     sync.add_argument(
@@ -407,27 +448,27 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="?",
         help="a source file; omit to sync every .txt/.md under <root>/sources/",
     )
-    sync.set_defaults(func=cmd_sync)
+    sync.set_defaults(func=cmd_sync, halt_safe=False)
 
     ingest = sub.add_parser("ingest", help="register a source file (converting docx/pdf to text)")
     ingest.add_argument("path", help="a .txt/.md file, or a .docx/.pdf to convert")
-    ingest.set_defaults(func=cmd_ingest)
+    ingest.set_defaults(func=cmd_ingest, halt_safe=False)
 
     query = sub.add_parser("query", help="translate pending NL questions to Datalog queries")
     query.add_argument("question", nargs="?", help="a question to add before translating")
-    query.set_defaults(func=cmd_query)
+    query.set_defaults(func=cmd_query, halt_safe=False)
 
     repair = sub.add_parser("repair", help="re-translate review_required questions (engine-gated)")
-    repair.set_defaults(func=cmd_repair)
+    repair.set_defaults(func=cmd_repair, halt_safe=False)
 
     coverage = sub.add_parser("coverage", help="report per-source engine-fact coverage")
     coverage.add_argument(
         "--strict", action="store_true", help="exit non-zero if any text source has no engine facts"
     )
-    coverage.set_defaults(func=cmd_coverage)
+    coverage.set_defaults(func=cmd_coverage, halt_safe=True)
 
     status = sub.add_parser("status", help="summarise KB state")
-    status.set_defaults(func=cmd_status)
+    status.set_defaults(func=cmd_status, halt_safe=True)
 
     policy = sub.add_parser("policy", help="manage this KB's logic policy file")
     policy_sub = policy.add_subparsers(dest="policy_command", required=True)
@@ -439,15 +480,21 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="required — confirm replacing this KB's logic policy with the default",
     )
-    policy_reset.set_defaults(func=cmd_policy_reset)
+    # The one command that must run *on* a halted KB: it is how a halt is cleared.
+    policy_reset.set_defaults(func=cmd_policy_reset, halt_safe=True)
 
     ui = sub.add_parser("ui", help="launch the web app")
     ui.add_argument("--host", default="127.0.0.1")
     ui.add_argument("--port", type=int, default=8731)
     ui.add_argument("--reload", action="store_true", help="auto-reload (dev)")
     ui.add_argument("--no-browser", action="store_true", help="do not open a browser")
-    ui.set_defaults(func=cmd_ui)
-    sub.add_parser("serve", help="alias for ui").set_defaults(func=cmd_ui, host="127.0.0.1", port=8731, reload=False, no_browser=True)
+    # Launchers, not writers: the web app has its own per-request halt guard, which
+    # blocks writes while still serving the /report page that explains the halt.
+    # Refusing to start the server would strand the user with no way to diagnose it.
+    ui.set_defaults(func=cmd_ui, halt_safe=True)
+    sub.add_parser("serve", help="alias for ui").set_defaults(
+        func=cmd_ui, halt_safe=True, host="127.0.0.1", port=8731, reload=False, no_browser=True
+    )
 
     return p
 
@@ -455,6 +502,13 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     cfg = Config.load_for_ui() if args.command in {"ui", "serve"} else Config.load()
+    # The single CLI enforcement point for a halted KB. It sits here, before
+    # dispatch, because every subcommand goes through this one line — a guard
+    # sprinkled per-command is a guard the next command will forget.
+    if not getattr(args, "halt_safe", False):
+        refusal = _refuse_on_halted_kb(cfg)
+        if refusal is not None:
+            return refusal
     return args.func(cfg, args)
 
 

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -41,37 +41,81 @@ class _SyncSummary:
 
 
 def _store(cfg: Config) -> Store:
+    from verinote.pipeline.policy_state import ensure_policy_marker
+
     store = Store(cfg.db_path)
     store.init_schema()
+    # Opening a KB is where an existing (pre-marker) policy file gets adopted, so
+    # KBs created before markers existed keep working — and any later loss of
+    # their policy file is loud rather than silently defaulted.
+    ensure_policy_marker(store, cfg.root)
     return store
 
 
-def _scaffold_policy(cfg: Config) -> Path | None:
-    """Write the default logic policy if the KB doesn't have one yet."""
-    from verinote.engine import DEFAULT_POLICY
-    from verinote.pipeline.verify import POLICY_RELPATH
+def _scaffold_policy(cfg: Config, store: Store) -> Path | None:
+    """Write the default logic policy only when the KB never had one.
 
-    path = cfg.root / POLICY_RELPATH
-    if path.exists():
+    A KB that recorded a policy whose file is now gone is *not* re-scaffolded:
+    rewriting the default there would overwrite the evidence of the loss with a
+    plausible-looking green KB. That recovery needs a human (`policy reset
+    --force`).
+    """
+    from verinote.pipeline.policy_state import (
+        PolicyMissingError,
+        PolicyStatus,
+        policy_missing_message,
+        resolve_policy,
+        write_default_policy,
+    )
+
+    state = resolve_policy(store)
+    if state.status is PolicyStatus.PRESENT:
         return None
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(DEFAULT_POLICY, encoding="utf-8")
-    return path
+    if state.status is PolicyStatus.MISSING_RECORDED:
+        raise PolicyMissingError(policy_missing_message(state))
+    return write_default_policy(store, cfg.root, origin="scaffold")
 
 
 def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.pipeline.policy_state import PolicyMissingError
+
     cfg.root.mkdir(parents=True, exist_ok=True)
     store = _store(cfg)
     if args.seed:
         _seed(store)
+    try:
+        policy = _scaffold_policy(cfg, store)
+    except PolicyMissingError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        store.close()
+        return 2
     store.close()
-    policy = _scaffold_policy(cfg)
     print(f"initialised KB at {cfg.root}")
     print(f"  db: {cfg.db_path}")
     if policy is not None:
         print(f"  policy: {policy}")
     if args.seed:
         print("  seeded demo facts (run `verinote status`)")
+    return 0
+
+
+def cmd_policy_reset(cfg: Config, args: argparse.Namespace) -> int:
+    """The only way a policy file is (re)created without one already existing."""
+    from verinote.pipeline.policy_state import write_default_policy
+
+    if not args.force:
+        print(
+            "refusing to reset the logic policy without --force: this overwrites "
+            "the KB's rules with the shipped default. Restore the policy file from "
+            "backup or version control if it was lost.",
+            file=sys.stderr,
+        )
+        return 2
+    cfg.root.mkdir(parents=True, exist_ok=True)
+    store = _store(cfg)
+    path = write_default_policy(store, cfg.root, origin="reset")
+    store.close()
+    print(f"policy reset to the shipped default: {path}")
     return 0
 
 
@@ -384,6 +428,18 @@ def build_parser() -> argparse.ArgumentParser:
 
     status = sub.add_parser("status", help="summarise KB state")
     status.set_defaults(func=cmd_status)
+
+    policy = sub.add_parser("policy", help="manage this KB's logic policy file")
+    policy_sub = policy.add_subparsers(dest="policy_command", required=True)
+    policy_reset = policy_sub.add_parser(
+        "reset", help="re-create the default logic policy (explicit human gate)"
+    )
+    policy_reset.add_argument(
+        "--force",
+        action="store_true",
+        help="required — confirm replacing this KB's logic policy with the default",
+    )
+    policy_reset.set_defaults(func=cmd_policy_reset)
 
     ui = sub.add_parser("ui", help="launch the web app")
     ui.add_argument("--host", default="127.0.0.1")

--- a/verinote/engine/__init__.py
+++ b/verinote/engine/__init__.py
@@ -5,6 +5,7 @@ from verinote.engine.coverage import Coverage, SourceCoverage, coverage
 from verinote.engine.duckdb_backend import DuckDBInferenceCache, run_check_duckdb
 from verinote.engine.wirelog import (
     DEFAULT_POLICY,
+    NO_FINDINGS_TEXT,
     CheckReport,
     compile_dl,
     run_check,
@@ -19,6 +20,7 @@ __all__ = [
     "validate_query",
     "CheckReport",
     "DEFAULT_POLICY",
+    "NO_FINDINGS_TEXT",
     "coverage",
     "Coverage",
     "SourceCoverage",

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -26,7 +26,7 @@ from verinote.engine.duckdb_terms import (
     term_to_duckdb_value,
 )
 from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Term, Var, render_term
-from verinote.engine.wirelog import CheckReport, DEFAULT_POLICY
+from verinote.engine.wirelog import CheckReport, DEFAULT_POLICY, NO_FINDINGS_TEXT
 
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
@@ -390,11 +390,7 @@ def _collect_report(
     ]
     findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
     summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {len(facts)}"
-    body = (
-        "\n".join(findings)
-        if findings
-        else "no findings — knowledge base is consistent."
-    )
+    body = "\n".join(findings) if findings else NO_FINDINGS_TEXT
     if answers:
         body += "\n\n--- answers ---\n" + "\n".join(answers)
     debug = (

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -120,6 +120,12 @@ def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
 
 _ANSWER_PREFIX = "answer_q"
 
+# The engine's "clean bill of health" body. Exported because it is a claim about
+# the policy that ran, so callers that ran a *different* policy than the KB's own
+# (see pipeline.policy_state) must be able to recognise and replace it rather
+# than re-declaring the sentence and drifting from it.
+NO_FINDINGS_TEXT = "no findings — knowledge base is consistent."
+
 
 @dataclass
 class CheckReport:
@@ -271,11 +277,7 @@ def run_check(
     ]
     findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
     summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {len(facts)}"
-    body = (
-        "\n".join(findings)
-        if findings
-        else "no findings — knowledge base is consistent."
-    )
+    body = "\n".join(findings) if findings else NO_FINDINGS_TEXT
     if answers:
         body += "\n\n--- answers ---\n" + "\n".join(answers)
     return CheckReport(

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -21,6 +21,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
 )
 from verinote.pipeline.normalize import normalize_for_extraction
+from verinote.pipeline.policy_state import assert_writable
 from verinote.prompts import PromptError, render_prompt
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
@@ -160,7 +161,15 @@ def process_extraction_job(
     job_id: int,
     schema_hint: str = "",
 ) -> ChunkedExtractionResult:
-    """Process pending chunks for one durable extraction job."""
+    """Process pending chunks for one durable extraction job.
+
+    Raises `PolicyMissingError` if this KB's recorded logic policy file is gone —
+    both at the start and, per chunk, at the write boundary in `_extract_chunk`.
+    A job is long-running (one LLM call per chunk) and the CLI's start-of-command
+    check cannot see a policy deleted *after* the job began, so the check has to
+    live next to the write itself.
+    """
+    assert_writable(store)
     job = store.get_extraction_job(job_id)
     if job is None:
         raise LLMError(f"missing extraction job: {job_id}")
@@ -231,6 +240,11 @@ def _extract_chunk(
         schema_hint=schema_hint,
         root=store.db_path.parent,
     )
+    # The write boundary. Re-checked for *every* chunk, after the LLM call and
+    # before the first insert: the policy file can vanish while a job is running
+    # (a job is many slow LLM calls), and a check done only at job start would let
+    # every chunk after the deletion land in a KB whose rules no longer exist.
+    assert_writable(store)
     aliases = _relation_aliases_or_error(store)
     rows = _candidate_rows(facts, source_text, relation_aliases=aliases)
     inserted = 0

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -52,6 +52,14 @@ POLICY_ORIGINS = frozenset({"scaffold", "adopted", "reset"})
 POLICY_UNRECORDED_FINDING = (
     "WARNING policy_unrecorded: no KB policy file; running the shipped default"
 )
+# The engine's own "clean bill of health" sentence (engine/wirelog.py,
+# engine/duckdb_backend.py). It is a claim about the policy that ran, so when the
+# policy that ran is not this KB's, the sentence is replaced rather than framed.
+ENGINE_NO_FINDINGS_TEXT = "no findings — knowledge base is consistent."
+POLICY_UNRECORDED_NO_FINDINGS_TEXT = (
+    "no findings from the shipped default policy — this KB has no policy file of "
+    "its own, so this result says nothing about the KB's own rules."
+)
 POLICY_UNRECORDED_BANNER = (
     "WARNING policy_unrecorded: this KB has no policy file and never recorded one, "
     "so the shipped default policy was used. Findings below are the default's, not "

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The single place that decides what a KB's logic policy *is*.
+
+A missing `policy/logic-policy.dl` has two very different meanings:
+
+* the KB never used rules (benign — run the shipped default), and
+* the KB's rules were lost (an error — a human wrote them and they are gone).
+
+Code cannot infer which one happened, and guessing produces the worst possible
+outcome: a green "no findings — knowledge base is consistent." report from a KB
+whose rules evaporated. So the KB *declares* it instead: when a policy file is
+written (or adopted), a `policy.logic` marker is recorded in `kb_meta`. The
+marker — never mtime, git state, or a leftover directory — is the only input to
+the judgement here.
+
+The marker stores a sha256 as *evidence* (so a report can say what was there),
+not as a verdict: editing a policy is normal and a hash mismatch is never an
+error. The `.dl` file remains the owner of the policy text; the DB never stores
+its body.
+
+Three states, one resolution point:
+
+| file    | marker  | status               | behaviour                        |
+|---------|---------|----------------------|----------------------------------|
+| present | either  | `PRESENT`            | use the file                     |
+| absent  | present | `MISSING_RECORDED`   | loud error, no engine run        |
+| absent  | absent  | `UNRECORDED_DEFAULT` | shipped default + loud warning   |
+
+Future states (e.g. an empty-policy state, #171) belong in `PolicyStatus` and in
+`resolve_policy`; they must not reintroduce a silent fallback to DEFAULT_POLICY.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from verinote.store import Store
+
+# Per-KB policy location, relative to the KB root (the db file's directory).
+POLICY_RELPATH = Path("policy") / "logic-policy.dl"
+
+# Marker origins. `scaffold`: written by init/first KB open. `adopted`: a policy
+# file already existed before markers were recorded. `reset`: an explicit human
+# `verinote policy reset --force`.
+POLICY_ORIGINS = frozenset({"scaffold", "adopted", "reset"})
+
+POLICY_UNRECORDED_FINDING = (
+    "WARNING policy_unrecorded: no KB policy file; running the shipped default"
+)
+POLICY_UNRECORDED_BANNER = (
+    "WARNING policy_unrecorded: this KB has no policy file and never recorded one, "
+    "so the shipped default policy was used. Findings below are the default's, not "
+    "this KB's rules. Run `verinote init` (or `verinote policy reset --force`) to "
+    "record a policy file for this KB."
+)
+
+
+class PolicyMissingError(RuntimeError):
+    """Raised when a KB recorded a logic policy but the policy file is gone."""
+
+
+class PolicyStatus(str, Enum):
+    """How the KB's policy file relates to what the KB declared about it."""
+
+    PRESENT = "present"
+    MISSING_RECORDED = "missing_recorded"
+    UNRECORDED_DEFAULT = "unrecorded_default"
+
+
+@dataclass(frozen=True)
+class PolicyState:
+    """The resolved policy situation for one KB — pure data, no side effects."""
+
+    status: PolicyStatus
+    path: Path
+    text: str | None = None
+    marker: dict[str, object] | None = None
+
+    @property
+    def is_missing(self) -> bool:
+        return self.status is PolicyStatus.MISSING_RECORDED
+
+
+def policy_sha256(text: str) -> str:
+    """Evidence hash for a policy body (never a verdict — edits are normal)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def policy_path(store: "Store") -> Path:
+    return store.db_path.parent / POLICY_RELPATH
+
+
+def resolve_policy(store: "Store") -> PolicyState:
+    """Resolve the KB's policy into exactly one of the three states.
+
+    The only judgement inputs are: does the file exist, and did the KB record a
+    marker. Nothing else is inferred.
+    """
+    path = policy_path(store)
+    marker = store.policy_marker()
+    if path.is_file():
+        return PolicyState(
+            status=PolicyStatus.PRESENT,
+            path=path,
+            text=path.read_text(encoding="utf-8"),
+            marker=marker,
+        )
+    if marker is not None:
+        return PolicyState(status=PolicyStatus.MISSING_RECORDED, path=path, marker=marker)
+    return PolicyState(status=PolicyStatus.UNRECORDED_DEFAULT, path=path)
+
+
+def policy_missing_message(state: PolicyState) -> str:
+    """The loud, actionable message for a recorded-but-missing policy."""
+    marker = state.marker or {}
+    origin = str(marker.get("origin") or "unknown")
+    recorded_at = str(marker.get("recorded_at") or "unknown")
+    sha = str(marker.get("sha256") or "")
+    sha_text = sha[:12] if sha else "unknown"
+    return (
+        f"policy file {state.path} is missing, but this KB recorded one "
+        f"(origin={origin}, recorded_at={recorded_at}, sha256={sha_text}). "
+        "Verification is halted instead of silently falling back to the shipped "
+        "default policy. Recover by either (1) restoring the policy file from a "
+        "backup or version control, or (2) running `verinote policy reset --force` "
+        "to explicitly re-create the default policy for this KB."
+    )
+
+
+def ensure_policy_marker(store: "Store", root: Path | None = None) -> PolicyState:
+    """Record/refresh the policy marker when a KB is opened.
+
+    * file present, no marker  -> adopt it (`origin="adopted"`); pre-marker KBs
+      keep working, and any *later* loss of the file is loud.
+    * file present, marker     -> refresh the evidence hash (never an error).
+    * file absent              -> do nothing; the two absent states are already
+      distinguishable and must stay that way.
+    """
+    path = (root / POLICY_RELPATH) if root is not None else policy_path(store)
+    marker = store.policy_marker()
+    if not path.is_file():
+        status = (
+            PolicyStatus.MISSING_RECORDED if marker is not None else PolicyStatus.UNRECORDED_DEFAULT
+        )
+        return PolicyState(status=status, path=path, marker=marker)
+    text = path.read_text(encoding="utf-8")
+    origin = str(marker.get("origin")) if marker else "adopted"
+    if origin not in POLICY_ORIGINS:
+        origin = "adopted"
+    refreshed = store.record_policy_marker(policy_sha256(text), origin=origin)
+    return PolicyState(
+        status=PolicyStatus.PRESENT, path=path, text=text, marker=refreshed
+    )
+
+
+def write_default_policy(store: "Store", root: Path | None = None, *, origin: str) -> Path:
+    """Write DEFAULT_POLICY and record the marker. Callers own the human gate."""
+    from verinote.engine import DEFAULT_POLICY
+
+    if origin not in POLICY_ORIGINS:
+        raise ValueError(f"unknown policy marker origin: {origin}")
+    path = (root / POLICY_RELPATH) if root is not None else policy_path(store)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(DEFAULT_POLICY, encoding="utf-8")
+    store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin=origin)
+    return path

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -52,10 +52,9 @@ POLICY_ORIGINS = frozenset({"scaffold", "adopted", "reset"})
 POLICY_UNRECORDED_FINDING = (
     "WARNING policy_unrecorded: no KB policy file; running the shipped default"
 )
-# The engine's own "clean bill of health" sentence (engine/wirelog.py,
-# engine/duckdb_backend.py). It is a claim about the policy that ran, so when the
-# policy that ran is not this KB's, the sentence is replaced rather than framed.
-ENGINE_NO_FINDINGS_TEXT = "no findings — knowledge base is consistent."
+# Replaces the engine's own clean-bill sentence (`engine.NO_FINDINGS_TEXT`) when
+# the policy that ran was not this KB's. The engine owns that sentence; this
+# module only owns the substitute, so the two cannot drift apart.
 POLICY_UNRECORDED_NO_FINDINGS_TEXT = (
     "no findings from the shipped default policy — this KB has no policy file of "
     "its own, so this result says nothing about the KB's own rules."

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -139,6 +139,25 @@ def policy_missing_message(state: PolicyState) -> str:
     )
 
 
+def assert_writable(store: "Store") -> PolicyState:
+    """Refuse to let a KB whose recorded policy file is gone be written to.
+
+    The single enforcement predicate: every write entrypoint (CLI dispatch, the
+    extraction worker's write boundary, the web guard) asks *this*, so the three
+    of them cannot disagree about what "halted" means. Enforcement points must
+    call it instead of re-deriving the state — `resolve_policy` is the only place
+    allowed to look at the file and the marker.
+
+    A halted KB still has to be *recoverable*, so this is deliberately not a
+    blanket lock on the DB: read-only diagnosis (`status`, `coverage`, the web
+    `/report` page) and `policy reset --force` do not go through here.
+    """
+    state = resolve_policy(store)
+    if state.status is PolicyStatus.MISSING_RECORDED:
+        raise PolicyMissingError(policy_missing_message(state))
+    return state
+
+
 def ensure_policy_marker(store: "Store", root: Path | None = None) -> PolicyState:
     """Record/refresh the policy marker when a KB is opened.
 
@@ -173,6 +192,12 @@ def write_default_policy(store: "Store", root: Path | None = None, *, origin: st
         raise ValueError(f"unknown policy marker origin: {origin}")
     path = (root / POLICY_RELPATH) if root is not None else policy_path(store)
     path.parent.mkdir(parents=True, exist_ok=True)
+    # ORDER IS LOAD-BEARING — file first, marker second. This is the function that
+    # un-halts a KB (`policy reset --force`), and it runs *on* a halted KB. Writing
+    # the file first flips `resolve_policy` to PRESENT before the marker write
+    # happens, so the DB write lands on a KB that is no longer halted. Reverse
+    # these two lines and the only recovery path starts tripping over the very
+    # halt it exists to clear.
     path.write_text(DEFAULT_POLICY, encoding="utf-8")
     store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin=origin)
     return path

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 from verinote.engine import CheckReport
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.policy_state import (
+    ENGINE_NO_FINDINGS_TEXT,
     POLICY_RELPATH,
     POLICY_UNRECORDED_BANNER,
     POLICY_UNRECORDED_FINDING,
+    POLICY_UNRECORDED_NO_FINDINGS_TEXT,
     PolicyMissingError,
     PolicyState,
     PolicyStatus,
@@ -100,8 +102,16 @@ def verify(store: Store) -> CheckReport:
 
 
 def _with_unrecorded_policy_warning(report: CheckReport) -> CheckReport:
-    """Annotate a default-policy run so it can never read as a clean bill of health."""
+    """Make a default-policy run unable to read as a clean bill of health.
+
+    A banner is not enough: the engine's "no findings — knowledge base is
+    consistent." sentence is a claim about *this KB's rules*, and no rules of
+    this KB were run. The sentence is replaced, not merely prefixed. `ok` and
+    `errors` are deliberately left alone — with no marker there is no evidence
+    that a policy was ever lost, and inventing an error would be inference.
+    """
     report.warnings += 1
     report.findings = [POLICY_UNRECORDED_FINDING, *report.findings]
+    report.text = report.text.replace(ENGINE_NO_FINDINGS_TEXT, POLICY_UNRECORDED_NO_FINDINGS_TEXT)
     report.text = f"{POLICY_UNRECORDED_BANNER}\n\n{report.text}"
     return report

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -1,27 +1,56 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Run the DuckDB-backed logic check against the KB policy."""
+"""Run the DuckDB-backed logic check against the KB policy.
+
+Policy resolution lives in `pipeline.policy_state`; this module only turns the
+three resolved states into a `CheckReport`. The one invariant worth stating: a
+report may never claim the KB is consistent without saying which policy produced
+that claim — a lost policy is an error, and an absent-and-never-recorded one is
+at minimum a warning.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from verinote.engine import CheckReport
 from verinote.pipeline.corroboration import CorroborationPolicyError
+from verinote.pipeline.policy_state import (
+    POLICY_RELPATH,
+    POLICY_UNRECORDED_BANNER,
+    POLICY_UNRECORDED_FINDING,
+    PolicyMissingError,
+    PolicyState,
+    PolicyStatus,
+    policy_missing_message,
+    policy_path,
+    resolve_policy,
+)
 from verinote.store import Store
 
-# Per-KB policy location, relative to the KB root (the db file's directory).
-POLICY_RELPATH = Path("policy") / "logic-policy.dl"
-
-
-def policy_path(store: Store) -> Path:
-    return store.db_path.parent / POLICY_RELPATH
+__all__ = [
+    "POLICY_RELPATH",
+    "PolicyMissingError",
+    "PolicyState",
+    "PolicyStatus",
+    "load_policy",
+    "policy_path",
+    "resolve_policy",
+    "verify",
+]
 
 
 def load_policy(store: Store) -> str | None:
-    """Read the KB's policy file, or None to fall back to the shipped default."""
-    path = policy_path(store)
-    if path.is_file():
-        return path.read_text(encoding="utf-8")
+    """The KB's policy text, or None to use the shipped default.
+
+    Raises `PolicyMissingError` when the KB recorded a policy file that is now
+    gone: returning None there would silently substitute the shipped default for
+    rules a human wrote. Every policy consumer (verification and the
+    corroboration/acceptance gates alike) goes through here, so none of them can
+    quietly disagree about what this KB's rules are.
+    """
+    state = resolve_policy(store)
+    if state.status is PolicyStatus.MISSING_RECORDED:
+        raise PolicyMissingError(policy_missing_message(state))
+    if state.status is PolicyStatus.PRESENT:
+        return state.text
     return None
 
 
@@ -29,6 +58,17 @@ def verify(store: Store) -> CheckReport:
     """Run confirmed/accepted facts through the deterministic DuckDB check."""
     from verinote.pipeline.query import load_query
     from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+
+    state = resolve_policy(store)
+    if state.status is PolicyStatus.MISSING_RECORDED:
+        message = policy_missing_message(state)
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"backend: DuckDB\n\npolicy error: {message}",
+            findings=[f"ERROR policy_missing: {message}"],
+        )
 
     try:
         rows = store.engine_fact_terms()
@@ -50,4 +90,18 @@ def verify(store: Store) -> CheckReport:
             text=f"backend: DuckDB\n\npolicy/error: {exc}",
             findings=[f"ERROR policy error: {exc}"],
         )
-    return store.inference_cache.run_check(rows, policy_dl=load_policy(store), query_dl=query_dl)
+
+    report = store.inference_cache.run_check(
+        rows, policy_dl=state.text, query_dl=query_dl
+    )
+    if state.status is PolicyStatus.UNRECORDED_DEFAULT:
+        return _with_unrecorded_policy_warning(report)
+    return report
+
+
+def _with_unrecorded_policy_warning(report: CheckReport) -> CheckReport:
+    """Annotate a default-policy run so it can never read as a clean bill of health."""
+    report.warnings += 1
+    report.findings = [POLICY_UNRECORDED_FINDING, *report.findings]
+    report.text = f"{POLICY_UNRECORDED_BANNER}\n\n{report.text}"
+    return report

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -10,10 +10,9 @@ at minimum a warning.
 
 from __future__ import annotations
 
-from verinote.engine import CheckReport
+from verinote.engine import NO_FINDINGS_TEXT, CheckReport
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.policy_state import (
-    ENGINE_NO_FINDINGS_TEXT,
     POLICY_RELPATH,
     POLICY_UNRECORDED_BANNER,
     POLICY_UNRECORDED_FINDING,
@@ -112,6 +111,6 @@ def _with_unrecorded_policy_warning(report: CheckReport) -> CheckReport:
     """
     report.warnings += 1
     report.findings = [POLICY_UNRECORDED_FINDING, *report.findings]
-    report.text = report.text.replace(ENGINE_NO_FINDINGS_TEXT, POLICY_UNRECORDED_NO_FINDINGS_TEXT)
+    report.text = report.text.replace(NO_FINDINGS_TEXT, POLICY_UNRECORDED_NO_FINDINGS_TEXT)
     report.text = f"{POLICY_UNRECORDED_BANNER}\n\n{report.text}"
     return report

--- a/verinote/store/__init__.py
+++ b/verinote/store/__init__.py
@@ -4,6 +4,7 @@
 from verinote.store.db import (
     DEFAULT_REVIEW_PAGE_SIZE,
     ENGINE_STATUSES,
+    POLICY_MARKER_KEY,
     REVIEW_PAGE_SIZES,
     REVIEW_STATUSES,
     ReviewQueuePage,
@@ -12,6 +13,7 @@ from verinote.store.db import (
 
 __all__ = [
     "Store",
+    "POLICY_MARKER_KEY",
     "REVIEW_STATUSES",
     "ENGINE_STATUSES",
     "DEFAULT_REVIEW_PAGE_SIZE",

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -10,6 +10,7 @@ for deterministic inference and attaches this same file read-only for analytics.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import datetime
 import json
 import sqlite3
 import threading
@@ -19,6 +20,8 @@ from typing import Any, Iterable
 
 # Status tiers (kept in code so the web/pipeline layers share one definition).
 REVIEW_STATUSES = frozenset({"candidate", "needs_review"})
+# kb_meta key under which a KB declares that it owns a logic policy file.
+POLICY_MARKER_KEY = "policy.logic"
 ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
 REVIEW_PAGE_SIZES = (25, 50, 100)
@@ -164,6 +167,57 @@ class Store:
 
     def __exit__(self, *exc: object) -> None:
         self.close()
+
+    # --- kb metadata -----------------------------------------------------
+    def get_meta(self, key: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT value FROM kb_meta WHERE key = ?", (key,)
+        ).fetchone()
+        return None if row is None else str(row["value"])
+
+    def set_meta(self, key: str, value: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO kb_meta(key, value) VALUES(?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+                "updated_at = datetime('now')",
+                (key, value),
+            )
+
+    def delete_meta(self, key: str) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM kb_meta WHERE key = ?", (key,))
+
+    def policy_marker(self) -> dict[str, object] | None:
+        """The KB's declaration that it has a logic policy file, or None.
+
+        Presence of the row *is* the declaration; a payload we cannot parse is
+        still a declaration (returning None there would silently downgrade a
+        lost policy to a benign one).
+        """
+        raw = self.get_meta(POLICY_MARKER_KEY)
+        if raw is None:
+            return None
+        try:
+            marker = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+        if not isinstance(marker, dict):
+            return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+        return marker
+
+    def record_policy_marker(self, sha256: str, *, origin: str) -> dict[str, object]:
+        """Record that this KB has a policy file. Hash is evidence, not a verdict."""
+        marker: dict[str, object] = {
+            "sha256": sha256,
+            "recorded_at": _utc_now(),
+            "origin": origin,
+        }
+        self.set_meta(POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False))
+        return marker
+
+    def clear_policy_marker(self) -> None:
+        self.delete_meta(POLICY_MARKER_KEY)
 
     # --- sources ---------------------------------------------------------
     def add_source(self, path: str, kind: str = "text") -> int:
@@ -1438,6 +1492,15 @@ class Store:
             "WHERE id = ?",
             (status, done, failed, message, job_id),
         )
+
+
+def _utc_now() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _display_fact_value(value: object) -> str:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -216,8 +216,10 @@ class Store:
         self.set_meta(POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False))
         return marker
 
-    def clear_policy_marker(self) -> None:
-        self.delete_meta(POLICY_MARKER_KEY)
+    # Deliberately no `clear_policy_marker()`: dropping the marker is exactly the
+    # move that downgrades a lost policy back to a benign default, which is the
+    # bug this table exists to prevent. Recovery is restoring the file or running
+    # `verinote policy reset --force`, both of which re-record the marker.
 
     # --- sources ---------------------------------------------------------
     def add_source(self, path: str, kind: str = "text") -> int:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -169,13 +169,19 @@ class Store:
         self.close()
 
     # --- kb metadata -----------------------------------------------------
-    def get_meta(self, key: str) -> str | None:
+    # `kb_meta` has exactly one client — the policy marker below — and no generic
+    # read/write/delete API is exposed for it. That is deliberate. A public
+    # `delete_meta("policy.logic")` (or a plain `set_meta`) is `clear_policy_marker`
+    # under another name: it downgrades a *lost* policy back to a KB that "never had
+    # one", which silently restores the shipped-default fallback this table exists
+    # to prevent. Keep the accessors private and the intent stays enforceable.
+    def _get_meta(self, key: str) -> str | None:
         row = self._conn.execute(
             "SELECT value FROM kb_meta WHERE key = ?", (key,)
         ).fetchone()
         return None if row is None else str(row["value"])
 
-    def set_meta(self, key: str, value: str) -> None:
+    def _set_meta(self, key: str, value: str) -> None:
         with self._lock:
             self._conn.execute(
                 "INSERT INTO kb_meta(key, value) VALUES(?, ?) "
@@ -184,10 +190,6 @@ class Store:
                 (key, value),
             )
 
-    def delete_meta(self, key: str) -> None:
-        with self._lock:
-            self._conn.execute("DELETE FROM kb_meta WHERE key = ?", (key,))
-
     def policy_marker(self) -> dict[str, object] | None:
         """The KB's declaration that it has a logic policy file, or None.
 
@@ -195,7 +197,7 @@ class Store:
         still a declaration (returning None there would silently downgrade a
         lost policy to a benign one).
         """
-        raw = self.get_meta(POLICY_MARKER_KEY)
+        raw = self._get_meta(POLICY_MARKER_KEY)
         if raw is None:
             return None
         try:
@@ -213,13 +215,14 @@ class Store:
             "recorded_at": _utc_now(),
             "origin": origin,
         }
-        self.set_meta(POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False))
+        self._set_meta(POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False))
         return marker
 
-    # Deliberately no `clear_policy_marker()`: dropping the marker is exactly the
-    # move that downgrades a lost policy back to a benign default, which is the
-    # bug this table exists to prevent. Recovery is restoring the file or running
-    # `verinote policy reset --force`, both of which re-record the marker.
+    # Deliberately no `clear_policy_marker()` — and, per the note above, no public
+    # `delete_meta` that would be one. Dropping the marker downgrades a lost policy
+    # back to a benign default, which is the bug this table exists to prevent.
+    # Recovery is restoring the file or running `verinote policy reset --force`,
+    # both of which re-record the marker.
 
     # --- sources ---------------------------------------------------------
     def add_source(self, path: str, kind: str = "text") -> int:

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -7,6 +7,19 @@
 PRAGMA journal_mode = WAL;        -- concurrent readers + a single writer
 PRAGMA foreign_keys = ON;
 
+-- KB-level declarations. Small key/value facts the KB states about itself, so
+-- code never has to *infer* them. `policy.logic` records that this KB has a
+-- logic policy file (sha256 + timestamp + origin as evidence only — the .dl
+-- file owns the policy text), which is what lets a later disappearance of that
+-- file be reported as an error instead of a benign "no rules" default.
+-- init_schema() runs this script on every open, so CREATE TABLE IF NOT EXISTS
+-- is also the migration for existing KBs.
+CREATE TABLE IF NOT EXISTS kb_meta (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- A source document the facts are cited against. For binary uploads this is the
 -- original file, not the converted text used for extraction.
 CREATE TABLE IF NOT EXISTS sources (

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -45,8 +45,8 @@ from verinote.pipeline import (
 from verinote.pipeline.policy_state import (
     PolicyMissingError,
     PolicyStatus,
+    assert_writable,
     ensure_policy_marker,
-    policy_missing_message,
     resolve_policy,
     write_default_policy,
 )
@@ -146,9 +146,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         """
         store = app.state.store
         if store is not None and not _policy_guard_exempt(request.method, request.url.path):
-            state = resolve_policy(store)
-            if state.status is PolicyStatus.MISSING_RECORDED:
-                return _policy_halted(request, policy_missing_message(state))
+            # Same predicate the CLI dispatch and the extraction worker use, so the
+            # three enforcement points cannot disagree about what "halted" means.
+            try:
+                assert_writable(store)
+            except PolicyMissingError as exc:
+                return _policy_halted(request, str(exc))
         return await call_next(request)
 
     def _policy_missing_handler(request: Request, exc: Exception):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -92,18 +92,24 @@ from verinote.store.fact_input import structural_term, term_input_kind
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
 _STATIC = resources.files("verinote.web").joinpath("static")
 
-# The only paths served while a KB's recorded policy file is missing: the report
-# (which explains the halt), the recovery/settings screens, KB switching, and
-# static assets. Everything else — including every write — fails closed, because
-# with the KB's rules unapplied neither a verdict nor a human accept is real.
-_POLICY_GUARD_ALLOWLIST = ("/report", "/settings", "/kb/select", "/static")
+# What is served while a KB's recorded policy file is missing. Default-deny, and
+# the allowlist is keyed by (method, path) rather than path alone: a page needed
+# to *diagnose* the halt is not licence to *write* under the same prefix. The
+# only writes allowed are the ones that leave this KB (switching root), because
+# every other write — facts, and policy files like relation-aliases.md — would be
+# a change made while this KB's rules are not being applied.
+_POLICY_GUARD_READ_PATHS = ("/report", "/settings", "/static")
+_POLICY_GUARD_WRITE_PATHS = ("/kb/select", "/settings/root")
 
 
-def _policy_guard_exempt(path: str) -> bool:
-    return any(
-        path == allowed or path.startswith(allowed + "/")
-        for allowed in _POLICY_GUARD_ALLOWLIST
-    )
+def _matches(path: str, allowed: tuple[str, ...]) -> bool:
+    return any(path == a or path.startswith(a + "/") for a in allowed)
+
+
+def _policy_guard_exempt(method: str, path: str) -> bool:
+    if method in {"GET", "HEAD", "OPTIONS"}:
+        return _matches(path, _POLICY_GUARD_READ_PATHS)
+    return path in _POLICY_GUARD_WRITE_PATHS
 
 
 def create_app(cfg: Config | None = None) -> FastAPI:
@@ -139,14 +145,22 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         the guard runs before the route does, and only the recovery paths pass.
         """
         store = app.state.store
-        if store is not None and not _policy_guard_exempt(request.url.path):
+        if store is not None and not _policy_guard_exempt(request.method, request.url.path):
             state = resolve_policy(store)
             if state.status is PolicyStatus.MISSING_RECORDED:
                 return _policy_halted(request, policy_missing_message(state))
         return await call_next(request)
 
     def _policy_missing_handler(request: Request, exc: Exception):
-        """Backstop: a route added outside the guard still gets the loud page."""
+        """Backstop for *display* only — it cannot prevent a write.
+
+        An exception handler runs after the route body has already run, so a
+        route that writes before it reads the policy would commit (SQLite
+        autocommits) and still render this page: "looks rejected, actually
+        written". Write blocking is the middleware's default-deny above; this
+        only guarantees that a route added outside the guard shows the loud page
+        instead of a stack trace.
+        """
         return _policy_halted(request, str(exc))
 
     app.add_exception_handler(PolicyMissingError, _policy_missing_handler)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -46,9 +46,11 @@ from verinote.pipeline.policy_state import (
     PolicyMissingError,
     PolicyStatus,
     ensure_policy_marker,
+    policy_missing_message,
     resolve_policy,
     write_default_policy,
 )
+from verinote.pipeline.query import load_query
 from verinote.pipeline.question_outcome import question_outcome_view
 from verinote.pipeline.ask import ask_question
 from verinote.pipeline.acceptance import (
@@ -90,6 +92,19 @@ from verinote.store.fact_input import structural_term, term_input_kind
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
 _STATIC = resources.files("verinote.web").joinpath("static")
 
+# The only paths served while a KB's recorded policy file is missing: the report
+# (which explains the halt), the recovery/settings screens, KB switching, and
+# static assets. Everything else — including every write — fails closed, because
+# with the KB's rules unapplied neither a verdict nor a human accept is real.
+_POLICY_GUARD_ALLOWLIST = ("/report", "/settings", "/kb/select", "/static")
+
+
+def _policy_guard_exempt(path: str) -> bool:
+    return any(
+        path == allowed or path.startswith(allowed + "/")
+        for allowed in _POLICY_GUARD_ALLOWLIST
+    )
+
 
 def create_app(cfg: Config | None = None) -> FastAPI:
     cfg = cfg if cfg is not None else Config.load_for_ui()
@@ -105,6 +120,36 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     templates = Jinja2Templates(directory=str(_TEMPLATES))
     app.mount("/static", StaticFiles(directory=str(_STATIC)), name="static")
+
+    def _policy_halted(request: Request, message: str):
+        return templates.TemplateResponse(
+            request,
+            "policy_halted.html",
+            {"message": message},
+            status_code=409,
+        )
+
+    @app.middleware("http")
+    async def policy_halted_guard(request: Request, call_next):
+        """Fail closed while this KB's recorded logic policy is missing.
+
+        A halted KB must not be *written* to either: an accept/reject decision
+        taken while the KB's rules are not being applied is a fake review gate,
+        and SQLite autocommits the status change long before rendering fails. So
+        the guard runs before the route does, and only the recovery paths pass.
+        """
+        store = app.state.store
+        if store is not None and not _policy_guard_exempt(request.url.path):
+            state = resolve_policy(store)
+            if state.status is PolicyStatus.MISSING_RECORDED:
+                return _policy_halted(request, policy_missing_message(state))
+        return await call_next(request)
+
+    def _policy_missing_handler(request: Request, exc: Exception):
+        """Backstop: a route added outside the guard still gets the loud page."""
+        return _policy_halted(request, str(exc))
+
+    app.add_exception_handler(PolicyMissingError, _policy_missing_handler)
 
     def _active_store() -> Store:
         store = app.state.store
@@ -932,10 +977,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         rep = verify(store)
         page_error = error
         if page_error is None:
-            page_error = next(
-                (finding for finding in rep.findings if "policy error" in finding),
-                None,
-            )
+            # Ask the thing that owns the answer, never the report's prose: a
+            # finding string is human-readable output, not a state field. (The
+            # missing-policy state is handled by the guard, which never routes
+            # here.) The query policy's own error type is what surfaces below.
+            try:
+                load_query(store)
+            except CorroborationPolicyError as exc:
+                page_error = f"policy error: {exc}"
         return templates.TemplateResponse(
             request,
             "questions.html",

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -42,6 +42,13 @@ from verinote.pipeline import (
     verify,
     write_query_file,
 )
+from verinote.pipeline.policy_state import (
+    PolicyMissingError,
+    PolicyStatus,
+    ensure_policy_marker,
+    resolve_policy,
+    write_default_policy,
+)
 from verinote.pipeline.question_outcome import question_outcome_view
 from verinote.pipeline.ask import ask_question
 from verinote.pipeline.acceptance import (
@@ -49,7 +56,7 @@ from verinote.pipeline.acceptance import (
     accept_recommendations_for,
     apply_auto_accept_recommendations,
 )
-from verinote.pipeline.report_trace import report_trace
+from verinote.pipeline.report_trace import ReportTrace, report_trace
 from verinote.pipeline.corroboration import (
     canonical_relation,
     CorroborationPolicyError,
@@ -93,6 +100,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
+        ensure_policy_marker(store, cfg.root)
         app.state.store = store
 
     templates = Jinja2Templates(directory=str(_TEMPLATES))
@@ -201,13 +209,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         next_store = Store(next_cfg.db_path)
         next_store.init_schema()
 
-        from verinote.engine import DEFAULT_POLICY
-        from verinote.pipeline.verify import POLICY_RELPATH
-
-        policy_path = root / POLICY_RELPATH
-        if not policy_path.exists():
-            policy_path.parent.mkdir(parents=True, exist_ok=True)
-            policy_path.write_text(DEFAULT_POLICY, encoding="utf-8")
+        # Adopt an existing policy file, then scaffold a default one *only* for a
+        # KB that never recorded a policy. A KB whose recorded policy file is gone
+        # is opened as-is: re-writing the default here would hide the loss, so the
+        # KB stays open and /report surfaces the error instead.
+        ensure_policy_marker(next_store, root)
+        if resolve_policy(next_store).status is PolicyStatus.UNRECORDED_DEFAULT:
+            write_default_policy(next_store, root, origin="scaffold")
 
         save_active_root(root)
         old_store = app.state.store
@@ -1013,10 +1021,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.get("/report", response_class=HTMLResponse)
     def report(request: Request):
         store = _active_store()
+        rep = verify(store)
+        try:
+            trace = report_trace(store)
+        except PolicyMissingError:
+            # The report itself already carries the policy_missing error; the
+            # trace needs the same (lost) policy, so it has nothing to say.
+            trace = ReportTrace(answers=(), excluded_candidate_count=0)
         return templates.TemplateResponse(
             request,
             "report.html",
-            {"rep": verify(store), "trace": report_trace(store)},
+            {"rep": rep, "trace": trace},
         )
 
     @app.get("/analytics", response_class=HTMLResponse)

--- a/verinote/web/templates/policy_halted.html
+++ b/verinote/web/templates/policy_halted.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Verification halted — verinote</title>
+  <link rel="stylesheet" href="/static/app.css">
+</head>
+<body>
+  <main class="chooser">
+    <h1>Verification halted: this KB's logic policy is missing</h1>
+
+    {# The one message about a lost policy lives in policy_missing_message();
+       re-wording the recovery instructions here would be a second answer to the
+       same question. Recovery is a human decision — there is deliberately no
+       "re-create the policy" button on this page. #}
+    <p class="error" role="alert">{{ message }}</p>
+
+    <p class="muted">Reviewing, accepting and rejecting facts are blocked while the
+      KB's rules are not being applied: an approval given under rules that are not
+      running is not a real review gate. Restore the policy file (backup or version
+      control), or run <code>verinote policy reset --force</code> to explicitly
+      re-create the default policy. The KB unblocks itself as soon as the policy
+      file is back.</p>
+
+    <p><a href="/report">Open the report</a> · <a href="/settings">Settings</a></p>
+  </main>
+</body>
+</html>

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -6,8 +6,11 @@
 <p class="warn">DuckDB verification backend is not available.</p>
 {% endif %}
 <p>
-  <span class="badge {{ 'badge-confirmed' if rep.ok and rep.errors == 0 else 'badge-superseded' }}">
-    {{ 'OK' if rep.ok and rep.errors == 0 else 'ERRORS' }}
+  {# A warning means something about the check itself is unsound (e.g. no policy
+     file for this KB), so it cannot show as OK — an OK badge is a claim. #}
+  {% set is_ok = rep.ok and rep.errors == 0 and rep.warnings == 0 %}
+  <span class="badge {{ 'badge-confirmed' if is_ok else 'badge-superseded' }}">
+    {{ 'OK' if is_ok else ('ERRORS' if rep.errors else 'WARNINGS') }}
   </span>
   errors: {{ rep.errors }} · warnings: {{ rep.warnings }}
 </p>


### PR DESCRIPTION
## The bug: benign and error were the same code path

`load_policy()` returned `None` whenever `policy/logic-policy.dl` was absent, and every consumer
(`engine/duckdb_backend.py`, `engine/wirelog.py`, and `pipeline/corroboration.py`'s
`store_functional_relations()`) read `None` as "use `DEFAULT_POLICY`". So a KB whose human-written
rules were deleted reported:

```
ok=True, errors=0 — "no findings — knowledge base is consistent."
```

A silently wrong green light. "Policy file absent" has two meanings and code cannot tell them apart:

- (a) new KB, never used rules -> benign
- (b) rules existed and were lost -> error

Since it cannot be *inferred*, the KB now **declares** it.

## The marker (declaration, not inference)

`kb_meta(key, value, updated_at)` in `store/schema.sql` (`init_schema()` runs it on every open, so
`CREATE TABLE IF NOT EXISTS` is also the migration). Key `policy.logic`, value
`{"sha256":..., "recorded_at":..., "origin":"scaffold"|"adopted"|"reset"}`.

- sha256 is **evidence** (the report can say what was there), never a verdict: editing a policy is
  normal, so a **hash mismatch is not an error**.
- The policy body is **never** stored in the DB — the `.dl` file owns it.
- The marker's presence is the only judgement input. No mtime, no git state, no directory
  heuristics. There is also **no `clear_policy_marker()`**: a named way to downgrade a loud state
  back to benign is a bypass waiting to be used.

## Three states, one interpretation point

`pipeline/policy_state.py::resolve_policy(store)`:

| file    | marker  | status               | behaviour                                                |
|---------|---------|----------------------|----------------------------------------------------------|
| present | either  | `PRESENT`            | use the file (unchanged)                                 |
| absent  | present | `MISSING_RECORDED`   | **loud error**: `PolicyMissingError`, engine not run     |
| absent  | absent  | `UNRECORDED_DEFAULT` | `DEFAULT_POLICY` + **explicit warning**; `ok` untouched  |

`load_policy()` delegates here, so the corroboration/acceptance gate became loud without a second
fix. **`PolicyStatus` is the only code that judges policy state** — nothing parses finding strings
to find out (a review round caught `/questions` doing exactly that, see below).

**After this change there is no path that reports "consistent" without saying which policy said so.**

## A halted KB reports; it does not crash, and it takes no new knowledge

> **Wording corrected in round 3.** This section originally said a halted KB "does not accept
> writes", which was stronger than the code: the extraction worker still rewinds its own job
> bookkeeping. The exact, enforced contract is in
> [*What "does not accept writes" actually means*](#what-does-not-accept-writes-actually-means)
> below. Everything in this section about *facts, evidence and policy files* holds as written.

`PolicyMissingError` propagating out of the trust/acceptance path used to 500 `/`, `/review`,
`/workbench` and `/sources` — so the user never reached `/report` and never saw the recovery
instructions. **A 500 is not loud, it is a crash.** Two layers, no per-route `try/except`:

1. **fail-closed middleware** runs before any route. With `MISSING_RECORDED` everything returns
   **409** with `policy_halted.html`, whose text is `policy_missing_message(state)` and nothing else.
   The allowlist is keyed by **(method, path)**, not path alone — a page needed to *diagnose* the
   halt is not licence to *write* under the same prefix:

   | allowed | why |
   |---|---|
   | `GET /report`, `GET /settings`, `GET /static/*` | see the halt and how to recover |
   | `POST /kb/select`, `POST /settings/root` | the only writes that *leave* this KB |

   Everything else fails closed — including `POST /settings/relation-aliases`, because relation
   aliases are a human-written policy that corroboration and query canonicalisation consume, so
   editing them while this KB's rules are not applied is the same category of mistake as accepting a
   fact.
2. **`app.add_exception_handler(PolicyMissingError, ...)`** as a **display-only** backstop: a route
   added outside the guard shows the loud page instead of a stack trace. It deliberately is *not*
   the write barrier — an exception handler runs after the route body, so without the middleware a
   write would commit (SQLite autocommits) and still render a 409: "looks rejected, actually
   written". Write blocking is the middleware's default-deny.

This also closes the write hole: `POST /facts/{id}/accept` used to autocommit the status change and
*then* fail while rendering, so the KB changed while the user saw an error. The guard runs before
the route, so nothing is written. **Blocking accept/reject on a halted KB is the point**: an approval
given while the KB's rules are not applied is a fake human gate. Restoring the policy file unblocks
the KB immediately, and there is deliberately no "re-create the policy" button — recovery is a human
`--force` decision.

## `UNRECORDED_DEFAULT` cannot read as a clean bill of health

This is exactly the state of a KB that lost its policy *before* upgrading, so it matters most for
the original victims of #155. The engine's `"no findings — knowledge base is consistent."` is a claim
about the policy that ran, and this KB's policy did not run — so the sentence is **replaced**, not
merely prefixed with a banner, and the report's OK badge now requires `warnings == 0`.

`ok`/`errors` are deliberately **not** escalated: with no marker there is no evidence a policy was
ever lost, and inventing an error would be inference — the same sin, mirrored. (The CLI does not
print report text, so there is no second surface to keep in sync.)

The sentence itself now has exactly one owner: `engine.NO_FINDINGS_TEXT`, used by both engine
backends and by `verify`'s substitution. It had been spelled out in three places, so re-wording it in
the engine would have silently turned the substitution into a no-op and revived the "consistent"
claim.

## Scaffold guard (without it the fix is pointless)

`cli._scaffold_policy()` and `web._open_root()` used to rewrite `DEFAULT_POLICY` whenever the file
was missing — i.e. they *erased the evidence of the loss*. The condition is now
`file absent AND marker absent`, and the write records `origin="scaffold"`. With a marker and no
file nothing is re-created: `verinote init` exits non-zero with the loud message, and the web app
opens the KB but halts as described above.

## Escape hatch

`verinote policy reset --force` rewrites the default policy and re-records the marker with
`origin="reset"`. Without `--force` it refuses. **No automatic recovery, anywhere.**

## Backwards compatibility (deliberate trade-off)

`ensure_policy_marker(store, root)` runs at every KB-open point (`cli._store()`, `web._open_root()`,
`create_app`):

- file present, no marker -> adopt (`origin="adopted"`); existing KBs behave identically, and any
  *later* deletion is loud
- file present, marker -> refresh the sha256 (never an error)
- file absent, no marker -> nothing (fresh KB -> warning path)
- file absent, marker -> nothing (preserve the loud state)

A KB that *already* had no policy at upgrade time carries no evidence of (a) vs (b), so it gets a
**warning, not a hard failure**. Fatal failure requires evidence — the marker. That is "do not infer",
applied to itself.

## Mutation verification (re-measured on the final tree)

Reverted `resolve_policy`/`verify` to the pre-#155 behaviour (marker check removed, `return None` on
a missing file, no warning annotation) and re-ran `tests/test_policy_state.py`:

```
FAILED tests/test_policy_state.py::test_deleting_a_recorded_policy_is_an_error_not_a_clean_report
FAILED tests/test_policy_state.py::test_resolve_policy_missing_recorded
FAILED tests/test_policy_state.py::test_unrecorded_policy_runs_default_with_a_warning
FAILED tests/test_policy_state.py::test_unrecorded_policy_still_reports_default_policy_errors
FAILED tests/test_policy_state.py::test_web_open_root_does_not_recreate_a_recorded_policy
FAILED tests/test_policy_state.py::test_store_functional_relations_raises_when_policy_is_lost
FAILED tests/test_policy_state.py::test_auto_accept_is_fail_closed_when_the_policy_is_lost
FAILED tests/test_policy_state.py::test_no_get_route_crashes_when_the_policy_is_lost
FAILED tests/test_policy_state.py::test_report_of_unrecorded_policy_kb_is_not_ok
9 failed, 13 passed in 1.59s
```

(This supersedes the "6 red" figure in the first revision of this description. The mutation is scoped
to `verify.py`, which is why the CLI-side guard test `test_init_refuses_to_recreate_a_recorded_policy`
survives it — that guard is pinned separately.) The mutation was reverted; the suite is green.

## Tests

`tests/test_policy_state.py` — 22 tests:

- the issue's measured scenario: `functional("employed_by")` + 2 conflicting facts -> `ok=False`;
  delete the policy file -> **still** `ok=False`, `policy_missing` finding, no "consistent"
- unrecorded default: warning finding + no clean-bill sentence + non-OK badge
- hash mismatch is not an error; `init` records `origin=scaffold`; a pre-marker policy file is adopted
- no re-creation: CLI non-zero exit, web `_open_root` leaves the file absent
- `policy reset --force` (and its refusal without `--force`)
- `store_functional_relations()` and `apply_auto_accept_recommendations()` propagate
  `PolicyMissingError` and change no fact status (fail-closed)
- **every GET route enumerated from `app.routes`** on a halted KB: no 500s, and every non-exempt page
  carries the `policy reset --force` recovery route — so a newly added route is covered automatically
- **every POST/PUT/PATCH/DELETE route enumerated the same way**: 409, no fact status changed, and no
  policy/settings file written behind the halt (`policy/relation-aliases.md`, `config.json`) — this
  locks the default-deny against future routes
- `POST /facts/{id}/accept` on a halted KB: 409 and the fact stays `candidate`
- restoring the policy file unblocks the KB

Full suite: **691 passed, 7 skipped** — no regressions.

## Note for #171 (empty policy file)

Do not "treat whitespace-only as missing". After #155 an empty-but-recorded policy must flow into the
loud path (or a new `EMPTY` member of `PolicyStatus`, which `resolve_policy` is structured to accept).
Re-introducing a silent fallback to `DEFAULT_POLICY` for any state re-opens exactly this bug. Equally:
do not judge policy state by parsing finding strings — findings are human-readable output.

Out of scope, tracked separately: #171 (empty policy), #159 (`.gitignore`), #180 (the engine's own
`None -> DEFAULT_POLICY` fallback), #181 (`recorded_at` immutability).

Closes #155


---

# Review round 2 (@justinjoy): the halt did not actually block writes

The review was right, and the hole was bigger than reported. `_store()` calls `ensure_policy_marker()`,
which for a missing file **only reported the state and returned** — it never blocked. So on a KB with a
deleted policy file, every write command succeeded:

| command | rc (before) | what it wrote into the halted KB |
|---|---|---|
| `ingest input.txt` | **0** | `sources/input.txt` + a `sources` row |
| `seed` | **0** | 4 `facts` rows |
| `query "..."` | **0** | a `questions` row + `facts/query.dl` |

The PR's own contract ("a halted KB must not be written to") was enforced only in the web middleware.

## Fix: one judgement, three enforcement points

**Judgement** is now a single predicate — `policy_state.assert_writable(store)` — raising
`PolicyMissingError` on `MISSING_RECORDED`. Nothing outside `resolve_policy` is allowed to infer policy
state (no ad-hoc `path.exists()` checks), so the enforcement points cannot drift apart in what "halted"
means.

**Enforcement** sits at the three places a write can enter:

1. **CLI — one check in `main()`'s dispatch.** Each subparser declares `set_defaults(halt_safe=...)`;
   `main` reads it with `getattr(args, "halt_safe", False)`, so it is **fail-closed**: a new subcommand
   that forgets to declare one is treated as a write and blocked.
2. **Worker — the write boundary inside `process_extraction_job()`** (`extract.py`): once at job start,
   then **re-checked before every chunk's candidates are persisted**. This is the only way to catch a
   policy deleted *mid-job*: the job is many slow LLM calls and the `Store` was opened before the
   deletion, so no open-time or start-of-command guard can see it. The CLI `sync` path and the web
   worker go through this same function, so both are closed at once.
3. **Web — unchanged behaviour**, but the middleware now calls `assert_writable` instead of
   re-deriving the state.

A Store-layer blanket guard was rejected: writes are spread across many `Store` methods (no single
choke point), and an open-time guard would miss case 2 entirely.

## Command classification

| command | class | on a halted KB |
|---|---|---|
| `init`, `seed`, `sync`, `ingest`, `query`, `repair` | write | **rc=2, writes nothing** |
| `status`, `coverage` | diagnosis | rc=0, still works |
| `policy reset --force` | recovery | rc=0, un-halts the KB |
| `ui` / `serve` | launcher | starts; the web guard blocks writes (409) while `/report` explains the halt |

Diagnosis and recovery stay open on purpose. **Loud is not the same as crash** — a halt the user can
neither inspect nor undo is just a bricked KB, and blocking `ui` would strand them with no route to the
recovery page.

`policy reset --force` runs *on* a halted KB, and works because `write_default_policy()` writes the
**file first and the marker second**: by the time the DB write happens, `resolve_policy` already reads
`PRESENT`. That ordering is now pinned with a comment — reversing those two lines would kill the only
recovery path.

### Where I did not follow the review: `init`

The review suggested exempting `init` from the guard. I did not, and I think exempting it would be a
real bug. `init` on a halted KB re-scaffolds `DEFAULT_POLICY` — which **overwrites the evidence that the
KB's human-written rules were lost with a plausible-looking green KB**, i.e. exactly the failure this PR
exists to prevent. It already returned rc=2 before this round and still does; what's new is that
`init --seed` no longer sneaks demo rows in on its way to the refusal (`_seed()` ran before the policy
check). Recovery is the explicit human gate, `policy reset --force`. Happy to be argued out of this.

(Also noted: there is no `report` **CLI** subcommand — the `/report` **page** is the web one, already
exempt via `_POLICY_GUARD_READ_PATHS`.)

## `delete_meta` (review point 3)

`Store.delete_meta()` had **zero callers** and was `clear_policy_marker()` under another name — sitting
next to the comment explaining why that function deliberately does not exist. It is **deleted**, and
`get_meta`/`set_meta` are demoted to `_get_meta`/`_set_meta`. `kb_meta` has exactly one client (the
policy marker), so no public API can now downgrade a *recorded-but-missing* policy back to
`UNRECORDED_DEFAULT`.

## Tests: 6 new, all mutation-verified

`test_cli_write_commands_refuse_on_halted_kb` (parametrized over ingest/seed/query/sync/repair — asserts
rc≠0, the loss message on stderr, **and** that no `sources/input.txt`, no `facts/query.dl`, and 0
sources/facts/questions rows landed) · `test_init_refuses_on_halted_kb` (rc=2, policy **not**
re-scaffolded, `--seed` writes nothing) · `test_status_and_coverage_survive_halt` (rc=0 — a regression
guard against over-broadening the halt) · `test_policy_reset_force_recovers_halted_kb` (rc=0, file back,
marker `origin="reset"`, and `ingest` works again afterwards) ·
`test_extraction_worker_halts_when_policy_disappears_mid_job` (2-chunk job, client deletes the policy
after chunk 1 → `PolicyMissingError`, and chunk 2's candidate/evidence are **not** in the DB) ·
`test_store_has_no_public_meta_delete`.

**Suite: 701 passed, 7 skipped** (was 691) · `ruff check`: clean.

**Mutation evidence** (each guard removed in turn → the matching test goes red):

| mutation | result |
|---|---|
| remove the CLI dispatch guard | `test_cli_write_commands_refuse_on_halted_kb` — **5 failed** (all params) |
| remove the worker per-chunk re-check | `test_extraction_worker_halts_when_policy_disappears_mid_job` — **failed** (`DID NOT RAISE PolicyMissingError`) |
| widen the guard over `status`/`coverage` | `test_status_and_coverage_survive_halt` — **failed** |

Reproduced the review's sequence by hand afterwards: all six write commands rc=2, `sources/input.txt`
and `facts/query.dl` absent, 0 rows, policy file still gone (loss evidence intact) — while `status`,
`coverage`, `ui` (GET `/report` 200, POST `/review` 409) and `policy reset --force` (rc=0, then `ingest`
rc=0) all work.

**Breaking:** `seed`/`sync`/`ingest`/`query`/`repair` now exit **2** instead of **0** on a KB whose
recorded policy file is missing, and write nothing. `Store.delete_meta()` / `get_meta` / `set_meta` are
no longer public.


---

# Review round 3 (@justinjoy): five holes, closed

Round 2 was measured and confirmed (701 green, mutations red, recovery path alive, fail-closed
dispatch). The follow-up review then found five things still wrong. All five are fixed in `36c987f`.

## 1. `verinote ui` wrote to a halted KB with zero HTTP requests served

`create_app()` ends by calling `_resume_source_extraction_jobs()`, which restarts pending/running jobs
in **worker threads that live outside the HTTP middleware**. The worker's `except Exception` then
caught the `PolicyMissingError` raised by `process_extraction_job` and called
`fail_extraction_job(...)` — a **write**, into the halted KB, from a process that had served no
requests. The PR's claim that "`ui` is only a launcher" was false.

Two layers, both new:

- `_resume_source_extraction_jobs()` is **gated on `assert_writable`** — a halted KB starts no workers.
  Which jobs were resumed is now recorded on `app.state.resumed_job_ids`, so "started no workers" is an
  assertable fact rather than a hope.
- the worker catches `PolicyMissingError` **above `except Exception`** and returns after logging,
  touching no DB. Marking the job `failed` was not just a write, it was a **lie**: the extraction did
  not fail, the KB's rules are gone.

Measured: halted KB + one pending job → `create_app()` → `resumed_job_ids == []` and the **db file is
byte-for-byte identical**.

## 2. A policy lost mid-`sync` was a traceback, not a loud failure

`cmd_sync` caught only `LLMError`, so `PolicyMissingError` reached `main()` and printed a stack trace —
the PR breaking its own "loud is not a crash" rule, and burying the message that names both recovery
routes.

Handled in **`main()`**, once, for the same reason the refusal already lives there ("a guard sprinkled
per-command is a guard the next command will forget"): `PolicyMissingError` → `error: <message>` on
stderr, **rc=2**. This covers `sync`, `repair`, `query` and any future command. A per-command handler in
`cmd_sync` would have been redundant with it — and a redundant guard cannot be mutation-tested, so it is
not there.

## 3. The job-start `assert_writable` had no test (it survived deletion)

Correct — the reviewer's mutation passed. Now pinned by
`test_process_extraction_job_on_halted_kb_writes_nothing_and_calls_no_llm`: on a halted KB the fake
client is called **0 times** and the job row, chunk rows and `runs` table are unchanged (`get_run(1) is
None`).

## 4. What "does not accept writes" actually means

The reviewer is right that the old wording was stronger than the code, and picking option (a) *or* (b)
was a false choice — (a) alone leaves a zombie job. **The contract, stated honestly and now enforced and
tested:**

> A halted KB gains **no candidate fact and no evidence row — ever**. Job/chunk bookkeeping is not
> equally absolute, because the policy can vanish *during* the LLM call of a chunk that was already
> claimed. So bookkeeping is only ever **rewound, never advanced**.

Concretely, in `process_extraction_job`:

- `assert_writable` now runs **before `mark_chunk_running`**, not after. No chunk after the deletion is
  claimed (`status='running'`, `attempts+1`) for work that will never happen.
- the one chunk in flight when the file vanished is **rolled back to `pending`**, which drops the job
  back to `pending` — resumable once a human runs `policy reset --force`. **No zombie `running` job.**
- the `runs` row (opened while the KB was still healthy) gets an honest summary instead of staying
  blank: `"halted: this KB's recorded logic policy file is missing; the job was rolled back to pending
  and no candidate facts were written"`.

The one residue is the in-flight chunk's `attempts` counter, which is not rewound — it truthfully
records that the chunk *was* attempted. Final state is pinned by tests in both directions
(`test_halt_mid_job_rewinds_the_job_to_pending`, `test_halt_between_chunks_never_claims_the_next_chunk`).

## 5. The CLI's only diagnostic surface stayed silent about the halt — this was #155 itself

The sharpest of the five. `verinote status` on a halted KB printed a tidy summary and exited 0, with not
one word about the missing policy; so did `coverage`. There is no CLI `verify`/`report`, so for anyone
not using the web UI, the only way to learn the KB was halted was to try a write and get refused. **"A KB
whose rules are gone must not look fine" was still true on the CLI.**

Every `halt_safe=True` command now reads `resolve_policy` and prints a banner on **stderr**:

- `MISSING_RECORDED` → the full `policy_missing_message` (names both recovery routes)
- `UNRECORDED_DEFAULT` → `POLICY_UNRECORDED_BANNER`

**Exit codes are unchanged** — diagnosis stays usable and pipeable under a halt; the banner is on stderr
so stdout stays parseable. Judgement is `resolve_policy` only; the file is never inspected directly.
A healthy KB prints nothing (`test_status_on_a_healthy_kb_says_nothing_about_the_policy`) — a banner that
is always on is wallpaper, not a signal.

## Verification

**Suite: 711 passed, 7 skipped** (was 701) · `ruff check`: clean · **10 new tests**.

Mutation evidence — each new guard deleted in turn, the matching test goes red:

| # | guard removed | test | result |
|---|---|---|---|
| 1a | `assert_writable` in `_resume_source_extraction_jobs` | `test_create_app_on_halted_kb_resumes_no_jobs_and_touches_no_row` | **RED** |
| 1b | worker's `except PolicyMissingError` (falls through to `except Exception`) | `test_web_worker_never_marks_a_halted_kb_job_failed` | **RED** |
| 2 | `main()`'s `PolicyMissingError` backstop | `test_sync_reports_a_policy_lost_mid_run_instead_of_crashing` | **RED** |
| 3 | job-start `assert_writable` | `test_process_extraction_job_on_halted_kb_writes_nothing_and_calls_no_llm` | **RED** |
| 4a | pre-claim `assert_writable` in `_process_chunks` | `test_halt_between_chunks_never_claims_the_next_chunk` | **RED** |
| 4b | `_rollback_halted_job` | `test_halt_mid_job_rewinds_the_job_to_pending` | **RED** |
| 5 | `_warn_on_degraded_policy` | `test_status_and_coverage_announce_the_halt_on_stderr`, `test_status_announces_an_unrecorded_policy` | **RED** |

Run by hand on a real KB, in order:

| check | result |
|---|---|
| halted KB + pending job → `create_app()` | `resumed_job_ids == []`, **db bytes identical** |
| halted KB → policy deleted mid-`sync` | **rc=2**, loud message, **no traceback**; job back to `pending`, 0 facts, run summary = the halt line |
| halted KB → `status` / `coverage` | **rc=0**, full output on stdout, halt banner on stderr |
| `policy reset --force` → `ingest` | rc=0, then rc=0 — the KB accepts writes again |

## Merge note (conflicts with #186)

#186 (`issue-165-init-seed-named-kb`) touches `verinote/cli.py` in three of the same places
(`cmd_init`'s imports, the `set_defaults` lines for `init`/`seed`, and `main()`'s `cfg = ...` vs its
`_config_for(args)`). **Taking only #186's side of those hunks silently drops the `halt_safe` declarations
and the guard.** When resolving:

- every subparser must keep `halt_safe=...` in its `set_defaults`;
- in `main()`, the `_refuse_on_halted_kb` / `_warn_on_degraded_policy` / `PolicyMissingError` block must
  stay, **after** `_config_for(args)`.

`init`/`seed` losing it would fail closed (annoying, safe); `status`/`coverage`/`ui`/`policy reset`
losing it would **brick the recovery path**.

## Breaking (updated)

In addition to round 2's list: `verinote status` / `coverage` (and the other `halt_safe` commands) now
write a warning banner to **stderr** on a KB whose recorded policy is missing or was never recorded.
Exit codes and stdout are unchanged. An extraction job interrupted by a halt is now left `pending`
(resumable), where it would previously have been left `running` (web) or `failed` (web `except
Exception`).
