### PR TITLE
fix(#168): enforce the fact schema types in parse_facts instead of coercing with str()

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -514,3 +514,89 @@ def test_parse_facts_skips_malformed_items_when_valid_facts_remain():
     assert [(fact.subject, fact.relation, fact.object) for fact in facts] == [
         ("Ada", "is_a", "mathematician")
     ]
+
+
+def _widget_fact(**overrides):
+    fact = {
+        "subject": "Widget",
+        "relation": "made_by",
+        "object": "Gadget",
+        "confidence": 0.9,
+        "note": "",
+    }
+    fact.update(overrides)
+    return fact
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # The repros as filed: an off-schema JSON type in a bare slot.
+        {"subject": ["Widget", "Alpha"]},
+        {"object": {"city": "Gadgetville"}},
+        {"subject": None},
+        {"subject": "   "},
+        # The same off-schema types smuggled through the {kind,value} branch,
+        # which str() used to coerce into plausible-looking review-queue text.
+        {"subject": {"kind": "string", "value": ["Widget", "Alpha"]}},
+        {"subject": {"kind": "string", "value": None}},
+        {"subject": {"kind": "string", "value": "   "}},
+        {"object": {"kind": "string", "value": {"city": "Gadgetville"}}},
+        {"object": {"kind": "term", "value": {"functor": "maker"}}},
+        {"relation": {"kind": ["string"], "value": "made_by"}},
+        # `note` is declared {"type": "string"}.
+        {"note": ["off", "schema"]},
+        # `confidence` is declared {"type": "number", "minimum": 0, "maximum": 1}.
+        {"confidence": True},
+        {"confidence": 90},
+        {"confidence": -1},
+    ],
+)
+def test_parse_facts_rejects_off_schema_slot_types_instead_of_coercing(overrides):
+    """The declared schema types every slot as a string; str() coercion would let
+    lists/objects/null reach the review queue as text like "['Widget', 'Alpha']"."""
+    with pytest.raises(LLMError):
+        parse_facts({"facts": [_widget_fact(**overrides)]})
+
+
+def test_parse_facts_still_accepts_plain_string_slots():
+    fact = parse_facts({"facts": [_widget_fact()]})[0]
+
+    assert (fact.subject, fact.relation, fact.object) == ("Widget", "made_by", "Gadget")
+    assert fact.subject_kind == fact.relation_kind == fact.object_kind == "string"
+    assert fact.confidence == 0.9
+
+
+def test_parse_facts_still_accepts_explicit_ground_term_slots():
+    """Fact-storage boundary: a structural fact is only a term when the model says
+    so with {"kind": "term"}. Enforcing slot types must not break that path."""
+    fact = parse_facts(
+        {"facts": [_widget_fact(object={"kind": "term", "value": "maker(gadget)"})]}
+    )[0]
+
+    assert fact.object == "maker(gadget)"
+    assert fact.object_kind == "term"
+    assert fact.note == ""
+
+
+def test_parse_facts_keeps_plain_functor_text_as_a_string_literal():
+    """A bare "maker(gadget)" string is a StringLit, never reinterpreted as a compound."""
+    fact = parse_facts({"facts": [_widget_fact(object="maker(gadget)")]})[0]
+
+    assert fact.object == "maker(gadget)"
+    assert fact.object_kind == "string"
+
+
+@pytest.mark.parametrize("note", [None, "seen in the spec"])
+def test_parse_facts_accepts_missing_or_null_note(note):
+    payload = _widget_fact()
+    if note is None:
+        payload.pop("note")
+    else:
+        payload["note"] = note
+
+    assert parse_facts({"facts": [payload]})[0].note == (note or "")
+
+
+def test_parse_facts_tolerates_numeric_string_confidence_from_prompt_only_providers():
+    assert parse_facts({"facts": [_widget_fact(confidence="0.75")]})[0].confidence == 0.75

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -489,14 +489,15 @@ def test_parse_facts_rejects_malformed_explicit_slots(slot):
         )
 
 
