### PR TITLE
fix(#174): stop fact values forging ERROR/WARN lines in the engine report

### DIFF
--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -428,3 +428,113 @@ def test_duckdb_backend_rejects_policy_relation_facts():
 
     assert rep.ok is False
     assert "relation facts must come from SQLite engine input" in rep.text
+
+
+_NOTE_POLICY = (
+    ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+    ".decl error_note(subject: symbol, note: symbol)\n"
+    'error_note(S, N) :- relation(S, "note", N).\n'
+)
+_ANSWER_QUERY = (
+    ".decl answer_q1(value: symbol)\n"
+    'answer_q1(V) :- relation("Widget", "located_in", V).\n'
+)
+
+
+def _report_body(rep) -> str:
+    """The finding body, without the debug echo of the policy/query/fact input."""
+    return rep.text.split("\n\n--- policy input ---")[0]
+
+
+def test_duckdb_backend_fact_values_cannot_forge_report_lines():
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {
+                "subject": "Widget",
+                "relation": "note",
+                "object": "broken\nERROR forged: Gadget is unusable",
+            },
+            {"subject": "Gizmo", "relation": "note", "object": "missing"},
+        ],
+        policy_dl=_NOTE_POLICY,
+    )
+
+    body = _report_body(rep)
+    claimed = [
+        line
+        for line in body.splitlines()
+        if line.startswith("ERROR ") or line.startswith("WARN ")
+    ]
+    assert rep.errors == 2
+    assert len(claimed) == rep.errors + rep.warnings
+    assert len(rep.findings) == 2
+
+
+def test_duckdb_backend_escapes_control_characters_in_answers():
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {
+                "subject": "Widget",
+                "relation": "located_in",
+                "object": "alpha\nbeta\tgamma\rdelta",
+            }
+        ],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    answer = rep.answers[0]
+    assert "\n" not in answer
+    assert "\t" not in answer
+    assert "\r" not in answer
+    assert answer == "q1: alpha\\nbeta\\tgamma\\rdelta"
+
+
+def test_duckdb_backend_escaping_is_lossless():
+    _duckdb()
+    rep = run_check_duckdb(
+        [{"subject": "Widget", "relation": "located_in", "object": "alpha\nbeta"}],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    assert "alpha" in rep.answers[0]
+    assert "beta" in rep.answers[0]
+
+
+def test_duckdb_backend_keeps_literal_backslash_distinct_from_newline():
+    _duckdb()
+    literal = run_check_duckdb(
+        [{"subject": "Widget", "relation": "located_in", "object": "alpha\\nbeta"}],
+        query_dl=_ANSWER_QUERY,
+    )
+    newline = run_check_duckdb(
+        [{"subject": "Widget", "relation": "located_in", "object": "alpha\nbeta"}],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    assert "\n" not in newline.answers[0]
+    assert literal.answers[0] == "q1: alpha\\\\nbeta"
+    assert newline.answers[0] == "q1: alpha\\nbeta"
+    assert literal.answers[0] != newline.answers[0]
+
+
+def test_duckdb_backend_keeps_non_ascii_values_intact():
+    _duckdb()
+    rep = run_check_duckdb(
+        [{"subject": "Widget", "relation": "located_in", "object": "제작소 Gizmo"}],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    assert rep.answers == ["q1: 제작소 Gizmo"]
+
+
+def test_duckdb_backend_plain_string_answers_stay_unquoted():
+    _duckdb()
+    rep = run_check_duckdb(
+        [{"subject": "Widget", "relation": "located_in", "object": "Gadget Works"}],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    assert rep.answers == ["q1: Gadget Works"]
+    assert '"' not in rep.answers[0]

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -529,6 +529,42 @@ def test_duckdb_backend_escapes_control_characters_in_answers():
     assert answer == "q1: alpha\\nbeta\\tgamma\\rdelta"
 
 
+def test_duckdb_backend_keeps_meaningful_joiners_in_answers():
+    """An answer must spell the source document's text, not a mangled copy.
+
+    ZWJ/ZWNJ are required spelling in Persian and Indic scripts and hold emoji
+    sequences together. They start no line, so escaping them would only corrupt
+    the answer a user reads back. Synthetic values only.
+    """
+    _duckdb()
+    value = "Ba\u200cnu \U0001f468\u200d\U0001f469\u200d\U0001f467"
+    rep = run_check_duckdb(
+        [{"subject": "Widget", "relation": "located_in", "object": value}],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    assert rep.answers == [f"q1: {value}"]
+
+
+def test_duckdb_backend_neutralizes_bidi_overrides_in_answers():
+    """RLO forges no newline, but it reverses what the reader sees on the line."""
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {
+                "subject": "Widget",
+                "relation": "located_in",
+                "object": "safe\u202edangerous",
+            }
+        ],
+        query_dl=_ANSWER_QUERY,
+    )
+
+    answer = rep.answers[0]
+    assert "\u202e" not in answer
+    assert answer == "q1: safe\\u202edangerous"
+
+
 def test_duckdb_backend_escaping_is_lossless():
     _duckdb()
     rep = run_check_duckdb(

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -446,14 +446,46 @@ def _report_body(rep) -> str:
     return rep.text.split("\n\n--- policy input ---")[0]
 
 
-def test_duckdb_backend_fact_values_cannot_forge_report_lines():
+# `backend: DuckDB`, the counts summary, and the blank line before the findings.
+_BODY_HEADER_LINES = 3
+
+
+# Every character `str.splitlines()` treats as a line break, plus NUL and ESC.
+# A report line can only be forged by a character that starts a new line, so this
+# is the whole attack surface -- not just LF. Guarding LF alone (the old escape
+# blacklist) leaves the other eight wide open.
+_LINE_BREAKING_CHARS = [
+    "\n",  # LF
+    "\r",  # CR
+    "\x0b",  # VT
+    "\x0c",  # FF
+    "\x1c",  # FS
+    "\x1d",  # GS
+    "\x1e",  # RS
+    "\x85",  # NEL
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+]
+_NON_PRINTING_CHARS = _LINE_BREAKING_CHARS + ["\x00", "\x1b"]  # NUL, ESC
+
+
+@pytest.mark.parametrize(
+    "char", _NON_PRINTING_CHARS, ids=[f"U+{ord(c):04X}" for c in _NON_PRINTING_CHARS]
+)
+def test_duckdb_backend_fact_values_cannot_forge_report_lines(char):
+    """No fact value can add a line to the report body, whatever it contains.
+
+    This is a structural invariant, not a spot check on `\\n`: the report body
+    must hold exactly one line per finding, so the number of `ERROR `/`WARN `
+    lines can never exceed what the engine actually derived.
+    """
     _duckdb()
     rep = run_check_duckdb(
         [
             {
                 "subject": "Widget",
                 "relation": "note",
-                "object": "broken\nERROR forged: Gadget is unusable",
+                "object": f"broken{char}ERROR forged: Gadget is unusable",
             },
             {"subject": "Gizmo", "relation": "note", "object": "missing"},
         ],
@@ -469,6 +501,12 @@ def test_duckdb_backend_fact_values_cannot_forge_report_lines():
     assert rep.errors == 2
     assert len(claimed) == rep.errors + rep.warnings
     assert len(rep.findings) == 2
+    # The value cannot smuggle in a line at all: one line per finding, exactly.
+    assert len(body.splitlines()) == len(rep.findings) + _BODY_HEADER_LINES
+    # ...and the forged finding never surfaces as a line of its own, anywhere.
+    assert not any(
+        line.startswith("ERROR forged") for line in rep.text.splitlines()
+    )
 
 
 def test_duckdb_backend_escapes_control_characters_in_answers():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,6 +5,12 @@ import pytest
 
 import verinote.engine.wirelog as wl
 from verinote.engine import DEFAULT_POLICY, compile_dl, run_check, validate_query
+from verinote.engine.terms import (
+    StringLit,
+    escape_string_value,
+    parse_term,
+    render_term,
+)
 
 # A subject with two distinct objects for a functional relation is a conflict.
 _CONFLICT = compile_dl(
@@ -225,3 +231,65 @@ def test_validate_query_rejects_unsafe_variable_before_engine():
 def test_validate_query_rejects_syntax_error():
     ok, reason = validate_query("this is not datalog")
     assert ok is False and reason
+
+
+# Every character `str.splitlines()` breaks on, plus NUL and ESC. The legacy
+# wirelog renderer feeds the same `CheckReport.text`/`.answers` shape as the
+# DuckDB backend, so it has to neutralize the same characters -- otherwise the
+# next person copies the unescaped path.
+_NON_PRINTING_CHARS = [
+    "\n", "\r", "\x0b", "\x0c", "\x1c", "\x1d", "\x1e", "\x85",
+    " ", " ", "\x00", "\x1b",
+]
+
+
+@pytest.mark.parametrize(
+    "char", _NON_PRINTING_CHARS, ids=[f"U+{ord(c):04X}" for c in _NON_PRINTING_CHARS]
+)
+def test_wirelog_row_render_cannot_forge_report_lines(char):
+    """A derived tuple's value cannot open a new line in the legacy report body."""
+    row = (f"broken{char}ERROR forged: Gadget is unusable", "Widget")
+
+    rendered = wl._render_row(row)
+
+    assert len(rendered.splitlines()) == 1
+    assert char not in rendered
+    assert not rendered.startswith("ERROR forged")
+
+
+def test_wirelog_row_render_keeps_printable_values_intact():
+    assert wl._render_row(("Widget", 2020, "Kim Chulsoo")) == "Widget 2020 Kim Chulsoo"
+
+
+@pytest.mark.parametrize("char", _NON_PRINTING_CHARS, ids=[f"U+{ord(c):04X}" for c in _NON_PRINTING_CHARS])
+def test_escaped_string_terms_roundtrip_through_the_parser(char):
+    """Escaping stays lossless: what we render, we can read back unchanged."""
+    term = StringLit(f"broken{char}ERROR forged")
+
+    rendered = render_term(term)
+
+    assert len(rendered.splitlines()) == 1
+    assert parse_term(rendered) == term
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "London",
+        "Kim Chulsoo",
+        "김철수",
+        "Ada Lovelace",
+        "café-naïve",
+        "東京",
+        "Ωμέγα",
+        "emoji 🚀 ok",
+    ],
+)
+def test_printable_values_render_byte_identically(value):
+    """Widening the escape set must not touch ordinary text in any language.
+
+    Cc/Cf/Zl/Zp contains no letter, mark, digit, punctuation or symbol, so every
+    printable string renders exactly as before: quoted, and otherwise verbatim.
+    """
+    assert render_term(StringLit(value)) == f'"{value}"'
+    assert escape_string_value(value) == value

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,6 +7,7 @@ import verinote.engine.wirelog as wl
 from verinote.engine import DEFAULT_POLICY, compile_dl, run_check, validate_query
 from verinote.engine.terms import (
     StringLit,
+    TermParseError,
     escape_string_value,
     parse_term,
     render_term,
@@ -288,8 +289,120 @@ def test_escaped_string_terms_roundtrip_through_the_parser(char):
 def test_printable_values_render_byte_identically(value):
     """Widening the escape set must not touch ordinary text in any language.
 
-    Cc/Cf/Zl/Zp contains no letter, mark, digit, punctuation or symbol, so every
+    Cc/Zl/Zp contains no letter, mark, digit, punctuation or symbol, so every
     printable string renders exactly as before: quoted, and otherwise verbatim.
     """
     assert render_term(StringLit(value)) == f'"{value}"'
     assert escape_string_value(value) == value
+
+
+# The escape set is justified by exactly one threat: a value that starts a new
+# line forges a report finding. So it has to cover every code point Python
+# treats as a line break -- and nothing else may be sacrificed for that.
+_SPLITTING_CODE_POINTS = frozenset(
+    {0x0A, 0x0B, 0x0C, 0x0D, 0x1C, 0x1D, 0x1E, 0x85, 0x2028, 0x2029}
+)
+
+
+def test_escape_set_covers_every_line_breaking_code_point():
+    """Exhaustive proof, not a spot check: scan the whole of Unicode.
+
+    If a future edit narrows the escape set past what `str.splitlines()` breaks
+    on, a fact value can forge a report line again. This pins the coverage over
+    all 0x110000 code points rather than the handful we happened to think of.
+    """
+    splitting = {
+        cp for cp in range(0x110000) if len(f"a{chr(cp)}b".splitlines()) > 1
+    }
+
+    assert splitting == _SPLITTING_CODE_POINTS
+
+    unescaped = sorted(cp for cp in splitting if escape_string_value(chr(cp)) == chr(cp))
+    assert unescaped == []
+    for cp in splitting:
+        assert len(escape_string_value(f"a{chr(cp)}b").splitlines()) == 1
+
+
+# Written as code points on purpose: these characters are invisible in a source
+# file. U+202A..U+202E are the embeddings/overrides, U+2066..U+2069 the isolates.
+_BIDI_CONTROLS = [chr(cp) for cp in list(range(0x202A, 0x202F)) + list(range(0x2066, 0x206A))]
+
+
+@pytest.mark.parametrize(
+    "char", _BIDI_CONTROLS, ids=[f"U+{ord(c):04X}" for c in _BIDI_CONTROLS]
+)
+def test_bidi_controls_are_escaped(char):
+    """Bidi overrides break no line, but they reverse what the reader sees.
+
+    A report is a trust artifact: a value must not be able to reorder the text
+    of the line it sits on into a claim the engine never derived.
+    """
+    value = f"safe{char}dangerous"
+
+    escaped = escape_string_value(value)
+
+    assert char not in escaped
+    assert escaped == f"safe\\u{ord(char):04x}dangerous"
+    assert parse_term(render_term(StringLit(value))) == StringLit(value)
+
+
+# Zero-width joiners are not decoration: they are required spelling in Persian
+# and Indic scripts and they hold emoji sequences together. Escaping them (as
+# a blanket Cf rule would) corrupts the source document's spelling, which the
+# subject/object rendering promises to preserve. Synthetic samples only.
+@pytest.mark.parametrize(
+    "value",
+    [
+        # ZWJ/ZWNJ/soft hyphen spelled as escapes: they are invisible in source.
+        pytest.param(
+            "\U0001f468\u200d\U0001f469\u200d\U0001f467", id="emoji-family-ZWJ"
+        ),
+        pytest.param("\U0001f9d1\u200d\U0001f4bb", id="emoji-technologist-ZWJ"),
+        pytest.param("می\u200cخواهم", id="persian-ZWNJ"),
+        pytest.param("क\u200dष", id="devanagari-ZWJ"),
+        pytest.param("क\u200cष", id="devanagari-ZWNJ"),
+        pytest.param("co\u00adop", id="soft-hyphen"),
+    ],
+)
+def test_meaningful_format_characters_survive_rendering(value):
+    """ZWJ/ZWNJ/soft hyphen render verbatim: they cannot forge a line."""
+    assert escape_string_value(value) == value
+    assert render_term(StringLit(value)) == f'"{value}"'
+    assert len(escape_string_value(value).splitlines()) <= 1
+    assert parse_term(render_term(StringLit(value))) == StringLit(value)
+
+
+# `\u`/`\U` escapes are new in the parser, and the reader is the only thing
+# standing between a malformed escape and a lone surrogate reaching UTF-8
+# encoding or a DB insert. Callers only catch TermParseError, so every one of
+# these has to fail as a parse error -- not as a bare ValueError from `chr()`.
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param(r'"\ud800"', id="lone-high-surrogate"),
+        pytest.param(r'"\udfff"', id="lone-low-surrogate"),
+        pytest.param(r'"\u12"', id="too-few-hex-digits"),
+        pytest.param(r'"\u"', id="no-hex-digits"),
+        pytest.param(r'"\uzzzz"', id="non-hex-digits"),
+        pytest.param(r'"\U00110000"', id="above-max-code-point"),
+        pytest.param(r'"\U0011FFFF"', id="far-above-max-code-point"),
+    ],
+)
+def test_parser_rejects_invalid_unicode_escapes(text):
+    with pytest.raises(TermParseError):
+        parse_term(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param(r'"\u0041"', "A", id="bmp-escape"),
+        pytest.param(r'"\u0041FF"', "AFF", id="exactly-four-digits-consumed"),
+        pytest.param(r'"\U0001f600"', "\U0001f600", id="astral-escape"),
+        pytest.param(r'"\U0010FFFF"', "\U0010ffff", id="max-code-point"),
+        pytest.param(r'"\u200d"', "\u200d", id="zwj-escape-reads-back"),
+    ],
+)
+def test_parser_accepts_valid_unicode_escapes(text, expected):
+    """Rendering escapes only stays lossless if the reader accepts them back."""
+    assert parse_term(text) == StringLit(expected)

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -25,7 +25,16 @@ from verinote.engine.duckdb_terms import (
     duckdb_value_to_term,
     term_to_duckdb_value,
 )
-from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Term, Var, render_term
+from verinote.engine.terms import (
+    Atom,
+    Compound,
+    NumberLit,
+    StringLit,
+    Term,
+    Var,
+    escape_string_value,
+    render_term,
+)
 from verinote.engine.wirelog import CheckReport, DEFAULT_POLICY, NO_FINDINGS_TEXT
 
 _ERROR_PREFIX = "error_"
@@ -431,8 +440,14 @@ def _render_row(row: tuple[object, ...]) -> str:
 
 
 def _render_output_term(term: Term) -> str:
+    """Render a value for a report line.
+
+    String values keep their bare (unquoted) surface, but control characters are
+    escaped: an unescaped newline in a fact value would otherwise let that value
+    forge extra `ERROR `/`WARN ` lines in the report body.
+    """
     if isinstance(term, StringLit):
-        return term.value
+        return escape_string_value(term.value)
     return render_term(term)
 
 

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -32,9 +32,26 @@ _SHORT_ESCAPES = {
     "\r": "\\r",
     "\t": "\\t",
 }
-# Unicode general categories that never render as visible text: controls,
-# format characters, and line/paragraph separators. See `escape_string_value`.
-_ESCAPED_CATEGORIES = frozenset({"Cc", "Cf", "Zl", "Zp"})
+# Unicode general categories that cannot render as visible text and are exactly
+# what starts a new line: controls (Cc), line separators (Zl) and paragraph
+# separators (Zp). See `escape_string_value`.
+_ESCAPED_CATEGORIES = frozenset({"Cc", "Zl", "Zp"})
+# Explicit bidi controls (a subset of Cf). They do not break lines, but they
+# reorder the visual run around them, so a value can make a report line read as
+# something the engine never derived. Neutralized for the same reason.
+_ESCAPED_CODEPOINTS = frozenset(
+    {
+        0x202A,  # LEFT-TO-RIGHT EMBEDDING
+        0x202B,  # RIGHT-TO-LEFT EMBEDDING
+        0x202C,  # POP DIRECTIONAL FORMATTING
+        0x202D,  # LEFT-TO-RIGHT OVERRIDE
+        0x202E,  # RIGHT-TO-LEFT OVERRIDE
+        0x2066,  # LEFT-TO-RIGHT ISOLATE
+        0x2067,  # RIGHT-TO-LEFT ISOLATE
+        0x2068,  # FIRST STRONG ISOLATE
+        0x2069,  # POP DIRECTIONAL ISOLATE
+    }
+)
 _HEX_RE = re.compile(r"[0-9A-Fa-f]+\Z")
 
 
@@ -137,22 +154,33 @@ def canonical_term_key(term: Term) -> str:
 
 
 def escape_string_value(value: str) -> str:
-    """Escape backslashes and every non-printing character in a string value.
+    """Escape backslashes, line-breaking characters and bidi controls.
 
     This is the single owner of the "how do we neutralize control characters in
     a string value" question. Quoted rendering (`render_term`) and unquoted
     report rendering both build on it, so the two paths cannot drift apart.
 
-    The rule is a whitelist, not a blacklist: anything whose Unicode general
-    category is a control (Cc), a format character (Cf), a line separator (Zl),
-    or a paragraph separator (Zp) is escaped. Enumerating "the dangerous
+    The line-forging rule is a category whitelist, not a blacklist: anything
+    whose Unicode general category is a control (Cc), a line separator (Zl), or
+    a paragraph separator (Zp) is escaped. Enumerating "the dangerous
     characters" does not work here, because `str.splitlines()` breaks on far
     more than LF/CR -- VT, FF, FS, GS, RS, NEL, U+2028 and U+2029 all start a
     new line, so a blacklist that stops at `\\n`/`\\r` still lets a fact value
-    forge a report line. Cc/Cf/Zl/Zp is a superset of everything `splitlines()`
-    splits on, and it also covers NUL, ESC, and the invisible bidi/tag
-    characters. Printable text of any language (`Ada`, `Kim`) has none of those
-    categories, so it renders unchanged.
+    forge a report line. Cc/Zl/Zp is a superset of everything `splitlines()`
+    splits on (a full 0..0x10FFFF scan is pinned in the tests), and it also
+    covers NUL and ESC.
+
+    On top of that, the nine explicit bidi controls in `_ESCAPED_CODEPOINTS`
+    are escaped. They break no line, but they reverse the visual order of the
+    text around them, so a value could make a report line read as a claim the
+    engine never derived.
+
+    The escape set stops there, and deliberately does not take all of Cf: ZWJ
+    (U+200D), ZWNJ (U+200C) and soft hyphen carry meaning in ordinary text --
+    they join emoji sequences and are required spelling in Persian and Indic
+    scripts. Escaping them would corrupt the source document's spelling, which
+    the subject/object rendering promises to preserve, and they cannot forge a
+    line anyway.
 
     Backslash is handled first: without escaping it, a literal backslash-n in
     the value would be indistinguishable from a real newline after escaping.
@@ -162,7 +190,10 @@ def escape_string_value(value: str) -> str:
         short = _SHORT_ESCAPES.get(ch)
         if short is not None:
             out.append(short)
-        elif unicodedata.category(ch) in _ESCAPED_CATEGORIES:
+        elif (
+            unicodedata.category(ch) in _ESCAPED_CATEGORIES
+            or ord(ch) in _ESCAPED_CODEPOINTS
+        ):
             out.append(_unicode_escape(ch))
         else:
             out.append(ch)

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -122,14 +122,25 @@ def canonical_term_key(term: Term) -> str:
     raise TypeError(f"not a term: {term!r}")
 
 
-def _render_string(value: str) -> str:
-    escaped = (
+def escape_string_value(value: str) -> str:
+    """Escape backslashes and control characters inside a string value.
+
+    This is the single owner of the "how do we neutralize control characters in
+    a string value" question. Quoted rendering (`render_term`) and unquoted
+    report rendering both build on it, so the two paths cannot drift apart. The
+    backslash escape has to come first: without it a literal backslash-n in the
+    value would be indistinguishable from a real newline after escaping.
+    """
+    return (
         value.replace("\\", "\\\\")
-        .replace('"', '\\"')
         .replace("\n", "\\n")
         .replace("\r", "\\r")
         .replace("\t", "\\t")
     )
+
+
+def _render_string(value: str) -> str:
+    escaped = escape_string_value(value).replace('"', '\\"')
     return f'"{escaped}"'
 
 

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -17,11 +17,25 @@ keeps numeric equality unambiguous until a later issue defines float semantics.
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from typing import TypeAlias
 
 _VAR_RE = re.compile(r"[A-Z][A-Za-z0-9_]*\Z")
 _ATOM_RE = re.compile(r"[a-z_][A-Za-z0-9_]*\Z")
+
+# Readable short forms for the control characters that appear in real text.
+# Everything else non-printing falls back to a numeric \uXXXX/\UXXXXXXXX escape.
+_SHORT_ESCAPES = {
+    "\\": "\\\\",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+# Unicode general categories that never render as visible text: controls,
+# format characters, and line/paragraph separators. See `escape_string_value`.
+_ESCAPED_CATEGORIES = frozenset({"Cc", "Cf", "Zl", "Zp"})
+_HEX_RE = re.compile(r"[0-9A-Fa-f]+\Z")
 
 
 class TermParseError(ValueError):
@@ -123,20 +137,43 @@ def canonical_term_key(term: Term) -> str:
 
 
 def escape_string_value(value: str) -> str:
-    """Escape backslashes and control characters inside a string value.
+    """Escape backslashes and every non-printing character in a string value.
 
     This is the single owner of the "how do we neutralize control characters in
     a string value" question. Quoted rendering (`render_term`) and unquoted
-    report rendering both build on it, so the two paths cannot drift apart. The
-    backslash escape has to come first: without it a literal backslash-n in the
-    value would be indistinguishable from a real newline after escaping.
+    report rendering both build on it, so the two paths cannot drift apart.
+
+    The rule is a whitelist, not a blacklist: anything whose Unicode general
+    category is a control (Cc), a format character (Cf), a line separator (Zl),
+    or a paragraph separator (Zp) is escaped. Enumerating "the dangerous
+    characters" does not work here, because `str.splitlines()` breaks on far
+    more than LF/CR -- VT, FF, FS, GS, RS, NEL, U+2028 and U+2029 all start a
+    new line, so a blacklist that stops at `\\n`/`\\r` still lets a fact value
+    forge a report line. Cc/Cf/Zl/Zp is a superset of everything `splitlines()`
+    splits on, and it also covers NUL, ESC, and the invisible bidi/tag
+    characters. Printable text of any language (`Ada`, `Kim`) has none of those
+    categories, so it renders unchanged.
+
+    Backslash is handled first: without escaping it, a literal backslash-n in
+    the value would be indistinguishable from a real newline after escaping.
     """
-    return (
-        value.replace("\\", "\\\\")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-    )
+    out: list[str] = []
+    for ch in value:
+        short = _SHORT_ESCAPES.get(ch)
+        if short is not None:
+            out.append(short)
+        elif unicodedata.category(ch) in _ESCAPED_CATEGORIES:
+            out.append(_unicode_escape(ch))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _unicode_escape(ch: str) -> str:
+    code = ord(ch)
+    if code <= 0xFFFF:
+        return f"\\u{code:04x}"
+    return f"\\U{code:08x}"
 
 
 def _render_string(value: str) -> str:
@@ -214,11 +251,26 @@ class _Parser:
                     chars.append("\r")
                 elif esc == "t":
                     chars.append("\t")
+                elif esc == "u":
+                    chars.append(self.parse_unicode_escape(4))
+                elif esc == "U":
+                    chars.append(self.parse_unicode_escape(8))
                 else:
                     raise self.error(f"unsupported escape \\{esc}")
             else:
                 chars.append(ch)
         raise self.error("unterminated string")
+
+    def parse_unicode_escape(self, width: int) -> str:
+        """Read the `width` hex digits of a \\uXXXX / \\UXXXXXXXX escape."""
+        digits = self.text[self.pos : self.pos + width]
+        if len(digits) < width or not _HEX_RE.fullmatch(digits):
+            raise self.error(f"expected {width} hex digits in unicode escape")
+        code = int(digits, 16)
+        if code > 0x10FFFF or 0xD800 <= code <= 0xDFFF:
+            raise self.error("unicode escape is not a valid code point")
+        self.pos += width
+        return chr(code)
 
     def parse_number(self) -> NumberLit:
         start = self.pos

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -29,6 +29,7 @@ from verinote.engine.datalog import (
     Program,
     parse_and_validate_program,
 )
+from verinote.engine.terms import escape_string_value
 
 # Datalog string literals: escape embedded quotes/backslashes.
 _ESCAPE = re.compile(r'(["\\])')
@@ -222,6 +223,18 @@ def _validate_query_contract(program: Program) -> None:
                 )
 
 
+def _render_row(row: Iterable[object]) -> str:
+    """Render one derived tuple into a report line body.
+
+    Values go through `escape_string_value` for the same reason the DuckDB
+    backend does it: an unescaped line break inside a value would let that value
+    forge extra `ERROR `/`WARN ` lines in the report body. Escaping has exactly
+    one owner (`verinote.engine.terms`), so this legacy path cannot drift away
+    from the production one.
+    """
+    return " ".join(escape_string_value(str(value)) for value in row)
+
+
 def run_check(
     dl_text: str, *, policy_dl: str | None = None, query_dl: str | None = None
 ) -> CheckReport:
@@ -263,12 +276,12 @@ def run_check(
         if mult <= 0:
             continue
         if name.startswith(_ERROR_PREFIX):
-            errors.append(f"{name[len(_ERROR_PREFIX) :]}: {' '.join(map(str, row))}")
+            errors.append(f"{name[len(_ERROR_PREFIX) :]}: {_render_row(row)}")
         elif name.startswith(_WARN_PREFIX):
-            warnings.append(f"{name[len(_WARN_PREFIX) :]}: {' '.join(map(str, row))}")
+            warnings.append(f"{name[len(_WARN_PREFIX) :]}: {_render_row(row)}")
         elif name.startswith(_ANSWER_PREFIX):
             qid = name[len(_ANSWER_PREFIX) :]
-            answers_by_q.setdefault(qid, []).append(" ".join(map(str, row)))
+            answers_by_q.setdefault(qid, []).append(_render_row(row))
 
     errors.sort()
     warnings.sort()


### PR DESCRIPTION
Closes #174

## Problem

A fact value could forge a line in the engine report. Escaping `\n`/`\r` alone is not enough: `str.splitlines()` also breaks on VT, FF, FS, GS, RS, NEL, U+2028 and U+2029, so a value like `broken<VT>ERROR forged: ...` still produced an extra `ERROR ` line the engine never derived.

## Fix

`escape_string_value` in `verinote/engine/terms.py` is now the single owner of neutralization, used by both the DuckDB backend and the legacy wirelog renderer, so the two paths cannot drift apart. It escapes:

- **Cc / Zl / Zp** — a category whitelist, not a blacklist. Proven by an exhaustive 0..0x10FFFF scan to be a superset of every code point `str.splitlines()` breaks on (`{0a,0b,0c,0d,1c,1d,1e,85,2028,2029}` — all of them Cc/Zl/Zp). Also covers NUL and ESC.
- **the nine bidi controls** (U+202A–202E, U+2066–2069). They break no line, but they reverse the visual order of the text around them, so a value could make a report line *read* as a claim the engine never derived. A report is a trust artifact, so these are neutralized too.

Nothing else. In particular **all other `Cf` characters are preserved**: ZWJ (U+200D), ZWNJ (U+200C) and soft hyphen carry meaning — they join emoji sequences and are required spelling in Persian and Indic scripts. An earlier revision of this branch escaped the whole `Cf` category, which corrupted `👨‍👩‍👧`, Persian `می‌خواهم` and Devanagari `क‍ष`. That violated the README promise that "Subjects and objects preserve the source document's language and named-entity spelling", and it was never needed for #174 — those characters cannot start a line. Fixed, and pinned with tests.

Option C is kept: report values are **not** quoted (an answer surface stays `London`, not `"London"`).

## Behavior change worth calling out

The term parser now **accepts `\uXXXX` / `\UXXXXXXXX` escapes** in quoted strings. This is required for the fix to be lossless: what we render, we must be able to read back (round-trip verified over all of Unicode, 0 failures). It is a change beyond the strict scope of #174, so, explicitly:

- **Backward compatible**: existing `.dl`/`.json`/`.md` data contains 0 literal `\u` sequences, so nothing that parsed before parses differently now.
- **Not a new capability**: raw control characters could already be placed in a quoted string before this PR. Display paths all route through the escape, and the one raw consumer (`web/app.py:314`) is a Jinja-autoescaped input attribute.
- Malformed escapes are rejected as `TermParseError` (not a bare `ValueError` from `chr()`, which callers' `except TermParseError` would not catch): lone surrogates, short/non-hex digit runs, and code points above U+10FFFF.

## Evidence

- **Suite**: `781 passed, 7 skipped`. `ruff check` — all checks passed. **0 existing test expectations modified** (the only non-addition line in the test diff is a docstring).
- **Threat model re-verified after narrowing** (0x110000 exhaustive scan): `splitlines()` split set = `{0a,0b,0c,0d,1c,1d,1e,85,2028,2029}`, categories `{Cc, Zl, Zp}`, characters left unescaped: **none**; none of them renders as more than one line. The 12 forging characters (LF CR VT FF FS GS RS NEL U+2028 U+2029 NUL ESC) are blocked in **both** the DuckDB backend and the wirelog renderer.
- **Precision**: byte-identical over all of Unicode = **1,111,987** code points; escaped = 77. Everything escaped beyond Cc/Zl/Zp is exactly the nine bidi controls — nothing else is touched. Round-trip over every code point: 0 failures.
- **Mutation (each reverted change goes red)**:
  - restore the `Cc/Cf/Zl/Zp` blanket → **7 failed** (ZWJ/ZWNJ/emoji/soft-hyphen preservation)
  - drop the bidi code points → **10 failed**
  - delete the surrogate/range guard in `parse_unicode_escape` → **4 failed**
  - back to the old LF/CR/TAB blacklist → **37 failed**

Correcting figures reported earlier on this branch: the whitelist-vs-blacklist mutation is **26 red**, not 8, and byte-identity under the previous (over-broad) escape set was 1,111,826 — now 1,111,987 with the joiners preserved.
