### PR TITLE
test(#163): sandbox HOME and CWD so no test can reach the real KB

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,29 @@
 `active_root()` falls back to `./data` relative to the *current working
 directory*. A test that forgets to isolate either one can rewrite the
 developer's real `app.json` — repointing the active KB — or open the repo's own
-`data/kb.sqlite`. The autouse fixture below closes both holes structurally, so
-isolation is no longer something each test author has to remember.
+`data/kb.sqlite`. `Config.for_root()` also reads every `VERINOTE_*` variable
+env-first, so an ambient export in the developer's shell can change what a test
+sees.
+
+The sandbox is two-tier on purpose:
+
+* `pytest_configure` seals the environment at *session start*, before any
+  fixture (of any scope) or any collected module's import-time code runs.
+  A function-scoped `monkeypatch` cannot do this: pytest instantiates
+  higher-scoped fixtures first, so a `scope="module"`/`"session"` fixture that
+  called `Config.load()` would run *before* a function-scoped sandbox and reach
+  the real home.
+* The autouse fixture below then lays a fresh per-test home and CWD on top, so
+  tests cannot see each other's writes.
+
+Either tier alone leaves a hole; both together mean no test — whatever its
+fixture scopes — can reach the real config.
 """
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
 
 import env_sandbox
 import pytest
@@ -16,23 +36,65 @@ import pytest
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.query_intent import parse_query_intent
 
+HOME_VARS = ("HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA")
+
+_session_patch: pytest.MonkeyPatch | None = None
+_session_tmp: str | None = None
+
+
+def _sandbox_env(patch: pytest.MonkeyPatch, home: Path, cwd: Path) -> None:
+    """Point the home-ish vars at `home`, drop every `VERINOTE_*`, chdir to `cwd`."""
+    for var in HOME_VARS:
+        patch.setenv(var, str(home))
+    for var in [name for name in os.environ if name.startswith("VERINOTE_")]:
+        patch.delenv(var, raising=False)
+    patch.chdir(cwd)
+
+
+def pytest_configure(config):
+    """Seal the environment before anything else in the session runs.
+
+    Runs after this conftest (and therefore `env_sandbox`) is imported, so the
+    *real* paths are still captured under the ambient environment — but before
+    collection, fixtures of any scope, and test-module import-time code.
+    """
+    global _session_patch, _session_tmp
+    _session_tmp = tempfile.mkdtemp(prefix="verinote-session-")
+    home = Path(_session_tmp) / "home"
+    cwd = Path(_session_tmp) / "cwd"
+    home.mkdir()
+    cwd.mkdir()
+    _session_patch = pytest.MonkeyPatch()
+    _sandbox_env(_session_patch, home, cwd)
+    env_sandbox.seal(home)
+
+
+def pytest_unconfigure(config):
+    global _session_patch, _session_tmp
+    env_sandbox.unseal()
+    if _session_patch is not None:
+        _session_patch.undo()
+        _session_patch = None
+    if _session_tmp is not None:
+        shutil.rmtree(_session_tmp, ignore_errors=True)
+        _session_tmp = None
+
 
 @pytest.fixture(autouse=True)
 def isolate_app_environment(monkeypatch, tmp_path_factory):
-    """Point every home-ish env var at a throwaway home, and CWD at a throwaway dir.
+    """Lay a throwaway per-test home and CWD over the session-wide seal.
 
     A dedicated temp dir (not `tmp_path`) is used for the fake home: many tests
     use `tmp_path` as a KB root and walk it, so planting a home inside it would
-    pollute them. `VERINOTE_ROOT` is dropped so an ambient export cannot leak in,
-    and the CWD is moved off the repo so `active_root()`'s `./data` fallback
-    cannot reach the repo's own KB. Tests that set these vars themselves still
-    win: this runs first, their `setenv` runs after.
+    pollute them. Every `VERINOTE_*` variable is dropped (`ROOT`, `PROVIDER`,
+    `MODEL`, `BASE_URL`, `API_KEY`, `LLM_TIMEOUT`, the `EXTRACTION_*` knobs and
+    `AUTO_ACCEPT_RECOMMENDATIONS` are all read env-first by `Config`), and the
+    CWD is moved off the repo so `active_root()`'s `./data` fallback cannot
+    reach the repo's own KB. Tests that set these vars themselves still win:
+    this runs first, their `setenv` runs after.
     """
     home = tmp_path_factory.mktemp("home")
-    for var in ("HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA"):
-        monkeypatch.setenv(var, str(home))
-    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
-    monkeypatch.chdir(tmp_path_factory.mktemp("cwd"))
+    _sandbox_env(monkeypatch, home, tmp_path_factory.mktemp("cwd"))
     env_sandbox.enter(home)
     try:
         yield home
@@ -42,15 +104,25 @@ def isolate_app_environment(monkeypatch, tmp_path_factory):
 
 @pytest.fixture(scope="session", autouse=True)
 def real_app_config_is_untouched():
-    """Fail the session if anything wrote to the developer's real app config."""
+    """Restore, then fail the session, if anything wrote the developer's real app config.
+
+    Detecting the leak is not enough: by teardown the user's `app.json` already
+    points at a pytest temp KB that is about to be deleted, so `verinote ui`
+    would open a KB that no longer exists. Put the bytes back first, then fail.
+    """
     path = env_sandbox.REAL_APP_CONFIG_PATH
     before = env_sandbox.snapshot(path)
     yield
     after = env_sandbox.snapshot(path)
-    if before is None:
-        assert after is None, f"the test run created the real app config at {path}"
-    else:
-        assert after == before, f"the test run modified the real app config at {path}"
+    if after == before:
+        return
+    env_sandbox.restore(path, before)
+    verb = "created" if before is None else "modified"
+    raise AssertionError(
+        f"the test run {verb} the real app config at {path}; "
+        "it has been restored to its pre-run state, but the leak is a bug — "
+        "a test escaped the environment sandbox"
+    )
 
 
 class FakeClient:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,56 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Shared test fakes — a canned `LLMClient` so the pipeline is exercised offline."""
+"""Shared test fakes and the environment sandbox that keeps tests off the real home.
 
+`verinote.config.app_config_dir()` resolves through `HOME`/`USERPROFILE`/
+`XDG_CONFIG_HOME`/`APPDATA`/`LOCALAPPDATA` depending on the platform, and
+`active_root()` falls back to `./data` relative to the *current working
+directory*. A test that forgets to isolate either one can rewrite the
+developer's real `app.json` — repointing the active KB — or open the repo's own
+`data/kb.sqlite`. The autouse fixture below closes both holes structurally, so
+isolation is no longer something each test author has to remember.
+"""
+
+import env_sandbox
 import pytest
 
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.query_intent import parse_query_intent
+
+
+@pytest.fixture(autouse=True)
+def isolate_app_environment(monkeypatch, tmp_path_factory):
+    """Point every home-ish env var at a throwaway home, and CWD at a throwaway dir.
+
+    A dedicated temp dir (not `tmp_path`) is used for the fake home: many tests
+    use `tmp_path` as a KB root and walk it, so planting a home inside it would
+    pollute them. `VERINOTE_ROOT` is dropped so an ambient export cannot leak in,
+    and the CWD is moved off the repo so `active_root()`'s `./data` fallback
+    cannot reach the repo's own KB. Tests that set these vars themselves still
+    win: this runs first, their `setenv` runs after.
+    """
+    home = tmp_path_factory.mktemp("home")
+    for var in ("HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA"):
+        monkeypatch.setenv(var, str(home))
+    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path_factory.mktemp("cwd"))
+    env_sandbox.enter(home)
+    try:
+        yield home
+    finally:
+        env_sandbox.exit()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def real_app_config_is_untouched():
+    """Fail the session if anything wrote to the developer's real app config."""
+    path = env_sandbox.REAL_APP_CONFIG_PATH
+    before = env_sandbox.snapshot(path)
+    yield
+    after = env_sandbox.snapshot(path)
+    if before is None:
+        assert after is None, f"the test run created the real app config at {path}"
+    else:
+        assert after == before, f"the test run modified the real app config at {path}"
 
 
 class FakeClient:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,27 +102,32 @@ def isolate_app_environment(monkeypatch, tmp_path_factory):
         env_sandbox.exit()
 
 
-@pytest.fixture(scope="session", autouse=True)
-def real_app_config_is_untouched():
+def pytest_sessionfinish(session, exitstatus):
     """Restore, then fail the session, if anything wrote the developer's real app config.
 
-    Detecting the leak is not enough: by teardown the user's `app.json` already
-    points at a pytest temp KB that is about to be deleted, so `verinote ui`
-    would open a KB that no longer exists. Put the bytes back first, then fail.
+    Detecting the leak is not enough: by now the user's `app.json` already points
+    at a pytest temp KB that is about to be deleted, so `verinote ui` would open a
+    KB that no longer exists. Put it back first, then fail.
+
+    A hook, not a session fixture, and it compares against a baseline taken when
+    `env_sandbox` was *imported*. A fixture is too late in both directions: its
+    setup runs after collection and after every test module's import-time code,
+    so a leak from there would be baked into the baseline and read as "clean";
+    and its teardown never runs at all when collection fails or when no test is
+    selected — exactly the runs where a stray import-time write goes unnoticed.
     """
-    path = env_sandbox.REAL_APP_CONFIG_PATH
-    before = env_sandbox.snapshot(path)
-    yield
-    after = env_sandbox.snapshot(path)
-    if after == before:
-        return
-    env_sandbox.restore(path, before)
-    verb = "created" if before is None else "modified"
-    raise AssertionError(
-        f"the test run {verb} the real app config at {path}; "
-        "it has been restored to its pre-run state, but the leak is a bug — "
-        "a test escaped the environment sandbox"
+    message = env_sandbox.leak_report(
+        env_sandbox.REAL_APP_CONFIG_PATH, env_sandbox.REAL_APP_CONFIG_BEFORE
     )
+    if message is None:
+        return
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is None:
+        print(message)
+        return
+    reporter.write_sep("=", "environment sandbox leak", red=True)
+    reporter.write_line(message)
 
 
 class FakeClient:

--- a/tests/env_sandbox.py
+++ b/tests/env_sandbox.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+"""State for the test-environment sandbox, shared by `conftest.py` and its tests.
+
+This lives in its own module rather than in `conftest.py` on purpose: pytest
+imports a conftest as the top-level module `conftest`, so a test doing
+`from tests.conftest import ...` would create a *second* module object with its
+own copy of the state. Both the conftest and the tests import this module under
+the same name, so there is exactly one.
+"""
+
+from pathlib import Path
+
+from verinote.config import app_config_dir
+
+# Captured at import time — i.e. under the *ambient* environment, before the
+# sandbox monkeypatches anything. These are the real paths the test run must
+# never touch, and they are what makes the isolation regression tests
+# non-vacuous.
+REAL_APP_CONFIG_DIR = app_config_dir()
+REAL_APP_CONFIG_PATH = REAL_APP_CONFIG_DIR / "app.json"
+
+_sandbox_home: Path | None = None
+
+
+def snapshot(path: Path) -> bytes | None:
+    """Return the file's bytes, or None when it does not exist."""
+    try:
+        return path.read_bytes()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+
+
+def sandbox_home() -> Path | None:
+    """The fake home installed for the running test, or None if the sandbox is off.
+
+    Read through a function rather than a fixture argument so the isolation
+    tests depend on the autouse fixture *implicitly*: requesting the fixture by
+    name would re-enable it even with `autouse=True` deleted, and the regression
+    tests would then prove nothing.
+    """
+    return _sandbox_home
+
+
+def enter(home: Path) -> None:
+    global _sandbox_home
+    _sandbox_home = home
+
+
+def exit() -> None:  # noqa: A001 - module-level verb, not the builtin
+    global _sandbox_home
+    _sandbox_home = None

--- a/tests/env_sandbox.py
+++ b/tests/env_sandbox.py
@@ -20,14 +20,49 @@ REAL_APP_CONFIG_DIR = app_config_dir()
 REAL_APP_CONFIG_PATH = REAL_APP_CONFIG_DIR / "app.json"
 
 _sandbox_home: Path | None = None
+_session_home: Path | None = None
 
 
 def snapshot(path: Path) -> bytes | None:
-    """Return the file's bytes, or None when it does not exist."""
+    """Return the file's bytes, or None when it is not a readable file.
+
+    The canary must never blow up on the way to its own assertion: an
+    unreadable path (`PermissionError`), a directory where the file should be
+    (`IsADirectoryError`), or a missing parent (`NotADirectoryError`) all mean
+    "no config bytes to compare", not "crash the session".
+    """
     try:
         return path.read_bytes()
-    except (FileNotFoundError, NotADirectoryError):
+    except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError):
         return None
+
+
+def restore(path: Path, before: bytes | None) -> None:
+    """Put a leaked-into file back the way it was: rewrite the bytes, or remove it."""
+    if before is None:
+        path.unlink(missing_ok=True)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(before)
+
+
+def session_home() -> Path | None:
+    """The fake home sealed in at session start, or None if the seal is off.
+
+    This is the tier that covers module/session-scoped fixtures and test-module
+    import time, both of which run before any function-scoped `monkeypatch`.
+    """
+    return _session_home
+
+
+def seal(home: Path) -> None:
+    global _session_home
+    _session_home = home
+
+
+def unseal() -> None:
+    global _session_home
+    _session_home = None
 
 
 def sandbox_home() -> Path | None:

--- a/tests/env_sandbox.py
+++ b/tests/env_sandbox.py
@@ -8,6 +8,13 @@ own copy of the state. Both the conftest and the tests import this module under
 the same name, so there is exactly one.
 """
 
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from verinote.config import app_config_dir
@@ -23,27 +30,126 @@ _sandbox_home: Path | None = None
 _session_home: Path | None = None
 
 
-def snapshot(path: Path) -> bytes | None:
-    """Return the file's bytes, or None when it is not a readable file.
+@dataclass(frozen=True)
+class Entry:
+    """What sits at a path: nothing, a regular file, a symlink, or something else.
 
-    The canary must never blow up on the way to its own assertion: an
-    unreadable path (`PermissionError`), a directory where the file should be
-    (`IsADirectoryError`), or a missing parent (`NotADirectoryError`) all mean
-    "no config bytes to compare", not "crash the session".
+    The canary compares two of these, so the *kind* has to be part of the value.
+    Reading through the path (`read_bytes`) would follow a symlink and report the
+    target's bytes, which makes a leak that replaces `app.json` with a symlink
+    look identical to no leak at all.
+    """
+
+    kind: str  # "missing" | "file" | "symlink" | "other"
+    data: bytes | None = None  # kind == "file"
+    target: str | None = None  # kind == "symlink"
+
+
+MISSING = Entry("missing")
+
+
+def snapshot(path: Path) -> Entry:
+    """Describe what is at `path` without following symlinks, and without raising.
+
+    The canary must never blow up on the way to its own assertion: an unreadable
+    path, a directory where the file should be, or a missing parent all mean
+    "nothing we can put back", not "crash the session".
     """
     try:
-        return path.read_bytes()
-    except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError):
-        return None
+        st = path.lstat()
+    except (FileNotFoundError, NotADirectoryError, PermissionError, OSError):
+        return MISSING
+    if stat.S_ISLNK(st.st_mode):
+        try:
+            return Entry("symlink", target=os.readlink(path))
+        except OSError:
+            return Entry("other")
+    if stat.S_ISREG(st.st_mode):
+        try:
+            return Entry("file", data=path.read_bytes())
+        except OSError:
+            return Entry("other")
+    return Entry("other")
 
 
-def restore(path: Path, before: bytes | None) -> None:
-    """Put a leaked-into file back the way it was: rewrite the bytes, or remove it."""
-    if before is None:
-        path.unlink(missing_ok=True)
+def _remove(path: Path) -> None:
+    """Delete whatever is at `path` — file, symlink, or directory — following nothing."""
+    try:
+        st = path.lstat()
+    except (FileNotFoundError, NotADirectoryError, PermissionError, OSError):
         return