-def test_parse_facts_skips_malformed_items_when_valid_facts_remain():
+def test_parse_facts_accepts_batch_of_only_valid_facts():
+    """A batch with no schema violations is parsed in full -- nothing raises."""
     facts = parse_facts(
         {
             "facts": [
                 {
                     "subject": "Ada",
-                    "relation": "",
-                    "object": "mathematician",
+                    "relation": "wrote",
+                    "object": "notes",
                     "confidence": 0.9,
                     "note": "",
                 },
@@ -512,8 +513,66 @@ def test_parse_facts_skips_malformed_items_when_valid_facts_remain():
     )
 
     assert [(fact.subject, fact.relation, fact.object) for fact in facts] == [
-        ("Ada", "is_a", "mathematician")
+        ("Ada", "wrote", "notes"),
+        ("Ada", "is_a", "mathematician"),
     ]
+
+
+def test_parse_facts_raises_when_valid_and_malformed_are_mixed():
+    """A violation next to valid facts must fail the whole batch, not drop.
+
+    Dropping the off-schema item while returning the valid one would report the
+    chunk as a success with the violating fact silently gone. `base.py` promises
+    `LLMError` on any schema violation so the caller can retry deterministically
+    (issue #168), so the mixed batch raises rather than smuggling a partial
+    result past the retry path.
+    """
+    with pytest.raises(LLMError):
+        parse_facts(
+            {
+                "facts": [
+                    {
+                        "subject": "Ada",
+                        "relation": "is_a",
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    },
+                    {
+                        "subject": "Ada",
+                        "relation": "",  # empty slot is a schema violation
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    },
+                ]
+            }
+        )
+
+
+def test_parse_facts_raises_when_every_item_is_malformed():
+    """A batch of only violations also fails loudly."""
+    with pytest.raises(LLMError):
+        parse_facts(
+            {
+                "facts": [
+                    {
+                        "subject": "",
+                        "relation": "is_a",
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    },
+                    {
+                        "subject": "Ada",
+                        "relation": "",
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    },
+                ]
+            }
+        )
 
 
 def _widget_fact(**overrides):

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -138,7 +138,6 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
         raise LLMError(f"extractor output did not match schema: {exc}") from exc
 
     facts: list[ExtractedFact] = []
-    errors = []
     for item in items:
         try:
             subject, subject_kind, subject_warning = _parse_fact_slot(item, "subject")
@@ -161,10 +160,14 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
                 )
             )
         except (KeyError, TypeError, ValueError, TermParseError) as exc:
-            errors.append(f"malformed fact object {item!r}: {exc}")
-            continue
-    if not facts and errors:
-        raise LLMError(errors[0])
+            # A single off-schema item fails the whole batch loudly: `base.py`
+            # promises `LLMError` on any schema violation "so the caller can
+            # retry deterministically", and `extract.py` only re-runs a chunk
+            # when it sees that error. Dropping the bad item while keeping the
+            # valid ones would report the chunk as a success with the violating
+            # fact silently gone -- exactly the smuggled-off-schema failure this
+            # parser exists to make loud (issue #168).
+            raise LLMError(f"malformed fact object {item!r}: {exc}") from exc
     return facts
 
 

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -144,7 +144,7 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
             subject, subject_kind, subject_warning = _parse_fact_slot(item, "subject")
             relation, relation_kind, relation_warning = _parse_fact_slot(item, "relation")
             obj, object_kind, object_warning = _parse_fact_slot(item, "object")
-            note = str(item.get("note", "")).strip()
+            note = _parse_fact_note(item)
             warnings = [w for w in (subject_warning, relation_warning, object_warning) if w]
             if warnings:
                 note = "; ".join([part for part in (note, *warnings) if part])
@@ -153,7 +153,7 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
                     subject=subject,
                     relation=relation,
                     object=obj,
-                    confidence=float(item["confidence"]),
+                    confidence=_parse_fact_confidence(item["confidence"]),
                     note=note,
                     subject_kind=subject_kind,
                     relation_kind=relation_kind,
@@ -194,14 +194,51 @@ def _decode_first_json(raw: str) -> Any:
         return decoder.raw_decode(text[min(starts):])[0]
 
 
