### PR TITLE
Escape legacy wirelog compiled input

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -258,6 +258,38 @@ def test_wirelog_row_render_cannot_forge_report_lines(char):
     assert not rendered.startswith("ERROR forged")
 
 
+@pytest.mark.parametrize(
+    "char", _NON_PRINTING_CHARS, ids=[f"U+{ord(c):04X}" for c in _NON_PRINTING_CHARS]
+)
+def test_compile_dl_cannot_forge_report_lines(char):
+    """The legacy compiled-input echo is report text too, so it must be escaped."""
+    value = f"broken{char}ERROR forged: Gadget is unusable"
+
+    dl = compile_dl([{"subject": "Widget", "relation": "note", "object": value}])
+
+    assert len(dl.splitlines()) == 1
+    assert not any(line.startswith("ERROR forged") for line in dl.splitlines())
+    assert wl._parse_relation_facts(dl) == [("Widget", "note", value)]
+
+
+def test_degraded_wirelog_report_cannot_echo_forged_lines(monkeypatch):
+    dl = compile_dl(
+        [
+            {
+                "subject": "Widget",
+                "relation": "note",
+                "object": "broken\nERROR forged: Gadget is unusable",
+            }
+        ]
+    )
+    monkeypatch.setattr(wl, "_load_engine", lambda: None)
+
+    rep = run_check(dl)
+
+    assert rep.engine_available is False
+    assert not any(line.startswith("ERROR forged") for line in rep.text.splitlines())
+
+
 def test_wirelog_row_render_keeps_printable_values_intact():
     assert wl._render_row(("Widget", 2020, "Kim Chulsoo")) == "Widget 2020 Kim Chulsoo"
 

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -31,9 +31,6 @@ from verinote.engine.datalog import (
 )
 from verinote.engine.terms import escape_string_value
 
-# Datalog string literals: escape embedded quotes/backslashes.
-_ESCAPE = re.compile(r'(["\\])')
-
 # Prefixes that mark a derived relation as a verinote finding.
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
@@ -65,7 +62,7 @@ error_functional_conflict(S, R) :-
 
 
 def _lit(value: str) -> str:
-    return '"' + _ESCAPE.sub(r"\\\1", value) + '"'
+    return '"' + escape_string_value(value).replace('"', '\\"') + '"'
 
 
 def compile_dl(facts: Iterable[Mapping[str, object]]) -> str:
@@ -85,8 +82,8 @@ def compile_dl(facts: Iterable[Mapping[str, object]]) -> str:
 def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
     """Recover (subject, rel, object) triples from `compile_dl` output.
 
-    Mirrors `_lit`'s escaping (``\\"`` -> ``"``, ``\\\\`` -> ``\\``) so the round
-    trip is exact, including embedded quotes.
+    Mirrors `_lit`'s escaping so the round trip is exact, including embedded
+    quotes, backslashes, short control escapes, and numeric Unicode escapes.
     """
     facts: list[tuple[str, str, str]] = []
     for line in dl_text.splitlines():
@@ -105,7 +102,39 @@ def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
             while i < n:
                 c = line[i]
                 if c == "\\" and i + 1 < n:
-                    buf.append(line[i + 1])
+                    esc = line[i + 1]
+                    if esc == '"':
+                        buf.append('"')
+                        i += 2
+                        continue
+                    if esc == "\\":
+                        buf.append("\\")
+                        i += 2
+                        continue
+                    if esc == "n":
+                        buf.append("\n")
+                        i += 2
+                        continue
+                    if esc == "r":
+                        buf.append("\r")
+                        i += 2
+                        continue
+                    if esc == "t":
+                        buf.append("\t")
+                        i += 2
+                        continue
+                    if esc in {"u", "U"}:
+                        width = 4 if esc == "u" else 8
+                        digits = line[i + 2 : i + 2 + width]
+                        if len(digits) == width and re.fullmatch(r"[0-9A-Fa-f]+", digits):
+                            code = int(digits, 16)
+                            if code <= 0x10FFFF and not 0xD800 <= code <= 0xDFFF:
+                                buf.append(chr(code))
+                                i += 2 + width
+                                continue
+                    # Preserve unsupported legacy escapes as the old parser did:
+                    # drop the escape marker and keep the escaped byte.
+                    buf.append(esc)
                     i += 2
                     continue
                 if c == '"':


### PR DESCRIPTION
## Summary

Fixes #203.

- Escape legacy `compile_dl()` string literals through `escape_string_value()` so compiled input echoed in `CheckReport.text` cannot introduce forged report lines.
- Teach `_parse_relation_facts()` to decode the same short and numeric Unicode escapes so `compile_dl()` -> `run_check()` keeps the original fact values.
- Add regression coverage for compiled-input line forgery and degraded legacy report echo behavior.

## Validation

- `.venv/bin/python -m pytest tests/test_engine.py -q` -> `90 passed, 7 skipped`
- `.venv/bin/ruff check verinote/engine/wirelog.py tests/test_engine.py` -> pass
- `.venv/bin/python -m pytest -q` -> `861 passed, 7 skipped`