+    if stat.S_ISDIR(st.st_mode) and not stat.S_ISLNK(st.st_mode):
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        # `unlink` removes the symlink itself, never its target.
+        path.unlink(missing_ok=True)
+
+
+def _write_atomically(path: Path, data: bytes) -> None:
+    """Replace `path` with `data` in one step, so a crash cannot leave it half-written."""
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".env-sandbox-")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def restore(path: Path, before: Entry) -> bool:
+    """Put `path` back the way `before` describes it. False when that is impossible.
+
+    A leak can leave anything at the path — a file, a symlink pointing at the
+    user's real KB config, or a directory — so the current entry is removed by
+    kind before the original is recreated. Writing through the path instead would
+    follow a planted symlink and corrupt whatever it aims at while leaving the
+    leak itself in place.
+
+    `other` (a directory, an unreadable file) is the one thing we cannot
+    reconstruct: we never learned its contents, so removing it would destroy what
+    we came to protect. Refuse instead, and let the caller report it.
+    """
+    if before.kind == "other":
+        return False
+    _remove(path)
+    if before.kind == "missing":
+        return True
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(before)
+    if before.kind == "symlink":
+        assert before.target is not None
+        path.symlink_to(before.target)
+        return True
+    assert before.data is not None
+    _write_atomically(path, before.data)
+    return True
+
+
+# The baseline for the real app config, taken at *import* time. It has to be this
+# early: `conftest` imports this module before `pytest_configure`, before
+# collection, and before any test module's import-time code, so a leak from any
+# of those is still measured against the user's true pre-run state. Capturing it
+# in a session fixture instead would bake an import-time leak into the baseline —
+# the run would then look clean and restore nothing.
+REAL_APP_CONFIG_BEFORE = snapshot(REAL_APP_CONFIG_PATH)
+
+
+def leak_report(path: Path, before: Entry) -> str | None:
+    """Restore a leaked-into path and return why it failed the run, or None if clean."""
+    after = snapshot(path)
+    if after == before:
+        return None
+    restored = restore(path, before)
+    verb = "created" if before.kind == "missing" else "modified"
+    tail = (
+        "it has been restored to its pre-run state"
+        if restored
+        else f"IT COULD NOT BE RESTORED (it was a {before.kind} before the run) — repair it by hand"
+    )
+    return (
+        f"the test run {verb} the real app config at {path}; {tail}. "
+        "The leak is a bug: a test escaped the environment sandbox."
+    )
 
 
 def session_home() -> Path | None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,23 +13,6 @@ from verinote.config import (
 )
 
 
