### PR TITLE
fix(#188): stop interpolating the KB path into ATTACH, and fail fast on a '?' in the KB root

### DIFF
--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
+import shutil
+import sys
+
 import pytest
 
 pytest.importorskip("duckdb")  # DuckDB is core; skip only in broken/minimal envs.
@@ -47,3 +50,42 @@ def test_compute_relation_aggregates_use_sqlite_display_mirror(tmp_path):
     s.close()
 
     assert dict(a.by_relation)["has_role"] == 1
+
+
+# A KB path is data, not SQL syntax. ATTACH takes no prepared parameters, so the
+# path is spliced into the statement text and every char below used to be read as
+# syntax: an apostrophe closed the literal and killed /analytics with a
+# ParserException. DuckDB's sqlite reader is happy with '?' (unlike its own
+# native storage, see test_duckdb_fact_terms), so analytics must not reject it.
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids these in filenames")
+@pytest.mark.parametrize("dirname", ["it's a kb", "semi;dir", "hash#dir", "weird?dir"])
+def test_compute_reads_a_kb_under_a_path_that_looks_like_sql(tmp_path, dirname):
+    # Seed in a plain directory, then read it from the awkward one, so this test
+    # pins the ATTACH path only and not the native-storage sidecar limits.
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    s = Store(plain / "kb.sqlite")
+    s.init_schema()
+    s.add_fact("A", "is_a", "B", status="confirmed", confidence=0.95)
+    s.close()
+
+    awkward = tmp_path / dirname
+    awkward.mkdir()
+    shutil.copy(plain / "kb.sqlite", awkward / "kb.sqlite")
+
+    a = compute(awkward / "kb.sqlite")
+
+    assert a.available is True
+    assert dict(a.by_status) == {"confirmed": 1}
+
+
+def test_compute_survives_an_apostrophe_that_would_close_the_sql_literal(tmp_path):
+    # The sharp end of the above: an unescaped ' terminates the ATTACH literal
+    # and the rest of the path is parsed as SQL.
+    awkward = tmp_path / "quote'dir"
+    awkward.mkdir()
+    s = Store(awkward / "kb.sqlite")
+    s.init_schema()
+    s.close()
+
+    assert compute(awkward / "kb.sqlite").by_status == []

--- a/tests/test_duckdb_fact_terms.py
+++ b/tests/test_duckdb_fact_terms.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+import sys
 
 import pytest
 
 from verinote.engine.duckdb_terms import term_to_duckdb_value
 from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
 from verinote.store.duckdb_fact_terms import (
+    FACT_TERMS_FILENAME,
     DuckDBFactTermStore,
     DuckDBFactTermStoreError,
     fact_terms_path,
@@ -215,3 +217,53 @@ def test_store_reports_missing_duckdb(monkeypatch):
 
     with pytest.raises(DuckDBFactTermStoreError, match="DuckDB is not installed"):
         DuckDBFactTermStore(None)
+
+
+# DuckDB's native storage splits a database path on '?' and reads the tail as
+# connection parameters, so a KB root containing one can never be opened: it used
+# to surface as `Cannot open file ".../weird.wal?dir/facts.duckdb"` -- a filename
+# nobody wrote -- after leaving a half-built facts.duckdb behind. The split
+# happens inside DuckDB, below any string we control, so we refuse the path up
+# front instead.
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids '?' in filenames")
+def test_store_refuses_a_kb_root_with_a_question_mark(tmp_path):
+    _duckdb()
+    root = tmp_path / "weird?dir"
+    root.mkdir()
+
+    with pytest.raises(DuckDBFactTermStoreError) as excinfo:
+        DuckDBFactTermStore.for_root(root)
+
+    message = str(excinfo.value)
+    assert "?" in message  # names the offending character
+    assert str(root) in message  # and the path it is in
+    assert "Move the KB" in message  # loud is not the same as a dead end: give a way out
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids '?' in filenames")
+def test_store_leaves_no_half_built_file_when_it_refuses_the_path(tmp_path):
+    _duckdb()
+    root = tmp_path / "weird?dir"
+    root.mkdir()
+    before = sorted(p.name for p in root.iterdir())
+
+    with pytest.raises(DuckDBFactTermStoreError):
+        DuckDBFactTermStore.for_root(root)
+
+    after = sorted(p.name for p in root.iterdir())
+    assert before == after == []
+    assert not (root / FACT_TERMS_FILENAME).exists()
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids these in filenames")
+@pytest.mark.parametrize("dirname", ["it's a kb", "semi;dir", "hash#dir"])
+def test_store_still_opens_under_other_awkward_path_chars(tmp_path, dirname):
+    # Only '?' is load-bearing for DuckDB's native storage. Do not over-reject.
+    _duckdb()
+    root = tmp_path / dirname
+    root.mkdir()
+
+    store = DuckDBFactTermStore.for_root(root)
+    store.put_fact_terms(1, "A", "is_a", "B")
+    assert store.get_fact_terms(1) is not None
+    store.close()

--- a/verinote/store/analytics.py
+++ b/verinote/store/analytics.py
@@ -44,6 +44,19 @@ _CONFIDENCE_CASE = """
 """
 
 
+def _sql_literal(value: str) -> str:
+    """Quote a value as a SQL string literal.
+
+    `ATTACH` takes no prepared parameters, so the path has to reach DuckDB
+    inside the statement text. That makes the path *data* which must not be
+    read as *syntax*: a KB under a directory with an apostrophe in it (say
+    `/home/o'neill/kb`) would otherwise close the literal early and blow up the
+    parser. Doubling `'` is the SQL standard escape and the only lever we have
+    here.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
 def compute(db_path: Path) -> Analytics:
     """ATTACH the SQLite KB read-only and return aggregate breakdowns.
 
@@ -56,7 +69,7 @@ def compute(db_path: Path) -> Analytics:
 
     con = duckdb.connect()
     try:
-        con.execute(f"ATTACH '{db_path}' AS kb (TYPE sqlite, READ_ONLY);")
+        con.execute(f"ATTACH {_sql_literal(str(db_path))} AS kb (TYPE sqlite, READ_ONLY);")
         by_status = con.execute(
             "SELECT status, COUNT(*) FROM kb.facts GROUP BY status ORDER BY COUNT(*) DESC, status"
         ).fetchall()

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -32,6 +32,7 @@ class DuckDBFactTermStore:
     def __init__(self, path: str | Path | None) -> None:
         self.path = Path(path).expanduser() if path is not None else None
         if self.path is not None:
+            _reject_unsupported_path(self.path)
             self.path.parent.mkdir(parents=True, exist_ok=True)
         self._con = _connect(self.path)
         self.init_schema()
@@ -133,6 +134,29 @@ class DuckDBFactTermStore:
 def fact_terms_path(root: str | Path) -> Path:
     """Return the default DuckDB fact-term store path for a KB root."""
     return Path(root).expanduser() / FACT_TERMS_FILENAME
+
+
+# DuckDB's native storage layer splits a database path on '?' and reads the tail
+# as connection parameters, so a KB root like `/data/weird?dir` sends it looking
+# for a file nobody named -- and it half-creates one on the way out. The split
+# happens inside DuckDB, below any string we hand it, so there is nothing for us
+# to quote or encode our way around: refuse the path instead of opening it.
+# This is a native-storage limit only. The SQLite ATTACH in `store.analytics`
+# handles '?' fine, so it stays unguarded.
+_UNSUPPORTED_PATH_CHARS = ("?",)
+
+
+def _reject_unsupported_path(path: Path) -> None:
+    """Fail before opening a store DuckDB cannot address, naming the way out."""
+    for char in _UNSUPPORTED_PATH_CHARS:
+        if char in str(path):
+            raise DuckDBFactTermStoreError(
+                f"cannot open the DuckDB fact-term store at {str(path)!r}: DuckDB reads "
+                f"everything after {char!r} in a database path as connection parameters, "
+                f"not as part of the filename, so this store can never be opened. "
+                f"Move the KB to a path with no {char!r} in it (rename the offending "
+                f"directory, or pass a different KB root) and retry."
+            )
 
 
 def _connect(path: Path | None):


### PR DESCRIPTION
A KB path is data. In two places we let it be read as something else.

## The real bug: the KB path was spliced into SQL as syntax

`store/analytics.py` built its `ATTACH` by f-string:

```python
con.execute(f"ATTACH '{db_path}' AS kb (TYPE sqlite, READ_ONLY);")
```

Every character of the path was parsed as SQL. An apostrophe in any ancestor
directory closes the string literal early and the rest of the path is parsed as
code, so `/analytics` dies with a `ParserException` before rendering:

```
"it's a kb"  -> ParserException: Parser Error: syntax error at or near "s"
```

`ATTACH` accepts no prepared parameters, so the path has to reach DuckDB inside
the statement text; doubling `'` (the SQL standard literal escape) is the lever
we actually have. After the fix all of these read fine:

| KB directory | before | after |
|---|---|---|
| `it's a kb` | `ParserException` | OK |
| `semi;dir` | OK | OK |
| `hash#dir` | OK | OK |
| `weird?dir` | OK | OK |

I swept the repo for other path-into-SQL/URI interpolation and this was the only
one: `engine/duckdb_backend.py` runs identifiers through `_quote_ident` (regex
allowlist), `store/db.py`'s `executescript` blocks are static literals, and
`sqlite3.connect`/`duckdb.connect` take the path as an argument, not as SQL.
Closing one hole and leaving the next is the mistake we made in #174; this time
the sweep is in the PR.

## The issue's proposed fix is not implementable

The issue suggests `Path.as_uri()` / percent-encoding to make `?` survive. It
cannot work. The `?` split happens **inside DuckDB's native storage layer**,
below any string we hand it, so there is nothing for us to encode. All six
encoding paths fail (DuckDB 1.5.4, KB root `weird?dir`):

| # | attempt | result |
|---|---|---|
| 1 | raw path | `TransactionException`: cannot open `.../weird.wal?dir/facts.duckdb` |
| 2 | `Path.as_uri()` | `IOException`: cannot open file |
| 3 | manual `?` -> `%3F` | `IOException`: cannot open file |
| 4 | `urllib.parse.quote(path)` | `IOException`: cannot open file |
| 5 | `file://` + quoted path | `IOException`: cannot open file |
| 6 | backslash-escaped `\?` | `IOException`: cannot open file |

Note what #1 does: DuckDB truncates at `?`, appends its `.wal` suffix to the
*head*, and then reports a filename **nobody ever wrote** —
`.../weird.wal?dir/facts.duckdb`.

## So `?` becomes an honest error instead

`?` in a KB root remains an upstream DuckDB limitation. What this PR changes is
how it *reads*. Before: a cryptic WAL error naming an invented path, plus a
half-built 12,288-byte `facts.duckdb` left in the KB. Now the store refuses the
path before opening anything, names the offending character and the path, and
points at the way out:

```
cannot open the DuckDB fact-term store at '/data/weird?dir/facts.duckdb': DuckDB
reads everything after '?' in a database path as connection parameters, not as
part of the filename, so this store can never be opened. Move the KB to a path
with no '?' in it (rename the offending directory, or pass a different KB root)
and retry.
```

Loud is not the same as crashing: the message has to get the user to a recovery.
And no half-built file is left behind — pinned by a before/after directory listing.

The guard is scoped to **DuckDB native storage only**. Analytics' SQLite `ATTACH`
handles `?` perfectly well, so it stays unguarded; over-rejecting would break a
path that works.

## No write-side exposure

Unlike #186's SQLite probe, there is no write path here: `analytics.compute`
attaches `READ_ONLY` and only ever runs aggregate `SELECT`s. The path is never
attacker-supplied either — it is the operator's own KB location. This is a
robustness/correctness fix (a legitimate path breaks a page), not a privilege
boundary.

## Tests

Both new guards are mutation-checked — reverting each fix turns them red:

- revert the `ATTACH` escaping -> 2 failed (`ParserException`)
- drop the `?` fail-fast guard -> 2 failed (leftover `facts.duckdb` assertion bites)

Full suite: 711 passed, 7 skipped. `ruff check` clean. The `?`/`'` tests skip on
Windows, which forbids those characters in filenames.

Closes #188 — the `?` half is closed as *documented upstream limitation surfaced
honestly*, not as a code fix, because the failure matrix above shows no code fix
exists on our side.
