### PR TITLE
docs: make Ask output evidence-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ spelling. Relation aliases are used by extraction, query planning, trust views,
 and verification query expansion so older source-language facts can still answer
 canonical English questions.
 
+## Ask Output Order
+
+The Ask tab is evidence-first. Once a question is routed, verinote shows the
+answer block immediately under its route label (`VERIFIED — engine`,
+`VERIFIED — engine (negative)`, or `UNVERIFIED — source exploration`) before
+route reasons, query details, source tables, or excerpts.
+
+Treat that first block as the evidence. Any surrounding explanation must follow
+it and stay short; do not restate, translate, or summarize the block rows before
+the user has seen them.
+
 ## License
 
 Mozilla Public License 2.0 — see [LICENSE](LICENSE). MPL-2.0 is a file-level

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1647,8 +1647,12 @@ def test_ask_post_renders_verified_engine_answer_without_persisting(
     r = c.post("/ask", data={"question": "샘플인물의 역할은 무엇인가?"})
 
     assert r.status_code == 200
-    assert "VERIFIED — engine" in r.text
-    assert "검토자" in r.text
+    body = unescape(r.text)
+    assert "VERIFIED — engine" in body
+    assert "검토자" in body
+    assert body.index("<pre>샘플인물, 역할, 검토자") < body.index(
+        "deterministic query matched confirmed/accepted facts"
+    )
     assert "Verified source facts" in r.text
     assert "sources/sample.txt" in r.text
     assert store.questions() == []
@@ -1691,9 +1695,13 @@ def test_ask_post_renders_unverified_llm_fallback(tmp_path, monkeypatch):
     r = c.post("/ask", data={"question": "Sample Entity overview"})
 
     assert r.status_code == 200
-    assert "UNVERIFIED — source exploration" in r.text
-    assert "Synthetic answer from excerpts." in r.text
-    assert "sources/sample.txt" in r.text
+    body = unescape(r.text)
+    assert "UNVERIFIED — source exploration" in body
+    assert "Synthetic answer from excerpts." in body
+    assert body.index("<pre>Synthetic answer from excerpts.</pre>") < body.index(
+        "unsupported synthetic question"
+    )
+    assert "sources/sample.txt" in body
 
 
 def test_delete_question_removes_query_file_entry(tmp_path):

--- a/verinote/web/templates/ask.html
+++ b/verinote/web/templates/ask.html
@@ -17,13 +17,13 @@
 {% if result %}
 <section class="ask-result ask-{{ result.route }}">
   <h2>{{ result.label }}</h2>
-  <p class="muted">{{ result.reason }}</p>
-  {% if result.warning %}
-  <div class="warn">{{ result.warning }}</div>
-  {% endif %}
   <div class="answer-box">
     <pre>{{ result.answer }}</pre>
   </div>
+  {% if result.warning %}
+  <div class="warn">{{ result.warning }}</div>
+  {% endif %}
+  <p class="muted">{{ result.reason }}</p>
 
   {% if result.query_dl %}
   <details>


### PR DESCRIPTION
## What changed

- Render the Ask answer block immediately under the route label before route reasons, warnings, query details, source tables, or excerpts.
- Document the Ask tab's evidence-first output order in the README.
- Add web tests that lock the verified-engine and unverified-fallback answer block ahead of the routing reason.

## Why

This ports the evidence-first output contract from semantic-reasoning/factlog#276 to verinote's Ask UI boundary. The user should see the engine or source-exploration answer block before surrounding interpretation or metadata.

## Validation

- `.venv/bin/python -m pytest tests/test_web.py -k ask -q`
- `.venv/bin/python -m pytest tests/test_ask.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`
- `git show --check HEAD`