+def _parse_fact_note(item: dict[str, Any]) -> str:
+    """`note` is declared `{"type": "string"}`; a missing/null note means "no note"."""
+    raw = item.get("note")
+    if raw is None:
+        return ""
+    return _require_schema_string(raw, "note")
+
+
+def _parse_fact_confidence(raw: Any) -> float:
+    """`confidence` is declared `{"type": "number", "minimum": 0, "maximum": 1}`.
+
+    Numeric strings stay tolerated -- prompt-only providers emit `"0.9"` often
+    enough -- but booleans and out-of-range values are schema violations, not
+    facts to be scored. `float(True)` would otherwise land as confidence 1.0.
+    """
+    if isinstance(raw, bool):
+        raise TypeError("confidence must be a number, got bool")
+    value = float(raw)
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"confidence must be between 0 and 1, got {value}")
+    return value
+
+
+def _require_schema_string(raw: Any, label: str) -> str:
+    """Enforce the `{"type": "string"}` the slot schema declares.
+
+    Coercing with `str()` instead would smuggle off-schema JSON (lists, objects,
+    null) into the review queue as plausible-looking text -- `["Widget", "Alpha"]`
+    would be stored as the literal `"['Widget', 'Alpha']"`, and `null` as `"None"`.
+    """
+    if not isinstance(raw, str):
+        raise TypeError(f"{label} must be a string, got {type(raw).__name__}")
+    return raw.strip()
+
+
 def _parse_fact_slot(item: dict[str, Any], field: str) -> tuple[str, str, str]:
     raw = item[field]
     if isinstance(raw, str):
+        # Prompt-only providers routinely emit a bare string for a plain slot;
+        # per the fact-storage boundary that is a StringLit, never a compound.
         value = raw.strip()
         kind = "string"
     elif isinstance(raw, dict):
-        kind = str(raw["kind"]).strip()
-        value = str(raw["value"]).strip()
+        kind = _require_schema_string(raw["kind"], f"{field}.kind")
+        value = _require_schema_string(raw["value"], f"{field}.value")
     else:
         raise TypeError(f"{field} must be a string or {{kind,value}} object")
     if kind not in {"string", "term"}:


### PR DESCRIPTION
Closes #168

## The issue was closed early — the repros still reproduce

#168 was closed as fixed after checking the three repro payloads as **bare** slots. Those do raise
`LLMError`, but only incidentally: a bare `{"subject": [...]}` has no `kind` key, so it dies on a
`raw["kind"]` KeyError. The `str()` coercion the issue is named after was still there, one branch over:

```python
elif isinstance(raw, dict):
    kind  = str(raw["kind"]).strip()
    value = str(raw["value"]).strip()   # <- off-schema JSON coerced to text
```

So wrapping the same off-schema value in a well-formed slot object walked straight past the parser
and into the review queue as plausible-looking text, with no warning note:

| payload | accepted on `main` as |
| --- | --- |
| `{"subject": {"kind":"string","value":["Widget","Alpha"]}}` | `subject = "['Widget', 'Alpha']"` |
| `{"subject": {"kind":"string","value":null}}` | `subject = "None"` |
| `{"object": {"kind":"string","value":{"city":"Gadgetville"}}}` | `object = "{'city': 'Gadgetville'}"` |

That is exactly the filed symptom. `FACT_SLOT_SCHEMA` declares `value` as
`{"type": "string", "minLength": 1}`; the parser enforced neither.

## Change

`parse_facts` now enforces the schema it declares, and raises `LLMError` on violation as
`llm/base.py` already promises:

- **slots** — `kind` and `value` must be strings (no `str()` coercion); lists, objects and `null`
  are violations. Non-empty is enforced after `strip()`.
- **`note`** — declared `{"type": "string"}`; a missing or `null` note still means "no note".
- **`confidence`** — declared `{"type": "number", "minimum": 0, "maximum": 1}`. Booleans are
  rejected (`float(True)` used to land as confidence `1.0`) and out-of-range values are rejected.
  Numeric strings (`"0.9"`) stay tolerated, since prompt-only providers emit them.

## A violation now fails the whole batch, loudly (review follow-up)

The first pass still let a schema violation slide when *other* items in the same batch were valid:
`parse_facts` collected per-item errors and only raised `LLMError` `if not facts and errors`. That
reintroduced the same silent loss the issue is about, one layer up — a mixed batch (1 valid + 1
off-schema) reported the chunk as a **success** with the violating fact silently gone. Because no
`LLMError` was raised, `extract.py`'s deterministic retry path never fired, so the loss was
invisible, not merely deferred.

`base.py:54-55` states `LLMError`'s reason for existing is "so the caller can retry
deterministically", and #168 asks to raise it "on violation as the docstring already promises". So
`parse_facts` now raises `LLMError` on the **first** schema violation, regardless of how many valid
facts sit beside it:

