### PR TITLE
Reject missing modern DuckDB fact terms

### DIFF
--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -10,7 +10,8 @@ from verinote.engine.terms import (
     Var,
 )
 from verinote.store import Store
-from verinote.store.duckdb_fact_terms import fact_terms_path
+from verinote.store.db import FACT_TERMS_MARKER_KEY
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError, fact_terms_path
 from verinote.store.fact_input import structural_term
 
 
@@ -182,7 +183,65 @@ def test_backfill_fact_terms_migrates_legacy_sqlite_text_as_stringlit(tmp_path):
         StringLit("is_a"),
         StringLit("person"),
     )
+    assert s._get_meta(FACT_TERMS_MARKER_KEY) is not None
     assert s.backfill_fact_terms() == 0
+
+
+def test_engine_fact_terms_rejects_missing_modern_sidecar_terms(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact(
+        Compound("person", (StringLit("Ada"),)),
+        Atom("is_a"),
+        StringLit("person"),
+        status="confirmed",
+    )
+    s.fact_terms.delete_fact_terms(fid)
+
+    with pytest.raises(DuckDBFactTermStoreError, match="Refusing to rebuild"):
+        s.engine_fact_terms()
+
+    assert s.get_fact_terms(fid) is None
+
+
+def test_engine_fact_terms_marks_complete_pre_marker_sidecar(tmp_path):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ('person("Ada")', "is_a", "person", "confirmed"),
+    )
+    fid = int(cur.fetchone()[0])
+    s.fact_terms.put_fact_terms(
+        fid,
+        Compound("person", (StringLit("Ada"),)),
+        Atom("is_a"),
+        StringLit("person"),
+    )
+    assert s._get_meta(FACT_TERMS_MARKER_KEY) is None
+
+    assert s.engine_fact_terms() == [
+        {
+            "id": fid,
+            "subject": Compound("person", (StringLit("Ada"),)),
+            "relation": Atom("is_a"),
+            "object": StringLit("person"),
+        }
+    ]
+    assert s._get_meta(FACT_TERMS_MARKER_KEY) is not None
+
+    s.fact_terms.delete_fact_terms(fid)
+    with pytest.raises(DuckDBFactTermStoreError, match="Refusing to rebuild"):
+        s.engine_fact_terms()
+
+
+def test_backfill_fact_terms_rejects_missing_terms_after_sidecar_marker(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("Ada", "born_in", "London", status="confirmed")
+    s.fact_terms.delete_fact_terms(fid)
+
+    with pytest.raises(DuckDBFactTermStoreError, match="missing DuckDB fact terms"):
+        s.backfill_fact_terms()
+
+    assert s.get_fact_terms(fid) is None
 
 
 def test_backfill_fact_terms_does_not_overwrite_structural_terms(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -7,6 +7,7 @@ from verinote.engine.terms import Compound, StringLit
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import load_policy, policy_path, verify
 from verinote.store import Store
+from verinote.store.duckdb_fact_terms import fact_terms_path
 from verinote.store.fact_input import structural_term
 
 # A hand-written policy tracked in the repo (see tests/test_gitignore.py), used
@@ -283,6 +284,46 @@ def test_verify_backfills_missing_duckdb_terms_for_legacy_engine_rows(tmp_path):
         StringLit("born_in"),
         StringLit("London"),
     )
+
+
+def test_verify_rejects_lost_sidecar_instead_of_backfilling_structural_terms(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact(
+        Compound("org", (StringLit("demo"),)),
+        "ceo",
+        StringLit("Alice"),
+        status="confirmed",
+    )
+    s.add_fact(
+        Compound("org", (StringLit("demo"),)),
+        "ceo",
+        StringLit("Bob"),
+        status="confirmed",
+    )
+    path = policy_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_two_ceos(object: symbol)\n"
+        'error_two_ceos(O) :- relation(org("demo"), "ceo", O), '
+        'relation(org("demo"), "ceo", P), O != P.\n',
+        encoding="utf-8",
+    )
+    assert verify(s).ok is False
+    s.close()
+    fact_terms_path(tmp_path).unlink()
+
+    reopened = Store(tmp_path / "kb.sqlite")
+    try:
+        rep = verify(reopened)
+    finally:
+        reopened.close()
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert "missing DuckDB fact terms" in rep.text
+    assert "Refusing to rebuild" in rep.text
+    assert "knowledge base is consistent" not in rep.text
 
 
 def test_verify_fails_closed_when_engine_fact_terms_remain_missing(tmp_path, monkeypatch):

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -22,6 +22,8 @@ from typing import Any, Iterable
 REVIEW_STATUSES = frozenset({"candidate", "needs_review"})
 # kb_meta key under which a KB declares that it owns a logic policy file.
 POLICY_MARKER_KEY = "policy.logic"
+# kb_meta key declaring that fact logical terms are managed by facts.duckdb.
+FACT_TERMS_MARKER_KEY = "fact_terms.duckdb"
 ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
 REVIEW_PAGE_SIZES = (25, 50, 100)
@@ -135,6 +137,18 @@ def _review_sort(value: object) -> str:
     return sort if sort in REVIEW_SORT_SQL else DEFAULT_REVIEW_SORT
 
 
+def _missing_fact_terms_error(fact_ids: Iterable[int]) -> Exception:
+    from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+
+    ids = ", ".join(str(fact_id) for fact_id in fact_ids)
+    return DuckDBFactTermStoreError(
+        "missing DuckDB fact terms for fact id(s): "
+        f"{ids}. Restore facts.duckdb from backup or re-enter the affected "
+        "facts. Refusing to rebuild them from SQLite display text because "
+        "that would reinterpret structural terms as strings."
+    )
+
+
 class Store:
     """A connection to one KB's SQLite file."""
 
@@ -189,7 +203,8 @@ class Store:
         self.close()
 
     # --- kb metadata -----------------------------------------------------
-    # `kb_meta` has exactly one client — the policy marker below — and no generic
+    # `kb_meta` has explicit clients — the policy and fact-term markers below —
+    # and no generic
     # read/write/delete API is exposed for it. That is deliberate. A public
     # `delete_meta("policy.logic")` (or a plain `set_meta`) is `clear_policy_marker`
     # under another name: it downgrades a *lost* policy back to a KB that "never had
@@ -203,12 +218,15 @@ class Store:
 
     def _set_meta(self, key: str, value: str) -> None:
         with self._lock:
-            self._conn.execute(
-                "INSERT INTO kb_meta(key, value) VALUES(?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
-                "updated_at = datetime('now')",
-                (key, value),
-            )
+            self._set_meta_unlocked(key, value)
+
+    def _set_meta_unlocked(self, key: str, value: str) -> None:
+        self._conn.execute(
+            "INSERT INTO kb_meta(key, value) VALUES(?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+            "updated_at = datetime('now')",
+            (key, value),
+        )
 
     def policy_marker(self) -> dict[str, object] | None:
         """The KB's declaration that it has a logic policy file, or None.
@@ -236,6 +254,37 @@ class Store:
             "origin": origin,
         }
         self._set_meta(POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False))
+        return marker
+
+    def fact_terms_marker(self) -> dict[str, object] | None:
+        """The KB's declaration that DuckDB owns canonical fact terms, or None."""
+        raw = self._get_meta(FACT_TERMS_MARKER_KEY)
+        if raw is None:
+            return None
+        try:
+            marker = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"version": 0, "recorded_at": "", "origin": "unknown"}
+        if not isinstance(marker, dict):
+            return {"version": 0, "recorded_at": "", "origin": "unknown"}
+        return marker
+
+    def _has_fact_terms_marker(self) -> bool:
+        return self._get_meta(FACT_TERMS_MARKER_KEY) is not None
+
+    def _record_fact_terms_marker(self, *, origin: str) -> dict[str, object]:
+        with self._lock:
+            return self._record_fact_terms_marker_unlocked(origin=origin)
+
+    def _record_fact_terms_marker_unlocked(self, *, origin: str) -> dict[str, object]:
+        marker: dict[str, object] = {
+            "version": 1,
+            "recorded_at": _utc_now(),
+            "origin": origin,
+        }
+        self._set_meta_unlocked(
+            FACT_TERMS_MARKER_KEY, json.dumps(marker, ensure_ascii=False)
+        )
         return marker
 
     # Deliberately no `clear_policy_marker()` — and, per the note above, no public