-def _clear_env(monkeypatch):
-    for var in (
-        "VERINOTE_PROVIDER",
-        "VERINOTE_MODEL",
-        "VERINOTE_BASE_URL",
-        "VERINOTE_API_KEY",
-        "VERINOTE_LLM_TIMEOUT",
-        "VERINOTE_EXTRACTION_CHUNK_CHARS",
-        "VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS",
-        "VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK",
-        "VERINOTE_AUTO_ACCEPT_RECOMMENDATIONS",
-        "VERINOTE_ROOT",
-        "XDG_CONFIG_HOME",
-    ):
-        monkeypatch.delenv(var, raising=False)
-
-
 def test_save_and_read_round_trip(tmp_path):
     save_settings(tmp_path, provider="ollama", model="llama3.1", base_url="http://x")
     assert read_settings(tmp_path) == {
@@ -39,22 +22,19 @@ def test_save_and_read_round_trip(tmp_path):
     }
 
 
-def test_for_root_uses_saved_settings(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
+def test_for_root_uses_saved_settings(tmp_path):
     save_settings(tmp_path, provider="openai", model="gpt-4o-mini")
     cfg = Config.for_root(tmp_path)
     assert (cfg.provider, cfg.model) == ("openai", "gpt-4o-mini")
 
 
 def test_env_overrides_saved_settings(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     save_settings(tmp_path, provider="openai", model="gpt-4o")
     monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
     assert Config.for_root(tmp_path).provider == "ollama"
 
 
-def test_default_model_when_nothing_set(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
+def test_default_model_when_nothing_set(tmp_path):
     cfg = Config.for_root(tmp_path)  # no settings file, no env
     assert (cfg.provider, cfg.model) == ("anthropic", "claude-opus-4-8")
     assert cfg.llm_timeout_seconds == 600.0
@@ -65,13 +45,11 @@ def test_default_model_when_nothing_set(tmp_path, monkeypatch):
 
 
 def test_llm_timeout_env_override(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     monkeypatch.setenv("VERINOTE_LLM_TIMEOUT", "900")
     assert Config.for_root(tmp_path).llm_timeout_seconds == 900.0
 
 
 def test_extraction_settings_round_trip_and_env_override(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     save_settings(
         tmp_path,
         provider="ollama",
@@ -106,15 +84,13 @@ def test_claude_cli_provider_is_available():
     assert "ollama" in TESTABLE_PROVIDERS
 
 
-def test_legacy_claude_provider_normalizes_to_claudecli(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
+def test_legacy_claude_provider_normalizes_to_claudecli(tmp_path):
     save_settings(tmp_path, provider="claude", model="")
     assert read_settings(tmp_path)["provider"] == "claudecli"
     assert Config.for_root(tmp_path).provider == "claudecli"
 
 
 def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     monkeypatch.setenv("VERINOTE_API_KEY", "supersecret")
     save_settings(tmp_path, provider="anthropic", model="m")
     cfg = Config.for_root(tmp_path)
@@ -123,13 +99,11 @@ def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):
 
 
 def test_active_root_uses_env_first(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
     assert active_root() == tmp_path.resolve()
 
 
 def test_active_root_uses_app_config_when_kb_exists(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
@@ -157,7 +131,6 @@ def test_active_root_uses_app_config_when_kb_exists(tmp_path, monkeypatch):
 
 
 def test_ui_config_is_none_without_selected_kb(tmp_path, monkeypatch):
-    _clear_env(monkeypatch)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -22,9 +22,14 @@ import pytest
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import conftest  # noqa: E402
+import env_sandbox  # noqa: E402
 from env_sandbox import (  # noqa: E402
+    MISSING,
     REAL_APP_CONFIG_DIR,
     REAL_APP_CONFIG_PATH,
+    Entry,
+    leak_report,
     restore,
     sandbox_home,
     session_home,
@@ -134,37 +139,132 @@ def test_module_scoped_config_load_stays_in_the_sandbox(module_scoped_config):
 
 
 def test_canary_restores_a_leaked_app_config_before_failing(tmp_path):
-    # The canary's teardown does not just detect a leak; it undoes it. Exercised
-    # here against a stand-in path — never the real one.
+    # The canary does not just detect a leak; it undoes it. Exercised here
+    # against a stand-in path — never the real one.
     path = tmp_path / "app.json"
     original = b'{"active_root": "/real/kb"}\n'
     path.write_bytes(original)
     before = snapshot(path)
 
     path.write_bytes(b'{"active_root": "/tmp/pytest-kb"}\n')  # the leak
-    restore(path, before)
+    message = leak_report(path, before)
 
     assert path.read_bytes() == original
+    assert message is not None
+    assert "modified" in message
+    assert "COULD NOT BE RESTORED" not in message
 
 
 def test_canary_restore_removes_a_config_the_run_created(tmp_path):
     path = tmp_path / "nested" / "app.json"
     before = snapshot(path)
 
-    assert before is None
+    assert before == MISSING
     path.parent.mkdir(parents=True)
     path.write_bytes(b"{}\n")  # the leak: a file that did not exist before
-    restore(path, before)
+    message = leak_report(path, before)
 
     assert not path.exists()
+    assert message is not None and "created" in message
+
+
+def test_canary_replaces_a_symlink_without_writing_through_it(tmp_path):
+    # The nastiest shape of the leak: the config is swapped for a symlink. Writing
+    # the original bytes *through* the path would corrupt the symlink's target and
+    # leave the symlink in place — so the real `app.json` would still be a link to
+    # somebody else's file when the run ends.
+    path = tmp_path / "app.json"
+    original = b'{"active_root": "/real/kb"}\n'
+    path.write_bytes(original)
+    before = snapshot(path)
+    victim = tmp_path / "victim.json"
+    victim.write_bytes(b"do not touch\n")
+
+    path.unlink()
+    path.symlink_to(victim)  # the leak
+    message = leak_report(path, before)
+
+    assert not path.is_symlink(), "the canary followed the symlink instead of replacing it"
+    assert path.read_bytes() == original
+    assert victim.read_bytes() == b"do not touch\n", "the canary wrote through the symlink"
+    assert message is not None
+
+
+def test_canary_removes_a_directory_left_where_the_config_was(tmp_path):
+    path = tmp_path / "app.json"
+    before = snapshot(path)
+
+    assert before == MISSING
+    (path / "nested").mkdir(parents=True)  # the leak: a directory at the config path
+    message = leak_report(path, before)
+
+    assert not path.exists()
+    assert message is not None
+
+
+def test_canary_refuses_to_destroy_what_it_cannot_reconstruct(tmp_path):
+    # If the *pre-run* entry was something we could not read (here: a directory),
+    # we never learned its contents. Removing it to "restore" would destroy the
+    # very thing the canary exists to protect, so it must refuse and say so.
+    path = tmp_path / "app.json"
+    path.mkdir()
+    (path / "keep.txt").write_text("precious", encoding="utf-8")
+    before = snapshot(path)
+
+    assert before.kind == "other"
+    restored = restore(path, before)
+
+    assert restored is False
+    assert (path / "keep.txt").read_text(encoding="utf-8") == "precious"
+
+
+def test_canary_reports_a_pre_run_entry_it_cannot_put_back(tmp_path):
+    # Same category, but now the leak *is* visible (the directory was replaced by
+    # a file): the canary must not claim it restored anything it could not.
+    path = tmp_path / "app.json"
+    path.mkdir()
+    before = snapshot(path)
+
+    assert before.kind == "other"
+    path.rmdir()
+    path.write_bytes(b"{}\n")  # the leak
+    message = leak_report(path, before)
+
+    assert message is not None and "COULD NOT BE RESTORED" in message
 
 
 def test_snapshot_never_raises_on_odd_paths(tmp_path):
-    # A directory where app.json should be, or a path under a file, must read as
-    # "nothing there" rather than exploding inside the session-scoped canary.
-    (tmp_path / "app.json").mkdir()
+    # A path under a file, or a missing parent, must read as "nothing there"
+    # rather than exploding inside the canary.
     (tmp_path / "file").write_text("x", encoding="utf-8")
 
-    assert snapshot(tmp_path / "app.json") is None
-    assert snapshot(tmp_path / "file" / "app.json") is None
-    assert snapshot(tmp_path / "missing" / "app.json") is None
+    assert snapshot(tmp_path / "file" / "app.json") == MISSING
+    assert snapshot(tmp_path / "missing" / "app.json") == MISSING
+
+
+def test_snapshot_distinguishes_a_symlink_from_the_file_it_points_at(tmp_path):
+    # Reading through the path would make these two indistinguishable, and a leak
+    # that swaps the config for a symlink would compare equal to no leak at all.
+    target = tmp_path / "target.json"
+    target.write_bytes(b"{}\n")
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+
+    assert snapshot(target).kind == "file"
+    assert snapshot(link).kind == "symlink"
+    assert snapshot(link) != snapshot(target)
+
+
+def test_the_real_config_baseline_is_captured_at_import_time():
+    # The baseline must be a module-level constant, not fixture state: a fixture's
+    # setup runs after collection and after every test module's import-time code,
+    # so a leak from there would be baked into the baseline and read as clean.
+    # Guard the *shape*, because that is what the bug was.
+    assert isinstance(env_sandbox.REAL_APP_CONFIG_BEFORE, Entry)
+    assert not hasattr(conftest, "real_app_config_is_untouched"), (
+        "the canary regressed to a session fixture; its baseline would be taken too late"
+    )
+    assert hasattr(conftest, "pytest_sessionfinish"), (
+        "the canary must run from a hook so it still fires when collection fails "
+        "or no test is selected"
+    )

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Tests for the test harness itself: the sandbox must contain a careless test.
+
+The bug these guard against is not hypothetical. `POST /settings/root` calls
+`save_active_root()`, which writes the platform app config resolved from `HOME`
+(and friends); a web test that forgot to isolate `HOME` therefore rewrote the
+developer's *real* `app.json` and repointed their active KB at a temp directory
+that pytest then deleted. `active_root()` also falls back to `./data` relative
+to the CWD, so an unisolated test run from the repo root opens the repo's own
+`data/kb.sqlite`.
+
+Every test below deliberately omits manual isolation and never requests the
+`isolate_app_environment` fixture by name — it must be the *autouse* fixture in
+`conftest.py` doing the work, so that deleting `autouse=True` turns these red.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from env_sandbox import (  # noqa: E402
+    REAL_APP_CONFIG_DIR,
+    REAL_APP_CONFIG_PATH,
+    sandbox_home,
+    snapshot,
+)
+from verinote.config import Config, active_root, app_config_dir, app_config_path  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+
+def test_pytest_cannot_reach_the_real_app_config():
+    home = sandbox_home()
+
+    assert home is not None, "the autouse environment sandbox is not installed"
+    assert app_config_dir() != REAL_APP_CONFIG_DIR
+    assert home in app_config_path().parents
+
+
+def test_settings_switch_without_manual_isolation_stays_in_the_sandbox(tmp_path):
+    # No monkeypatch.setenv("HOME", ...) here — that is the whole point: this is
+    # the test an author would write after forgetting to isolate.
+    before = snapshot(REAL_APP_CONFIG_PATH)
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+    other = tmp_path / "other-kb"
+
+    r = client.post("/settings/root", data={"root": str(other)}, follow_redirects=False)
+
+    assert r.status_code == 303
+    assert snapshot(REAL_APP_CONFIG_PATH) == before, (
+        f"the KB switch escaped the sandbox and wrote {REAL_APP_CONFIG_PATH}"
+    )
+    home = sandbox_home()
+    assert home is not None
+    assert home in app_config_path().parents
+    assert app_config_path().is_file()
+    assert active_root() == other.resolve()
+
+
+def test_config_load_does_not_fall_back_to_the_repo_data_kb():
+    # No VERINOTE_ROOT, no app.json, and the CWD is off the repo — so
+    # `active_root()`'s `./data` fallback must not resolve to the repo's own KB.
+    repo_data = Path(__file__).resolve().parent.parent / "data"
+
+    root = active_root()
+
+    assert root != repo_data
+    assert root is None

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -11,7 +11,8 @@ to the CWD, so an unisolated test run from the repo root opens the repo's own
 
 Every test below deliberately omits manual isolation and never requests the
 `isolate_app_environment` fixture by name — it must be the *autouse* fixture in
-`conftest.py` doing the work, so that deleting `autouse=True` turns these red.
+`conftest.py` (or the `pytest_configure` seal beneath it) doing the work, so
+that deleting either turns these red.
 """
 
 from pathlib import Path
@@ -24,11 +25,31 @@ from fastapi.testclient import TestClient  # noqa: E402
 from env_sandbox import (  # noqa: E402
     REAL_APP_CONFIG_DIR,
     REAL_APP_CONFIG_PATH,
+    restore,
     sandbox_home,
+    session_home,
     snapshot,
 )
 from verinote.config import Config, active_root, app_config_dir, app_config_path  # noqa: E402
 from verinote.web import create_app  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def module_scoped_app_config_dir():
+    # Higher-scoped fixtures are instantiated *before* function-scoped ones, so
+    # this resolves the app config dir before the per-test `monkeypatch` sandbox
+    # exists. Only the session-start seal can keep it off the real home.
+    return app_config_dir()
+
+
+@pytest.fixture(scope="module")
+def module_scoped_config():
+    # The realistic version of the hole: a module-scoped fixture built for speed
+    # that loads config once. Without the seal this reads the developer's real
+    # `app.json` and can pick their real KB.
+    return Config.load()
 
 
 def test_pytest_cannot_reach_the_real_app_config():
@@ -67,12 +88,83 @@ def test_settings_switch_without_manual_isolation_stays_in_the_sandbox(tmp_path)
     assert active_root() == other.resolve()
 
 
-def test_config_load_does_not_fall_back_to_the_repo_data_kb():
-    # No VERINOTE_ROOT, no app.json, and the CWD is off the repo — so
-    # `active_root()`'s `./data` fallback must not resolve to the repo's own KB.
-    repo_data = Path(__file__).resolve().parent.parent / "data"
+def test_active_root_fallback_is_cwd_relative_and_the_sandbox_cwd_is_off_the_repo(
+    tmp_path, monkeypatch
+):
+    # Prove the CWD guard without relying on the repo's own `data/` (which is
+    # gitignored, so it does not exist on CI — asserting `active_root() is None`
+    # there would pass even with the chdir isolation deleted). Instead: plant a
+    # KB under a temp CWD and show the fallback follows the CWD, then show the
+    # sandbox CWD has no KB and is not the repo.
+    planted = tmp_path / "data"
+    planted.mkdir()
+    (planted / "kb.sqlite").write_text("", encoding="utf-8")
 
-    root = active_root()
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        assert active_root() == planted.resolve(), "the `./data` fallback is CWD-relative"
 
-    assert root != repo_data
-    assert root is None
+    cwd = Path.cwd()
+
+    assert cwd != REPO_ROOT, "the test run must not sit in the repo root"
+    assert REPO_ROOT not in cwd.parents, "the test run must not sit inside the repo"
+    assert active_root() is None, "the sandbox CWD must hold no KB to fall back to"
+
+
+def test_module_scoped_fixtures_run_inside_the_sandbox(module_scoped_app_config_dir):
+    # The reviewer's reproduction: a module-scoped fixture resolves before any
+    # function-scoped monkeypatch, so a function-only sandbox let it read the
+    # developer's real `~/Library/Application Support/verinote`.
+    home = session_home()
+
+    assert home is not None, "the session-start environment seal is not installed"
+    assert module_scoped_app_config_dir != REAL_APP_CONFIG_DIR
+    assert home in module_scoped_app_config_dir.parents
+
+
+def test_module_scoped_config_load_stays_in_the_sandbox(module_scoped_config):
+    # `Config.load()` resolves the root through the real `app.json` *and* the
+    # CWD-relative `./data` fallback, so both tiers of the leak show up here.
+    root = module_scoped_config.root
+
+    assert session_home() is not None, "the session-start environment seal is not installed"
+    assert root != REPO_ROOT / "data", "a module-scoped Config.load() reached the repo's KB"
+    assert REPO_ROOT not in root.parents
+    assert module_scoped_config.db_path == root / "kb.sqlite"
+
+
+def test_canary_restores_a_leaked_app_config_before_failing(tmp_path):
+    # The canary's teardown does not just detect a leak; it undoes it. Exercised
+    # here against a stand-in path — never the real one.
+    path = tmp_path / "app.json"
+    original = b'{"active_root": "/real/kb"}\n'
+    path.write_bytes(original)
+    before = snapshot(path)
+
+    path.write_bytes(b'{"active_root": "/tmp/pytest-kb"}\n')  # the leak
+    restore(path, before)
+
+    assert path.read_bytes() == original
+
+
+def test_canary_restore_removes_a_config_the_run_created(tmp_path):
+    path = tmp_path / "nested" / "app.json"
+    before = snapshot(path)
+
+    assert before is None
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"{}\n")  # the leak: a file that did not exist before
+    restore(path, before)
+
+    assert not path.exists()
+
+
+def test_snapshot_never_raises_on_odd_paths(tmp_path):
+    # A directory where app.json should be, or a path under a file, must read as
+    # "nothing there" rather than exploding inside the session-scoped canary.
+    (tmp_path / "app.json").mkdir()
+    (tmp_path / "file").write_text("x", encoding="utf-8")
+
+    assert snapshot(tmp_path / "app.json") is None
+    assert snapshot(tmp_path / "file" / "app.json") is None
+    assert snapshot(tmp_path / "missing" / "app.json") is None


### PR DESCRIPTION
Closes #163

## What this actually is

The test the issue points at (`test_settings_switches_active_kb_root`) **already isolates `HOME`** — it was fixed in 2bb0bae6 and is isolated on `main` today. So there is no line to fix there. What remained was the issue's fix direction: **structural containment**, so isolation is not something each test author has to remember. That is what this PR adds. The existing manual isolation is left in place as defence in depth.

## The leak paths

Two, not one:

1. **`HOME` (and friends).** `POST /settings/root` calls `save_active_root()`, which writes the platform app config from `app_config_dir()` (`verinote/config.py:63-77`). That resolves through `Path.home()` on macOS, `APPDATA`/`LOCALAPPDATA` on Windows, and `XDG_CONFIG_HOME`/`Path.home()` elsewhere — so a sandbox has to pin **all five** of `HOME`, `USERPROFILE`, `XDG_CONFIG_HOME`, `APPDATA`, `LOCALAPPDATA`. An unisolated test rewrites the developer's real `app.json` and repoints their active KB at a temp dir pytest then deletes.
2. **`./data` (found while writing this).** `active_root()` falls back to `_default_root()` = `Path("./data").resolve()` — **relative to the CWD**. pytest runs from the repo root, so any unisolated test that reaches `Config.load()` opens the repo's own `data/kb.sqlite`. Isolating `HOME` alone does not close this; the sandbox also `chdir`s off the repo and drops an ambient `VERINOTE_ROOT`.

## Change

- `tests/conftest.py`: function-scoped **autouse** fixture pinning the five home vars at a per-test throwaway home (from `tmp_path_factory`, *not* `tmp_path` — many tests use `tmp_path` as a KB root and walk it), `delenv("VERINOTE_ROOT")`, and `chdir` to a throwaway CWD. Autouse runs first, so tests that set these vars themselves still win. Plus a **session-scoped canary** that snapshots the real `app.json` and fails the run if anything wrote to it.
- `tests/env_sandbox.py`: the sandbox's shared state. Separate module because pytest imports a conftest as top-level `conftest`, so `from tests.conftest import ...` would create a *second* module object with its own copy of the state — and would break under CI's bare `pytest` invocation, where the repo root is not on `sys.path`.
- `tests/test_env_isolation.py`: three tests that verify the guard itself. They deliberately omit manual isolation and never request the fixture by name, so they depend on it *implicitly*.
- **`verinote/**` diff is 0 lines.** No test-only override (`VERINOTE_APP_CONFIG_DIR` or similar) was added to `config.py` — that would just be one more production switch that repoints the active KB. conftest-level env isolation is sufficient.

## Red evidence

Deleting `autouse=True` from the fixture (with `HOME` pointed at a sacrificial copy of the real app config, so the demo does no damage) turns all three tests red, plus the session canary:

```
>       assert home is not None, "the autouse environment sandbox is not installed"
E       AssertionError: the autouse environment sandbox is not installed
E       assert None is not None
tests/test_env_isolation.py:37: AssertionError

        assert r.status_code == 303
>       assert snapshot(REAL_APP_CONFIG_PATH) == before, (
E       AssertionError: the KB switch escaped the sandbox and wrote /var/folders/.../Library/Application Support/verinote/app.json
E       assert b'{\n  "activ...ther-kb"\n}\n' == b'{\n  "activ...te/data"\n}\n'
tests/test_env_isolation.py:60: AssertionError

>       assert root != repo_data
E       AssertionError: assert PosixPath('/Users/seoyun/Desktop/verinote/data') != PosixPath('/Users/seoyun/Desktop/verinote/data')
tests/test_env_isolation.py:63: AssertionError

>           assert after == before, f"the test run modified the real app config at {path}"
E           AssertionError: the test run modified the real app config at /var/folders/.../verinote/app.json
tests/conftest.py:53: AssertionError

FAILED tests/test_env_isolation.py::test_pytest_cannot_reach_the_real_app_config
FAILED tests/test_env_isolation.py::test_settings_switch_without_manual_isolation_stays_in_the_sandbox
FAILED tests/test_env_isolation.py::test_config_load_does_not_fall_back_to_the_repo_data_kb
3 failed, 1 error
```

Note the second failure: the byte diff shows the app config flipping from the real KB (`.../verinote/data`) to the temp `other-kb` — that is the exact damage the issue describes, reproduced. The third shows the `./data` fallback resolving to the repo's own KB.

## Verification

- `pytest -q` (CI-style bare invocation, repo root off `sys.path`): **672 passed, 7 skipped** (669 + 3 new; no existing test broken by the `delenv` + `chdir` union).
- `ruff check`: All checks passed.


---

## Review round 2 (1c6adde): the four holes the review found, closed

**1. Isolation was function-scope only.** pytest instantiates higher-scoped fixtures *first*, so a `scope="module"`/`"session"` fixture (or import-time code) ran **before** the function-scoped `monkeypatch` and reached the real home — the issue's guarantee ("no future test can reach the real config") did not hold. The sandbox is now **two-tier**: `pytest_configure` seals `HOME`/`USERPROFILE`/`XDG_CONFIG_HOME`/`APPDATA`/`LOCALAPPDATA`/CWD with a session `pytest.MonkeyPatch()` **at session start** (before collection, before any fixture, before any test module's import-time code), undone in `pytest_unconfigure`; the autouse function fixture then lays a fresh per-test home and CWD on top. The reviewer's reproduction is now locked in as two regression tests using module-scoped fixtures (`test_module_scoped_fixtures_run_inside_the_sandbox`, `test_module_scoped_config_load_stays_in_the_sandbox`).

**2. The CWD regression test was vacuous on CI.** `.gitignore` ignores `/data/`, so a CI checkout has no `data/kb.sqlite` and `assert active_root() is None` passed even with the chdir isolation deleted. It no longer depends on the repo's `data/` at all: it plants `data/kb.sqlite` in a **tmp** dir, proves the fallback follows the CWD there, and then asserts the sandbox CWD holds no KB **and is not the repo root / not inside the repo**. The repo's real `data/` is never created or touched.

**3. The canary only detected leaks.** By teardown the user's `app.json` already pointed at a pytest temp KB about to be deleted. It now **restores the pre-run bytes (or unlinks a file the run created) and then fails**, saying so in the message. `snapshot()` also swallows `PermissionError`/`IsADirectoryError` (as well as `FileNotFoundError`/`NotADirectoryError`) so the canary cannot explode on its way to its own assertion.

**4. Only `VERINOTE_ROOT` was cleared.** `Config.for_root` reads `PROVIDER`/`MODEL`/`BASE_URL`/`API_KEY`/`LLM_TIMEOUT`/`EXTRACTION_*`/`AUTO_ACCEPT_RECOMMENDATIONS` env-first, so a developer's ambient export changed test results. Both tiers now `delenv` **every `VERINOTE_*` variable**; `tests/test_config.py`'s manual `_clear_env()` is deleted so the sandbox is the single source of truth (suite stays green without it). The fixture docstring no longer overstates what it clears.

`verinote/**` diff is still **0 lines**.

## Red evidence (round 2)

All three run against a **sacrificial `HOME`** and a copy of the repo **without `data/`** (matching CI), so the real `~/Library/Application Support/verinote/app.json` and the repo's `data/` are never touched.

**(a) Session seal removed → the module-scoped reproduction reaches the (sacrificial) real home:**
```
E  AssertionError: assert PosixPath('<sacrificial-home>/Library/Application Support/verinote')
                       != PosixPath('<sacrificial-home>/Library/Application Support/verinote')
E  AssertionError: a module-scoped Config.load() reached the repo's KB
E  assert PosixPath('<repo>/data') != (PosixPath('<repo>') / 'data')
FAILED tests/test_env_isolation.py::test_module_scoped_fixtures_run_inside_the_sandbox
FAILED tests/test_env_isolation.py::test_module_scoped_config_load_stays_in_the_sandbox
2 failed, 6 passed
```

**(b) chdir isolation removed, in a checkout with NO `data/` → the new CWD test is red (the old assertion was not):**
```
E  AssertionError: the test run must not sit in the repo root
E  assert PosixPath('<repo>') != PosixPath('<repo>')
FAILED tests/test_env_isolation.py::test_active_root_fallback_is_cwd_relative_and_the_sandbox_cwd_is_off_the_repo
2 failed, 6 passed

# same conftest, but with the OLD assertion `assert active_root() is None`:
1 passed        <- vacuous, exactly as the review said
```

**(c) Canary restores, then fails.** A deliberately leaky test writes the real `app.json` via `save_active_root()`:
```
--- sacrificial app.json BEFORE: {"active_root": "/Users/seoyun/real-kb"}
E  AssertionError: the test run modified the real app config at <...>/verinote/app.json;
   it has been restored to its pre-run state, but the leak is a bug — a test escaped the environment sandbox
1 passed, 1 error
--- sacrificial app.json AFTER:  {"active_root": "/Users/seoyun/real-kb"}   <- restored
```

## Verification

- `pytest -q` (bare, as CI runs it): **677 passed, 7 skipped** (669 before + 8 new).
- `ruff check .`: clean.
- `git diff -- verinote/ | wc -l` → **0**.
