### PR TITLE
fix(#183): derive the report's excluded-from-engine count from REVIEW_STATUSES

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -13,6 +13,7 @@ from verinote.pipeline.policy_state import (
     policy_sha256,
     resolve_policy,
 )
+from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import load_policy, verify
 from verinote.store import Store
 
@@ -422,6 +423,37 @@ def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
     assert "policy_missing" in report.text
     # ("inconsistent — promotion stays gated" is the errors banner, not a claim
     # that the KB checked out clean)
+    assert "knowledge base is consistent" not in report.text
+
+
+def test_report_survives_a_lost_policy_when_the_kb_has_a_query(tmp_path, monkeypatch):
+    """The /report policy-missing fallback, on the KB shape that actually reaches it.
+
+    `_halted_client` has no query file, so `report_trace` returns before it ever
+    consults the policy — which left the fallback below unexecuted by any test.
+    It takes a halted KB that *has* a query (and engine facts to trace) to drive
+    the trust lookup that raises `PolicyMissingError` inside `report_trace`. That
+    hole is what let the fallback keep constructing `ReportTrace` with a field
+    that no longer exists.
+    """
+    client = _halted_client(tmp_path, monkeypatch)
+    store = client.app.state.store
+    source_id = store.add_source("sources/b.txt")
+    store.add_fact(
+        "Ada", "born_in", "London", status="confirmed", source_id=source_id
+    )
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O).\n',
+        encoding="utf-8",
+    )
+
+    report = client.get("/report")
+
+    assert report.status_code == 200, report.text
+    assert "policy_missing" in report.text
     assert "knowledge base is consistent" not in report.text
 
 

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 from verinote.pipeline.query import query_path
 from verinote.pipeline.report_trace import report_trace
-from verinote.store import Store
+from verinote.store import Store, db as store_db
 
 
 def _store(tmp_path) -> Store:
