### PR TITLE
fix(#165): keep init/seed on a local KB and gate demo facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ verinote init /path/to/kb     # a named root
 verinote seed /path/to/kb     # demo facts into an existing KB
 ```
 
+Creating a KB does not make it the active one. Every other command still reads
+the saved active KB, so to work with the KB you just created either point
+`VERINOTE_ROOT` at it or select it in the UI:
+
+```bash
+VERINOTE_ROOT=/path/to/kb verinote status
+```
+
 Seeded demo facts land as `candidate`/`needs_review`, never as engine input —
 demo data has to pass through human review like anything else.
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,18 @@ tests, and one-off launches.
 VERINOTE_ROOT=/path/to/kb verinote ui
 ```
 
-You can also scaffold a KB explicitly:
+You can also scaffold a KB explicitly. `init` and `seed` are *local* commands:
+they never write to the saved active KB. They target the root you name, else
+`VERINOTE_ROOT`, else `./data` in the current directory.
 
 ```bash
-verinote init      # uses VERINOTE_ROOT, the saved active KB, or ./data
+verinote init                 # ./data here (or $VERINOTE_ROOT if set)
+verinote init /path/to/kb     # a named root
+verinote seed /path/to/kb     # demo facts into an existing KB
 ```
+
+Seeded demo facts land as `candidate`/`needs_review`, never as engine input —
+demo data has to pass through human review like anything else.
 
 DuckDB is a core dependency because it powers verification. The `analytics` extra is
 kept as a compatibility no-op; analytics uses the same DuckDB dependency. The

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
+from pathlib import Path
+
+import pytest
+
 import verinote.cli as cli
+from verinote import config
 from verinote.engine import DEFAULT_POLICY
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.ingest import register_converter
 from verinote.pipeline.query_intent import parse_query_intent
-from verinote.store import Store
+from verinote.store import ENGINE_STATUSES, Store
 from verinote.store.fact_input import structural_term
 
 
@@ -541,3 +546,135 @@ def test_coverage_counts_structural_engine_fact_metadata(tmp_path, monkeypatch, 
     out = capsys.readouterr().out
     assert "sources/a.txt: 1/1 engine facts" in out
     assert "gap(s)" in out
+
+
+# --- local KB commands must not target the saved (global) active KB ----------
+
+
+def _isolated(monkeypatch, tmp_path):
+    """Neutralise every ambient KB pointer, then give the app config a fake HOME."""
+    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(home / ".config"))
+    monkeypatch.setenv("APPDATA", str(home / "AppData"))
+    return home
+
+
+def _existing_kb(tmp_path) -> Path:
+    """A populated KB registered as the saved active root (as the web picker does)."""
+    root = tmp_path / "existing"
+    root.mkdir(parents=True, exist_ok=True)
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    sid = store.add_source("sources/real.txt")
+    store.add_fact("Real Org", "is_a", "participant", status="confirmed", source_id=sid)
+    store.close()
+    config.save_active_root(root)
+    return root
+
+
+def test_init_seed_in_empty_dir_ignores_saved_active_kb(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    existing = _existing_kb(tmp_path)
+    before = (existing / "kb.sqlite").read_bytes()
+
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["init", "--seed"]) == 0
+
+    new_db = workdir / "data" / "kb.sqlite"
+    assert new_db.is_file()
+    # The saved KB is untouched, byte for byte.
+    assert (existing / "kb.sqlite").read_bytes() == before
+    assert not (existing / "sources").exists()
+
+    out = capsys.readouterr().out
+    assert f"initialised KB at {workdir / 'data'}" in out
+    assert str(existing) not in out
+
+
+def test_init_uses_explicit_root_argument(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    target = tmp_path / "named-kb"
+
+    assert cli.main(["init", str(target)]) == 0
+
+    assert (target / "kb.sqlite").is_file()
+    assert not (workdir / "data").exists()
+    assert f"initialised KB at {target}" in capsys.readouterr().out
+
+
+def test_init_still_honours_verinote_root(tmp_path, monkeypatch):
+    _isolated(monkeypatch, tmp_path)
+    _existing_kb(tmp_path)
+    env_root = tmp_path / "from-env"
+    monkeypatch.setenv("VERINOTE_ROOT", str(env_root))
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["init"]) == 0
+
+    assert (env_root / "kb.sqlite").is_file()
+    assert not (workdir / "data").exists()
+
+
+def test_demo_facts_are_never_engine_input():
+    demo_statuses = {status for _, _, _, status, _, _, _ in cli._DEMO_FACTS}
+    assert demo_statuses & ENGINE_STATUSES == set()
+
+
+def test_seeded_kb_has_no_engine_facts(tmp_path, monkeypatch):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "kb"
+
+    assert cli.main(["init", str(root), "--seed"]) == 0
+
+    store = Store(root / "kb.sqlite")
+    assert store.facts(statuses=ENGINE_STATUSES) == []
+    assert store.facts() != []  # the demo facts did land, just not as engine input
+    store.close()
+
+
+def test_seed_without_a_kb_fails_and_creates_nothing(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["seed"]) == 1
+
+    assert not (workdir / "data").exists()
+    assert "run `verinote init` first" in capsys.readouterr().err
+
+
+def test_seed_targets_the_named_root(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    existing = _existing_kb(tmp_path)
+    before = (existing / "kb.sqlite").read_bytes()
+    root = tmp_path / "kb"
+    assert cli.main(["init", str(root)]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["seed", str(root)]) == 0
+
+    store = Store(root / "kb.sqlite")
+    assert len(store.facts()) == len(cli._DEMO_FACTS)
+    store.close()
+    assert (existing / "kb.sqlite").read_bytes() == before
+    assert f"seeded demo facts into {root}" in capsys.readouterr().out
+
+
+def test_init_help_does_not_promise_verinote_root_only(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["init", "--help"])
+    out = capsys.readouterr().out
+    assert "under VERINOTE_ROOT (./data)" not in out
+    assert "ROOT" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from verinote.engine import DEFAULT_POLICY
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.ingest import register_converter
 from verinote.pipeline.query_intent import parse_query_intent
-from verinote.store import ENGINE_STATUSES, Store
+from verinote.store import Store, engine_statuses
 from verinote.store.fact_input import structural_term
 
 
@@ -632,10 +632,13 @@ def test_init_still_honours_verinote_root(tmp_path, monkeypatch):
 
 def test_demo_facts_are_never_engine_input():
     demo_statuses = {status for _, _, _, status, _, _, _ in cli._DEMO_FACTS}
+    # Asked through the accessor, not a frozenset imported at module load: an
+    # import binds the tier at import time, which is the split #176 closed.
+    engine = engine_statuses()
     # Both sides must be non-empty, else the disjointness check below is vacuous.
     assert demo_statuses
-    assert ENGINE_STATUSES
-    assert demo_statuses & ENGINE_STATUSES == set()
+    assert engine
+    assert demo_statuses & engine == set()
 
 
 def test_seeded_kb_has_no_engine_facts(tmp_path, monkeypatch):
@@ -645,7 +648,7 @@ def test_seeded_kb_has_no_engine_facts(tmp_path, monkeypatch):
     assert cli.main(["init", str(root), "--seed"]) == 0
 
     store = Store(root / "kb.sqlite")
-    assert store.facts(statuses=ENGINE_STATUSES) == []
+    assert store.facts(statuses=engine_statuses()) == []
     assert store.facts() != []  # the demo facts did land, just not as engine input
     store.close()
 
@@ -769,6 +772,42 @@ def test_seed_rejects_a_corrupt_db_file_without_a_traceback(tmp_path, monkeypatc
     err = capsys.readouterr().err
     assert "is not a verinote KB" in err
     assert f"verinote init {root}" in err
+
+
+def test_init_refuses_a_corrupt_db_instead_of_raising(tmp_path, monkeypatch, capsys):
+    # The file may be a real KB with a damaged header — every review decision the
+    # user ever made — so `init` must not scaffold over it, and must not hand them
+    # a raw sqlite3 traceback either.
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "corrupt"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    db.write_bytes(b"definitely not sqlite\n")
+
+    assert cli.main(["init", str(root)]) == 1
+
+    assert db.read_bytes() == b"definitely not sqlite\n"
+    assert not (root / "policy").exists(), "init scaffolded onto an unreadable KB"
+    err = capsys.readouterr().err
+    assert cli.KB_UNREADABLE in err
+    assert "restore it from backup" in err
+
+
+def test_init_still_scaffolds_a_database_that_merely_has_no_schema(tmp_path, monkeypatch):
+    # The other half of the same check: an empty `kb.sqlite` *is* a readable
+    # database with no schema, and putting a schema into it is exactly `init`'s
+    # job. Collapsing the two states into "unusable" would break the fresh-KB path.
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "empty"
+    root.mkdir()
+    (root / "kb.sqlite").touch()
+
+    assert cli.main(["init", str(root)]) == 0
+
+    store = Store(root / "kb.sqlite")
+    assert store.facts() == []
+    store.close()
+    assert (root / "policy" / "logic-policy.dl").is_file()
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids `?` in paths")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -591,6 +591,9 @@ def test_init_seed_in_empty_dir_ignores_saved_active_kb(tmp_path, monkeypatch, c
     # The saved KB is untouched, byte for byte.
     assert (existing / "kb.sqlite").read_bytes() == before
     assert not (existing / "sources").exists()
+    # And `init` must not repoint the global active KB at what it just made:
+    # a local command may never mutate global state (that is the whole issue).
+    assert config.read_app_config()["active_root"] == str(existing)
 
     out = capsys.readouterr().out
     assert f"initialised KB at {workdir / 'data'}" in out
@@ -628,6 +631,9 @@ def test_init_still_honours_verinote_root(tmp_path, monkeypatch):
 
 def test_demo_facts_are_never_engine_input():
     demo_statuses = {status for _, _, _, status, _, _, _ in cli._DEMO_FACTS}
+    # Both sides must be non-empty, else the disjointness check below is vacuous.
+    assert demo_statuses
+    assert ENGINE_STATUSES
     assert demo_statuses & ENGINE_STATUSES == set()
 
 
@@ -678,3 +684,87 @@ def test_init_help_does_not_promise_verinote_root_only(capsys):
     out = capsys.readouterr().out
     assert "under VERINOTE_ROOT (./data)" not in out
     assert "ROOT" in out
+
+
+def test_init_tells_you_how_to_actually_use_the_kb_it_made(tmp_path, monkeypatch, capsys):
+    """The KB `init` creates is not the active one, so the hint must name it."""
+    _isolated(monkeypatch, tmp_path)
+    _existing_kb(tmp_path)  # a different KB is the saved active one
+    root = tmp_path / "fresh"
+
+    assert cli.main(["init", str(root), "--seed"]) == 0
+
+    out = capsys.readouterr().out
+    assert f"VERINOTE_ROOT={root} verinote status" in out
+    # It must not claim a bare `verinote status` would show this KB.
+    assert "(run `verinote status`)" not in out
+
+
+def test_init_rejects_a_root_that_is_an_existing_file(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    target = tmp_path / "afile.txt"
+    target.write_text("not a KB\n", encoding="utf-8")
+
+    assert cli.main(["init", str(target)]) == 1
+
+    err = capsys.readouterr().err
+    assert "not a directory" in err
+    assert target.read_text(encoding="utf-8") == "not a KB\n"
+
+
+def test_init_rejects_an_empty_root_argument(tmp_path, monkeypatch, capsys):
+    """An empty ROOT must fail, not silently fall back to ./data."""
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["init", ""]) == 1
+
+    assert not (workdir / "data").exists()
+    assert "empty string" in capsys.readouterr().err
+
+
+def test_seed_rejects_an_empty_root_argument(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["seed", ""]) == 1
+
+    assert not (workdir / "data").exists()
+    assert "empty string" in capsys.readouterr().err
+
+
+def test_seed_rejects_an_empty_db_file_instead_of_creating_a_schema(
+    tmp_path, monkeypatch, capsys
+):
+    """`kb.sqlite` existing is not enough: seed only fills an *initialised* KB."""
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "broken"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    db.write_bytes(b"")
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    assert db.read_bytes() == b""  # no schema was created behind our back
+    err = capsys.readouterr().err
+    assert "is not a verinote KB" in err
+    assert f"verinote init {root}" in err  # recovery path
+
+
+def test_seed_rejects_a_corrupt_db_file_without_a_traceback(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "corrupt"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    db.write_bytes(b"definitely not sqlite\n")
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    assert db.read_bytes() == b"definitely not sqlite\n"
+    err = capsys.readouterr().err
+    assert "is not a verinote KB" in err
+    assert f"verinote init {root}" in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
+import sys
 from pathlib import Path
 
 import pytest
@@ -768,3 +769,51 @@ def test_seed_rejects_a_corrupt_db_file_without_a_traceback(tmp_path, monkeypatc
     err = capsys.readouterr().err
     assert "is not a verinote KB" in err
     assert f"verinote init {root}" in err
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids `?` in paths")
+def test_kb_schema_probe_survives_a_uri_metacharacter_in_the_path(tmp_path):
+    """A `?` in the root must not truncate the SQLite URI we probe the schema with.
+
+    Interpolating the path raw into `file:{db}?mode=ro` cut the URI at the `?`,
+    which (a) misreported this healthy KB as having no `facts` table and (b) lost
+    `mode=ro`, so SQLite opened read-write and created a stray file at the
+    truncated path — writing outside the root the caller ever named.
+    """
+    parent = tmp_path / "parent"
+    root = parent / "weird?dir"
+    root.mkdir(parents=True)
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    store.close()
+    before = sorted(p.name for p in parent.iterdir())
+
+    assert cli._kb_schema_problem(root / "kb.sqlite") is None  # (a) no false alarm
+
+    # (b) no stray file at the truncated path (`.../parent/weird`).
+    assert sorted(p.name for p in parent.iterdir()) == before == ["weird?dir"]
+
+
+def test_seed_accepts_a_kb_whose_path_holds_a_uri_metacharacter(tmp_path, monkeypatch, capsys):
+    """End-to-end twin of the probe test, through the command a user actually runs.
+
+    Uses `#` (a URI fragment marker, and legal on every platform) rather than `?`
+    so the assertion stays on the schema probe.
+    """
+    _isolated(monkeypatch, tmp_path)
+    parent = tmp_path / "parent"
+    root = parent / "weird#dir"
+    root.mkdir(parents=True)
+
+    assert cli.main(["init", str(root)]) == 0
+    capsys.readouterr()
+    before = sorted(p.name for p in parent.iterdir())
+
+    assert cli.main(["seed", str(root)]) == 0  # no false "is not a verinote KB"
+
+    assert "seeded demo facts" in capsys.readouterr().out
+    assert sorted(p.name for p in parent.iterdir()) == before == ["weird#dir"]
+
+    store = Store(root / "kb.sqlite")
+    assert len(store.facts()) == len(cli._DEMO_FACTS)
+    store.close()

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -9,18 +9,26 @@ import sys
 from pathlib import Path
 
 from verinote import __version__
-from verinote.config import Config
+from verinote.config import Config, local_root
 from verinote.pipeline.question_outcome import format_question_outcome
 from verinote.store import Store
+
+# Local commands own their KB location: they never inherit the KB the web UI
+# last selected, so `verinote init` cannot scribble into somebody else's data.
+_LOCAL_ROOT_COMMANDS = frozenset({"init", "seed"})
 
 _DEMO_FACTS = [
     # (subject, relation, object, status, confidence, source, note)
     # Obviously-fictional placeholder data: it only demonstrates the status
     # lifecycle and the (subject, relation, object) shape. Do NOT put real
     # organisations, people, or grant references here.
+    #
+    # No demo fact may carry an engine status (see `ENGINE_STATUSES`): demo data
+    # must not become engine input without a human passing it through review.
+    # `tests/test_cli.py` enforces that as an invariant.
     ("Example Org", "is_a", "participant", "needs_review", 0.95, "sources/example-grant.txt", "participant"),
-    ("Example Org", "established_on", "2020-01-01", "confirmed", 0.98, "sources/example-grant.txt", ""),
-    ("Demo Project", "has_participant", "Example Org", "confirmed", 0.92, "sources/example-grant.txt", ""),
+    ("Example Org", "established_on", "2020-01-01", "candidate", 0.98, "sources/example-grant.txt", ""),
+    ("Demo Project", "has_participant", "Example Org", "candidate", 0.92, "sources/example-grant.txt", ""),
     ("wirelog", "is_a", "deterministic logic engine", "candidate", 0.90, "sources/example-notes.txt", ""),
 ]
 
@@ -126,10 +134,17 @@ def _seed(store: Store) -> None:
 
 
 def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
+    if not cfg.db_path.is_file():
+        print(
+            f"no KB at {cfg.root}; run `verinote init` first (or name a root: "
+            f"`verinote seed <path>`)",
+            file=sys.stderr,
+        )
+        return 1
     store = _store(cfg)
     _seed(store)
     store.close()
-    print("seeded demo facts")
+    print(f"seeded demo facts into {cfg.root}")
     return 0
 
 
@@ -435,11 +450,27 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--version", action="version", version=f"verinote {__version__}")
     sub = p.add_subparsers(dest="command", required=True)
 
-    init = sub.add_parser("init", help="scaffold a local KB (SQLite) under VERINOTE_ROOT (./data)")
+    init = sub.add_parser(
+        "init",
+        help="scaffold a KB (SQLite) at ROOT (default: $VERINOTE_ROOT, else ./data in the current directory)",
+    )
+    init.add_argument(
+        "root",
+        nargs="?",
+        help="where to create the KB (default: $VERINOTE_ROOT, else ./data here)",
+    )
     init.add_argument("--seed", action="store_true", help="insert demo facts")
     init.set_defaults(func=cmd_init, halt_safe=False)
 
-    seed = sub.add_parser("seed", help="insert demo facts into the KB")
+    seed = sub.add_parser(
+        "seed",
+        help="insert demo facts into an existing KB at ROOT (default: $VERINOTE_ROOT, else ./data in the current directory)",
+    )
+    seed.add_argument(
+        "root",
+        nargs="?",
+        help="an existing KB root (default: $VERINOTE_ROOT, else ./data here)",
+    )
     seed.set_defaults(func=cmd_seed, halt_safe=False)
 
     sync = sub.add_parser("sync", help="extract candidate facts from sources via the LLM")
@@ -499,9 +530,17 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _config_for(args: argparse.Namespace) -> Config | None:
+    if args.command in {"ui", "serve"}:
+        return Config.load_for_ui()
+    if args.command in _LOCAL_ROOT_COMMANDS:
+        return Config.for_root(local_root(args.root))
+    return Config.load()
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    cfg = Config.load_for_ui() if args.command in {"ui", "serve"} else Config.load()
+    cfg = _config_for(args)
     # The single CLI enforcement point for a halted KB. It sits here, before
     # dispatch, because every subcommand goes through this one line — a guard
     # sprinkled per-command is a guard the next command will forget.

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from dataclasses import dataclass
 import sys
 from pathlib import Path
@@ -87,6 +88,15 @@ def _scaffold_policy(cfg: Config, store: Store) -> Path | None:
 def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.pipeline.policy_state import PolicyMissingError
 
+    # `mkdir(exist_ok=True)` still raises when a *file* sits at the root path,
+    # so name the problem instead of showing a traceback.
+    if cfg.root.exists() and not cfg.root.is_dir():
+        print(
+            f"cannot create a KB at {cfg.root}: it exists and is not a directory; "
+            f"name a different root (`verinote init <path>`)",
+            file=sys.stderr,
+        )
+        return 1
     cfg.root.mkdir(parents=True, exist_ok=True)
     store = _store(cfg)
     if args.seed:
@@ -103,7 +113,11 @@ def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
     if policy is not None:
         print(f"  policy: {policy}")
     if args.seed:
-        print("  seeded demo facts (run `verinote status`)")
+        print("  seeded demo facts")
+    # Other commands read the KB the web UI last selected, not the one we just
+    # made, so point at this root explicitly rather than promise `verinote
+    # status` shows it (see issue #185).
+    print(f"  use this KB: VERINOTE_ROOT={cfg.root} verinote status")
     return 0
 
 
@@ -133,11 +147,39 @@ def _seed(store: Store) -> None:
         store.add_fact(subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note)
 
 
+def _kb_schema_problem(db_path: Path) -> str | None:
+    """Say why `db_path` isn't a usable verinote KB, or None when it is one.
+
+    A bare `is_file()` check passes for an empty or corrupt `kb.sqlite`, which
+    would let `seed` silently create a schema (it must only fill an existing KB)
+    or blow up with a raw `sqlite3` traceback.
+    """
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'facts'"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError:
+        return "not a readable SQLite database"
+    return None if row else "no `facts` table"
+
+
 def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
     if not cfg.db_path.is_file():
         print(
             f"no KB at {cfg.root}; run `verinote init` first (or name a root: "
             f"`verinote seed <path>`)",
+            file=sys.stderr,
+        )
+        return 1
+    problem = _kb_schema_problem(cfg.db_path)
+    if problem is not None:
+        print(
+            f"{cfg.db_path} is not a verinote KB ({problem}); move it aside and run "
+            f"`verinote init {cfg.root}` to scaffold one",
             file=sys.stderr,
         )
         return 1
@@ -540,7 +582,11 @@ def _config_for(args: argparse.Namespace) -> Config | None:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    cfg = _config_for(args)
+    try:
+        cfg = _config_for(args)
+    except ValueError as exc:  # e.g. a blank explicit KB root
+        print(str(exc), file=sys.stderr)
+        return 1
     # The single CLI enforcement point for a halted KB. It sits here, before
     # dispatch, because every subcommand goes through this one line — a guard
     # sprinkled per-command is a guard the next command will forget.

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -460,10 +460,18 @@ def _refuse_on_halted_kb(cfg: Config | None) -> int | None:
     judgement lives in `policy_state.assert_writable` alone. The db-file check is
     only "is there a KB at all" — with no database there can be no marker, hence
     nothing that could be halted, and `init` on a fresh root must still work.
+
+    An empty or corrupt `kb.sqlite` is the same category: it holds no marker, so
+    there is nothing here to halt. It must not be opened, because `init_schema()`
+    would *create* a schema in it — which would hand `seed` a KB the user never
+    scaffolded, and turn a corrupt file into a raw `sqlite3` traceback. Leave it
+    to the subcommand, which names the problem and exits non-zero.
     """
     from verinote.pipeline.policy_state import PolicyMissingError, assert_writable
 
     if cfg is None or not cfg.db_path.is_file():
+        return None
+    if _kb_schema_problem(cfg.db_path) is not None:
         return None
     store = Store(cfg.db_path)
     store.init_schema()

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -153,9 +153,15 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     A bare `is_file()` check passes for an empty or corrupt `kb.sqlite`, which
     would let `seed` silently create a schema (it must only fill an existing KB)
     or blow up with a raw `sqlite3` traceback.
+
+    The path is percent-encoded via `Path.as_uri()` before it goes into the
+    SQLite URI. Interpolating it raw truncates any root holding a `?` or `#` at
+    that character, which both misreports a healthy KB as schema-less *and*
+    drops `mode=ro`, so SQLite would create a stray file at the truncated path.
     """
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
         try:
             row = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'facts'"

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -97,6 +97,20 @@ def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+    # A `kb.sqlite` that SQLite cannot read is not an empty slot to scaffold into:
+    # `init_schema()` would raise a raw `sqlite3.DatabaseError` at the user. It may
+    # also be a real KB with a damaged header — every review decision they ever
+    # made — so overwriting it is not ours to choose. Refuse, and say what to do.
+    # A readable database with no schema is the opposite case: filling it in is
+    # exactly what `init` is for, so that one is left to proceed.
+    if cfg.db_path.is_file() and _kb_schema_problem(cfg.db_path) == KB_UNREADABLE:
+        print(
+            f"cannot initialise {cfg.root}: {cfg.db_path} exists and is {KB_UNREADABLE}. "
+            "If it is a damaged KB, restore it from backup; if it is not a KB at all, "
+            "move it aside and run this again.",
+            file=sys.stderr,
+        )
+        return 1
     cfg.root.mkdir(parents=True, exist_ok=True)
     store = _store(cfg)
     if args.seed:
@@ -147,6 +161,14 @@ def _seed(store: Store) -> None:
         store.add_fact(subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note)
 
 
+# The two ways an existing `kb.sqlite` can fail to be a usable KB. They are not
+# interchangeable: `init`'s whole job is to put a schema into a database that has
+# none, so only the *unreadable* one may stop it. `seed` must refuse both — it
+# fills an existing KB and never creates one.
+KB_UNREADABLE = "not a readable SQLite database"
+KB_NO_SCHEMA = "no `facts` table"
+
+
 def _kb_schema_problem(db_path: Path) -> str | None:
     """Say why `db_path` isn't a usable verinote KB, or None when it is one.
 
@@ -169,8 +191,8 @@ def _kb_schema_problem(db_path: Path) -> str | None:
         finally:
             conn.close()
     except sqlite3.DatabaseError:
-        return "not a readable SQLite database"
-    return None if row else "no `facts` table"
+        return KB_UNREADABLE
+    return None if row else KB_NO_SCHEMA
 
 
 def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -69,8 +69,14 @@ def local_root(explicit: Path | str | None = None) -> Path:
     working directory. The saved app config (`active_root()`) is deliberately
     **not** consulted — otherwise `verinote init` in an empty directory would
     write into somebody else's KB.
+
+    A blank explicit root raises `ValueError`: falling back would write the KB
+    somewhere the caller never named, which is exactly what these commands
+    promise not to do.
     """
-    if explicit:
+    if explicit is not None:
+        if isinstance(explicit, str) and not explicit.strip():
+            raise ValueError("KB root must be a path, not an empty string")
         return Path(explicit).expanduser().resolve()
     env_root = os.environ.get("VERINOTE_ROOT")
     if env_root:

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -60,6 +60,24 @@ def _root() -> Path:
     return root if root is not None else _default_root()
 
 
+def local_root(explicit: Path | str | None = None) -> Path:
+    """Resolve the KB root for *local* commands that must never target a saved KB.
+
+    Commands like `init` and `seed` act on a location the caller names, not on
+    whatever KB the web UI last selected. Precedence (highest first): the
+    explicit argument, `VERINOTE_ROOT`, then `./data` relative to the current
+    working directory. The saved app config (`active_root()`) is deliberately
+    **not** consulted — otherwise `verinote init` in an empty directory would
+    write into somebody else's KB.
+    """
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    env_root = os.environ.get("VERINOTE_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+    return _default_root()
+
+
 def app_config_dir() -> Path:
     """Return the platform-native directory for verinote's app-level config."""
     if sys.platform == "win32":


### PR DESCRIPTION
Closes #165

## The bug

`main()` built the config with `Config.load()` for every command except `ui`/`serve`, so `init` and `seed` resolved the KB through `active_root()` — i.e. the saved global `app.json` that the web KB picker writes. Running `verinote init --seed` in an empty directory scaffolded and seeded **the saved active KB**, not a local one.

Worse, two of the four `_DEMO_FACTS` were seeded as `confirmed`. `confirmed` is in `ENGINE_STATUSES`, which `pipeline/ask.py` uses to select engine input — so demo facts became engine input with no human ever reviewing them. That is the determinism-boundary violation, and it's the more serious half of this issue.

## The fix

- **`config.local_root(explicit)`** (new): explicit arg → `VERINOTE_ROOT` → `./data` relative to the CWD. It never reads `read_app_config()`/`active_root()`. `active_root()`/`_root()`/`_default_root()` are unchanged.
- **`init` / `seed` take an optional `[root]` positional.** `main()` routes only those two through `Config.for_root(local_root(args.root))`; every other command keeps its existing `Config.load()` path, so there is no regression in global KB selection.
- **`seed` no longer creates a KB implicitly.** With no `kb.sqlite` at the target it exits 1 with `no KB at <root>; run \`verinote init\` first`.
- **Demo facts are back inside the human gate**: the two `confirmed` entries are now `candidate`. Rather than trusting the literal, a test enforces the invariant — `{status for _DEMO_FACTS} & ENGINE_STATUSES == set()` — and a second test asserts `store.facts(statuses=ENGINE_STATUSES) == []` after `init --seed`.
- Help text corrected (it claimed `under VERINOTE_ROOT (./data)`); README section on scaffolding updated.

`init` still does **not** call `save_active_root()` — it reads no global state and writes none.

## Out of scope (deliberately)

The `./data` CWD-relative fallback inside `active_root()`, the unconfirmed global `app.json` write in `web/app.py`, and the `Config.load()`/`load_for_ui()` global-selection design are untouched — that is #185.

## ⚠️ Breaking behaviour change (intended)

Anyone who had a saved active KB and ran `verinote init` from elsewhere now gets a **new KB in `./data` under the current directory** instead of silently reusing the saved one. The old behaviour was the bug. To target an existing KB, name it explicitly: `verinote seed <path>`, `verinote init <path>`, or `VERINOTE_ROOT=<path> verinote init`.

## Verification

- `.venv/bin/python -m pytest tests -q` → **677 passed, 7 skipped** (669 before; 8 new tests, no existing test changed).
- `ruff check` → All checks passed.
- Smoke run in an empty dir with a saved active KB present: `init --seed` created `./data/kb.sqlite` locally, the saved KB stayed byte-identical, and the seeded KB holds 3 `candidate` + 1 `needs_review` and **zero** engine-status facts.

New tests: saved-active-KB repro (byte-for-byte immutability of the existing KB), explicit-root `init`, `VERINOTE_ROOT` still wins, demo-status ∩ `ENGINE_STATUSES` == ∅, no engine facts after `init --seed`, `seed` with no KB → rc=1 creating nothing, `seed <root>` targeting, and help text no longer lying.

Each new test controls its own env (`VERINOTE_ROOT` deleted; `HOME`/`XDG_CONFIG_HOME`/`APPDATA` pointed at `tmp_path`) and builds the saved-KB fixture by calling `config.save_active_root()` rather than duplicating the platform branching. `tests/conftest.py` is untouched, so this stays compatible with the autouse sandbox in #184.


---

## Review round 2 (all six items closed)

**1. `init` no longer misdirects you to `verinote status` [WARNING].** The seeded-KB line said ``run `verinote status` ``, but `status`/`sync`/`ask`/`verify` still resolve through `Config.load()` → `active_root()`, so with a saved active KB that command showed a *different* KB. The false hint is gone; `init` now always prints the root it actually created as usable input:

```
initialised KB at /tmp/x/mine
  db: /tmp/x/mine/kb.sqlite
  policy: /tmp/x/mine/policy/logic-policy.dl
  seeded demo facts
  use this KB: VERINOTE_ROOT=/tmp/x/mine verinote status
```

`active_root()` itself is untouched (#185 boundary) and `cmd_init` still never calls `save_active_root()` — making `init` grab the global pointer would *be* the failure mode this issue is about. A test pins the hint to `cfg.root`.

**2. `seed` detects an unusable `kb.sqlite` [WARNING].** The guard was `db_path.is_file()`, so a 0-byte file let `_store()` create a schema (violating "only fills an existing KB") and a corrupt file raised a raw `sqlite3.DatabaseError` traceback. New `_kb_schema_problem()` opens the DB read-only and looks for the `facts` table; both cases now exit 1 with a recovery path (`... is not a verinote KB (no \`facts\` table); move it aside and run \`verinote init <root>\``) and the file is left byte-identical.

**3. `init <existing-file>` exits 1 instead of tracebacking [WARNING].** `mkdir(parents=True, exist_ok=True)` still raises `FileExistsError` when a *file* occupies the root path — a surface the new `[root]` positional opened. Guarded with a message, rc=1.

**4. A blank root is rejected, not swallowed [INFO].** `local_root()` used `if explicit:`, so `verinote init ""` fell back to `VERINOTE_ROOT`/`./data` and created a KB somewhere the caller never named. Now `if explicit is not None:`, and a blank/whitespace string raises `ValueError` → rc=1 in `main()`. `VERINOTE_ROOT="   "` behaviour is unchanged (that is `active_root()`, i.e. #185).

**5. The demo-status gate can't pass vacuously [INFO].** Added `assert demo_statuses` and `assert ENGINE_STATUSES` before the disjointness check.

**6. Regression guard for the global pointer [INFO].** `test_init_seed_in_empty_dir_ignores_saved_active_kb` now also asserts `config.read_app_config()["active_root"] == str(existing)`, so a future "helpful" `save_active_root(new)` inside `cmd_init` fails loudly instead of sliding through a bytes-only check.

### Known limitation (by design, tracked in #185)

The KB `init` creates does **not** become the active one. To use it you must pass `VERINOTE_ROOT=<root>` or select it in the UI — which is exactly what the new hint and the README now say. Fixing that properly means changing how the active KB is selected, which is #185's territory, not this PR's.

### Verification

- `.venv/bin/python -m pytest -q` → **683 passed, 7 skipped** (677 before; 6 new tests, no existing test's intent changed).
- `.venv/bin/ruff check verinote tests` → All checks passed.
- **Mutation evidence** — each new guard was removed in turn and the matching test went red, so none of them are vacuous: drop the non-dir guard → 1 failed; drop the seed schema guard → 2 failed; revert `local_root` to `if explicit:` → 2 failed; restore the false `status` hint → 1 failed; make `cmd_init` call `save_active_root()` → 1 failed; empty `_DEMO_FACTS` → 1 failed.
- End-to-end run under a fake `HOME` with a *different* KB saved as active: `init --seed` created only the named root, `VERINOTE_ROOT=<root> verinote status` read it back (4 facts), empty/corrupt `kb.sqlite` and a file-as-root and `init ""` each exited 1 changing nothing, and `app.json` still pointed at the original KB.

### Follow-up, not fixed here

Running `seed` twice duplicates the demo facts (8 rows after two runs) — pre-existing, out of scope for this PR, and worth its own issue.


---

## Follow-up fix: unescaped KB path in the SQLite URI (review round 2)

The schema guard added above shipped with a bug of its own, caught in review. `_kb_schema_problem()` built its probe URI by interpolation:

```python
conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
```

A KB root containing `?` or `#` truncates that URI at the metacharacter, with two consequences (both measured on a real KB at `/tmp/X/weird?dir/`):

1. **False rejection.** The probe read a truncated path, found no `facts` table, and `seed` refused a perfectly healthy KB with rc=1.
2. **Worse: an unnamed write.** With the URI cut short, `mode=ro` was no longer parsed as a query parameter, so SQLite opened **read-write** and created a stray empty file (`/tmp/X/weird`) in the *parent* directory — writing to a location the user never named. That is a miniature of the exact behaviour this PR exists to forbid.

**Fix:** build the URI with `Path.as_uri()`, which percent-encodes both characters, so `mode=ro` survives and the probe can never create a file.

```python
uri = f"{db_path.resolve().as_uri()}?mode=ro"
conn = sqlite3.connect(uri, uri=True)
```

**Regression tests (2 new).** `test_kb_schema_probe_survives_a_uri_metacharacter_in_the_path` drives the probe directly with a `?` root; `test_seed_accepts_a_kb_whose_path_holds_a_uri_metacharacter` drives full `init` → `seed` with a `#` root. Each asserts both symptoms: (a) the healthy KB is not misreported, and (b) a before/after listing of the parent directory is unchanged, so no stray file appears.

**Mutation evidence:** reverting the fix to the interpolated URI turns **both** new tests red (`2 failed`); restoring it returns them to green (`2 passed`). Neither test is vacuous.

**Verification:** `.venv/bin/python -m pytest -q` → **685 passed, 7 skipped**; `.venv/bin/ruff check` → All checks passed.

### Second follow-up candidate (pre-existing, not fixed here)

While testing the `?` path I found that the **DuckDB** fact-term store splits paths at `?` as well, independently of this PR: seeding a KB whose root contains `?` dies with `Cannot open file ".../weird.wal?dir/facts.duckdb"`. This reproduces on the commit *before* this fix, so it is not a regression from this branch — it deserves its own issue. (It is why the end-to-end test above uses `#` rather than `?`.)
