### PR TITLE
fix(#176): derive the engine-input status filter from ENGINE_STATUSES

### DIFF
--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,7 +1,22 @@
 # SPDX-License-Identifier: MPL-2.0
 from verinote.engine import coverage
-from verinote.store import Store
+from verinote.store import Store, db
 from verinote.store.fact_input import structural_term
+
+
+def _engine_facts_for_source(store: Store, source_id: int) -> int:
+    """Count the facts the engine itself would read for one source.
+
+    Deliberately routed through the same status constant the engine reads
+    (`db.ENGINE_STATUSES`, looked up at call time) rather than a literal, so the
+    assertions below fix an invariant instead of a snapshot number.
+    """
+    rows = store.facts(statuses=db.ENGINE_STATUSES)
+    return len([r for r in rows if r["source_id"] == source_id])
+
+
+def _source_coverage(store: Store, tmp_path, path: str):
+    return next(s for s in coverage(store, root=tmp_path).sources if s.path == path)
 
 
 def _store(tmp_path) -> Store:
@@ -67,3 +82,62 @@ def test_orphan_when_backing_file_missing(tmp_path):
     sc = cov.sources[0]
     assert sc.is_orphan is True
     assert sc in cov.orphans
+
+
+def test_coverage_engine_tier_follows_engine_statuses(tmp_path, monkeypatch):
+    """Coverage must derive its engine tier from ENGINE_STATUSES, not from SQL.
+
+    A source whose only facts are `superseded` is a gap today. Widen
+    ENGINE_STATUSES to include `superseded` and the very same source must stop
+    being a gap — because the engine would now read those facts. Hard-coding
+    `IN ('confirmed','accepted')` back into the query makes this test fail.
+    """
+    s = _store(tmp_path)
+    path = _with_file(tmp_path, "a.txt")
+    sid = s.add_source(path)
+    s.add_fact("A", "is_a", "B", status="superseded", source_id=sid)
+    s.add_fact("C", "is_a", "D", status="superseded", source_id=sid)
+    superseded_count = 2
+
+    before = _source_coverage(s, tmp_path, path)
+    assert before.engine_facts == 0
+    assert before.is_gap
+    assert before.total_facts == superseded_count
+
+    monkeypatch.setattr(
+        db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"}
+    )
+
+    after = _source_coverage(s, tmp_path, path)
+    assert after.engine_facts == superseded_count
+    assert not after.is_gap
+    assert after.total_facts == superseded_count
+
+
+def test_coverage_engine_facts_match_the_engines_own_input(tmp_path, monkeypatch):
+    """The number coverage reports == the number of facts the engine reads.
+
+    Asserted against the engine's own input path (`facts(statuses=...)`) rather
+    than a literal, and re-checked under a mutated ENGINE_STATUSES so the two
+    definitions cannot drift apart silently.
+    """
+    s = _store(tmp_path)
+    path = _with_file(tmp_path, "a.txt")
+    sid = s.add_source(path)
+    s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+    s.add_fact("C", "is_a", "D", status="accepted", source_id=sid)
+    s.add_fact("E", "is_a", "F", status="needs_review", source_id=sid)
+    s.add_fact("G", "is_a", "H", status="superseded", source_id=sid)
+
+    default_cov = _source_coverage(s, tmp_path, path)
+    assert default_cov.engine_facts == _engine_facts_for_source(s, sid)
+
+    monkeypatch.setattr(
+        db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"}
+    )
+
+    mutated_cov = _source_coverage(s, tmp_path, path)
+    assert mutated_cov.engine_facts == _engine_facts_for_source(s, sid)
+    # The invariant held both times *and* the tier actually moved, so the
+    # equality above is not vacuous.
+    assert mutated_cov.engine_facts == default_cov.engine_facts + 1

--- a/tests/test_status_tiers.py
+++ b/tests/test_status_tiers.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: MPL-2.0
+"""One runtime definition of the status tiers, proven by mutation.
+
+`verinote.store.db` owns `ENGINE_STATUSES` / `REVIEW_STATUSES`. Every consumer
+must answer "is this fact engine input?" from that one constant, *at call time*.
+The failure this file exists to prevent is not hypothetical: consumers used to
+do `from verinote.store import ENGINE_STATUSES`, which binds the frozenset
+object at import time, so widening the tier moved `Store.engine_fact_terms()`
+(a call-time lookup) while `build_query_schema_snapshot()` and
+`ask.grounding_facts()` stayed on the old tier — the deterministic engine would
+consume facts the planner's schema hint and the Ask/trust layers cannot see.
+
+Each test below widens `db.ENGINE_STATUSES` (or empties a tier) and asserts the
+consumer moves with it. Reverting a consumer to an import-time binding turns
+these red.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from verinote.pipeline.acceptance import accept_recommendation, accept_recommendations
+from verinote.pipeline.ask import grounding_facts
+from verinote.pipeline.corroboration import (
+    store_corroboration,
+    store_single_valued_conflicts,
+)
+from verinote.pipeline.query_schema import build_query_schema_snapshot
+from verinote.pipeline.trust import fact_trust_summary
+from verinote.pipeline.workbench import trust_workbench
+from verinote.store import Store, db
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def _widen(monkeypatch) -> None:
+    """Add `superseded` to the engine-input tier, the reviewer's mutation."""
+    monkeypatch.setattr(db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"})
+
+
+def test_engine_input_readers_agree_after_the_tier_is_widened(tmp_path, monkeypatch):
+    """The reviewer's exact repro: Store saw the fact, schema and Ask did not.
+
+    A `superseded` fact is invisible to every engine-input reader today. Widen
+    the tier and all of them must see it together — otherwise the engine reasons
+    over facts the planner's schema hint and Ask never learned about.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/a.md")
+    store.add_fact("Acme", "uses", "FastAPI", status="superseded", source_id=source_id)
+
+    # Before: nobody reads it.
+    assert store.engine_fact_terms() == []
+    assert build_query_schema_snapshot(store).fact_count == 0
+    assert grounding_facts(store, question="Acme uses what?") == []
+
+    _widen(monkeypatch)
+
+    # After: everybody reads it, from the same constant, at call time.
+    assert [row["id"] for row in store.engine_fact_terms()] == [1]
+    snapshot = build_query_schema_snapshot(store)
+    assert snapshot.fact_count == 1
+    assert [r.relation.display for r in snapshot.relations] == ["uses"]
+    grounded = grounding_facts(store, question="Acme uses what?")
+    assert [(f.subject, f.relation, f.object) for f in grounded] == [
+        ("Acme", "uses", "FastAPI")
+    ]
+
+
+def test_trust_follows_the_engine_tier(tmp_path, monkeypatch):
+    """Trust labels a fact "engine input" from the tier, not from a stale copy."""
+    store = _store(tmp_path)
+    a = store.add_source("sources/a.md")
+    b = store.add_source("sources/b.md")
+    confirmed = store.add_fact("Acme", "uses", "FastAPI", status="confirmed", source_id=a)
+    superseded = store.add_fact(
+        "Acme", "uses", "FastAPI", status="superseded", source_id=b
+    )
+
+    before = fact_trust_summary(store, superseded)
+    assert before.engine_input is False
+    # The superseded twin does not corroborate the confirmed fact yet.
+    assert fact_trust_summary(store, confirmed).support.source_count == 1
+
+    _widen(monkeypatch)
+
+    after = fact_trust_summary(store, superseded)
+    assert after.engine_input is True
+    # ...and now it is distinct source support, exactly like the engine sees it.
+    assert fact_trust_summary(store, confirmed).support.source_count == 2
+
+
+def test_corroboration_and_conflicts_follow_the_engine_tier(tmp_path, monkeypatch):
+    """The dashboard's corroboration/conflict sections must not lag the card."""
+    policy = tmp_path / "policy"
+    policy.mkdir()
+    (policy / "logic-policy.dl").write_text(
+        '.decl functional(rel: symbol)\nfunctional("established_on").\n',
+        encoding="utf-8",
+    )
+    store = _store(tmp_path)
+    a = store.add_source("sources/a.md")
+    b = store.add_source("sources/b.md")
+    store.add_fact("Acme", "uses", "FastAPI", status="confirmed", source_id=a)
+    store.add_fact("Acme", "uses", "FastAPI", status="superseded", source_id=b)
+    store.add_fact("Org", "established_on", "2020", status="confirmed", source_id=a)
+    store.add_fact("Org", "established_on", "2021", status="superseded", source_id=b)
+
+    def _support() -> dict[tuple[str, str, str], tuple[str, ...]]:
+        return {
+            (f.subject, f.relation, f.object): f.sources
+            for f in store_corroboration(store)
+        }
+
+    assert _support()[("Acme", "uses", "FastAPI")] == ("sources/a.md",)
+    assert list(store_single_valued_conflicts(store)) == []
+    bench = trust_workbench(store)
+    assert [g.sources for g in bench.corroborated] == []
+    assert list(bench.conflicts) == []
+
+    _widen(monkeypatch)
+
+    assert _support()[("Acme", "uses", "FastAPI")] == ("sources/a.md", "sources/b.md")
+    conflicts = store_single_valued_conflicts(store)
+    assert [(c.subject, c.relation) for c in conflicts] == [("Org", "established_on")]
+    bench = trust_workbench(store)
+    assert [g.sources for g in bench.corroborated] == [("sources/a.md", "sources/b.md")]
+    assert [(c.subject, c.relation) for c in bench.conflicts] == [
+        ("Org", "established_on")
+    ]
+
+
+def test_acceptance_support_follows_the_engine_tier(tmp_path, monkeypatch):
+    """Auto-accept counts distinct source support over the *current* engine tier."""
+    store = _store(tmp_path)
+    a = store.add_source("sources/a.md")
+    b = store.add_source("sources/b.md")
+    target = store.add_fact(
+        "Acme", "uses", "FastAPI", status="needs_review", source_id=a
+    )
+    store.add_fact("Acme", "uses", "FastAPI", status="superseded", source_id=b)
+
+    before = accept_recommendation(store, target)
+    assert before.support_sources == ("sources/a.md",)
+    assert "insufficient_distinct_source_support" in before.reasons
+
+    _widen(monkeypatch)
+
+    after = accept_recommendation(store, target)
+    assert after.support_sources == ("sources/a.md", "sources/b.md")
+    assert "insufficient_distinct_source_support" not in after.reasons
+
+
+def test_engine_input_consumers_refuse_an_empty_engine_tier(tmp_path, monkeypatch):
+    """An empty tier is a crash, not a silent "no facts", in every consumer."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/a.md")
+    fact_id = store.add_fact(
+        "Acme", "uses", "FastAPI", status="confirmed", source_id=source_id
+    )
+
+    monkeypatch.setattr(db, "ENGINE_STATUSES", frozenset())
+
+    for call in (
+        lambda: build_query_schema_snapshot(store),
+        lambda: grounding_facts(store, question="Acme uses what?"),
+        lambda: fact_trust_summary(store, fact_id),
+        lambda: store_corroboration(store),
+        lambda: store_single_valued_conflicts(store),
+        lambda: trust_workbench(store),
+        lambda: accept_recommendation(store, fact_id),
+    ):
+        with pytest.raises(ValueError, match="must not be empty"):
+            call()
+
+
+def test_acceptance_refuses_an_empty_review_tier(tmp_path, monkeypatch):
+    """The human gate must not quietly recommend nothing when the tier is empty."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/a.md")
+    fact_id = store.add_fact(
+        "Acme", "uses", "FastAPI", status="needs_review", source_id=source_id
+    )
+
+    monkeypatch.setattr(db, "REVIEW_STATUSES", frozenset())
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        accept_recommendations(store)
+    with pytest.raises(ValueError, match="must not be empty"):
+        accept_recommendation(store, fact_id)
+    with pytest.raises(ValueError, match="must not be empty"):
+        trust_workbench(store)
+
+    # The fact was not promoted behind our back.
+    assert store.get_fact(fact_id)["status"] == "needs_review"
+
+
+def test_no_module_binds_a_status_tier_at_import_time():
+    """The regression is an import statement, so guard the import statement.
+
+    `from verinote.store import ENGINE_STATUSES` (or from `verinote.store.db`)
+    freezes the tier at import time and re-opens the split above. `db.py` owns
+    the constants and `tiers.py` is the single call-time accessor; nobody else
+    may name them in an import.
+    """
+    package = Path(__file__).resolve().parent.parent / "verinote"
+    allowed = {package / "store" / "db.py", package / "store" / "tiers.py"}
+    offenders = []
+    for path in sorted(package.rglob("*.py")):
+        if path in allowed:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                names = {alias.name for alias in node.names}
+                bound = names & {"ENGINE_STATUSES", "REVIEW_STATUSES"}
+                if bound:
+                    offenders.append(f"{path.name}: {sorted(bound)}")
+    assert offenders == []

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -468,19 +468,85 @@ def test_sources_with_counts_engine_count_follows_engine_statuses(tmp_path, monk
     assert after["fact_count"] == 3
 
 
-def test_sources_with_counts_engine_count_matches_coverage(tmp_path):
-    """One definition, two consumers: the Sources page and the coverage report."""
+def test_sources_with_counts_engine_count_matches_coverage(tmp_path, monkeypatch):
+    """One definition, two consumers: the Sources page and the coverage report.
+
+    Checked under a mutated tier as well — agreement between two consumers that
+    both read the same hard-coded literal would be agreement on a wrong number.
+    """
     s = _store(tmp_path)
     sid = s.add_source("sources/a.txt")
     s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
     s.add_fact("C", "is_a", "D", status="accepted", source_id=sid)
     s.add_fact("E", "is_a", "F", status="needs_review", source_id=sid)
+    s.add_fact("G", "is_a", "H", status="superseded", source_id=sid)
 
     row = s.sources_with_counts()[0]
     sc = coverage(s, root=tmp_path).sources[0]
-
-    assert row["engine_count"] == sc.engine_facts
+    assert row["engine_count"] == sc.engine_facts == 2
     assert row["fact_count"] == sc.total_facts
+
+    monkeypatch.setattr(db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"})
+
+    row = s.sources_with_counts()[0]
+    sc = coverage(s, root=tmp_path).sources[0]
+    assert row["engine_count"] == sc.engine_facts == 3
+    assert row["fact_count"] == sc.total_facts
+
+
+def test_status_filter_rejects_an_empty_tier(tmp_path):
+    """An empty tier must crash, not quietly answer zero.
+
+    SQLite returns zero rows for `status IN ()` rather than raising, so an empty
+    constant would silently make coverage call every source a gap and make
+    `accept_review_facts_for_source` promote nothing while reporting success.
+    """
+    s = _store(tmp_path)
+    s.add_fact("A", "is_a", "B", status="confirmed")
+
+    # Positive: a populated tier filters normally.
+    assert len(s.facts(statuses=ENGINE_STATUSES)) == 1
+    # None still means "no filter at all", not "an empty filter".
+    assert len(s.facts(statuses=None)) == 1
+
+    # Negative: an empty tier is refused rather than answered with zero rows.
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.facts(statuses=frozenset())
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.facts(statuses=[])
+
+
+def test_engine_reads_are_refused_when_the_engine_tier_is_empty(tmp_path, monkeypatch):
+    """The guard covers the real engine-input paths, not just the helper."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+
+    monkeypatch.setattr(db, "ENGINE_STATUSES", frozenset())
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.source_fact_counts()
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.sources_with_counts()
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.facts(statuses=db.ENGINE_STATUSES)
+
+
+def test_review_promotion_is_refused_when_the_review_tier_is_empty(tmp_path, monkeypatch):
+    """An empty review tier must not silently no-op the human gate."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="needs_review", source_id=sid)
+
+    monkeypatch.setattr(db, "REVIEW_STATUSES", frozenset())
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.accept_review_facts_for_source(sid)
+    with pytest.raises(ValueError, match="must not be empty"):
+        s.review_queue_page()
+
+    # The fact was not promoted behind our back.
+    assert s.get_fact(1)["status"] == "needs_review"
 
 
 def test_extraction_job_rejects_artifact_from_another_source(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,8 +3,8 @@ import json
 
 import pytest
 
-from verinote.engine import compile_dl
-from verinote.store import ENGINE_STATUSES, Store
+from verinote.engine import compile_dl, coverage
+from verinote.store import ENGINE_STATUSES, Store, db
 
 
 def _store(tmp_path) -> Store:
@@ -435,6 +435,52 @@ def test_sources_with_counts_includes_latest_analysis_summary(tmp_path):
     assert row["analysis_candidate_count"] == 3
     assert row["provider"] == "ollama"
     assert row["model"] == "qwen3.5:9b"
+
+
+def test_sources_with_counts_engine_count_follows_engine_statuses(tmp_path, monkeypatch):
+    """The Sources page's "N confirmed" must mean the same thing as coverage.
+
+    `engine_count` is derived from ENGINE_STATUSES, so widening the tier moves
+    the Sources page in lockstep with the coverage report. Re-hard-coding
+    `IN ('confirmed','accepted')` makes this fail.
+    """
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="superseded", source_id=sid)
+    s.add_fact("C", "is_a", "D", status="superseded", source_id=sid)
+    s.add_fact("E", "is_a", "F", status="candidate", source_id=sid)
+    superseded_count = 2
+
+    before = s.sources_with_counts()[0]
+    assert before["engine_count"] == 0
+    # The per-status count columns are a different question and must not move.
+    assert before["candidate_count"] == 1
+    assert before["fact_count"] == 3
+
+    monkeypatch.setattr(db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"})
+
+    after = s.sources_with_counts()[0]
+    assert after["engine_count"] == superseded_count
+    assert after["engine_count"] == len(
+        [r for r in s.facts(statuses=db.ENGINE_STATUSES) if r["source_id"] == sid]
+    )
+    assert after["candidate_count"] == 1
+    assert after["fact_count"] == 3
+
+
+def test_sources_with_counts_engine_count_matches_coverage(tmp_path):
+    """One definition, two consumers: the Sources page and the coverage report."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+    s.add_fact("C", "is_a", "D", status="accepted", source_id=sid)
+    s.add_fact("E", "is_a", "F", status="needs_review", source_id=sid)
+
+    row = s.sources_with_counts()[0]
+    sc = coverage(s, root=tmp_path).sources[0]
+
+    assert row["engine_count"] == sc.engine_facts
+    assert row["fact_count"] == sc.total_facts
 
 
 def test_extraction_job_rejects_artifact_from_another_source(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,7 +4,7 @@ import json
 import pytest
 
 from verinote.engine import compile_dl, coverage
-from verinote.store import ENGINE_STATUSES, Store, db
+from verinote.store import Store, db, engine_statuses
 
 
 def _store(tmp_path) -> Store:
@@ -109,7 +109,7 @@ def test_compile_dl_only_projects_triples(tmp_path):
     # non-ASCII placeholder keeps UTF-8 round-trip coverage (not a real entity)
     s.add_fact("예시기관", "is_a", "참여기관", status="confirmed")
     s.add_fact("x", "y", "z", status="needs_review")  # must NOT appear
-    dl = compile_dl(s.facts(statuses=ENGINE_STATUSES))
+    dl = compile_dl(s.facts(statuses=engine_statuses()))
     assert 'relation("예시기관", "is_a", "참여기관").' in dl
     assert "needs_review" not in dl
     assert '"x"' not in dl
@@ -118,7 +118,7 @@ def test_compile_dl_only_projects_triples(tmp_path):
 def test_compile_dl_escapes_quotes(tmp_path):
     s = _store(tmp_path)
     s.add_fact('a"b', "r", "c", status="confirmed")
-    dl = compile_dl(s.facts(statuses=ENGINE_STATUSES))
+    dl = compile_dl(s.facts(statuses=engine_statuses()))
     assert r'relation("a\"b", "r", "c").' in dl
 
 
@@ -505,7 +505,7 @@ def test_status_filter_rejects_an_empty_tier(tmp_path):
     s.add_fact("A", "is_a", "B", status="confirmed")
 
     # Positive: a populated tier filters normally.
-    assert len(s.facts(statuses=ENGINE_STATUSES)) == 1
+    assert len(s.facts(statuses=engine_statuses())) == 1
     # None still means "no filter at all", not "an empty filter".
     assert len(s.facts(statuses=None)) == 1
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+import re
 import time
 from html import unescape
 
@@ -15,6 +16,7 @@ from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
 from verinote.pipeline.query import query_path  # noqa: E402
 from verinote.pipeline.query_intent import parse_query_intent  # noqa: E402
 from verinote.store import Store  # noqa: E402
+from verinote.store import db as store_db  # noqa: E402
 from verinote.store.fact_input import structural_term  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
@@ -111,6 +113,44 @@ def test_dashboard_shows_factlog_borrowed_source_signals(tmp_path):
     assert "2020" in body
     assert "2021" in body
     assert "(1 source)" in body
+
+
+def _engine_input_card(body: str) -> int:
+    """Read the number the dashboard's "engine input" card actually renders."""
+    match = re.search(
+        r'<div class="num">(\d+)</div><div class="lbl">engine input</div>', body
+    )
+    assert match is not None, "engine input card not found in dashboard"
+    return int(match.group(1))
+
+
+def test_dashboard_engine_input_card_follows_engine_statuses(tmp_path, monkeypatch):
+    """The dashboard's headline card must answer from ENGINE_STATUSES too.
+
+    It used to sum `confirmed + accepted` in the template — a third answer to
+    "what is engine input". Widening the tier must move this card in lockstep
+    with coverage and the Sources badge, or the top of the UI asserts a number
+    the engine disagrees with.
+    """
+    c = _client(tmp_path)  # seeds one needs_review fact
+    store = c.app.state.store
+    sid = store.add_source("sources/a.md")
+    store.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+    store.add_fact("C", "is_a", "D", status="accepted", source_id=sid)
+    store.add_fact("E", "is_a", "F", status="superseded", source_id=sid)
+
+    assert _engine_input_card(c.get("/").text) == 2
+
+    monkeypatch.setattr(
+        store_db, "ENGINE_STATUSES", store_db.ENGINE_STATUSES | {"superseded"}
+    )
+
+    body = c.get("/").text
+    assert _engine_input_card(body) == 3
+    # ...and it still agrees with what the engine would actually read.
+    assert _engine_input_card(body) == len(
+        store.facts(statuses=store_db.ENGINE_STATUSES)
+    )
 
 
 def test_dashboard_shows_action_queue_counts_and_links(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -730,6 +730,29 @@ def test_sources_page_lists_sources(tmp_path):
     assert "Accept all" in r.text
 
 
+def test_sources_page_labels_the_engine_count_by_what_it_means(tmp_path, monkeypatch):
+    """`engine_count` is the engine-input tier, not the `confirmed` status.
+
+    The badge used to read "N confirmed" while the number already counted
+    `accepted` too — and, since the tier is read at call time, it counts whatever
+    ENGINE_STATUSES says. Labelling it after one member status misreads the KB.
+    """
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/a.txt", kind="text")
+    store.add_fact("A", "is_a", "B", status="accepted", source_id=sid)
+    store.add_fact("C", "is_a", "D", status="superseded", source_id=sid)
+
+    body = c.get("/sources").text
+    assert "1 engine input" in body
+    assert "confirmed" not in body
+
+    monkeypatch.setattr(
+        store_db, "ENGINE_STATUSES", store_db.ENGINE_STATUSES | {"superseded"}
+    )
+    assert "2 engine input" in c.get("/sources").text
+
+
 def test_sources_accept_all_promotes_review_facts_for_that_source(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store

--- a/verinote/engine/coverage.py
+++ b/verinote/engine/coverage.py
@@ -22,7 +22,7 @@ from verinote.store import Store
 class SourceCoverage:
     path: str
     kind: str
-    engine_facts: int  # confirmed/accepted facts citing this source
+    engine_facts: int  # facts in ENGINE_STATUSES citing this source
     total_facts: int
     is_gap: bool  # zero engine-input facts
     is_orphan: bool  # backing file missing under the KB root

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -15,7 +15,7 @@ from verinote.pipeline.corroboration import (
     store_typed_relations,
     TypedRelationSpec,
 )
-from verinote.store import ENGINE_STATUSES, REVIEW_STATUSES, Store
+from verinote.store import Store, is_engine_input, is_review_eligible, review_statuses
 
 RULE_NAME = "corroborated_no_conflict"
 
@@ -41,7 +41,7 @@ def accept_recommendation(store: Store, fact_id: int) -> AcceptRecommendation | 
 def accept_recommendations(store: Store) -> dict[int, AcceptRecommendation]:
     engine = _engine(store)
     recommendations = {}
-    for fact in store.facts(statuses=REVIEW_STATUSES):
+    for fact in store.facts(statuses=review_statuses()):
         recommendations[int(fact["id"])] = engine.recommend(fact)
     return recommendations
 
@@ -118,7 +118,7 @@ class _RecommendationEngine:
     def recommend(self, fact_row) -> AcceptRecommendation:
         target = _view_fact(fact_row, self.aliases, self.typed)
         reasons = []
-        if target.status not in REVIEW_STATUSES:
+        if not is_review_eligible(target.status):
             reasons.append("not_review_candidate")
         if not target.source:
             reasons.append("source_missing")
@@ -151,7 +151,7 @@ class _RecommendationEngine:
         return [
             fact
             for fact in self.facts
-            if fact.status in REVIEW_STATUSES | ENGINE_STATUSES
+            if (is_review_eligible(fact.status) or is_engine_input(fact.status))
             and fact.subject == target.subject
             and fact.canonical_relation == target.canonical_relation
             and fact.object_key == target.object_key
@@ -162,7 +162,7 @@ class _RecommendationEngine:
         if target.canonical_relation not in self.single_valued:
             return False
         for fact in self.facts:
-            if fact.status not in ENGINE_STATUSES:
+            if not is_engine_input(fact.status):
                 continue
             if fact.subject != target.subject:
                 continue

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -15,7 +15,7 @@ from verinote.pipeline.corroboration import CorroborationPolicyError, store_rela
 from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_query_flow
 from verinote.pipeline.query_candidate_eval import RELATION_DECL
 from verinote.pipeline.report_trace import trace_query_answers
-from verinote.store import ENGINE_STATUSES, Store
+from verinote.store import Store, engine_statuses
 
 ASK_QID = 0
 MAX_CONTEXT_CHARS = 12000
@@ -300,7 +300,7 @@ def grounding_facts(
 ) -> list[AskGroundingFact]:
     normalized_question = _fold(question)
     rows: list[AskGroundingFact] = []
-    for fact in store.facts(statuses=ENGINE_STATUSES):
+    for fact in store.facts(statuses=engine_statuses()):
         subject = str(fact["subject"])
         relation = str(fact["relation"])
         obj = str(fact["object"])

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -22,7 +22,7 @@ from verinote.policy_defaults import (
     RELATION_ALIASES_RELPATH,
     TYPED_RELATIONS_RELPATH,
 )
-from verinote.store import ENGINE_STATUSES, Store
+from verinote.store import Store, is_engine_input
 
 _FUNCTIONAL_RE = re.compile(r'functional\("((?:\\.|[^"\\])*)"\)\.')
 _TYPED_REL_RE = re.compile(
@@ -247,7 +247,7 @@ def corroboration(facts: Iterable[Mapping[str, object]]) -> list[FactSupport]:
     """Return distinct-source support for confirmed/accepted SPO triples."""
     sources: dict[tuple[str, str, str], set[str]] = {}
     for row in facts:
-        if str(_value(row, "status", "")) not in ENGINE_STATUSES:
+        if not is_engine_input(_value(row, "status", "")):
             continue
         source = _source_ref(row)
         if not source:
@@ -274,7 +274,7 @@ def single_valued_conflicts(
         tuple[str, str], dict[tuple[str, object], dict[str, set[str]]]
     ] = {}
     for row in facts:
-        if str(_value(row, "status", "")) not in ENGINE_STATUSES:
+        if not is_engine_input(_value(row, "status", "")):
             continue
         relation = _canonical_relation(str(row["relation"]), aliases)
         if relation not in canonical_single_valued:

--- a/verinote/pipeline/query_schema.py
+++ b/verinote/pipeline/query_schema.py
@@ -29,7 +29,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
     store_typed_relations,
 )
-from verinote.store import ENGINE_STATUSES, Store
+from verinote.store import Store, engine_statuses
 
 
 @dataclass(frozen=True)
@@ -161,7 +161,9 @@ def build_query_schema_snapshot(
 
 
 def _engine_facts(store: Store) -> list[_Fact]:
-    display_rows = {int(row["id"]): row for row in store.facts(statuses=ENGINE_STATUSES)}
+    display_rows = {
+        int(row["id"]): row for row in store.facts(statuses=engine_statuses())
+    }
     term_rows = {int(row["id"]): row for row in store.engine_fact_terms()}
     facts: list[_Fact] = []
     for fact_id in sorted(display_rows):

--- a/verinote/pipeline/trust.py
+++ b/verinote/pipeline/trust.py
@@ -17,7 +17,7 @@ from verinote.pipeline.corroboration import (
     store_typed_relations,
     TypedRelationSpec,
 )
-from verinote.store import ENGINE_STATUSES, REVIEW_STATUSES, Store
+from verinote.store import Store, engine_statuses, is_engine_input, is_review_eligible
 
 
 @dataclass(frozen=True)
@@ -172,8 +172,8 @@ def fact_trust_summary(store: Store, fact_id: int) -> FactTrustSummary | None:
         display=display,
         canonical_terms=_canonical_terms(store, fact_id),
         status=status,
-        review_eligible=status in REVIEW_STATUSES,
-        engine_input=status in ENGINE_STATUSES,
+        review_eligible=is_review_eligible(status),
+        engine_input=is_engine_input(status),
         confidence=float(fact["confidence"]),
         note=str(fact["note"]),
         source=_source_metadata(store, fact["source_id"]),
@@ -215,7 +215,7 @@ def _support_summary(
     relation = canonical_relation(display.relation, aliases)
     object_key = _object_key(relation, display.object, typed)
     sources: set[str] = set()
-    for row in store.facts(statuses=ENGINE_STATUSES):
+    for row in store.facts(statuses=engine_statuses()):
         if str(row["subject"]) != display.subject:
             continue
         row_relation = canonical_relation(str(row["relation"]), aliases)
@@ -369,7 +369,7 @@ def _trust_labels(
         labels.append("corroborated")
     if conflict is not None:
         labels.append("conflicted")
-    if status in ENGINE_STATUSES:
+    if is_engine_input(status):
         labels.append("reviewed")
     if status == "superseded":
         labels.append("superseded")

--- a/verinote/pipeline/workbench.py
+++ b/verinote/pipeline/workbench.py
@@ -14,7 +14,7 @@ from verinote.pipeline.corroboration import (
     store_typed_relations,
     TypedRelationSpec,
 )
-from verinote.store import ENGINE_STATUSES, REVIEW_STATUSES, Store
+from verinote.store import Store, is_engine_input, is_review_eligible
 
 
 @dataclass(frozen=True)
@@ -107,11 +107,11 @@ def trust_workbench(store: Store) -> TrustWorkbench:
         )
         key = (subject, canonical, object_key)
         sr_key = (subject, canonical)
-        if status in ENGINE_STATUSES:
+        if is_engine_input(status):
             engine.setdefault(key, []).append(fact)
             if canonical in single_valued:
                 by_subject_relation.setdefault(sr_key, {}).setdefault(object_key, []).append(fact)
-        elif status in REVIEW_STATUSES:
+        elif is_review_eligible(status):
             candidates.setdefault(key, []).append(fact)
             candidate_by_subject_relation.setdefault(sr_key, []).append(fact)
 

--- a/verinote/store/__init__.py
+++ b/verinote/store/__init__.py
@@ -3,19 +3,29 @@
 
 from verinote.store.db import (
     DEFAULT_REVIEW_PAGE_SIZE,
-    ENGINE_STATUSES,
     POLICY_MARKER_KEY,
     REVIEW_PAGE_SIZES,
-    REVIEW_STATUSES,
     ReviewQueuePage,
     Store,
 )
+from verinote.store.tiers import (
+    engine_statuses,
+    is_engine_input,
+    is_review_eligible,
+    review_statuses,
+)
 
+# The raw `ENGINE_STATUSES` / `REVIEW_STATUSES` frozensets are deliberately not
+# re-exported: importing them binds the tier at import time, which is how the
+# engine and the Ask/trust/planner layers drifted onto different tiers. Ask the
+# accessors above instead — they resolve `db.ENGINE_STATUSES` at call time.
 __all__ = [
     "Store",
     "POLICY_MARKER_KEY",
-    "REVIEW_STATUSES",
-    "ENGINE_STATUSES",
+    "engine_statuses",
+    "review_statuses",
+    "is_engine_input",
+    "is_review_eligible",
     "DEFAULT_REVIEW_PAGE_SIZE",
     "REVIEW_PAGE_SIZES",
     "ReviewQueuePage",

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -46,6 +46,18 @@ REVIEW_SORT_SQL = {
 }
 
 
+def _status_filter(statuses: frozenset[str]) -> tuple[str, tuple[str, ...]]:
+    """Deterministic (placeholders, params) for a `status IN (...)` filter.
+
+    Status values are bound as parameters, never spliced into SQL text, and
+    `sorted()` fixes the parameter order a `frozenset` would otherwise leave
+    unspecified. Callers must read the status constant at call time so the
+    constant stays the single definition of the tier.
+    """
+    ordered = tuple(sorted(statuses))
+    return ",".join("?" * len(ordered)), ordered
+
+
 def _load_schema() -> str:
     return resources.files("verinote.store").joinpath("schema.sql").read_text(encoding="utf-8")
 
@@ -252,7 +264,13 @@ class Store:
         ).fetchone()
 
     def sources_with_counts(self) -> list[sqlite3.Row]:
-        """Sources plus analysis and fact summaries for the Sources listing."""
+        """Sources plus analysis and fact summaries for the Sources listing.
+
+        `engine_count` is derived from `ENGINE_STATUSES` (read at call time), so
+        the Sources page and the coverage report can never disagree about what
+        the engine actually reads.
+        """
+        placeholders, params = _status_filter(ENGINE_STATUSES)
         return list(
             self._conn.execute(
                 "SELECT s.id, s.path, s.kind, s.added_at, "
@@ -263,7 +281,7 @@ class Store:
                 "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
                 "AND f.status = 'needs_review') AS needs_review_count, "
                 "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
-                "AND f.status IN ('confirmed','accepted')) AS engine_count, "
+                f"AND f.status IN ({placeholders})) AS engine_count, "
                 "j.id AS job_id, j.status AS analysis_status, "
                 "j.total_chunks, j.completed_chunks, j.failed_chunks, "
                 "j.candidate_count AS analysis_candidate_count, "
@@ -274,7 +292,8 @@ class Store:
                 "  SELECT MAX(j2.id) FROM extraction_jobs j2 "
                 "  WHERE j2.source_id = s.id"
                 ") "
-                "ORDER BY s.path"
+                "ORDER BY s.path",
+                params,
             )
         )
 
@@ -353,15 +372,21 @@ class Store:
         )
 
     def source_fact_counts(self) -> list[sqlite3.Row]:
-        """Per-source total vs engine-input (confirmed/accepted) fact counts."""
+        """Per-source total vs engine-input fact counts.
+
+        The engine tier is derived from `ENGINE_STATUSES` (read at call time) so
+        the coverage report counts exactly the facts the engine consumes.
+        """
+        placeholders, params = _status_filter(ENGINE_STATUSES)
         return list(
             self._conn.execute(
                 "SELECT s.id, s.path, s.kind, "
                 "COUNT(f.id) AS total, "
-                "COALESCE(SUM(CASE WHEN f.status IN ('confirmed','accepted') "
+                f"COALESCE(SUM(CASE WHEN f.status IN ({placeholders}) "
                 "THEN 1 ELSE 0 END), 0) AS engine "
                 "FROM sources s LEFT JOIN facts f ON f.source_id = s.id "
-                "GROUP BY s.id ORDER BY s.path"
+                "GROUP BY s.id ORDER BY s.path",
+                params,
             )
         )
 
@@ -902,8 +927,7 @@ class Store:
 
     def review_queue_ids(self, *, sort: object = DEFAULT_REVIEW_SORT) -> list[int]:
         sort = _review_sort(sort)
-        statuses = tuple(sorted(REVIEW_STATUSES))
-        placeholders = ",".join("?" * len(statuses))
+        placeholders, statuses = _status_filter(REVIEW_STATUSES)
         rows = self._conn.execute(
             "SELECT f.id FROM facts f "
             "LEFT JOIN sources s ON s.id = f.source_id "
@@ -939,8 +963,7 @@ class Store:
         page_size = _review_page_size(page_size)
         page = _positive_int(page, 1)
         sort = _review_sort(sort)
-        statuses = tuple(sorted(REVIEW_STATUSES))
-        placeholders = ",".join("?" * len(statuses))
+        placeholders, statuses = _status_filter(REVIEW_STATUSES)
         where = f"f.status IN ({placeholders})"
         total = int(
             self._conn.execute(
@@ -996,14 +1019,15 @@ class Store:
 
     def accept_review_facts_for_source(self, source_id: int) -> list[sqlite3.Row]:
         """Promote all review-queue facts for one source to confirmed."""
+        placeholders, statuses = _status_filter(REVIEW_STATUSES)
         with self._lock:
             self._conn.execute("BEGIN")
             try:
                 facts = list(
                     self._conn.execute(
                         "SELECT * FROM facts WHERE source_id = ? "
-                        "AND status IN ('candidate','needs_review') ORDER BY id",
-                        (source_id,),
+                        f"AND status IN ({placeholders}) ORDER BY id",
+                        (source_id, *statuses),
                     )
                 )
                 accepted: list[sqlite3.Row] = []

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -46,15 +46,23 @@ REVIEW_SORT_SQL = {
 }
 
 
-def _status_filter(statuses: frozenset[str]) -> tuple[str, tuple[str, ...]]:
+def _status_filter(statuses: Iterable[str]) -> tuple[str, tuple[str, ...]]:
     """Deterministic (placeholders, params) for a `status IN (...)` filter.
 
     Status values are bound as parameters, never spliced into SQL text, and
     `sorted()` fixes the parameter order a `frozenset` would otherwise leave
     unspecified. Callers must read the status constant at call time so the
     constant stays the single definition of the tier.
+
+    An empty tier is rejected loudly. SQLite answers `status IN ()` with zero
+    rows instead of an error, which would turn an empty constant into exactly
+    the silent wrong answer this filter exists to prevent: coverage would call
+    every source a gap, and `accept_review_facts_for_source` would promote
+    nothing while reporting success. A crash is cheaper.
     """
-    ordered = tuple(sorted(statuses))
+    ordered = tuple(sorted(frozenset(statuses)))
+    if not ordered:
+        raise ValueError("status filter must not be empty")
     return ",".join("?" * len(ordered)), ordered
 
 
@@ -915,10 +923,8 @@ class Store:
         )
         params: tuple[Any, ...] = ()
         if statuses is not None:
-            statuses = list(statuses)
-            placeholders = ",".join("?" * len(statuses))
+            placeholders, params = _status_filter(statuses)
             sql += f" WHERE f.status IN ({placeholders})"
-            params = tuple(statuses)
         sql += " ORDER BY f.id"
         return list(self._conn.execute(sql, params))
 

--- a/verinote/store/tiers.py
+++ b/verinote/store/tiers.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Call-time accessors for the fact status tiers.
+
+`verinote.store.db` owns the tier constants, but owning them is not enough: a
+consumer that writes `from verinote.store import ENGINE_STATUSES` binds the
+frozenset *object* at import time, so widening the tier later moves the Store
+(which resolves its own module global on every call) while leaving that
+consumer on the old tier. That is exactly the split this package exists to
+prevent — the deterministic engine would read facts that Ask, trust and the
+planner's schema hint never see.
+
+So the raw frozensets are no longer re-exported from `verinote.store`. Every
+status-tier question goes through the accessors here, which resolve
+`db.ENGINE_STATUSES` / `db.REVIEW_STATUSES` at call time. One question, one
+answer, one runtime definition.
+
+The empty tier is refused here too, for the same reason `_status_filter`
+refuses it: an empty tier turns every membership test into a silent "no" —
+coverage would call every source a gap, acceptance would promote nothing while
+reporting success. A crash is cheaper than a quiet wrong answer.
+"""
+
+from __future__ import annotations
+
+from verinote.store import db as _db
+
+
+def _require_populated(statuses: frozenset[str], name: str) -> frozenset[str]:
+    if not statuses:
+        raise ValueError(f"{name} status tier must not be empty")
+    return statuses
+
+
+def engine_statuses() -> frozenset[str]:
+    """The engine-input tier, read at call time."""
+    return _require_populated(_db.ENGINE_STATUSES, "engine-input")
+
+
+def review_statuses() -> frozenset[str]:
+    """The human-review tier, read at call time."""
+    return _require_populated(_db.REVIEW_STATUSES, "review")
+
+
+def is_engine_input(status: object) -> bool:
+    """Whether `status` is read by the deterministic engine, decided at call time."""
+    return str(status) in engine_statuses()
+
+
+def is_review_eligible(status: object) -> bool:
+    """Whether `status` sits in the human-review tier, decided at call time."""
+    return str(status) in review_statuses()

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -82,11 +82,13 @@ from verinote.prompts import (
 from verinote.engine.terms import StringLit, render_term
 from verinote.store import (
     DEFAULT_REVIEW_PAGE_SIZE,
-    ENGINE_STATUSES,
     REVIEW_PAGE_SIZES,
     ReviewQueuePage,
     Store,
 )
+# Imported as a module, not `from ... import ENGINE_STATUSES`: the tier must be
+# read at call time so the web layer cannot pin a stale copy of the constant.
+from verinote.store import db as store_db
 from verinote.store.fact_input import structural_term, term_input_kind
 
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
@@ -528,7 +530,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         typed = store_typed_relations(store)
         support_sources: dict[tuple[str, str, tuple[str, object]], set[str]] = {}
         for fact in facts:
-            if str(fact["status"]) not in ENGINE_STATUSES:
+            if str(fact["status"]) not in store_db.ENGINE_STATUSES:
                 continue
             source_path = str(fact["source_path"] or "").strip()
             if not source_path:
@@ -645,6 +647,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             {
                 "counts": counts,
                 "total": sum(counts.values()),
+                # Derived here, not summed in the template: the dashboard's
+                # "engine input" card must answer the same question as coverage
+                # and the Sources badge, from the same constant.
+                "engine_input": sum(
+                    counts.get(status, 0) for status in store_db.ENGINE_STATUSES
+                ),
                 "sources": store.sources(),
                 "coverage": coverage(store, root=cfg.root),
                 "corroboration": store_corroboration(store),

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -8,7 +8,7 @@
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>
   <div class="card"><div class="num">{{ total }}</div><div class="lbl">facts</div></div>
   <div class="card"><div class="num">{{ counts.get('needs_review', 0) + counts.get('candidate', 0) }}</div><div class="lbl">needs review</div></div>
-  <div class="card ok"><div class="num">{{ counts.get('confirmed', 0) + counts.get('accepted', 0) }}</div><div class="lbl">engine input</div></div>
+  <div class="card ok"><div class="num">{{ engine_input }}</div><div class="lbl">engine input</div></div>
 </section>
 
 <h2>Action queues</h2>

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -72,7 +72,9 @@
       <td class="conf">
         {{ s["candidate_count"] }} candidate(s)
         {% if s["needs_review_count"] %}<br>{{ s["needs_review_count"] }} needs review{% endif %}
-        {% if s["engine_count"] %}<br>{{ s["engine_count"] }} confirmed{% endif %}
+        {# Derived from ENGINE_STATUSES, which already includes `accepted`:
+           label it by what it means (the engine reads it), not by one status. #}
+        {% if s["engine_count"] %}<br>{{ s["engine_count"] }} engine input{% endif %}
         <div class="source-trust">
           <span class="badge trust-unsupported">{{ s["unsupported_count"] }} unsupported</span>
           <span class="badge trust-conflicted">{{ s["conflicted_count"] }} conflicted</span>


### PR DESCRIPTION
Closes #176

## Problem

Two pieces of code answered "what is engine input": the `ENGINE_STATUSES` constant (`db.py:22`) and `IN ('confirmed','accepted')` hard-coded in SQL. They agreed only by coincidence.

The stale line number in the issue body hid the blast radius — the literal appeared in **two** query sites, and a **third** answer lived in the web dashboard template:

| Location | Function | Consumer |
|---|---|---|
| `db.py:207` | `sources_with_counts` -> `engine_count` | `web/app.py` -> `sources.html:75` ("N confirmed") |
| `db.py:302` | `source_fact_counts` -> `engine` | `engine/coverage.py:52` -> `coverage()` -> `cli.py:296`, `web/app.py` |
| `dashboard.html:11` | template summed `confirmed + accepted` | the "engine input" card at the top of the UI |

Add a status and the coverage report asserts engine-input counts the engine does not agree with — and a user deletes facts on the strength of that report.

## Change

Factor out `_status_filter(statuses) -> (placeholders, params)`, the idiom the repo already had inline in `review_queue_ids` / `review_queue_page`:

- **Parameter binding, not string building.** Status values never enter SQL text, so the SQL-injection boundary does not rest on a "these are constants, so it's safe" invariant that will eventually break.
- **`sorted()`** fixes the parameter order a `frozenset` leaves unspecified.
- **Read at call time.** No default-arg capture, no import-time frozen SQL — otherwise the mutation tests below are impossible and the drift net disappears.
- **Empty tier rejected loudly.** SQLite answers `status IN ()` with zero rows instead of raising. An empty constant would therefore have made `coverage()` call *every* source a gap, and made `accept_review_facts_for_source` promote nothing while returning success — the human review gate silently disabled. Unreachable today, but this PR's whole claim is that the constant is the single handle; leaving its fatal input undefended contradicts that. A crash is cheaper than a quiet wrong answer.

Call sites: `sources_with_counts`, `source_fact_counts`, and `facts()` — the engine's *real* input path, which `ask.py`, `trust.py`, `query_schema.py` and `engine_fact_terms` all read through. Plus pure refactors of `review_queue_ids`, `review_queue_page`, and the one-line review-tier filter in `accept_review_facts_for_source`.

The dashboard card is now derived in the route (`sum(counts.get(s, 0) for s in ENGINE_STATUSES)`) and merely rendered by the template. `web/app.py` imports the store as a module so the tier resolves at call time rather than pinning a stale copy at import.

Deliberately untouched: the `candidate` / `needs_review` per-status count columns (different question — individual counts, not a set filter), `SET status = 'confirmed'` (a single write target, not set membership), `schema.sql` CHECK constraints (DDL, not runtime-derivable), `report_trace.py`'s separate `REVIEW_STATUSES` redefinition (same family, different constant — its own issue), and the membership of `ENGINE_STATUSES` itself. This unifies the definition; it does not change policy.

## Tests

Pinned by behaviour, not by snapshot numbers and not by string-matching the source (the string-matching-drift failure mode from the #155 review).

- **T1** (`test_coverage_engine_tier_follows_engine_statuses`): a source with only `superseded` facts is a gap with `engine_facts == 0`. `monkeypatch` `ENGINE_STATUSES |= {"superseded"}` and the same source stops being a gap with `engine_facts == 2`.
- **T2** (`test_coverage_engine_facts_match_the_engines_own_input`): `coverage.engine_facts == len(store.facts(statuses=db.ENGINE_STATUSES) for this source)` — cross-checked against the engine's own input path, asserted under both default and mutated tiers. What is fixed is the invariant, not a number.
- **T3** (`test_sources_with_counts_engine_count_follows_engine_statuses`): same mutation assertion for `engine_count`, so the Sources page cannot report a different number than coverage. Also asserts the `candidate_count` / `fact_count` columns do **not** move.
- **Dashboard** (`test_dashboard_engine_input_card_follows_engine_statuses`): parses the rendered card and asserts it tracks the tier, and equals what the engine would actually read.
- **Empty tier**: positive/negative cases across the engine and review paths (`facts`, `source_fact_counts`, `sources_with_counts`, `review_queue_page`, `accept_review_facts_for_source`), including that no fact is promoted behind our back. `statuses=None` still means "no filter", not "empty filter".
- **Consumer agreement** (`test_sources_with_counts_engine_count_matches_coverage`) now mutates too. It previously *survived* the literal revert: two consumers reading the same wrong literal still agree with each other, so agreement alone was not evidence.

**Mutation proof (run, not assumed).** Reverted both queries to the literals and the template to its inline sum:

```
FAILED tests/test_store.py::test_sources_with_counts_engine_count_follows_engine_statuses
FAILED tests/test_store.py::test_sources_with_counts_engine_count_matches_coverage
FAILED tests/test_store.py::test_engine_reads_are_refused_when_the_engine_tier_is_empty
FAILED tests/test_coverage.py::test_coverage_engine_tier_follows_engine_statuses
FAILED tests/test_coverage.py::test_coverage_engine_facts_match_the_engines_own_input
FAILED tests/test_web.py::test_dashboard_engine_input_card_follows_engine_statuses
6 failed, 127 passed
```

(The coverage failure is `assert 0 == 2` — the report still says "no engine facts" while the engine would read two.) Restored; the net catches the regression it exists to catch, on every consumer.

## Verification

- Full suite: **677 passed, 7 skipped** — no regressions. Under the default `ENGINE_STATUSES` every number is byte-identical; the production behaviour change is a refactor plus a new guard on an unreachable input.
- `verinote coverage` output unchanged on a scratch KB (`1/1 engine facts`, `0/1 ... GAP`, `coverage: 1 covered, 1 gap(s), 0 orphan(s)`).

---

## Review round 2 (justinjoy, CHANGES_REQUESTED)

The first round moved Store/coverage/dashboard to call-time lookup but left the escape hatch open: `from verinote.store import ENGINE_STATUSES` binds the frozenset **object** at import time. So the reviewer's repro was real — widen `db.ENGINE_STATUSES` and `Store.engine_fact_terms()` reads the new fact while `build_query_schema_snapshot().fact_count` stays `0` and `ask.grounding_facts()` stays empty. The deterministic engine would consume facts the planner's schema hint and the Ask/trust layers cannot see.

**Fix: first-class accessors, and no way to bind the tier at import time.**

New `verinote/store/tiers.py` — `engine_statuses()`, `review_statuses()`, `is_engine_input(status)`, `is_review_eligible(status)` — all resolving `db.ENGINE_STATUSES` / `db.REVIEW_STATUSES` at call time, all refusing an empty tier for the same reason `_status_filter` does. `verinote/store` **no longer re-exports the raw frozensets** (breaking for any importer of `verinote.store.ENGINE_STATUSES`; `db.py` keeps them as the owner). Chose the accessor route over "sprinkle `store_db.X` everywhere" because the repeated lesson here is that two places answering one question drift — an accessor cannot be cached by accident, and removing the re-export makes the old mistake unavailable rather than merely discouraged.

Consumers converted (blocking item 1, plus 2 and 3): `pipeline/query_schema.py`, `pipeline/ask.py`, `pipeline/trust.py`, `pipeline/corroboration.py` (this is what the dashboard's corroboration/conflict sections go through — item 2), `pipeline/workbench.py`, `pipeline/acceptance.py` (item 3).

Item 4: `sources.html` now labels `engine_count` **"N engine input"**, matching the dashboard card and what the number actually means (`ENGINE_STATUSES` membership, `accepted` included).

`web/app.py` and `db.py` are untouched this round — app.py already read `store_db.ENGINE_STATUSES` at call time, and keeping both files out of the diff avoids churn against #179.

### Mutation evidence (`tests/test_status_tiers.py`, 7 tests)

Every test widens `db.ENGINE_STATUSES` with `superseded` (or empties a tier) and asserts the consumer moves. Reverting the six pipeline modules to their import-time bindings (and re-adding the re-export so they still import) turns **all 7 red**, including the reviewer's exact split:

```
>       assert snapshot.fact_count == 1
E       AssertionError: assert 0 == 1
        # while store.engine_fact_terms() already returned [1]
```

- engine-input readers agree after widening: `engine_fact_terms` / `build_query_schema_snapshot` / `grounding_facts`
- trust: `engine_input` flag and distinct-source support
- corroboration + single-valued conflicts + workbench (the dashboard sections)
- acceptance: support sources / `insufficient_distinct_source_support`
- empty engine tier -> every consumer raises `ValueError` (not "zero facts")
- empty review tier -> `accept_recommendations()` / `accept_recommendation()` raise, and the fact is **not** promoted behind our back (item 3 closed)
- an AST guard: no module outside `db.py`/`tiers.py` may name the tiers in an import — the regression is an import statement, so it is guarded as one

Also new: `test_sources_page_labels_the_engine_count_by_what_it_means` (item 4 — asserts "N engine input", no "confirmed", and that the badge tracks a widened tier).

### Validation

- `.venv/bin/python -m pytest -q` -> **685 passed, 7 skipped** (677 before this round)
- `.venv/bin/ruff check .` -> All checks passed
- Merge simulation against `issue-155-loud-missing-policy` (#179): `db.py` and `web/app.py` auto-merge cleanly; one 5-line conflict in `verinote/store/__init__.py` (#179 adds `POLICY_MARKER_KEY` to the same import/`__all__` lists this PR trims) — resolve by keeping `POLICY_MARKER_KEY` and dropping the two tier names.
