### PR TITLE
fix(#159): stop ignoring hand-written policy; anchor generated KB artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ venv/
 #   data/policy/relation-aliases.md, data/policy/typed-relations.md
 #                               hand-written policy inputs
 # Back these up yourself, or keep the KB outside the working tree entirely
-# (`verinote init <path>` / VERINOTE_ROOT). See README, "Your KB is not a repo
-# artifact". `git clean -fdx` deletes all of it.
+# (`VERINOTE_ROOT=~/verinote-kb verinote init`). See README, "Your KB is not a
+# repo artifact". `git clean -fdx` deletes all of it.
 /data/
 
 # Generated engine artifacts, anchored to the KB layout.
@@ -29,8 +29,15 @@ venv/
 # miss: an uncommitted policy makes `load_policy()` return None, verinote falls
 # back to the shipped default policy, and the check still reports "consistent".
 # Match generated *paths*, never bare extensions. See tests/test_gitignore.py.
+#
+# Engine sidecars are listed explicitly for both stores: DuckDB leaves a `.wal`
+# behind on an unclean shutdown and spills to `.tmp/`, exactly as SQLite leaves
+# `-wal`/`-shm`. Anchored paths do not glob these in for free, so omitting them
+# would leak a generated file into `git status`.
 **/facts/query.dl
 **/facts.duckdb
+**/facts.duckdb.wal
+**/facts.duckdb.tmp/
 **/kb.sqlite
 **/kb.sqlite-wal
 **/kb.sqlite-shm

--- a/.gitignore
+++ b/.gitignore
@@ -8,13 +8,32 @@ dist/
 .venv/
 venv/
 
-# verinote local state (a KB's data is local, like a working dir)
-*.sqlite
-*.sqlite-wal
-*.sqlite-shm
-*.duckdb
+# verinote local state (a KB's data is local, like a working dir).
+#
+# The default KB lives here. It is USER DATA, not a repo artifact, so it is
+# never committed — and nothing in it is reproducible from this repo:
+#   data/kb.sqlite              every accept/reject decision + the audit log
+#   data/policy/*.dl            hand-written logic policy
+#   data/policy/relation-aliases.md, data/policy/typed-relations.md
+#                               hand-written policy inputs
+# Back these up yourself, or keep the KB outside the working tree entirely
+# (`verinote init <path>` / VERINOTE_ROOT). See README, "Your KB is not a repo
+# artifact". `git clean -fdx` deletes all of it.
 /data/
-*.dl
+
+# Generated engine artifacts, anchored to the KB layout.
+#
+# These are ANCHORED ON PURPOSE. Bare extension globs (`*.dl`, `*.sqlite`,
+# `*.duckdb`) match at any depth, so they silently ignored hand-written policy,
+# test fixtures and doc examples anywhere in the tree. That is not a cosmetic
+# miss: an uncommitted policy makes `load_policy()` return None, verinote falls
+# back to the shipped default policy, and the check still reports "consistent".
+# Match generated *paths*, never bare extensions. See tests/test_gitignore.py.
+**/facts/query.dl
+**/facts.duckdb
+**/kb.sqlite
+**/kb.sqlite-wal
+**/kb.sqlite-shm
 
 # tooling
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,21 @@ venv/
 # verinote local state (a KB's data is local, like a working dir).
 #
 # The default KB lives here. It is USER DATA, not a repo artifact, so it is
-# never committed — and nothing in it is reproducible from this repo:
+# never committed — and the only file in it this repo can regenerate is
+# `facts/query.dl`:
 #   data/kb.sqlite              every accept/reject decision + the audit log
+#   data/facts.duckdb           the canonical fact terms. NOT rebuildable from
+#                               kb.sqlite: the SQLite columns are display mirrors,
+#                               so a lost sidecar re-types compounds as strings
+#                               (#156). Ignored because it is user data, not
+#                               because it is disposable.
+#   data/sources/, data/artifacts/
+#                               the ingested documents and their extracted text
 #   data/policy/*.dl            hand-written logic policy
 #   data/policy/relation-aliases.md, data/policy/typed-relations.md
 #                               hand-written policy inputs
+#   data/policy/prompts/, data/config.json
+#                               hand-written prompt overrides and settings
 # Back these up yourself, or keep the KB outside the working tree entirely
 # (`VERINOTE_ROOT=~/verinote-kb verinote init`). See README, "Your KB is not a
 # repo artifact". `git clean -fdx` deletes all of it.

--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,12 @@ venv/
 # These are ANCHORED ON PURPOSE. Bare extension globs (`*.dl`, `*.sqlite`,
 # `*.duckdb`) match at any depth, so they silently ignored hand-written policy,
 # test fixtures and doc examples anywhere in the tree. That is not a cosmetic
-# miss: an uncommitted policy makes `load_policy()` return None, verinote falls
-# back to the shipped default policy, and the check still reports "consistent".
-# Match generated *paths*, never bare extensions. See tests/test_gitignore.py.
+# miss: git refuses to add an ignored file without `-f`, so a hand-written policy
+# never enters history — and nothing in this repo can regenerate one. Lose the
+# working copy (`git clean -fdx`, a wiped disk) and those rules are gone for
+# good, whether verinote then shrugs and uses the shipped default policy or
+# refuses to run at all (#155 makes that fallback loud). Match generated *paths*,
+# never bare extensions. See tests/test_gitignore.py.
 #
 # Engine sidecars are listed explicitly for both stores: DuckDB leaves a `.wal`
 # behind on an unclean shutdown and spills to `.tmp/`, exactly as SQLite leaves

--- a/README.md
+++ b/README.md
@@ -79,6 +79,38 @@ DuckDB is a core dependency because it powers verification. The `analytics` extr
 kept as a compatibility no-op; analytics uses the same DuckDB dependency. The
 `wirelog` extra installs the legacy `pyrewire` path for compatibility/debugging only.
 
+## Your KB is not a repo artifact
+
+A KB holds **user data**, so verinote never commits it. Nothing in it can be
+regenerated from this repo — if you lose it, it is gone:
+
+| Path (KB root) | What it holds | Irreplaceable because |
+| --- | --- | --- |
+| `kb.sqlite` | facts, sources, questions | it records **every accept/reject decision and the full audit log** |
+| `policy/logic-policy.dl` | your review rules | hand-written |
+| `policy/relation-aliases.md` | raw -> canonical relation names | hand-written |
+| `policy/typed-relations.md` | typed relation declarations | hand-written |
+
+Only `facts/query.dl` and `facts.duckdb` are rebuilt from `kb.sqlite`.
+
+**Keep the KB outside this working tree.** The default root (`./data`) is a
+convenience for a first run, not a safe home:
+
+```bash
+verinote init ~/verinote-kb          # scaffold a KB outside the repo
+VERINOTE_ROOT=~/verinote-kb verinote ui
+```
+
+**`git clean -fdx` deletes your KB**, and `-x` makes ignoring it irrelevant:
+`clean` removes *untracked* files whether or not they are ignored, and user data
+cannot be committed to fix that. Running it inside the working tree destroys the
+KB and its audit log with no undo. Moving the default root outside the working
+tree is tracked in
+[#185](https://github.com/semantic-reasoning/verinote/issues/185).
+
+**Backups are your responsibility.** verinote takes none. Copy the KB root (it
+is a plain folder) or snapshot `kb.sqlite` plus `policy/` on your own schedule.
+
 ## Fact Storage Boundary
 
 Each KB stores two coordinated files under the KB root:

--- a/README.md
+++ b/README.md
@@ -81,21 +81,41 @@ kept as a compatibility no-op; analytics uses the same DuckDB dependency. The
 
 ## Your KB is not a repo artifact
 
-A KB holds **user data**, so verinote never commits it. Nothing in it can be
-regenerated from this repo — if you lose it, it is gone:
+A KB holds **user data**, so verinote never commits it. Treat the whole KB root
+as source: **the only file in it that can be rebuilt is `facts/query.dl`.**
+Everything else, if you lose it, is gone.
 
 | Path (KB root) | What it holds | Irreplaceable because |
 | --- | --- | --- |
 | `kb.sqlite` | facts, sources, questions | it records **every accept/reject decision and the full audit log** |
+| `facts.duckdb` | the canonical logical fact terms | see below — it is **not** rebuildable from `kb.sqlite` |
+| `sources/` | the documents you ingested, byte for byte | verinote never re-downloads them |
+| `artifacts/` | the extracted text of each source | `kb.sqlite` stores only its path and checksum, not the text |
 | `policy/logic-policy.dl` | your review rules | scaffolded by `init`, then hand-edited |
 | `policy/relation-aliases.md` | raw -> canonical relation names | hand-written |
 | `policy/typed-relations.md` | typed relation declarations | hand-written |
+| `policy/prompts/` | your prompt overrides | hand-written |
+| `config.json` | provider/model settings | hand-written |
 
-Only `facts/query.dl`, `facts.duckdb` (and its `.wal` / `.tmp/` sidecars) are
-rebuilt from `kb.sqlite`. `init` writes a starting `logic-policy.dl` for you, but
-every edit you make to it afterwards is yours alone and is not reproducible from
-this repo — which is why it must stay committable rather than be swept up by a
-blanket `*.dl` ignore rule.
+`init` writes a starting `logic-policy.dl` for you, but every edit you make to it
+afterwards is yours alone and is not reproducible from this repo — which is why
+it must stay committable rather than be swept up by a blanket `*.dl` ignore rule.
+
+**`facts.duckdb` is data, not a cache.** It owns the logical fact terms; the
+`facts.subject/relation/object` columns in `kb.sqlite` are display mirrors, and
+rendering a term into text is lossy. If the sidecar goes missing, the terms are
+*re-typed* from those mirrors rather than restored: a compound collapses into a
+string, and even a plain string gains the quotes it was rendered with.
+
+```text
+before:  Compound('person', (StringLit('Ada'),))   Atom('works_at')       StringLit('Acme')
+after:   StringLit('person("Ada")')                StringLit('works_at')  StringLit('"Acme"')
+```
+
+Rules that matched the structural terms stop firing, and the report still says
+the knowledge base is consistent. Silent re-typing on a lost sidecar is tracked
+in [#156](https://github.com/semantic-reasoning/verinote/issues/156) — until it
+is fixed, **back the sidecar up with the rest of the KB.**
 
 **Keep the KB outside this working tree.** The default root (`./data`) is a
 convenience for a first run, not a safe home:
@@ -109,21 +129,40 @@ VERINOTE_ROOT=~/verinote-kb verinote ui
 your shell profile keeps all of your data out of this working tree.
 
 **If you do keep a KB inside the repo tree** (any path other than `data/`, e.g.
-`./my-kb`), be aware that `policy/logic-policy.dl` is *not* ignored — it shows up
-as untracked and a stray `git add -A` will commit it. That is deliberate: the
-ignore rules match generated *paths*, never bare extensions, because a blanket
-`*.dl` rule is exactly what used to swallow hand-written policy. Keep the KB
-outside the tree, or do not blind-add.
+`./my-kb`), a stray `git add -A` will commit most of it. Only the generated
+artifacts are ignored; the sources are not, and that is deliberate — the ignore
+rules match generated *paths*, never bare extensions, because a blanket `*.dl`
+rule is exactly what used to swallow hand-written policy. What gets staged:
 
-**`git clean -fdx` deletes your KB**, and `-x` makes ignoring it irrelevant:
-`clean` removes *untracked* files whether or not they are ignored, and user data
-cannot be committed to fix that. Running it inside the working tree destroys the
-KB and its audit log with no undo. Moving the default root outside the working
-tree is tracked in
+```text
+my-kb/sources/confidential.pdf        <- the document you ingested, byte for byte
+my-kb/artifacts/sources/1/<sha>.txt   <- its extracted text
+my-kb/policy/logic-policy.dl          <- your review rules
+my-kb/config.json                     <- your provider/model settings
+```
+
+So the exposure is not one policy file — it is **the documents themselves**, which
+is exactly what [AGENTS.md](AGENTS.md) forbids committing. Keep the KB outside
+the tree, or do not blind-add.
+
+**`git clean -fdx` deletes your KB.** Ignoring it does not save it: `-x` removes
+ignored files too, and user data cannot be committed to fix that. (Without `-x`,
+ignoring *does* protect the generated artifacts — but not `sources/` or
+`policy/`, which are not ignored.) Running it inside the working tree destroys
+the KB and its audit log with no undo. Moving the default root outside the
+working tree is tracked in
 [#185](https://github.com/semantic-reasoning/verinote/issues/185).
 
-**Backups are your responsibility.** verinote takes none. Copy the KB root (it
-is a plain folder) or snapshot `kb.sqlite` plus `policy/` on your own schedule.
+**Backups are your responsibility.** verinote takes none. Copy **the whole KB
+root** — it is a plain folder — on your own schedule:
+
+```bash
+cp -a ~/verinote-kb ~/backups/verinote-kb-$(date +%F)
+```
+
+Do not snapshot only part of it. `kb.sqlite` alone is not a backup: without
+`facts.duckdb` the fact terms come back re-typed (see above), and without
+`sources/` and `artifacts/` the provenance behind every confirmed fact is gone.
 
 ## Fact Storage Boundary
 

--- a/README.md
+++ b/README.md
@@ -87,19 +87,33 @@ regenerated from this repo — if you lose it, it is gone:
 | Path (KB root) | What it holds | Irreplaceable because |
 | --- | --- | --- |
 | `kb.sqlite` | facts, sources, questions | it records **every accept/reject decision and the full audit log** |
-| `policy/logic-policy.dl` | your review rules | hand-written |
+| `policy/logic-policy.dl` | your review rules | scaffolded by `init`, then hand-edited |
 | `policy/relation-aliases.md` | raw -> canonical relation names | hand-written |
 | `policy/typed-relations.md` | typed relation declarations | hand-written |
 
-Only `facts/query.dl` and `facts.duckdb` are rebuilt from `kb.sqlite`.
+Only `facts/query.dl`, `facts.duckdb` (and its `.wal` / `.tmp/` sidecars) are
+rebuilt from `kb.sqlite`. `init` writes a starting `logic-policy.dl` for you, but
+every edit you make to it afterwards is yours alone and is not reproducible from
+this repo — which is why it must stay committable rather than be swept up by a
+blanket `*.dl` ignore rule.
 
 **Keep the KB outside this working tree.** The default root (`./data`) is a
 convenience for a first run, not a safe home:
 
 ```bash
-verinote init ~/verinote-kb          # scaffold a KB outside the repo
+VERINOTE_ROOT=~/verinote-kb verinote init   # scaffold a KB outside the repo
 VERINOTE_ROOT=~/verinote-kb verinote ui
 ```
+
+`VERINOTE_ROOT` selects the KB root for every command, so exporting it once in
+your shell profile keeps all of your data out of this working tree.
+
+**If you do keep a KB inside the repo tree** (any path other than `data/`, e.g.
+`./my-kb`), be aware that `policy/logic-policy.dl` is *not* ignored — it shows up
+as untracked and a stray `git add -A` will commit it. That is deliberate: the
+ignore rules match generated *paths*, never bare extensions, because a blanket
+`*.dl` rule is exactly what used to swallow hand-written policy. Keep the KB
+outside the tree, or do not blind-add.
 
 **`git clean -fdx` deletes your KB**, and `-x` makes ignoring it irrelevant:
 `clean` removes *untracked* files whether or not they are ignored, and user data

--- a/tests/fixtures/policy/sample-policy.dl
+++ b/tests/fixtures/policy/sample-policy.dl
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+// Hand-written sample KB policy, tracked on purpose.
+//
+// This file is a *source input*, not a generated artifact: it is the kind of
+// file a KB owner writes by hand at `<root>/policy/logic-policy.dl`. It is
+// loaded for real by `tests/test_verify.py::test_verify_loads_hand_written_
+// fixture_policy` and it is the regression lock in `tests/test_gitignore.py`:
+// a bare `*.dl` glob in .gitignore silently ignores files like this one, so a
+// deleted or never-committed policy degrades into `load_policy() -> None` and
+// the engine happily reports "consistent" against the shipped default policy.
+
+.decl relation(subject: symbol, rel: symbol, object: symbol)
+
+// Relations that may hold at most one object per subject.
+.decl functional(rel: symbol)
+functional("established_on").
+
+// A functional relation must not carry two distinct objects for one subject.
+.decl error_functional_conflict(subject: symbol, rel: symbol)
+error_functional_conflict(S, R) :-
+    relation(S, R, A), relation(S, R, B), functional(R), A != B.
+
+// Fixture-only rule: proves this policy (not the shipped default) was loaded.
+.decl warn_fixture_policy_loaded(subject: symbol)
+warn_fixture_policy_loaded(S) :- relation(S, "is_a", O).

--- a/tests/fixtures/policy/sample-policy.dl
+++ b/tests/fixtures/policy/sample-policy.dl
@@ -2,12 +2,17 @@
 // Hand-written sample KB policy, tracked on purpose.
 //
 // This file is a *source input*, not a generated artifact: it is the kind of
-// file a KB owner writes by hand at `<root>/policy/logic-policy.dl`. It is
-// loaded for real by `tests/test_verify.py::test_verify_loads_hand_written_
-// fixture_policy` and it is the regression lock in `tests/test_gitignore.py`:
-// a bare `*.dl` glob in .gitignore silently ignores files like this one, so a
-// deleted or never-committed policy degrades into `load_policy() -> None` and
-// the engine happily reports "consistent" against the shipped default policy.
+// file a KB owner writes by hand at `<root>/policy/logic-policy.dl`. Nothing in
+// verinote can regenerate it — the rules below exist only because a person typed
+// them, so the only copy that survives a lost disk is the one in git.
+//
+// That is why it must stay committable, and why it is the regression lock in
+// `tests/test_gitignore.py`: a bare `*.dl` glob in .gitignore swallows files
+// like this one, git then refuses to add them without `-f`, and a policy that
+// never reaches history is one `git clean -fdx` away from being gone for good.
+//
+// It is also loaded for real by
+// `tests/test_verify.py::test_verify_loads_hand_written_fixture_policy`.
 
 .decl relation(subject: symbol, rel: symbol, object: symbol)
 

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -3,8 +3,12 @@
 
 `.gitignore` used to carry bare, unanchored globs (`*.dl`, `*.sqlite`,
 `*.duckdb`). Those match at *any* depth, so hand-written policy, test fixtures
-and doc examples were silently ignored — and a policy that never got committed
-falls back to the shipped default policy, which happily reports "consistent".
+and doc examples were silently ignored. An ignored file cannot be `git add`-ed
+without `-f`, so a KB owner's policy never entered history — and no part of this
+repo can regenerate a hand-written policy. The loss is permanent whether verinote
+then falls back to the shipped default policy or refuses to run outright (#155),
+which is why these tests pin the ignore rules rather than the engine's reaction
+to a policy that is already gone.
 
 These tests assert both directions with `git check-ignore`'s exit status
 (0 = ignored, 1 = not ignored). It is pattern-based, so it works for paths that
@@ -75,7 +79,8 @@ def _check_ignore(path: str) -> int:
 def test_hand_written_sources_are_not_ignored(path: str) -> None:
     assert _check_ignore(path) == 1, (
         f"{path} is ignored by .gitignore; hand-written policy/fixtures must be "
-        "committable. A missing policy silently falls back to the shipped default."
+        "committable. An ignored policy never reaches git, and nothing in this "
+        "repo can regenerate it."
     )
 
 

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Regression lock on .gitignore's source/artifact split.
+
+`.gitignore` used to carry bare, unanchored globs (`*.dl`, `*.sqlite`,
+`*.duckdb`). Those match at *any* depth, so hand-written policy, test fixtures
+and doc examples were silently ignored — and a policy that never got committed
+falls back to the shipped default policy, which happily reports "consistent".
+
+These tests assert both directions with `git check-ignore`'s exit status
+(0 = ignored, 1 = not ignored). It is pattern-based, so it works for paths that
+do not exist on disk. Asserting only one direction would be vacuous: emptying
+.gitignore passes the "sources are tracked" half, and ignoring everything passes
+the "artifacts are ignored" half. Both halves together pin the actual split.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# A real, tracked, hand-written policy. Under the old `*.dl` rule this file was
+# ignored and could not even be `git add`-ed without `-f`.
+TRACKED_POLICY_FIXTURE = "tests/fixtures/policy/sample-policy.dl"
+
+# Source inputs: hand-edited, irreplaceable, must stay committable.
+SOURCE_PATHS = [
+    TRACKED_POLICY_FIXTURE,
+    "tests/fixtures/policy/relation-aliases.md",
+    "tests/fixtures/policy/typed-relations.md",
+    "docs/examples/logic-policy.dl",
+    "verinote/policy/logic-policy.dl",
+    "some/other/kb/policy/logic-policy.dl",
+    "tests/fixtures/kb/facts.sqlite",
+    "tests/fixtures/kb/sample.duckdb",
+]
+
+# Generated engine artifacts: rebuilt from the KB, must stay ignored.
+ARTIFACT_PATHS = [
+    "data/facts/query.dl",
+    "data/kb.sqlite",
+    "data/facts.duckdb",
+    "some/other/kb/facts/query.dl",
+    "some/other/kb/facts.duckdb",
+    "some/other/kb/kb.sqlite",
+    "some/other/kb/kb.sqlite-wal",
+    "some/other/kb/kb.sqlite-shm",
+]
+
+
+def _check_ignore(path: str) -> int:
+    """Exit status of `git check-ignore -q <path>`: 0 ignored, 1 not ignored."""
+    proc = subprocess.run(
+        ["git", "check-ignore", "-q", "--no-index", path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    assert proc.returncode in (0, 1), (
+        f"git check-ignore errored on {path!r}: {proc.stderr.decode()}"
+    )
+    return proc.returncode
+
+
+@pytest.mark.parametrize("path", SOURCE_PATHS)
+def test_hand_written_sources_are_not_ignored(path: str) -> None:
+    assert _check_ignore(path) == 1, (
+        f"{path} is ignored by .gitignore; hand-written policy/fixtures must be "
+        "committable. A missing policy silently falls back to the shipped default."
+    )
+
+
+@pytest.mark.parametrize("path", ARTIFACT_PATHS)
+def test_generated_kb_artifacts_stay_ignored(path: str) -> None:
+    assert _check_ignore(path) == 0, f"{path} is a generated artifact and must stay ignored"
+
+
+def test_sample_policy_fixture_is_actually_tracked() -> None:
+    """Non-vacuity guard: the fixture is committed, not just un-ignored."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", TRACKED_POLICY_FIXTURE],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, (
+        f"{TRACKED_POLICY_FIXTURE} is not tracked by git: {proc.stderr.decode()}"
+    )
+    assert (REPO_ROOT / TRACKED_POLICY_FIXTURE).is_file()
+
+
+def test_user_kb_under_data_stays_untracked() -> None:
+    """The default KB holds user data, not repo artifacts: never commit it."""
+    proc = subprocess.run(
+        ["git", "ls-files", "data/"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    )
+    assert proc.stdout.decode().strip() == "", "no file under data/ may be tracked"

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -27,10 +27,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TRACKED_POLICY_FIXTURE = "tests/fixtures/policy/sample-policy.dl"
 
 # Source inputs: hand-edited, irreplaceable, must stay committable.
+#
+# Only extensions that a plausible ignore rule could actually swallow are listed.
+# `.md` policy inputs are deliberately absent: no pattern in .gitignore has ever
+# threatened them, so asserting they stay un-ignored would pass even against the
+# pre-fix .gitignore — a decoration, not a regression lock.
 SOURCE_PATHS = [
     TRACKED_POLICY_FIXTURE,
-    "tests/fixtures/policy/relation-aliases.md",
-    "tests/fixtures/policy/typed-relations.md",
     "docs/examples/logic-policy.dl",
     "verinote/policy/logic-policy.dl",
     "some/other/kb/policy/logic-policy.dl",
@@ -39,12 +42,16 @@ SOURCE_PATHS = [
 ]
 
 # Generated engine artifacts: rebuilt from the KB, must stay ignored.
+# Both stores' sidecars are pinned: DuckDB leaves `.wal` behind on an unclean
+# shutdown and spills to `.tmp/`, mirroring SQLite's `-wal`/`-shm`.
 ARTIFACT_PATHS = [
     "data/facts/query.dl",
     "data/kb.sqlite",
     "data/facts.duckdb",
     "some/other/kb/facts/query.dl",
     "some/other/kb/facts.duckdb",
+    "some/other/kb/facts.duckdb.wal",
+    "some/other/kb/facts.duckdb.tmp/spill-0.tmp",
     "some/other/kb/kb.sqlite",
     "some/other/kb/kb.sqlite-wal",
     "some/other/kb/kb.sqlite-shm",

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,12 +1,19 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+from pathlib import Path
 
 import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.engine.terms import Compound, StringLit
 from verinote.pipeline.query import query_path
-from verinote.pipeline.verify import policy_path, verify
+from verinote.pipeline.verify import load_policy, policy_path, verify
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
+
+# A hand-written policy tracked in the repo (see tests/test_gitignore.py): a bare
+# `*.dl` ignore rule used to swallow files like this, and a policy that never
+# gets committed degrades into load_policy() -> None, i.e. a silent fall back to
+# the shipped default policy that still reports "consistent".
+SAMPLE_POLICY_FIXTURE = Path(__file__).parent / "fixtures" / "policy" / "sample-policy.dl"
 
 
 def _store(tmp_path) -> Store:
@@ -56,6 +63,27 @@ def test_verify_loads_kb_policy_file(tmp_path):
     rep = verify(s)
     assert rep.errors == 1
     assert "has_isa: Org company" in "\n".join(rep.findings)
+
+
+def test_verify_loads_hand_written_fixture_policy(tmp_path):
+    """The tracked sample policy is loaded for real, not just shipped alongside."""
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    s.add_fact("Org", "established_on", "2020", status="confirmed")
+    s.add_fact("Org", "established_on", "2021", status="confirmed")
+    p = policy_path(s)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(SAMPLE_POLICY_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    rep = verify(s)
+
+    assert load_policy(s) == SAMPLE_POLICY_FIXTURE.read_text(encoding="utf-8")
+    assert rep.ok is False
+    assert rep.errors == 1
+    # `warn_fixture_policy_loaded` exists only in the fixture: the shipped default
+    # policy cannot produce it, so this pins that the KB's own policy was used.
+    assert "WARN fixture_policy_loaded: Org" in rep.findings
+    assert "ERROR functional_conflict: Org established_on" in rep.findings
 
 
 def test_verify_loads_query_file(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -9,10 +9,13 @@ from verinote.pipeline.verify import load_policy, policy_path, verify
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
 
-# A hand-written policy tracked in the repo (see tests/test_gitignore.py): a bare
-# `*.dl` ignore rule used to swallow files like this, and a policy that never
-# gets committed degrades into load_policy() -> None, i.e. a silent fall back to
-# the shipped default policy that still reports "consistent".
+# A hand-written policy tracked in the repo (see tests/test_gitignore.py), used
+# here exactly as verinote loads a KB's own `policy/logic-policy.dl`. Such a
+# policy is authored by hand and unreproducible — a bare `*.dl` ignore rule used
+# to swallow files like this, keeping them out of git, which is how a KB owner's
+# rules get lost for good. What verify() does when the policy is *absent* is a
+# separate question (see #155); this fixture pins the other half: a policy that
+# is present is really the one that runs.
 SAMPLE_POLICY_FIXTURE = Path(__file__).parent / "fixtures" / "policy" / "sample-policy.dl"
 
 


### PR DESCRIPTION
Closes #159

## What was actually broken

The real bug is the **unanchored `*.dl` glob**. Gitignore extension globs match at *any* depth, so `*.dl` silently ignored every hand-written policy, test fixture and doc example in the tree.

That is not cosmetic. It is a compound failure: a policy that never gets committed makes `load_policy()` return `None`, verinote **falls back to the shipped default policy**, and the check still reports **"consistent"**. The gate looks green while the KB's own review rules are simply absent.

Same class of bug for `*.sqlite` / `*.duckdb`. I narrowed those too rather than deferring them: `config.py` always names the DB `kb.sqlite` and the sidecar `facts.duckdb`, so anchoring by path loses no real coverage, while the bare globs would swallow any test-fixture DB the same way `*.dl` swallowed policy. Fixing one member of the family and leaving two behind would just reopen the issue later.

Generated artifacts are now ignored by **KB-layout path**, never by bare extension:

```
**/facts/query.dl
**/facts.duckdb         (+ .wal, .tmp/)
**/kb.sqlite            (+ -wal, -shm)
```

Both stores' sidecars are pinned: DuckDB leaves a `.wal` on unclean shutdown and spills to `.tmp/`, exactly as SQLite leaves `-wal`/`-shm`. Anchored paths do not glob those in for free.

`/data/` (the user KB) stays ignored. `git ls-files 'data/'` is still empty.

## The issue's fix direction is wrong — disproved by experiment

The issue asks to "at minimum un-ignore the KB so `git clean -x` can't destroy it." **That does not work.** `git clean -x` removes *untracked* files **regardless of ignore status**; only *tracked* files survive. With the KB un-ignored but still untracked:

```
git clean -ndx  ->  Would remove data/          # still destroyed
git clean -nd   ->  Would remove data/policy/   # newly destroyed (ignore used to protect this)
```

So un-ignoring does not stop `-fdx` and it *strips* the ordinary `clean -fd` protection that ignoring was already giving. It is a **net loss against its own goal**, so I did not adopt it.

(Trap for anyone retrying this: a naive re-include like `!data/policy/logic-policy.dl` is a silent no-op — git does not descend into an excluded directory.)

A user KB is **user data, not a repo artifact**, so it cannot be committed either. **`clean -fdx` safety is therefore unreachable inside #159**; it is owned by #185 (move the default root out of the working tree). **This PR fixes the misclassification; it does not make `git clean -fdx` safe.**

## Red evidence (two distinct variants — do not conflate)

`tests/fixtures/policy/sample-policy.dl` is a real hand-written policy tracked in the repo. On main it is matched by `*.dl`, so it **cannot even be `git add`-ed without `-f`** — which is what makes the lock non-vacuous.

The suite goes red in two different ways, and the counts differ. Measured, not estimated:

**(a) revert `.gitignore` to main, keep the fixture -> 6 failed, 12 passed**

```
FAILED test_hand_written_sources_are_not_ignored[tests/fixtures/policy/sample-policy.dl]
FAILED test_hand_written_sources_are_not_ignored[docs/examples/logic-policy.dl]
FAILED test_hand_written_sources_are_not_ignored[verinote/policy/logic-policy.dl]
FAILED test_hand_written_sources_are_not_ignored[some/other/kb/policy/logic-policy.dl]
FAILED test_hand_written_sources_are_not_ignored[tests/fixtures/kb/facts.sqlite]
FAILED test_hand_written_sources_are_not_ignored[tests/fixtures/kb/sample.duckdb]
6 failed, 12 passed
```

**(b) revert `.gitignore` **and** delete the fixture -> 7 failed, 11 passed**

The 7th (`test_sample_policy_fixture_is_actually_tracked`) is the non-vacuity guard; it only goes red once the fixture itself is gone. An earlier revision of this PR body reported "7 failed" for the gitignore-only case, which mixed the two variants. Corrected above.

**(c) mutation: drop the two new DuckDB sidecar rules -> 2 failed, 16 passed**

```
FAILED test_generated_kb_artifacts_stay_ignored[some/other/kb/facts.duckdb.wal]
FAILED test_generated_kb_artifacts_stay_ignored[some/other/kb/facts.duckdb.tmp/spill-0.tmp]
2 failed, 16 passed
```

After, all variants restored: `18 passed`.

The lock asserts **both directions** via `git check-ignore`'s exit status (0 = ignored, 1 = not) — sources not-ignored *and* artifacts ignored. One direction alone would be vacuous: emptying `.gitignore` passes half of it, ignoring everything passes the other half.

The fixture is **not a dead file**: `test_verify_loads_hand_written_fixture_policy` loads it into a KB for real and asserts a `warn_fixture_policy_loaded` finding that the shipped default policy cannot produce — pinning that the KB's own policy was used, not the fallback.

## Docs

`.gitignore` and README now name what is **irreplaceable**: `kb.sqlite` (every accept/reject decision + audit log), `policy/logic-policy.dl`, and `policy/relation-aliases.md` / `policy/typed-relations.md` (hand-edited inputs the issue omitted — they don't match `*.dl` but die with `/data/` all the same). README adds: keep the KB outside the tree, backups are the user's responsibility, and the `git clean -fdx` hazard with a link to #185.

## Review round 2 — all 5 findings closed

**1. [CRITICAL] The README prescribed a command that does not exist.** `verinote init <path>` (positional) is introduced by #186; on this branch `init` takes no positional argument, so the single remedy this PR offered a user **could not be run**. Since this PR's deliverable is essentially documentation, its escape hatch being inert was the whole product failing.

Fixed to the form that works **today**, verified by running it on this branch alone (origin/main + this PR):

```
$ VERINOTE_ROOT=~/verinote-kb-smoke verinote init
initialised KB at /Users/seoyun/verinote-kb-smoke
  db: /Users/seoyun/verinote-kb-smoke/kb.sqlite
  policy: /Users/seoyun/verinote-kb-smoke/policy/logic-policy.dl
exit=0
```

No dependency on #186 is stated, so the two PRs merge in either order. Confirmed on the merged state (main + #186 + this PR): **both** `VERINOTE_ROOT=... verinote init` and `verinote init <path>` succeed, no conflict, **704 passed, 7 skipped**.

**2. [WARNING] `policy/logic-policy.dl` is scaffolded, not hand-written.** `cli.py` writes it from `DEFAULT_POLICY` at `init`, so the README table calling it "hand-written" was inaccurate. Corrected to **"scaffolded by `init`, then hand-edited"**. Also surfaced the real limitation the reviewer measured: a KB kept **inside the repo tree at a non-`data/` path** exposes its policy as untracked, so a blind `git add -A` commits it. Deliberately **documented, not ignored** — an ignore rule here would reintroduce the exact bug this PR exists to fix.

**3. [WARNING] DuckDB sidecars were missing.** `facts.duckdb.wal` and `facts.duckdb.tmp/` were not ignored while SQLite's `-wal`/`-shm` were listed — an inconsistency in a PR whose entire purpose is enumerating generated files correctly. Both added and locked in `ARTIFACT_PATHS`, with mutation red evidence above (variant c).

**4. [INFO] Two `.md` assertions were permanently vacuous.** No pattern in `.gitignore` — before or after — has ever threatened `.md`, so those two assertions pass even against the pre-fix `.gitignore`. Decoration, not a regression lock. **Removed**, with a comment recording why.

**5. [INFO] Red-evidence counts conflated two variants.** Corrected and split above.

**Scope held:** `verinote/**` diff is still **0 lines**; no file owned by #184 or #186 was touched.

## Verification

- `pytest -q` -> **688 passed, 7 skipped** (this PR alone)
- merged with #186 -> **704 passed, 7 skipped**, no conflict
- `ruff check` -> **All checks passed!**
- README's prescribed command **executed on this branch** -> exit 0 (above)
- `git check-ignore -q tests/fixtures/policy/sample-policy.dl` -> exit **1**, and it appears in `git ls-files`
- `git check-ignore -q data/facts/query.dl` -> exit **0**
- `git ls-files 'data/'` -> empty
- **Zero code change**: `git diff origin/main -- verinote/` is 0 lines


---

### Follow-up: rationale rewritten to survive #179 (`59008a1`)

Four places explained *why* the ignore rules had to change, and all four argued
from engine behaviour: a missing policy falls back to the shipped default and
the check **still reports "consistent"**. That is true today and false the moment
sibling PR #179 (issue #155) lands `PolicyMissingError` — false in the very
comments that justify this PR, with a green suite, because they are only prose.

Rewritten to argue from the loss that holds in both worlds: an ignored policy is
never `git add`-ed without `-f`, nothing in this repo can regenerate hand-written
rules, so they die with the working copy — whether verinote then shrugs (now) or
refuses to run (#155). #155 is *referenced*, never depended on, so the wording
stays true if it never merges.

| Location | Reader |
|---|---|
| `.gitignore` | why these globs are anchored |
| `tests/fixtures/policy/sample-policy.dl` | why this `.dl` is tracked |
| `tests/test_gitignore.py` | why the ignore rules are pinned, not the engine |
| `tests/test_verify.py` | why a *present* policy is the thing under test |

Comments and docstrings only: no ignore pattern, no assertion condition, and no
line under `verinote/**` changed. 688 passed, `ruff check` clean.