| batch | before | now |
| --- | --- | --- |
| all valid | parsed in full | parsed in full |
| valid + violation | valid kept, violation **silently dropped** | **`LLMError`** (whole batch fails) |
| all violations | `LLMError` | `LLMError` |

Tolerated-by-schema cases are unchanged and do **not** trip this: an optional/absent `note`, a
numeric-string `confidence`, and the "marked `term` but unparseable -> stored as string with a note"
downgrade are schema-permitted, not violations, so they still parse.

### Existing expectation adjusted (with reason)

`tests/test_llm_schema.py::test_parse_facts_skips_malformed_items_when_valid_facts_remain` codified
the silent drop and directly contradicted the issue's "raise `LLMError` on violation" requirement, so
it was re-scoped rather than kept. It is replaced by three regression tests:

- `test_parse_facts_accepts_batch_of_only_valid_facts` — valid-only batch parses in full.
- `test_parse_facts_raises_when_valid_and_malformed_are_mixed` — mixed batch raises `LLMError` (no drop).
- `test_parse_facts_raises_when_every_item_is_malformed` — all-bad batch raises `LLMError`.

This is the only pre-existing expectation changed, and it is changed because it encoded the exact
behaviour #168 was filed to remove.

## The fact-storage boundary is preserved

This was the trap worth being careful about: `object` legitimately arrives as a **dict** on the
structural-term path, so "a dict is always a violation" would have broken a working feature.
It doesn't. Only the *inner* `value` is type-checked, so per README's Fact Storage Boundary:

- `{"kind": "term", "value": "maker(gadget)"}` -> still parses as a ground term, `object_kind="term"`.
- a bare `"maker(gadget)"` string -> still a `StringLit`, never reinterpreted as a compound.

Both are pinned by tests (`..._still_accepts_explicit_ground_term_slots`,
`..._keeps_plain_functor_text_as_a_string_literal`), as is the existing
"marked term but stored as string" downgrade path.

## Deliberate scope notes

- **No DB CHECK.** The issue also asked for a non-empty `CHECK` on the fact columns. Left out on
  purpose: `schema.sql` runs via `executescript` with `CREATE TABLE IF NOT EXISTS`, so a new `CHECK`
  never reaches an existing KB, and SQLite cannot add one via `ALTER TABLE` — it needs a table-rebuild
  migration in `store/db.py`, which is owned by an open PR. With the parser rejecting blanks at the
  source, the CHECK is defence-in-depth; a **follow-up issue** candidate, not silently dropped.
- **`confidence` numeric-string tolerance is intentional and documented** in
  `_parse_fact_confidence`'s docstring: prompt-only providers emit `"0.9"` often enough that
  coercing the string is the pragmatic contract. Booleans and out-of-range values are still rejected;
  only a parseable numeric string is tolerated. (Deliberately asymmetric with the strict slot typing.)
- **`additionalProperties: false` is declared but not parser-enforced**: an extra key like
  `{"kind":"string","value":"W","evil":1}` passes, since the parser reads only the keys it needs and
  ignores the rest. Harmless today (extra keys are inert); a candidate for the same follow-up if we
  want the parser to mirror the schema exactly.

## Verification

- `pytest -q`: **723 passed, 7 skipped** — the one changed expectation is the re-scoped drop test above.
- `ruff check verinote/llm/schema.py tests/test_llm_schema.py`: clean (CI runs `ruff check` + `pytest -q`).
- **Mutation**: reverting the batch-fail `raise` back to `continue`/drop turns the mixed-batch and
  all-bad regression tests red (`DID NOT RAISE LLMError`) while valid-only stays green. Reverting the
  slot `str()` coercion turns the smuggling payloads red as before.
- **Live smoke**: a mixed batch (`Ada is_a mathematician` + empty-relation item) now raises
  `LLMError: ... relation was empty` instead of returning the single valid fact.
- **Merge check**: local `git merge-tree` against the seven open branches
  (`issue-176`, `issue-163`, `issue-165`, `issue-183`, `issue-159`, `issue-174`, `issue-188`) is
  conflict-free.

Test data is synthetic (`Widget`/`Gadget`/`Gadgetville`) per AGENTS.md.

## Behaviour change (breaking)

Off-schema model output that used to be silently coerced into a stored fact — or silently dropped
when other items in the same batch were valid — is now rejected with `LLMError`, failing the whole
batch so the caller can retry deterministically.