@@ -834,6 +883,7 @@ class Store:
                 )
                 fact_id = int(cur.fetchone()[0])
                 self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
+                self._record_fact_terms_marker_unlocked(origin="write")
                 self._add_fact_event(
                     fact_id=fact_id,
                     event_type="candidate_created",
@@ -868,16 +918,15 @@ class Store:
         terms = self.fact_terms.get_many_fact_terms(ids)
         missing = [fact_id for fact_id in ids if fact_id not in terms]
         if missing:
+            if self._has_fact_terms_marker():
+                raise _missing_fact_terms_error(missing)
             self.backfill_fact_terms()
             terms = self.fact_terms.get_many_fact_terms(ids)
             missing = [fact_id for fact_id in ids if fact_id not in terms]
         if missing:
-            from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
-
-            raise DuckDBFactTermStoreError(
-                "missing DuckDB fact terms for engine fact id(s): "
-                + ", ".join(str(fact_id) for fact_id in missing)
-            )
+            raise _missing_fact_terms_error(missing)
+        if not self._has_fact_terms_marker():
+            self._record_fact_terms_marker(origin="existing_sidecar")
 
         return [
             {
@@ -890,7 +939,7 @@ class Store:
         ]
 
     def backfill_fact_terms(self) -> int:
-        """Backfill missing DuckDB term rows from SQLite text mirrors as StringLit."""
+        """Backfill legacy SQLite-only fact rows into DuckDB as StringLit terms."""
         with self._lock:
             rows = list(
                 self._conn.execute(
@@ -898,6 +947,9 @@ class Store:
                 )
             )
             existing = self.fact_terms.get_many_fact_terms(row["id"] for row in rows)
+            missing = [int(row["id"]) for row in rows if int(row["id"]) not in existing]
+            if missing and self._has_fact_terms_marker():
+                raise _missing_fact_terms_error(missing)
             written = 0
             for row in rows:
                 fact_id = int(row["id"])
@@ -907,6 +959,9 @@ class Store:
                     fact_id, row["subject"], row["relation"], row["object"]
                 )
                 written += 1
+            if rows:
+                origin = "legacy_backfill" if written else "existing_sidecar"
+                self._record_fact_terms_marker_unlocked(origin=origin)
             return written
 
     def get_fact(self, fact_id: int) -> sqlite3.Row | None:
@@ -1082,6 +1137,7 @@ class Store:
             try:
                 self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
                 terms_written = True
+                self._record_fact_terms_marker_unlocked(origin="write")
                 self._conn.execute(
                     "UPDATE facts SET subject = ?, relation = ?, object = ?, note = ?, "
                     "updated_at = datetime('now') WHERE id = ?",


### PR DESCRIPTION
## Summary
- add a `fact_terms.duckdb` KB metadata marker for sidecar-managed fact terms
- preserve legacy SQLite-only backfill, then mark the KB as sidecar-managed
- fail closed when marked KBs are missing DuckDB fact terms instead of rebuilding structural terms from display text
- cover modern sidecar loss, pre-marker complete sidecars, and verify-level regression behavior

Closes #156

## Tests
- `.venv/bin/python -m pytest tests/test_store_fact_terms.py tests/test_verify.py -q`
- `.venv/bin/python -m ruff check verinote/store/db.py tests/test_store_fact_terms.py tests/test_verify.py`
- `.venv/bin/python -m pytest -q`
