### PR TITLE
Propagate Ollama extraction schema errors

### DIFF
--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -96,7 +96,7 @@ def test_ollama_extract_uses_configured_timeout(tmp_path, monkeypatch):
     assert facts[0].subject == "Ada"
 
 
-def test_ollama_extract_ignores_malformed_only_fact_payload(tmp_path, monkeypatch):
+def test_ollama_extract_raises_on_malformed_only_fact_payload(tmp_path, monkeypatch):
     def fake_urlopen(req, *, timeout):
         return _Response(
             json.dumps(
@@ -114,10 +114,11 @@ def test_ollama_extract_ignores_malformed_only_fact_payload(tmp_path, monkeypatc
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-    assert OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada") == []
+    with pytest.raises(LLMError, match="malformed fact object"):
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
 
 
-def test_ollama_extract_ignores_schema_mismatch_payload(tmp_path, monkeypatch):
+def test_ollama_extract_raises_on_schema_mismatch_payload(tmp_path, monkeypatch):
     def fake_urlopen(req, *, timeout):
         return _Response(
             json.dumps(
@@ -133,7 +134,37 @@ def test_ollama_extract_ignores_schema_mismatch_payload(tmp_path, monkeypatch):
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-    assert OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada") == []
+    with pytest.raises(LLMError, match="extractor output did not match schema"):
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+
+def test_ollama_extract_raises_on_mixed_valid_and_malformed_payload(tmp_path, monkeypatch):
+    def fake_urlopen(req, *, timeout):
+        return _Response(
+            json.dumps(
+                [
+                    {
+                        "subject": "Ada",
+                        "relation": "is_a",
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    },
+                    {
+                        "subject": [],
+                        "relation": "is_a",
+                        "object": "mathematician",
+                        "confidence": 0.9,
+                        "note": "",
+                    },
+                ]
+            )
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(LLMError, match="malformed fact object"):
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
 
 
 def test_ollama_extract_uses_kb_prompt_override(tmp_path, monkeypatch):

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -79,16 +79,7 @@ class OllamaAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
             raise LLMError(f"ollama request failed: {exc}") from exc
 
-        try:
-            return parse_facts(body.get("message", {}).get("content", ""))
-        except LLMError as exc:
-            message = str(exc)
-            if (
-                "malformed fact object" in message
-                or "extractor output did not match schema" in message
-            ):
-                return []
-            raise
+        return parse_facts(body.get("message", {}).get("content", ""))
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
         system = _with_schema_hint(


### PR DESCRIPTION
## Summary

Fixes #205.

- Remove the Ollama adapter branch that converted extraction schema `LLMError`s into an empty fact list.
- Update malformed-only and schema-mismatch Ollama tests to expect `LLMError`.
- Add a mixed valid + malformed payload test so partial-success drops stay blocked.

## Validation

- `.venv/bin/python -m pytest tests/test_ollama_adapter.py -q` -> `6 passed`
- `.venv/bin/python -m pytest tests/test_ollama_adapter.py tests/test_llm_schema.py tests/test_pipeline.py -q` -> `101 passed`
- `.venv/bin/ruff check verinote/llm/ollama_adapter.py tests/test_ollama_adapter.py` -> pass
- `.venv/bin/python -m pytest -q` -> `884 passed, 7 skipped`