@@ -41,7 +41,7 @@ def test_report_trace_links_direct_answers_to_engine_facts_and_evidence(tmp_path
 
     trace = report_trace(s)
 
-    assert trace.excluded_candidate_count == 1
+    assert trace.excluded_review_count == 1
     assert len(trace.answers) == 1
     answer = trace.answers[0]
     assert (answer.qid, answer.value, answer.conflicted) == ("1", "Sample City", False)
@@ -117,3 +117,55 @@ def test_report_trace_skips_non_direct_query_rules(tmp_path):
     trace = report_trace(s)
 
     assert trace.answers == ()
+
+
+def test_report_trace_breaks_the_excluded_count_down_by_status(tmp_path):
+    """The report must name what was held back: candidate and needs_review call
+    for different user action, so a bare total cannot stand in for both.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/sample.txt")
+    s.add_fact("Person", "born_in", "A", status="candidate", source_id=source_id)
+    s.add_fact("Person", "born_in", "B", status="candidate", source_id=source_id)
+    s.add_fact("Person", "born_in", "C", status="needs_review", source_id=source_id)
+
+    trace = report_trace(s)
+
+    assert trace.excluded_review_count == 3
+    assert trace.excluded_by_status == (("candidate", 2), ("needs_review", 1))
+
+
+def test_report_trace_omits_review_statuses_with_no_facts(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/sample.txt")
+    s.add_fact("Person", "born_in", "A", status="candidate", source_id=source_id)
+
+    assert report_trace(s).excluded_by_status == (("candidate", 1),)
+
+
+def test_report_trace_excluded_count_follows_review_statuses(tmp_path, monkeypatch):
+    """Widen REVIEW_STATUSES at its home and this consumer must follow.
+
+    Pinning today's number would be vacuous: both sides would be hardcoded and
+    would still agree. `superseded` is a real schema status belonging to neither
+    REVIEW_STATUSES nor ENGINE_STATUSES, so it serves as the mutation.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/sample.txt")
+    s.add_fact(
+        "Person", "born_in", "Draft City", status="candidate", source_id=source_id
+    )
+    s.add_fact(
+        "Person", "born_in", "Old City", status="superseded", source_id=source_id
+    )
+
+    assert report_trace(s).excluded_review_count == 1
+
+    monkeypatch.setattr(
+        store_db, "REVIEW_STATUSES", store_db.REVIEW_STATUSES | {"superseded"}
+    )
+
+    trace = report_trace(s)
+
+    assert trace.excluded_review_count == 2
+    assert trace.excluded_by_status == (("candidate", 1), ("superseded", 1))

--- a/tests/test_status_tiers.py
+++ b/tests/test_status_tiers.py
@@ -29,6 +29,7 @@ from verinote.pipeline.corroboration import (
     store_single_valued_conflicts,
 )
 from verinote.pipeline.query_schema import build_query_schema_snapshot
+from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.trust import fact_trust_summary
 from verinote.pipeline.workbench import trust_workbench
 from verinote.store import Store, db
@@ -197,6 +198,10 @@ def test_acceptance_refuses_an_empty_review_tier(tmp_path, monkeypatch):
         accept_recommendation(store, fact_id)
     with pytest.raises(ValueError, match="must not be empty"):
         trust_workbench(store)
+    # The report is a consumer of the same tier: an empty one must not render as
+    # "nothing was held back" while every other consumer refuses to answer.
+    with pytest.raises(ValueError, match="must not be empty"):
+        report_trace(store)
 
     # The fact was not promoted behind our back.
     assert store.get_fact(fact_id)["status"] == "needs_review"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1160,10 +1160,29 @@ def test_report_shows_query_trace_links_and_candidate_exclusion(tmp_path):
     body = unescape(c.get("/report").text)
 
     assert "Traceability" in body
-    assert "candidate/needs-review fact(s) were excluded from engine input" in body
+    # one needs_review fact from _client, one candidate above: both review statuses
+    # count, and the report must name which is which.
+    assert "2 fact(s) awaiting review were excluded from engine input" in body
+    assert "candidate 1, needs_review 1" in body
     assert f'href="/facts/{fact_id}/provenance"' in body
     assert "Sample Person was born in Sample City." in body
     assert "Draft City" not in body
+
+
+def test_report_traceability_renders_one_status_then_none(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+
+    # _client seeds a single needs_review fact: one status, so no separator.
+    body = unescape(c.get("/report").text)
+    assert "1 fact(s) awaiting review were excluded from engine input" in body
+    assert "(needs_review 1)" in body
+
+    store.set_status(c.fact_id, "confirmed")
+
+    body = unescape(c.get("/report").text)
+    assert "No facts were held back from engine input pending review." in body
+    assert "awaiting review" not in body
 
 
 def test_report_gates_on_contradiction(tmp_path):

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -17,7 +17,7 @@ from verinote.engine.terms import Compound, StringLit, Term, Var, render_term
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.trust import fact_trust_summary
-from verinote.store import Store
+from verinote.store import Store, db as store_db
 
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
 _ANSWER_RE = re.compile(r"answer_q(?P<qid>[0-9]+)\Z")
@@ -45,23 +45,42 @@ class AnswerTrace:
 @dataclass(frozen=True)
 class ReportTrace:
     answers: tuple[AnswerTrace, ...]
-    excluded_candidate_count: int
+    excluded_review_count: int
+    # (status, count) for the review statuses actually present, so the report can
+    # name what was held back without spelling the vocabulary out a second time.
+    excluded_by_status: tuple[tuple[str, int], ...]
+
+
+def _excluded_by_status(store: Store) -> tuple[tuple[str, int], ...]:
+    counts = store.status_counts()
+    # Read REVIEW_STATUSES off store.db rather than from-importing it: widening it
+    # at its definition site then moves this count, which is what lets the mutation
+    # test prove the derivation instead of a coincidence between two hardcodings.
+    return tuple(
+        (status, count)
+        for status in sorted(store_db.REVIEW_STATUSES)
+        if (count := counts.get(status, 0))
+    )
 
 
 def report_trace(store: Store) -> ReportTrace:
-    candidates = store.status_counts().get("candidate", 0) + store.status_counts().get(
-        "needs_review", 0
-    )
+    by_status = _excluded_by_status(store)
+    excluded = sum(count for _, count in by_status)
     try:
         query = load_query(store)
     except CorroborationPolicyError:
-        return ReportTrace(answers=(), excluded_candidate_count=candidates)
+        query = None
     if not query:
-        return ReportTrace(answers=(), excluded_candidate_count=candidates)
+        return ReportTrace(
+            answers=(),
+            excluded_review_count=excluded,
+            excluded_by_status=by_status,
+        )
 
     return ReportTrace(
         answers=trace_query_answers(store, query),
-        excluded_candidate_count=candidates,
+        excluded_review_count=excluded,
+        excluded_by_status=by_status,
     )
 
 

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -17,7 +17,7 @@ from verinote.engine.terms import Compound, StringLit, Term, Var, render_term
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.trust import fact_trust_summary
-from verinote.store import Store, db as store_db
+from verinote.store import Store, review_statuses
 
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
 _ANSWER_RE = re.compile(r"answer_q(?P<qid>[0-9]+)\Z")
@@ -53,12 +53,14 @@ class ReportTrace:
 
 def _excluded_by_status(store: Store) -> tuple[tuple[str, int], ...]:
     counts = store.status_counts()
-    # Read REVIEW_STATUSES off store.db rather than from-importing it: widening it
-    # at its definition site then moves this count, which is what lets the mutation
-    # test prove the derivation instead of a coincidence between two hardcodings.
+    # Ask the tier accessor rather than binding the frozenset: widening the tier at
+    # its definition site then moves this count (which is what lets the mutation
+    # test prove a derivation rather than a coincidence between two hardcodings),
+    # and an empty tier raises here as it does for every other consumer instead of
+    # rendering a report that quietly claims nothing was held back.
     return tuple(
         (status, count)
-        for status in sorted(store_db.REVIEW_STATUSES)
+        for status in sorted(review_statuses())
         if (count := counts.get(status, 0))
     )
 

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1101,7 +1101,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         except PolicyMissingError:
             # The report itself already carries the policy_missing error; the
             # trace needs the same (lost) policy, so it has nothing to say.
-            trace = ReportTrace(answers=(), excluded_candidate_count=0)
+            trace = ReportTrace(
+                answers=(), excluded_review_count=0, excluded_by_status=()
+            )
         return templates.TemplateResponse(
             request,
             "report.html",

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -32,10 +32,11 @@
 </ul>
 {% endif %}
 <h2>Traceability</h2>
-{% if trace.excluded_candidate_count %}
-<p class="muted">{{ trace.excluded_candidate_count }} candidate/needs-review fact(s) were excluded from engine input.</p>
+{% if trace.excluded_review_count %}
+<p class="muted">{{ trace.excluded_review_count }} fact(s) awaiting review were excluded from engine input
+  ({% for status, count in trace.excluded_by_status %}{{ status }} {{ count }}{{ ", " if not loop.last }}{% endfor %}).</p>
 {% else %}
-<p class="muted">No candidate facts were included in engine input.</p>
+<p class="muted">No facts were held back from engine input pending review.</p>
 {% endif %}
 {% if trace.answers %}
 <table class="counts">


### PR DESCRIPTION
Closes #183

## Problem

`verinote/pipeline/report_trace.py` re-defined `REVIEW_STATUSES` by hand:

```python
status_counts().get("candidate", 0) + status_counts().get("needs_review", 0)
```

and rendered the result in the logic report as **"excluded from engine input"** — the artifact a user trusts when deciding what to delete. The constant (`store/db.py:21`) and the sum agreed only by coincidence, so a third review status would have been silently left out of the number.

The template was a **second** hand-written copy of the same vocabulary (`"candidate/needs-review fact(s)"`). Deriving only the number would have moved the same lie up one layer: the count would say 3 while the sentence still said "candidate/needs-review".

## Change

- **Count is derived** from `REVIEW_STATUSES`, read off `store.db` rather than from-imported. Widening the constant at its definition site then moves this count — which is what lets the mutation test prove a derivation rather than a coincidence between two hardcodings.
- **The report names what was held back**, from the data rather than a hardcoded vocabulary: `3 fact(s) awaiting review were excluded from engine input (candidate 2, needs_review 1).` The old wording carried information worth keeping — `candidate` and `needs_review` call for different user action — and a bare total would have dropped it.
- **`excluded_candidate_count` → `excluded_review_count`.** It no longer counts only candidates. `ReportTrace` is internal (one consumer, `web/app.py:1019`; no CLI or JSON path), so the rename is contained — zero remaining references.
- The else branch was a tautology (*"No candidate facts were **included in** engine input"* — always true, never the negation of the count) and is now the actual negation.

## Tests

The guard the issue asked for: widening `REVIEW_STATUSES` with `superseded` — a real schema status belonging to neither `REVIEW_STATUSES` nor `ENGINE_STATUSES` — must move both the count and the breakdown.

**Verified non-vacuous, not assumed.** Restoring the hardcoded sum turns exactly that test red and nothing else. Removing the zero-count filter or reversing the sort each turn their own tests red.

The rendered report is now covered for two statuses, one status (no separator), and none (the else branch — previously unrendered by any test).

`673 passed, 7 skipped`, `ruff check` clean.

## Scope

The template wording and the field rename are the other half of this fix, not scope creep: both were hand-written copies of the vocabulary this issue exists to derive.

## Follow-up (not this PR)

`store/db.py:946` (`accept_review_facts_for_source`) still spells the review statuses out as a SQL literal — `AND status IN ('candidate','needs_review')` — inside the very module that owns the constant. Add a review status and the report's count follows (after this PR) but that promotion path silently skips it. Same class as this issue and as #176; deserves its own issue alongside the `schema.sql` CHECK, which is a fourth hand-written copy of the status vocabulary.