### PR TITLE
fix(#194): close the five halt holes — CLI diagnosis, the UI launcher, the mid-job worker, the legacy sync boundary (#235), and the mid-sync traceback (#246)

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -7,9 +7,14 @@ import verinote.cli as cli
 from verinote.engine import DEFAULT_POLICY
 from verinote.pipeline.corroboration import store_functional_relations
 from verinote.pipeline.policy_state import (
+    POLICY_CLI_LINE_MISSING_RECORDED,
+    POLICY_CLI_LINE_PRESENT,
+    POLICY_CLI_LINE_UNRECORDED_DEFAULT,
     POLICY_RELPATH,
     PolicyMissingError,
+    PolicyState,
     PolicyStatus,
+    policy_cli_line,
     policy_sha256,
     resolve_policy,
 )
@@ -623,6 +628,21 @@ def test_policy_reset_force_recovers_halted_kb(tmp_path, monkeypatch, capsys):
     assert (tmp_path / "sources" / "input.txt").is_file()
 
 
+class _ChunkClient:
+    """One fact per chunk, subject = the chunk text. Never touches the policy."""
+
+    name = "fake"
+
+    def __init__(self):
+        self.calls = 0
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        from verinote.llm.base import ExtractedFact
+
+        self.calls += 1
+        return [ExtractedFact(source_text, "is_a", "chunk", 0.9)]
+
+
 class _PolicyDeletingClient:
     """Deletes the KB's policy file just as the *second* chunk is extracted."""
 
@@ -669,6 +689,240 @@ def test_extraction_worker_halts_when_policy_disappears_mid_job(tmp_path):
     snippets = [e["snippet"] for f in facts for e in store.fact_evidence(f["id"])]
     assert "beta" not in snippets
     store.close()
+
+
+# --- #194: the three holes left in the halt --------------------------------
+# --- (a) the CLI's diagnostic surface never said the KB was halted ----------
+
+
+def test_policy_cli_line_covers_every_policy_status():
+    """Every `PolicyStatus` has a line; a new one without a line is a KeyError.
+
+    A blank/absent marker for an unknown state would be exactly the silent
+    fallback this module exists to kill, so the lookup is deliberately total.
+    """
+    from pathlib import Path
+
+    lines = {
+        status: policy_cli_line(PolicyState(status=status, path=Path("policy.dl")))
+        for status in PolicyStatus
+    }
+
+    assert set(lines) == set(PolicyStatus)  # no member left unlined
+    assert all(line.strip() for line in lines.values())
+    assert len(set(lines.values())) == len(PolicyStatus)  # states are distinguishable
+    assert lines[PolicyStatus.MISSING_RECORDED] == POLICY_CLI_LINE_MISSING_RECORDED
+    assert lines[PolicyStatus.PRESENT] == POLICY_CLI_LINE_PRESENT
+    assert lines[PolicyStatus.UNRECORDED_DEFAULT] == POLICY_CLI_LINE_UNRECORDED_DEFAULT
+    assert "HALTED" in POLICY_CLI_LINE_MISSING_RECORDED
+
+
+def test_status_says_the_kb_is_halted_on_stdout(tmp_path, monkeypatch, capsys):
+    """`status` on a halted KB used to read as perfectly healthy.
+
+    The marker goes to *stdout*, with the rest of the summary: `verinote status >
+    out.txt` and a CI health check read stdout, and a halt they cannot see is not
+    a halt. The loud recovery text still goes to stderr.
+    """
+    _halted_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["status"]) == 0  # diagnosis must still work *on* a halted KB
+
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_MISSING_RECORDED in captured.out
+    assert "policy reset --force" in captured.err
+    assert "version control" in captured.err
+
+
+def test_coverage_says_the_kb_is_halted_on_stdout(tmp_path, monkeypatch, capsys):
+    _halted_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["coverage"]) == 0  # plain coverage is a recovery path: rc=0
+
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_MISSING_RECORDED in captured.out
+    assert "coverage:" in captured.out
+    assert "policy reset --force" in captured.err
+
+
+def test_coverage_strict_fails_on_a_halted_kb(tmp_path, monkeypatch, capsys):
+    """`--strict` is a machine gate: a KB with no rules does not pass it."""
+    _halted_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["coverage", "--strict"]) == 1
+
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_MISSING_RECORDED in captured.out
+    assert "logic policy file is missing" in captured.err
+
+
+def test_coverage_strict_passes_on_a_healthy_kb(tmp_path, monkeypatch, capsys):
+    """The rc=1 above is the halt talking, not a coverage gap."""
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+
+    assert cli.main(["coverage", "--strict"]) == 0
+
+    assert POLICY_CLI_LINE_PRESENT in capsys.readouterr().out
+
+
+def test_status_of_unrecorded_kb_prints_the_default_line(tmp_path, monkeypatch, capsys):
+    """The benign state is reported as itself — not as "ok", and not as halted."""
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.close()
+
+    assert cli.main(["status"]) == 0
+
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_UNRECORDED_DEFAULT in captured.out
+    assert "HALTED" not in captured.out
+    assert captured.err == ""  # the benign state is not an error
+
+
+# --- (b) the worker: a mid-job halt must rewind the job, not strand it ------
+
+
+class _PolicyVanishingStore(Store):
+    """A Store whose policy file disappears just as the *second* chunk is dequeued.
+
+    This is the gap the per-chunk write boundary cannot see: the policy is gone
+    before chunk 2 is even claimed, and claiming a chunk (`status='running'`,
+    `attempts + 1`) is itself a write to a halted KB.
+    """
+
+    def __init__(self, db_path, policy_path):
+        super().__init__(db_path)
+        self.policy_path = policy_path
+        self.dequeues = 0
+        self.claims = []
+
+    def next_pending_chunk(self, job_id: int):
+        row = super().next_pending_chunk(job_id)
+        self.dequeues += 1
+        if row is not None and self.dequeues == 2:
+            self.policy_path.unlink()
+        return row
+
+    def mark_chunk_running(self, chunk_id: int):
+        self.claims.append(chunk_id)
+        return super().mark_chunk_running(chunk_id)
+
+
+def _halted_mid_job_kb(tmp_path, chunks=("alpha", "beta")):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    source_id = store.add_source("sources/a.txt")
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=len(chunks)
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=list(chunks))
+    store.close()
+    return path, job_id
+
+
+def test_chunk_is_not_claimed_on_a_kb_that_went_halted(tmp_path):
+    """The gate sits *before* `mark_chunk_running` — claiming a chunk is a write."""
+    from verinote.pipeline.extract import process_extraction_job
+
+    path, job_id = _halted_mid_job_kb(tmp_path)
+    store = _PolicyVanishingStore(tmp_path / "kb.sqlite", path)
+    store.init_schema()
+    client = _ChunkClient()
+
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(store, client, job_id=job_id)
+
+    chunks = store.source_chunks(job_id)
+    assert [c["status"] for c in chunks] == ["done", "pending"]
+    # chunk 2 was never claimed: not marked running, no attempt burned, no LLM call
+    assert store.claims == [int(chunks[0]["id"])]
+    assert chunks[1]["attempts"] == 0
+    assert client.calls == 1
+    store.close()
+
+
+def test_mid_job_halt_rolls_the_job_back_to_pending(tmp_path):
+    """A `running` job with a `running` chunk is stranded forever — nothing resets it."""
+    from verinote.pipeline.extract import process_extraction_job
+
+    path, job_id = _halted_mid_job_kb(tmp_path)
+    store = _PolicyVanishingStore(tmp_path / "kb.sqlite", path)
+    store.init_schema()
+
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(store, _ChunkClient(), job_id=job_id)
+
+    job = store.get_extraction_job(job_id)
+    assert job["status"] == "pending"
+    assert "policy reset --force" in job["message"]
+    assert "1/2" in job["message"]
+    # the work that really happened is kept; the rest is back in the queue
+    assert job["completed_chunks"] == 1
+    assert job["failed_chunks"] == 0
+    assert job["candidate_count"] == 1
+    assert store.next_pending_chunk(job_id) is not None
+    store.close()
+
+
+def test_mid_job_halt_run_summary_reports_the_real_counts(tmp_path):
+    """A halt notice that claims "nothing was written" would be a fresh lie.
+
+    Chunk 1's candidate facts exist and carry this run's `run_id`; a summary
+    saying the run wrote nothing would make the provenance page contradict the
+    facts sitting in front of the user.
+    """
+    from verinote.pipeline.extract import process_extraction_job
+
+    path, job_id = _halted_mid_job_kb(tmp_path)
+    store = _PolicyVanishingStore(tmp_path / "kb.sqlite", path)
+    store.init_schema()
+
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(store, _ChunkClient(), job_id=job_id)
+
+    facts = store.facts()
+    assert [f["subject"] for f in facts] == ["alpha"]
+    run_id = int(facts[0]["run_id"])
+    summary = store.get_run(run_id)["summary"]
+    assert "halted after 1/2 chunk(s)" in summary
+    assert "1 candidate(s) written by this run" in summary
+    assert "rolled back to pending" in summary
+    assert "0 candidate" not in summary
+    store.close()
+
+
+def test_resumed_job_summary_counts_only_this_run(tmp_path):
+    """`run_candidates` is what *this* run wrote — not the job's cumulative count."""
+    from verinote.pipeline.extract import process_extraction_job
+
+    path, job_id = _halted_mid_job_kb(tmp_path, chunks=("alpha", "beta", "gamma"))
+    # first run: halts after chunk 1 (1 candidate written by that run)
+    first = _PolicyVanishingStore(tmp_path / "kb.sqlite", path)
+    first.init_schema()
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(first, _ChunkClient(), job_id=job_id)
+    first.close()
+
+    # policy restored, job resumed, and it halts again — this time after chunk 2
+    _write_policy(tmp_path)
+    second = _PolicyVanishingStore(tmp_path / "kb.sqlite", path)
+    second.init_schema()
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(second, _ChunkClient(), job_id=job_id)
+
+    job = second.get_extraction_job(job_id)
+    assert job["candidate_count"] == 2  # cumulative across both runs
+    summaries = [
+        row["summary"] for row in second._conn.execute("SELECT summary FROM runs ORDER BY id")
+    ]
+    second.close()
+    # the second run wrote one candidate, not two: the summary must not inherit
+    # the job's cumulative counter
+    assert "halted after 1/3 chunk(s), 1 candidate(s) written by this run" in summaries[0]
+    assert "halted after 2/3 chunk(s), 1 candidate(s) written by this run" in summaries[1]
 
 
 def test_store_has_no_public_meta_delete(tmp_path):

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -724,6 +724,34 @@ def test_legacy_sync_halts_mid_batch_when_policy_disappears(tmp_path):
     store.close()
 
 
+def test_sync_gives_a_clean_halt_diagnosis_instead_of_a_traceback(tmp_path, monkeypatch, capsys):
+    """A policy lost mid-`sync` exits with the halt message, not a raw traceback.
+
+    `sync` clears its start-of-command halt check, then the policy vanishes while
+    the batch runs (here, as the second source is extracted). The legacy
+    `sync_sources` gate raises `PolicyMissingError`; `cmd_sync` must catch it, print
+    the actionable recovery text, and exit rc=2 like every other halted-write
+    refusal — not leak a `RuntimeError` traceback the way it used to (#246).
+    """
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    policy = tmp_path / POLICY_RELPATH
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir(exist_ok=True)
+    (sources_dir / "a.txt").write_text("alpha", encoding="utf-8")
+    (sources_dir / "b.txt").write_text("beta", encoding="utf-8")
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _PolicyDeletingClient(policy))
+
+    rc = cli.main(["sync"])
+
+    assert rc == 2  # the same code the start-of-command refusal uses
+    err = capsys.readouterr().err
+    assert "policy file" in err and "missing" in err
+    assert "policy reset --force" in err  # the recovery route is named
+    assert "Traceback" not in err  # a clean diagnosis, not a leaked stack trace
+    assert not policy.exists()  # the evidence of the loss is intact
+
+
 # --- #194: the three holes left in the halt --------------------------------
 # --- (a) the CLI's diagnostic surface never said the KB was halted ----------
 

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -693,6 +693,37 @@ def test_extraction_worker_halts_when_policy_disappears_mid_job(tmp_path):
     store.close()
 
 
+def test_legacy_sync_halts_mid_batch_when_policy_disappears(tmp_path):
+    """The unregistered-source `sync_sources` path has the same write boundary.
+
+    `sync_sources` loops one LLM call per source under one run row; the CLI's
+    start-of-command check cannot see a policy deleted *after* the batch began. A
+    source reached *after* the loss must be refused at the write boundary in
+    `extract_source`, while sources written *before* it stay — the partial run row
+    is left for inspection, exactly as an `LLMError` mid-batch would leave it.
+    """
+    from verinote.pipeline.extract import sync_sources
+
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+
+    client = _PolicyDeletingClient(path)  # deletes the policy as source #2 is extracted
+    sources = [
+        ("sources/a.txt", "alpha"),
+        ("sources/b.txt", "beta"),
+        ("sources/c.txt", "gamma"),
+    ]
+    with pytest.raises(PolicyMissingError):
+        sync_sources(store, client, sources, provider="fake", model="m")
+
+    assert client.calls == 2  # source #2 was extracted but never persisted; #3 unreached
+    # only the source written before the halt survives
+    assert [s["path"] for s in store.sources()] == ["sources/a.txt"]
+    assert [f["subject"] for f in store.facts()] == ["alpha"]
+    store.close()
+
+
 # --- #194: the three holes left in the halt --------------------------------
 # --- (a) the CLI's diagnostic surface never said the KB was halted ----------
 

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -4,7 +4,9 @@
 import pytest
 
 import verinote.cli as cli
+import verinote.pipeline.acceptance as acceptance
 from verinote.engine import DEFAULT_POLICY
+from verinote.pipeline.acceptance import AcceptRecommendation
 from verinote.pipeline.corroboration import store_functional_relations
 from verinote.pipeline.policy_state import (
     POLICY_CLI_LINE_MISSING_RECORDED,
@@ -887,15 +889,21 @@ def test_mid_job_halt_run_summary_reports_the_real_counts(tmp_path):
     assert [f["subject"] for f in facts] == ["alpha"]
     run_id = int(facts[0]["run_id"])
     summary = store.get_run(run_id)["summary"]
-    assert "halted after 1/2 chunk(s)" in summary
-    assert "1 candidate(s) written by this run" in summary
+    assert "job progress 1/2 chunk(s)" in summary
+    assert "this run wrote 1 candidate(s) from 1 chunk(s)" in summary
     assert "rolled back to pending" in summary
     assert "0 candidate" not in summary
     store.close()
 
 
 def test_resumed_job_summary_counts_only_this_run(tmp_path):
-    """`run_candidates` is what *this* run wrote — not the job's cumulative count."""
+    """`run_candidates`/`run_chunks` are what *this* run did — not the job's totals.
+
+    The second run processes exactly ONE chunk and writes ONE candidate, while the
+    job's progress stands at 2/3. Both numbers must appear, in separate clauses:
+    "halted after 2/3 chunk(s), 1 candidate(s) written by this run" reads as "this
+    run did two chunks and wrote one candidate", which is false.
+    """
     from verinote.pipeline.extract import process_extraction_job
 
     path, job_id = _halted_mid_job_kb(tmp_path, chunks=("alpha", "beta", "gamma"))
@@ -919,10 +927,84 @@ def test_resumed_job_summary_counts_only_this_run(tmp_path):
         row["summary"] for row in second._conn.execute("SELECT summary FROM runs ORDER BY id")
     ]
     second.close()
-    # the second run wrote one candidate, not two: the summary must not inherit
-    # the job's cumulative counter
-    assert "halted after 1/3 chunk(s), 1 candidate(s) written by this run" in summaries[0]
-    assert "halted after 2/3 chunk(s), 1 candidate(s) written by this run" in summaries[1]
+    # the second run wrote one candidate from one chunk, not two: the summary must
+    # neither inherit the job's cumulative counter nor let the job's progress be
+    # read as this run's work
+    assert "job progress 1/3 chunk(s)" in summaries[0]
+    assert "this run wrote 1 candidate(s) from 1 chunk(s)" in summaries[0]
+    assert "job progress 2/3 chunk(s)" in summaries[1]
+    assert "this run wrote 1 candidate(s) from 1 chunk(s)" in summaries[1]
+    # the job stands at 2/3 but this run did one chunk — the two counts must never
+    # be glued into a single clause that reads as one scope
+    assert "2/3 chunk(s), 1 candidate(s) written by this run" not in summaries[1]
+
+
+class _AlwaysEligibleEngine:
+    """A recommendation engine that reads no policy and accepts everything.
+
+    Stands in for the engine the real one is one refactor away from being: cache
+    the policy, or move functional relations into a table, and `_engine` stops
+    touching `load_policy` — the accident that refuses a halted KB today.
+    """
+
+    def recommend(self, row):
+        return AcceptRecommendation(
+            fact_id=int(row["id"]),
+            eligible=True,
+            reasons=(),
+            support_sources=("sources/a.txt", "sources/b.txt"),
+            support_fact_ids=(int(row["id"]),),
+            canonical_relation=str(row["relation"]),
+            typed_normalization="",
+        )
+
+
+def _auto_accept_kb(tmp_path):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store.record_policy_marker(policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold")
+    store.add_fact("X", "is_a", "Y", status="candidate")
+    return store, path
+
+
+def test_auto_accept_refuses_a_halted_kb_by_its_own_guard(tmp_path, monkeypatch):
+    """`apply_auto_accept_recommendations` must refuse a halted KB ITSELF (#194).
+
+    A halted KB stops auto-accept today only by coincidence: `_engine` builds its
+    single-valued set through `store_functional_relations` -> `load_policy`, which
+    raises. The refusal belongs to the write entrypoint, not to whatever the
+    recommendation engine happens to read on the way — so this test removes the
+    coincidence (an engine that reads no policy at all) and demands the refusal
+    survive. Without `assert_writable`, a KB whose rules are gone gets facts stamped
+    `accepted`: a review gate that no rule was ever applied to.
+    """
+    store, path = _auto_accept_kb(tmp_path)
+    monkeypatch.setattr(acceptance, "_engine", lambda store: _AlwaysEligibleEngine())
+    path.unlink()  # the KB recorded a policy and the file is gone: halted
+
+    with pytest.raises(PolicyMissingError):
+        acceptance.apply_auto_accept_recommendations(store)
+
+    assert [f["status"] for f in store.facts()] == ["candidate"]
+    events = [e["event_type"] for e in store.fact_events(int(store.facts()[0]["id"]))]
+    store.close()
+    assert "auto_accept_applied" not in events
+
+
+def test_auto_accept_still_accepts_on_a_healthy_kb(tmp_path, monkeypatch):
+    """The control: the guard refuses a *halted* KB, it does not disable auto-accept.
+
+    Without this, a stub engine that quietly recommended nothing would make the test
+    above pass for the wrong reason.
+    """
+    store, _ = _auto_accept_kb(tmp_path)
+    monkeypatch.setattr(acceptance, "_engine", lambda store: _AlwaysEligibleEngine())
+
+    applied = acceptance.apply_auto_accept_recommendations(store)
+
+    assert [r.fact_id for r in applied] == [int(store.facts()[0]["id"])]
+    assert [f["status"] for f in store.facts()] == ["accepted"]
+    store.close()
 
 
 def test_store_has_no_public_meta_delete(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -644,6 +644,115 @@ def test_reset_running_chunks_makes_job_resumable(tmp_path):
     assert s.get_extraction_job(job_id)["status"] == "pending"
 
 
+def _job_with_mixed_chunks(s, sid):
+    """A job caught mid-flight: one chunk done, one failed, one in flight."""
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=3
+    )
+    chunks = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b", "c"])
+    s.mark_extraction_job_running(job_id)
+    s.mark_chunk_running(chunks[0])
+    s.mark_chunk_done(chunks[0], candidates=2)
+    s.mark_chunk_running(chunks[1])
+    s.mark_chunk_failed(chunks[1], "provider down")
+    s.mark_chunk_running(chunks[2])
+    return job_id, chunks
+
+
+def test_rollback_extraction_job_requeues_only_the_in_flight_chunk(tmp_path):
+    """A halted job must be resumable: `running` is a state nothing ever resets (#194)."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id, chunks = _job_with_mixed_chunks(s, sid)
+
+    s.rollback_extraction_job(job_id, "Halted: policy missing. Rolled back to pending.")
+
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "pending"
+    assert job["message"] == "Halted: policy missing. Rolled back to pending."
+    rows = s.source_chunks(job_id)
+    # done work is kept (its candidate facts are real), the failure keeps its
+    # error, and only the in-flight chunk goes back in the queue
+    assert [row["status"] for row in rows] == ["done", "failed", "pending"]
+    assert rows[1]["error"] == "provider down"
+    assert rows[2]["error"] == ""
+    assert s.next_pending_chunk(job_id)["id"] == chunks[2]
+
+
+def test_rollback_extraction_job_leaves_the_counters_true(tmp_path):
+    """Counters count `done`/`failed` chunks; a rollback changes neither."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id, _ = _job_with_mixed_chunks(s, sid)
+    before = s.get_extraction_job(job_id)
+    counters = (
+        before["completed_chunks"],
+        before["failed_chunks"],
+        before["candidate_count"],
+        before["total_chunks"],
+    )
+
+    s.rollback_extraction_job(job_id, "halted")
+
+    after = s.get_extraction_job(job_id)
+    assert (
+        after["completed_chunks"],
+        after["failed_chunks"],
+        after["candidate_count"],
+        after["total_chunks"],
+    ) == counters == (1, 1, 2, 3)
+
+
+def test_rollback_extraction_job_records_a_fact_event(tmp_path):
+    """The rewind is part of the KB's history, not an invisible edit."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id, _ = _job_with_mixed_chunks(s, sid)
+
+    s.rollback_extraction_job(job_id, "halted")
+
+    events = list(
+        s._conn.execute(
+            "SELECT event_type, actor, job_id, source_id, before_json, after_json "
+            "FROM fact_events WHERE event_type = 'extraction_job_rolled_back'"
+        )
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event["actor"] == "system"
+    assert event["job_id"] == job_id
+    assert event["source_id"] == sid
+    # the job carried a failed chunk, so it stood at 'failed' before the rewind
+    assert json.loads(event["before_json"])["status"] == "failed"
+    assert json.loads(event["after_json"])["status"] == "pending"
+
+
+def test_rollback_extraction_job_does_not_revive_a_canceled_job(tmp_path):
+    """A human cancelled it; a halt must not put it back in the queue."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id, _ = _job_with_mixed_chunks(s, sid)
+    s._conn.execute(
+        "UPDATE extraction_jobs SET status = 'canceled', message = 'canceled by user' "
+        "WHERE id = ?",
+        (job_id,),
+    )
+
+    s.rollback_extraction_job(job_id, "halted")
+
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "canceled"
+    assert job["message"] == "canceled by user"
+
+
+def test_rollback_extraction_job_ignores_an_unknown_job(tmp_path):
+    s = _store(tmp_path)
+
+    s.rollback_extraction_job(9999, "halted")
+
+    assert list(s._conn.execute("SELECT id FROM fact_events")) == []
+
+
 def test_mark_chunk_running_returns_none_when_chunk_already_claimed(tmp_path):
     s = _store(tmp_path)
     sid = s.add_source("sources/a.txt")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -728,7 +728,13 @@ def test_rollback_extraction_job_records_a_fact_event(tmp_path):
 
 
 def test_rollback_extraction_job_does_not_revive_a_canceled_job(tmp_path):
-    """A human cancelled it; a halt must not put it back in the queue."""
+    """A human cancelled it; a halt must not put it — or its chunks — back in the queue.
+
+    Guarding the job row alone is not enough. With the chunk UPDATE left ungated,
+    the in-flight chunk goes back to `pending` and `next_pending_chunk` starts
+    handing out chunks of a job that is `canceled` — the queue and the job row
+    disagreeing about the same job.
+    """
     s = _store(tmp_path)
     sid = s.add_source("sources/a.txt")
     job_id, _ = _job_with_mixed_chunks(s, sid)
@@ -743,6 +749,31 @@ def test_rollback_extraction_job_does_not_revive_a_canceled_job(tmp_path):
     job = s.get_extraction_job(job_id)
     assert job["status"] == "canceled"
     assert job["message"] == "canceled by user"
+    # the in-flight chunk stays `running`: it is not back in the queue
+    assert [row["status"] for row in s.source_chunks(job_id)] == ["done", "failed", "running"]
+    assert s.next_pending_chunk(job_id) is None
+
+
+def test_rollback_extraction_job_records_no_event_for_a_canceled_job(tmp_path):
+    """Nothing was rolled back, so claiming a rollback in the history is a lie.
+
+    `extraction_job_rolled_back` with before == after == `canceled` is exactly the
+    kind of KB self-misreport #194 exists to remove — written by the fix for it.
+    """
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id, _ = _job_with_mixed_chunks(s, sid)
+    s._conn.execute(
+        "UPDATE extraction_jobs SET status = 'canceled' WHERE id = ?", (job_id,)
+    )
+
+    s.rollback_extraction_job(job_id, "halted")
+
+    events = [
+        row["event_type"]
+        for row in s._conn.execute("SELECT event_type FROM fact_events WHERE job_id = ?", (job_id,))
+    ]
+    assert "extraction_job_rolled_back" not in events
 
 
 def test_rollback_extraction_job_ignores_an_unknown_job(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1185,9 +1185,8 @@ def test_launching_the_ui_on_a_halted_kb_resumes_nothing(tmp_path, monkeypatch, 
     )
     before = _job_row(cfg, job_id)
 
-    app = create_app(cfg)
+    create_app(cfg)
 
-    assert app.state.resumed_job_ids == []  # not one job revived
     time.sleep(0.2)  # a worker thread, had one been started, would have written by now
     assert clients == []  # no worker was started at all
     assert _job_row(cfg, job_id) == before  # job untouched: still pending, same message
@@ -1198,21 +1197,21 @@ def test_launching_the_ui_on_a_halted_kb_resumes_nothing(tmp_path, monkeypatch, 
 def test_launching_the_ui_on_a_healthy_kb_still_resumes(tmp_path, monkeypatch, fake_client):
     """The gate above refuses a *halted* KB, not every KB."""
     cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    clients = []
     monkeypatch.setattr(
         webapp,
         "get_client",
-        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+        lambda cfg: clients.append(cfg) or fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
     )
 
-    app = create_app(cfg)
-    c = TestClient(app)
-
-    assert app.state.resumed_job_ids == [job_id]
+    c = TestClient(create_app(cfg))
 
     def resumed():
         assert "is_a" in c.get("/review").text
 
     _wait_for(resumed)
+    assert clients != []  # the worker really was started
+    assert _job_row(cfg, job_id)["status"] == "done"
 
 
 def test_worker_halt_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):
@@ -1272,6 +1271,130 @@ def test_worker_still_fails_the_job_on_an_ordinary_error(tmp_path, monkeypatch, 
 
     _wait_for(failed)
     assert "boom" in _job_row(cfg, job_id)["message"]
+
+
+def _auto_accept_kb(tmp_path):
+    """A KB one finished job away from auto-accepting a fact.
+
+    `sources/b.txt` already contributed `X is_a Y` from a `done` job, so the moment
+    the pending job on `sources/a.txt` extracts the same triple, both facts have two
+    distinct corroborating sources and become auto-accept eligible.
+    """
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+        auto_accept_recommendations=True,
+    )
+    policy = tmp_path / POLICY_RELPATH
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        corroborating = store.add_source("sources/b.txt")
+        done_job = store.create_extraction_job(
+            source_id=corroborating, provider="anthropic", model="m", total_chunks=1
+        )
+        chunk = store.add_source_chunks(
+            job_id=done_job, source_id=corroborating, chunks=["prior text"]
+        )[0]
+        store.mark_extraction_job_running(done_job)
+        store.mark_chunk_running(chunk)
+        store.mark_chunk_done(chunk, candidates=1)
+        store.finish_extraction_job(done_job)
+        store.add_fact(
+            "X", "is_a", "Y", status="candidate", source_id=corroborating, job_id=done_job
+        )
+
+        sid = store.add_source("sources/a.txt")
+        job_id = store.create_extraction_job(
+            source_id=sid, provider="anthropic", model="m", total_chunks=1
+        )
+        store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["some text"])
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+    return cfg, job_id, policy
+
+
+def _fact_statuses(cfg):
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        return sorted(str(fact["status"]) for fact in store.facts())
+
+
+def test_worker_does_not_auto_accept_on_a_kb_that_went_halted(
+    tmp_path, monkeypatch, fake_client
+):
+    """End-to-end: a policy lost after the last chunk must not still auto-accept (#194).
+
+    `apply_auto_accept_recommendations` fires in the same `with Store(...)` block the
+    instant `process_extraction_job` returns, so a policy deleted after the final
+    chunk's write boundary lands squarely on it — and `status='accepted'` on a KB
+    with no rules is a review gate no rule was ever applied to.
+
+    Scope, honestly: this path is double-guarded, so it does not pin
+    `apply_auto_accept_recommendations`'s own `assert_writable` — the engine's
+    `store_functional_relations` -> `load_policy` would also raise here.
+    `test_auto_accept_refuses_a_halted_kb_by_its_own_guard` is the test that pins the
+    guard; this one pins the worker's end-to-end behaviour: job `done`, nothing
+    accepted, no `auto_accept_applied` in the history.
+    """
+    cfg, job_id, policy = _auto_accept_kb(tmp_path)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    real = webapp.process_extraction_job
+
+    def vanish_after_the_job(*args, **kwargs):
+        # the exact gap the guard covers: every chunk passed its write boundary, the
+        # job is `done`, and the policy disappears before auto-accept runs
+        result = real(*args, **kwargs)
+        policy.unlink()
+        return result
+
+    monkeypatch.setattr(webapp, "process_extraction_job", vanish_after_the_job)
+
+    create_app(cfg)
+
+    def job_finished():
+        assert _job_row(cfg, job_id)["status"] == "done"
+
+    _wait_for(job_finished)
+    time.sleep(0.2)  # let an unguarded auto-accept land, if the guard regressed
+    # both facts were auto-accept *eligible*; on a halted KB neither may be accepted
+    assert _fact_statuses(cfg) == ["candidate", "candidate"]
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        events = [
+            row["event_type"]
+            for row in store._conn.execute("SELECT event_type FROM fact_events")
+        ]
+    assert "auto_accept_applied" not in events
+
+
+def test_worker_still_auto_accepts_on_a_healthy_kb(tmp_path, monkeypatch, fake_client):
+    """The control: the guard refuses a *halted* KB, it does not disable auto-accept.
+
+    Without this, deleting the auto-accept call outright would pass the test above.
+    """
+    cfg, job_id, _ = _auto_accept_kb(tmp_path)  # policy left in place
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    create_app(cfg)
+
+    def auto_accepted():
+        assert _job_row(cfg, job_id)["status"] == "done"
+        assert _fact_statuses(cfg) == ["accepted", "accepted"]
+
+    _wait_for(auto_accepted)
 
 
 def test_report_ok_for_consistent_kb(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
 import re
+import threading
 import time
 from html import unescape
 
@@ -11,8 +12,14 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 import verinote.web.app as webapp  # noqa: E402
 from verinote.config import Config  # noqa: E402
+from verinote.engine import DEFAULT_POLICY  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
+from verinote.pipeline.policy_state import (  # noqa: E402
+    POLICY_RELPATH,
+    PolicyMissingError,
+    policy_sha256,
+)
 from verinote.pipeline.query import query_path  # noqa: E402
 from verinote.pipeline.query_intent import parse_query_intent  # noqa: E402
 from verinote.store import Store  # noqa: E402
@@ -1114,6 +1121,157 @@ def test_create_app_resumes_pending_source_jobs(tmp_path, monkeypatch, fake_clie
         assert "Analysis complete: 1/1 chunk(s)" in c.get("/sources").text
 
     _wait_for(resumed)
+
+
+def _job_kb(tmp_path, *, with_policy: bool):
+    """A KB with one pending extraction job — optionally with a *recorded* policy."""
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    policy = tmp_path / POLICY_RELPATH
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        sid = store.add_source("sources/a.txt")
+        job_id = store.create_extraction_job(
+            source_id=sid, provider="anthropic", model="m", total_chunks=1
+        )
+        store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["some text"])
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+    if not with_policy:
+        policy.unlink()  # the KB recorded a policy and the file is gone: halted
+    return cfg, job_id, policy
+
+
+def _job_row(cfg, job_id):
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        return dict(store.get_extraction_job(job_id))
+
+
+def _job_event_types(cfg, job_id):
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        return [
+            row["event_type"]
+            for row in store._conn.execute(
+                "SELECT event_type FROM fact_events WHERE job_id = ? ORDER BY id",
+                (job_id,),
+            )
+        ]
+
+
+def test_launching_the_ui_on_a_halted_kb_resumes_nothing(tmp_path, monkeypatch, fake_client):
+    """Zero HTTP requests, and still the launcher used to write to a halted KB (#194).
+
+    `_resume_source_extraction_jobs` runs inside `create_app()`, outside the
+    request middleware that guards every route — so the middleware's halt never
+    covered it. The worker it started raised, `except Exception` "helpfully"
+    marked the job `failed`, and a KB whose rules were gone took a write from a
+    process that had not served a single request.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=False)
+    clients = []
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: clients.append(cfg) or fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    before = _job_row(cfg, job_id)
+
+    app = create_app(cfg)
+
+    assert app.state.resumed_job_ids == []  # not one job revived
+    time.sleep(0.2)  # a worker thread, had one been started, would have written by now
+    assert clients == []  # no worker was started at all
+    assert _job_row(cfg, job_id) == before  # job untouched: still pending, same message
+    assert before["status"] == "pending"
+    assert _job_event_types(cfg, job_id) == []  # no started / failed / rolled_back
+
+
+def test_launching_the_ui_on_a_healthy_kb_still_resumes(tmp_path, monkeypatch, fake_client):
+    """The gate above refuses a *halted* KB, not every KB."""
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    app = create_app(cfg)
+    c = TestClient(app)
+
+    assert app.state.resumed_job_ids == [job_id]
+
+    def resumed():
+        assert "is_a" in c.get("/review").text
+
+    _wait_for(resumed)
+
+
+def test_worker_halt_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):
+    """`except PolicyMissingError` must stay ABOVE `except Exception` in the worker.
+
+    Below it, the generic handler "reports" the halt by calling
+    `fail_extraction_job` — a write to the very KB the halt exists to protect, and
+    one that buries the job in a `failed` state nothing resumes.
+    `process_extraction_job` already rewound the job to `pending`; the right move
+    is to touch the DB not at all.
+    """
+    cfg, job_id, policy = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    called = threading.Event()
+
+    def halt(*args, **kwargs):
+        # the shape of a mid-job halt: the job has already been rolled back to
+        # `pending` by `process_extraction_job` before the error reaches the worker
+        policy.unlink()
+        called.set()
+        raise PolicyMissingError("policy file is missing; run `verinote policy reset --force`")
+
+    monkeypatch.setattr(webapp, "process_extraction_job", halt)
+
+    create_app(cfg)
+
+    assert called.wait(timeout=2.0)
+    time.sleep(0.2)  # let a (wrong) `fail_extraction_job` land, if the order regressed
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "pending", "the halted job was buried in `failed` by a write"
+    assert "analysis failed" not in job["message"]
+    assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
+
+
+def test_worker_still_fails_the_job_on_an_ordinary_error(tmp_path, monkeypatch, fake_client):
+    """The control for the test above: a non-halt crash *is* still reported."""
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(webapp, "process_extraction_job", boom)
+
+    create_app(cfg)
+
+    def failed():
+        assert _job_row(cfg, job_id)["status"] == "failed"
+
+    _wait_for(failed)
+    assert "boom" in _job_row(cfg, job_id)["message"]
 
 
 def test_report_ok_for_consistent_kb(tmp_path):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -262,6 +262,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         process_extraction_job,
         sync_sources,
     )
+    from verinote.pipeline.policy_state import PolicyMissingError
     from verinote.prompts import PromptError
 
     def extraction_schema_hint() -> str:
@@ -312,6 +313,15 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         else:
             pairs = [(source.source_path, source.text) for source in sources]
             result = sync_sources(store, client, pairs, provider=cfg.provider, model=cfg.model)
+    except PolicyMissingError as exc:
+        # The policy vanished after the command's preflight — mid-job (the worker's
+        # write boundary re-raises this after rolling the job back to `pending`) or
+        # mid-batch (a later source in `sync_sources` hits the write gate). Either
+        # way, report the clean halt diagnosis instead of a traceback, and exit with
+        # the same rc=2 the start-of-command refusal (`_refuse_on_halted_kb`) uses.
+        print(f"error: {exc}", file=sys.stderr)
+        store.close()
+        return 2
     except LLMError as e:
         print(f"extraction failed: {e}", file=sys.stderr)
         store.close()

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -418,11 +418,44 @@ def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def _print_policy_state(store: Store) -> bool:
+    """Print the KB's policy state on a diagnostic command. True when halted.
+
+    `status` and `coverage` are the whole diagnostic surface a non-web user has,
+    and before this they reported a halted KB as perfectly healthy — the only way
+    to discover a lost policy was to attempt a write and be refused (#194). That is
+    #155's own thesis ("a KB whose rules are gone must not look fine") surviving on
+    the CLI.
+
+    The marker goes to *stdout*, next to the rest of the summary: a banner on
+    stderr alone is invisible to `verinote status > out.txt` and to a CI health
+    check, which is exactly where a silent halt does its damage. The loud,
+    actionable recovery text still goes to stderr, where errors belong.
+
+    The judgement is `resolve_policy`'s alone — this function never looks at the
+    filesystem. One predicate, or the enforcement points drift apart.
+    """
+    from verinote.pipeline.policy_state import (
+        PolicyStatus,
+        policy_cli_line,
+        policy_missing_message,
+        resolve_policy,
+    )
+
+    state = resolve_policy(store)
+    print(policy_cli_line(state))
+    if state.status is PolicyStatus.MISSING_RECORDED:
+        print(f"error: {policy_missing_message(state)}", file=sys.stderr)
+        return True
+    return False
+
+
 def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.engine import coverage
 
     store = _store(cfg)
     cov = coverage(store, root=cfg.root)
+    halted = _print_policy_state(store)
     store.close()
     for s in cov.sources:
         flags = []
@@ -436,6 +469,13 @@ def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
         f"coverage: {len(cov.covered)} covered, {len(cov.gaps)} gap(s), "
         f"{len(cov.orphans)} orphan(s)"
     )
+    # `--strict` exists to be a machine-read gate. A KB whose rules have evaporated
+    # is not a KB that passes a gate, so the halt fails it just like a coverage gap
+    # does — otherwise automation greenlights a KB with no rules. Plain `coverage`
+    # stays rc=0: it is a recovery path, and a halt you cannot inspect is a brick.
+    if args.strict and halted:
+        print("strict: this KB's logic policy file is missing", file=sys.stderr)
+        return 1
     if args.strict and cov.gaps:
         print("strict: uncovered text source(s) present", file=sys.stderr)
         return 1
@@ -450,6 +490,10 @@ def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     print(f"facts:   {sum(counts.values())}")
     for s in ("candidate", "needs_review", "confirmed", "accepted", "superseded"):
         print(f"  {s:<13} {counts.get(s, 0)}")
+    # `status` stays rc=0 even when halted: it is one of the paths that must keep
+    # working *on* a halted KB, and a diagnosis command that fails is not a
+    # diagnosis. The stdout marker is what makes the halt impossible to miss.
+    _print_policy_state(store)
     store.close()
     return 0
 

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -15,6 +15,7 @@ from verinote.pipeline.corroboration import (
     store_typed_relations,
     TypedRelationSpec,
 )
+from verinote.pipeline.policy_state import assert_writable
 from verinote.store import Store, is_engine_input, is_review_eligible, review_statuses
 
 RULE_NAME = "corroborated_no_conflict"
@@ -60,6 +61,22 @@ def accept_recommendations_for(
 
 
 def apply_auto_accept_recommendations(store: Store) -> list[AcceptRecommendation]:
+    """Promote every eligible candidate to `accepted` — never on a halted KB.
+
+    A halted KB already stops this today, but only by COINCIDENCE: `_engine` builds
+    its single-valued set from `store_functional_relations`, which calls
+    `load_policy`, which raises on a KB whose policy file is gone. The refusal is
+    therefore a side effect of what the recommendation engine happens to read — and
+    the day functional relations move into a table, or the policy gets cached, that
+    side effect evaporates while this remains a write entrypoint that stamps
+    `status='accepted'` on facts no rule was ever applied to.
+
+    So the refusal is made this function's OWN, asked of the same predicate every
+    other write entrypoint asks (#194), before a single row is read. The extraction
+    worker calls this the instant a job finishes, in the same `with Store(...)`, so
+    a policy deleted after the final chunk's write boundary lands exactly here.
+    """
+    assert_writable(store)
     applied = []
     for recommendation in accept_recommendations(store).values():
         if not recommendation.eligible:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -170,9 +170,14 @@ def process_extraction_job(
     the check has to live next to the write itself.
 
     On a mid-job halt the job is rolled back to `pending` (see
-    `_halt_extraction_job`) before the error propagates. Leaving it `running` would
-    strand the source forever: no code path resets a `running` job, so it could
-    neither finish nor be re-synced.
+    `_halt_extraction_job`) before the error propagates. Left `running`, the job row
+    would simply be false — the job is not running, nothing is processing it — and a
+    KB that lies about its own state is what this change exists to stop. It would
+    also make recovery depend on the web launcher: `_resume_source_extraction_jobs`
+    is the only thing that revives a `running` job (and only when someone next
+    starts the UI), while `reset_running_chunks` below rewinds the *chunks* of a job
+    already being processed, not a job nobody is processing. `pending` is the state
+    that says what is true and that every resume path already understands.
     """
     assert_writable(store)
     job = store.get_extraction_job(job_id)
@@ -187,6 +192,7 @@ def process_extraction_job(
     run_id = store.add_run(provider=job["provider"], model=job["model"])
 
     candidates = 0
+    run_chunks = 0
     try:
         while chunk := store.next_pending_chunk(job_id):
             # Pre-claim gate. Claiming a chunk (`status='running'`, `attempts + 1`)
@@ -215,6 +221,7 @@ def process_extraction_job(
                 continue
             candidates += inserted
             store.mark_chunk_done(int(running["id"]), candidates=inserted)
+            run_chunks += 1
     except PolicyMissingError:
         # The policy vanished mid-job — either before this chunk was claimed (the
         # gate above) or between its LLM call and its first insert (the boundary in
@@ -225,6 +232,7 @@ def process_extraction_job(
             run_id=run_id,
             source_path=str(source["path"]),
             run_candidates=candidates,
+            run_chunks=run_chunks,
         )
         raise
 
@@ -251,6 +259,7 @@ def _halt_extraction_job(
     run_id: int,
     source_path: str,
     run_candidates: int,
+    run_chunks: int,
 ) -> None:
     """Rewind a job whose KB went halted mid-flight, and record what really happened.
 
@@ -262,8 +271,13 @@ def _halt_extraction_job(
     change that exists to stop the KB lying about its state must not plant a new
     lie, so every number below is read back from the KB rather than assumed.
 
-    `run_candidates` is what *this* run inserted (the job's own `candidate_count`
-    is cumulative across resumes, and would over-report for a resumed job).
+    TWO DIFFERENT SCOPES, AND THEY MUST STAY GRAMMATICALLY APART. `completed`/
+    `total` are the *job's* progress, cumulative across every resume; `run_chunks`
+    and `run_candidates` are what *this* run did. Phrase them as one clause
+    ("halted after 2/3 chunk(s), 1 candidate(s) written by this run") and a resumed
+    job reads as "this run did 2 chunks and wrote 1 candidate" when this run may
+    have done exactly one chunk. A sentence that has to be cross-checked against the
+    job row to be understood is not a fix for a KB that misreports itself.
     """
     job = store.get_extraction_job(job_id)
     completed = int(job["completed_chunks"]) if job is not None else 0
@@ -276,9 +290,9 @@ def _halt_extraction_job(
     )
     store.set_run_summary(
         run_id,
-        f"{source_path}: halted after {completed}/{total} chunk(s), "
-        f"{run_candidates} candidate(s) written by this run before this KB's policy "
-        f"file went missing; job rolled back to pending",
+        f"{source_path}: halted because this KB's policy file went missing; "
+        f"job rolled back to pending at job progress {completed}/{total} chunk(s); "
+        f"this run wrote {run_candidates} candidate(s) from {run_chunks} chunk(s)",
     )
 
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -21,7 +21,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
 )
 from verinote.pipeline.normalize import normalize_for_extraction
-from verinote.pipeline.policy_state import assert_writable
+from verinote.pipeline.policy_state import PolicyMissingError, assert_writable
 from verinote.prompts import PromptError, render_prompt
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
@@ -164,10 +164,15 @@ def process_extraction_job(
     """Process pending chunks for one durable extraction job.
 
     Raises `PolicyMissingError` if this KB's recorded logic policy file is gone —
-    both at the start and, per chunk, at the write boundary in `_extract_chunk`.
-    A job is long-running (one LLM call per chunk) and the CLI's start-of-command
-    check cannot see a policy deleted *after* the job began, so the check has to
-    live next to the write itself.
+    at the start, before each chunk is claimed, and again at the write boundary in
+    `_extract_chunk`. A job is long-running (one LLM call per chunk) and the CLI's
+    start-of-command check cannot see a policy deleted *after* the job began, so
+    the check has to live next to the write itself.
+
+    On a mid-job halt the job is rolled back to `pending` (see
+    `_halt_extraction_job`) before the error propagates. Leaving it `running` would
+    strand the source forever: no code path resets a `running` job, so it could
+    neither finish nor be re-synced.
     """
     assert_writable(store)
     job = store.get_extraction_job(job_id)
@@ -182,29 +187,46 @@ def process_extraction_job(
     run_id = store.add_run(provider=job["provider"], model=job["model"])
 
     candidates = 0
-    while chunk := store.next_pending_chunk(job_id):
-        running = store.mark_chunk_running(int(chunk["id"]))
-        if running is None:
-            continue
-        try:
-            inserted = _extract_chunk(
-                store,
-                client,
-                source_id=int(source["id"]),
-                source_text=str(running["text"]),
-                run_id=run_id,
-                job_id=job_id,
-                artifact_id=(
-                    int(job["artifact_id"]) if job["artifact_id"] is not None else None
-                ),
-                chunk_id=int(running["id"]),
-                schema_hint=schema_hint,
-            )
-        except LLMError as exc:
-            store.mark_chunk_failed(int(running["id"]), str(exc))
-            continue
-        candidates += inserted
-        store.mark_chunk_done(int(running["id"]), candidates=inserted)
+    try:
+        while chunk := store.next_pending_chunk(job_id):
+            # Pre-claim gate. Claiming a chunk (`status='running'`, `attempts + 1`)
+            # is itself a write, so it must not happen on a halted KB — the check
+            # belongs *before* `mark_chunk_running`, not after it.
+            assert_writable(store)
+            running = store.mark_chunk_running(int(chunk["id"]))
+            if running is None:
+                continue
+            try:
+                inserted = _extract_chunk(
+                    store,
+                    client,
+                    source_id=int(source["id"]),
+                    source_text=str(running["text"]),
+                    run_id=run_id,
+                    job_id=job_id,
+                    artifact_id=(
+                        int(job["artifact_id"]) if job["artifact_id"] is not None else None
+                    ),
+                    chunk_id=int(running["id"]),
+                    schema_hint=schema_hint,
+                )
+            except LLMError as exc:
+                store.mark_chunk_failed(int(running["id"]), str(exc))
+                continue
+            candidates += inserted
+            store.mark_chunk_done(int(running["id"]), candidates=inserted)
+    except PolicyMissingError:
+        # The policy vanished mid-job — either before this chunk was claimed (the
+        # gate above) or between its LLM call and its first insert (the boundary in
+        # `_extract_chunk`). Rewind so the KB is recoverable, then let the error out.
+        _halt_extraction_job(
+            store,
+            job_id=job_id,
+            run_id=run_id,
+            source_path=str(source["path"]),
+            run_candidates=candidates,
+        )
+        raise
 
     store.finish_extraction_job(job_id)
     final = store.get_extraction_job(job_id)
@@ -219,6 +241,44 @@ def process_extraction_job(
         candidates=int(final["candidate_count"]),
         completed_chunks=int(final["completed_chunks"]),
         failed_chunks=int(final["failed_chunks"]),
+    )
+
+
+def _halt_extraction_job(
+    store: Store,
+    *,
+    job_id: int,
+    run_id: int,
+    source_path: str,
+    run_candidates: int,
+) -> None:
+    """Rewind a job whose KB went halted mid-flight, and record what really happened.
+
+    The summary must carry the REAL counts. It is tempting to write a constant here
+    ("halted; no candidate facts were written") — and it is a lie the moment any
+    chunk completed before the halt. Those candidate facts exist, they carry a
+    `run_id` pointing at *this* run, and the provenance page would then tell the
+    user that the run which produced the facts in front of them wrote nothing. A
+    change that exists to stop the KB lying about its state must not plant a new
+    lie, so every number below is read back from the KB rather than assumed.
+
+    `run_candidates` is what *this* run inserted (the job's own `candidate_count`
+    is cumulative across resumes, and would over-report for a resumed job).
+    """
+    job = store.get_extraction_job(job_id)
+    completed = int(job["completed_chunks"]) if job is not None else 0
+    total = int(job["total_chunks"]) if job is not None else 0
+    store.rollback_extraction_job(
+        job_id,
+        f"Halted: this KB's policy file is missing. Rolled back to pending at "
+        f"{completed}/{total} chunk(s). Restore the policy file (or run "
+        f"`verinote policy reset --force`), then re-run the analysis.",
+    )
+    store.set_run_summary(
+        run_id,
+        f"{source_path}: halted after {completed}/{total} chunk(s), "
+        f"{run_candidates} candidate(s) written by this run before this KB's policy "
+        f"file went missing; job rolled back to pending",
     )
 
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -86,6 +86,14 @@ def extract_source(
         schema_hint=schema_hint,
         root=store.db_path.parent,
     )
+    # The write boundary, mirroring `_extract_chunk`'s per-chunk gate. The CLI's
+    # start-of-command check cannot see a policy deleted *after* the command began,
+    # and `sync_sources` loops one LLM call per source — so a policy that vanishes
+    # mid-batch must stop the *next* source's inserts. Placed after the LLM call and
+    # before the first DB write, this keeps every source extracted from a halt point
+    # out of a KB whose rules no longer exist, while sources written before the halt
+    # stay (the run row is left for inspection, as with `LLMError`).
+    assert_writable(store)
     aliases = _relation_aliases_or_error(store)
     rows = _candidate_rows(facts, analysis_text, relation_aliases=aliases)
 

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -67,6 +67,23 @@ POLICY_UNRECORDED_BANNER = (
 )
 
 
+# --- the CLI's diagnostic surface ------------------------------------------
+#
+# `status` and `coverage` are the only diagnosis a non-web user has, and a halt
+# they never mention is a halt discovered only by trying to write (#194). These
+# lines go to *stdout*, not stderr: `verinote status > out.txt` and CI health
+# checks read stdout, and a halt marker they cannot see is not a marker.
+#
+# Deliberately one short line per state, not a banner. The UNRECORDED_DEFAULT
+# case is the *normal* state of a brand-new KB; shouting at every `status` teaches
+# people to ignore the policy line, and then the HALTED line gets ignored with it.
+# The loud, actionable text for a real halt is `policy_missing_message`, which the
+# CLI prints to stderr *in addition* to the stdout marker.
+POLICY_CLI_LINE_PRESENT = "policy: ok (this KB's own rules are present)"
+POLICY_CLI_LINE_MISSING_RECORDED = "policy: HALTED (rules missing)"
+POLICY_CLI_LINE_UNRECORDED_DEFAULT = "policy: default (this KB records no rules of its own)"
+
+
 class PolicyMissingError(RuntimeError):
     """Raised when a KB recorded a logic policy but the policy file is gone."""
 
@@ -137,6 +154,23 @@ def policy_missing_message(state: PolicyState) -> str:
         "backup or version control, or (2) running `verinote policy reset --force` "
         "to explicitly re-create the default policy for this KB."
     )
+
+
+def policy_cli_line(state: PolicyState) -> str:
+    """The one-line stdout marker for a resolved policy state.
+
+    A new `PolicyStatus` must add its line to `_POLICY_CLI_LINES`; the KeyError
+    that follows otherwise is deliberate. A blank line silently standing in for an
+    unknown policy state is exactly the class of bug this module exists to kill.
+    """
+    return _POLICY_CLI_LINES[state.status]
+
+
+_POLICY_CLI_LINES = {
+    PolicyStatus.PRESENT: POLICY_CLI_LINE_PRESENT,
+    PolicyStatus.MISSING_RECORDED: POLICY_CLI_LINE_MISSING_RECORDED,
+    PolicyStatus.UNRECORDED_DEFAULT: POLICY_CLI_LINE_UNRECORDED_DEFAULT,
+}
 
 
 def assert_writable(store: "Store") -> PolicyState:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -742,6 +742,52 @@ class Store:
                     after=_job_event_payload(after),
                 )
 
+    def rollback_extraction_job(self, job_id: int, message: str) -> None:
+        """Rewind an interrupted job to `pending` so it can be resumed later.
+
+        Used when this KB's logic policy file vanishes mid-job (#194). The job must
+        not be left `running` with a `running` chunk: nothing resets that state, so
+        the source becomes permanently stuck — it can neither finish nor be
+        re-synced. `failed` is no better, since the chunks that never ran are not
+        failures. `pending` is the only state from which "restore the policy file,
+        re-run the analysis" actually works.
+
+        Chunks already `done` stay `done` (their candidate facts are real, and
+        re-extracting them would just re-do work), and `failed` chunks keep their
+        error. Only the in-flight `running` chunk is returned to the queue, which is
+        safe: it was rolled back *before* any of its facts were written.
+
+        Counters are untouched on purpose — `completed_chunks`/`failed_chunks`/
+        `candidate_count` count `done`/`failed` chunks, and this method changes
+        neither, so they stay true.
+        """
+        with self._lock:
+            before = self.get_extraction_job(job_id)
+            if before is None:
+                return
+            self._conn.execute(
+                "UPDATE source_chunks SET status = 'pending', error = '', "
+                "updated_at = datetime('now') "
+                "WHERE job_id = ? AND status = 'running'",
+                (job_id,),
+            )
+            self._conn.execute(
+                "UPDATE extraction_jobs SET status = 'pending', message = ?, "
+                "updated_at = datetime('now') WHERE id = ? AND status != 'canceled'",
+                (message, job_id),
+            )
+            after = self.get_extraction_job(job_id)
+            if after is not None:
+                self._add_fact_event(
+                    fact_id=None,
+                    event_type="extraction_job_rolled_back",
+                    actor="system",
+                    source_id=int(after["source_id"]),
+                    job_id=job_id,
+                    before=_job_event_payload(before),
+                    after=_job_event_payload(after),
+                )
+
     def fact_exists_for_source(
         self, *, source_id: int, subject: object, relation: object, obj: object
     ) -> bool:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -760,10 +760,20 @@ class Store:
         Counters are untouched on purpose — `completed_chunks`/`failed_chunks`/
         `candidate_count` count `done`/`failed` chunks, and this method changes
         neither, so they stay true.
+
+        A `canceled` job is left alone ENTIRELY — job row, chunks and history. A
+        human took it out of the queue, and reviving its in-flight chunk would put
+        it back in (`next_pending_chunk` would hand out a chunk of a canceled job),
+        while recording an `extraction_job_rolled_back` event for a job that was not
+        rolled back would write a fresh falsehood into the very history this change
+        exists to keep honest. Hence the early return rather than a `WHERE` clause
+        on the job UPDATE alone.
         """
         with self._lock:
             before = self.get_extraction_job(job_id)
             if before is None:
+                return
+            if before["status"] == "canceled":
                 return
             self._conn.execute(
                 "UPDATE source_chunks SET status = 'pending', error = '', "
@@ -773,7 +783,7 @@ class Store:
             )
             self._conn.execute(
                 "UPDATE extraction_jobs SET status = 'pending', message = ?, "
-                "updated_at = datetime('now') WHERE id = ? AND status != 'canceled'",
+                "updated_at = datetime('now') WHERE id = ?",
                 (message, job_id),
             )
             after = self.get_extraction_job(job_id)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -123,9 +123,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app = FastAPI(title="verinote")
     app.state.cfg = cfg
     app.state.store = None
-    # Which jobs the launcher actually revived. Observable on purpose: "the resume
-    # path did nothing" is otherwise only visible as the absence of a DB write.
-    app.state.resumed_job_ids = []
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
@@ -717,10 +714,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # here as an ordinary exception; the generic handler below would
                 # "report" it by calling `fail_extraction_job` — a WRITE to the very
                 # KB the halt exists to protect, and one that buries the job in a
-                # `failed` state nothing resumes. `process_extraction_job` has
-                # already rolled the job back to `pending`, so the right move here
-                # is to touch the DB not at all and just say so. (#194)
-                logger.warning("extraction job %s halted, rolled back: %s", job_id, e)
+                # `failed` state nothing resumes. So this handler writes NOTHING and
+                # only logs. (#194)
+                #
+                # It catches halts from two places, and they leave the job in
+                # different states: `process_extraction_job` has already rolled a
+                # mid-job halt back to `pending`, while `apply_auto_accept_
+                # recommendations` halts *after* the job finished `done`, with no
+                # rollback at all. The message must therefore not assert a rollback
+                # — a log line claiming one for a `done` job would be the same class
+                # of falsehood this change removes. Whoever rewinds, rewinds; this
+                # handler reports.
+                logger.warning("extraction job %s halted (KB policy missing): %s", job_id, e)
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
@@ -767,7 +772,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         Same predicate as the middleware and the CLI dispatch: one judgement,
         three enforcement points.
         """
-        app.state.resumed_job_ids = []
         if app.state.store is None or app.state.cfg is None:
             return
         try:
@@ -777,7 +781,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return
         for job in app.state.store.source_extraction_jobs():
             if job["status"] in {"pending", "running"}:
-                app.state.resumed_job_ids.append(int(job["id"]))
                 _start_source_extraction(int(job["id"]), app.state.cfg)
 
     @app.get("/", response_class=HTMLResponse)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -8,6 +8,7 @@ swaps a single row partial). No JS build step. The app owns one `Store` (SQLite)
 from __future__ import annotations
 
 from importlib import resources
+import logging
 from pathlib import Path
 import threading
 import unicodedata
@@ -91,6 +92,8 @@ from verinote.store import (
 from verinote.store import db as store_db
 from verinote.store.fact_input import structural_term, term_input_kind
 
+logger = logging.getLogger(__name__)
+
 _TEMPLATES = resources.files("verinote.web").joinpath("templates")
 _STATIC = resources.files("verinote.web").joinpath("static")
 
@@ -120,6 +123,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app = FastAPI(title="verinote")
     app.state.cfg = cfg
     app.state.store = None
+    # Which jobs the launcher actually revived. Observable on purpose: "the resume
+    # path did nothing" is otherwise only visible as the absence of a DB write.
+    app.state.resumed_job_ids = []
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
@@ -705,6 +711,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     )
                     if cfg.auto_accept_recommendations:
                         apply_auto_accept_recommendations(worker_store)
+            except PolicyMissingError as e:
+                # ORDER IS LOAD-BEARING — this must stay ABOVE `except Exception`.
+                # The worker runs outside the request middleware, so a halt surfaces
+                # here as an ordinary exception; the generic handler below would
+                # "report" it by calling `fail_extraction_job` — a WRITE to the very
+                # KB the halt exists to protect, and one that buries the job in a
+                # `failed` state nothing resumes. `process_extraction_job` has
+                # already rolled the job back to `pending`, so the right move here
+                # is to touch the DB not at all and just say so. (#194)
+                logger.warning("extraction job %s halted, rolled back: %s", job_id, e)
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
@@ -740,10 +756,28 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             _delete_source_file(path, root)
 
     def _resume_source_extraction_jobs() -> None:
+        """Revive interrupted extraction jobs — but never on a halted KB.
+
+        This runs at `create_app()` time, *outside* the request middleware, so the
+        middleware's guard does not cover it: before this gate existed, merely
+        launching `verinote ui` against a halted KB with a pending job wrote to it
+        (the worker raised, and `except Exception` "helpfully" marked the job
+        `failed`) — a write to a halted KB with zero HTTP requests made (#194).
+
+        Same predicate as the middleware and the CLI dispatch: one judgement,
+        three enforcement points.
+        """
+        app.state.resumed_job_ids = []
         if app.state.store is None or app.state.cfg is None:
+            return
+        try:
+            assert_writable(app.state.store)
+        except PolicyMissingError as exc:
+            logger.warning("not resuming extraction jobs: %s", exc)
             return
         for job in app.state.store.source_extraction_jobs():
             if job["status"] in {"pending", "running"}:
+                app.state.resumed_job_ids.append(int(job["id"]))
                 _start_source_extraction(int(job["id"]), app.state.cfg)
 
     @app.get("/", response_class=HTMLResponse)


### PR DESCRIPTION
Closes #194, closes #235, closes #246.

#155 established that a KB whose logic policy file is gone must halt: it must not look healthy, and it must not be written to. The request middleware and the extraction write boundary enforced that. Three paths did not.

## The three holes

**1. The CLI never said it was halted.** `status` and `coverage` are the entire diagnostic surface a non-web user has, and both reported a halted KB as perfectly healthy — the only way to discover a lost policy was to attempt a write and be refused. Both commands now print a one-line policy marker to *stdout*, next to the rest of the summary: a banner on stderr alone is invisible to `verinote status > out.txt` and to a CI health check, which is exactly where a silent halt does its damage. The loud, actionable recovery text still goes to stderr.

`status` stays rc=0 when halted — it is one of the paths that must keep working *on* a halted KB, and a diagnosis command that fails is not a diagnosis. `coverage --strict` returns 1, because `--strict` exists to be a machine-read gate and a KB whose rules have evaporated is not a KB that passes a gate.

**2. The UI launcher wrote to a halted KB with zero HTTP requests made.** `_resume_source_extraction_jobs()` runs at `create_app()` time, *outside* the request middleware, so the middleware's guard never covered it. Merely launching `verinote ui` against a halted KB with a pending job wrote to it: the worker raised, and a generic `except Exception` "helpfully" marked the job `failed`. The launcher now runs the same `assert_writable` predicate before reviving anything, and the worker's `except PolicyMissingError` sits **above** `except Exception` so the halt is never "reported" by writing to the very KB the halt exists to protect.

**3. A mid-job halt stranded the source forever.** A job is long-running (one LLM call per chunk), so a policy deleted *after* the job began was caught only at the write boundary — leaving the job `running` with a `running` chunk. Nothing resets that state, so the source could neither finish nor be re-synced. The policy is now also checked *before* each chunk is claimed (claiming a chunk is itself a write), and on a halt the job is rolled back to `pending` — the only state from which "restore the policy file, re-run the analysis" actually works. Chunks already `done` stay `done`; only the in-flight chunk returns to the queue, which is safe because it was rolled back before any of its facts were written.

The rollback's run summary carries the **real** counts, read back from the KB. A constant ("halted; no candidate facts were written") would be a lie the moment any chunk completed before the halt: those candidate facts exist and carry this run's `run_id`, and the provenance page would then tell the user that the run which produced the facts in front of them wrote nothing. A change that exists to stop the KB lying about its state must not plant a new lie.

One predicate (`resolve_policy` / `assert_writable`), three new enforcement points.

## Tests

19 new tests, each verified by mutation — the fix was broken in 10 distinct ways and every mutation turned a test red:

| Mutation | Caught by |
|---|---|
| Drop `_print_policy_state` from `cmd_status` | `test_status_says_the_kb_is_halted_on_stdout` |
| Drop the halt branch from `coverage --strict` | `test_coverage_strict_fails_on_a_halted_kb` |
| Remove `MISSING_RECORDED` from `_POLICY_CLI_LINES` | `test_policy_cli_line_covers_every_policy_status` |
| Drop `assert_writable` from the launcher | `test_launching_the_ui_on_a_halted_kb_resumes_nothing` |
| Move `except PolicyMissingError` below `except Exception` | `test_worker_halt_does_not_mark_the_job_failed` |
| Drop the pre-claim `assert_writable` | `test_chunk_is_not_claimed_on_a_kb_that_went_halted` |
| Drop the `_halt_extraction_job` call | `test_mid_job_halt_rolls_the_job_back_to_pending` |
| Make `rollback_extraction_job` a no-op | 2 store tests + the rollback test |
| Summary uses cumulative `candidate_count` | `test_resumed_job_summary_counts_only_this_run` |
| Rollback revives a `canceled` job | `test_rollback_extraction_job_does_not_revive_a_canceled_job` |

Each halt test has a healthy-KB control, so the assertions prove the halt caused the behaviour rather than the command merely failing.

Full suite: 917 passed, 7 skipped. `ruff check` clean.



## Review round 2 — the fourth hole and the traceback (owner review)

The owner's review found two more holes, and they are now closed in this PR rather than deferred:

**4. The legacy sync path never re-checked the halt (#235).** `extract_source` — the path unregistered raw sources take via `sync_sources` — had no write-boundary guard, so a policy deleted mid-batch kept writing candidates to a halted KB with rc=0. `extract_source` now runs `assert_writable` after the LLM call and before its first DB write (`add_source`), symmetric with the chunked path's per-chunk gate. Sources written before the halt stay; everything after is refused (`5f1ed45`).

**5. A mid-sync halt surfaced as a traceback (#246).** `cmd_sync` caught only `LLMError`, so the `PolicyMissingError` raised at a mid-job halt escaped `main` as a raw traceback, and the rollback guidance lived only in the DB job message. `cmd_sync` now catches `PolicyMissingError` **above** `LLMError`, prints the policy-missing diagnosis to stderr, and exits rc=2 — consistent with every other halt path (`27cc288`).

Both are pinned by tests (mid-batch halt leaves exactly the pre-halt source; the CLI run asserts rc=2, the recovery text, and the absence of "Traceback") and verified by mutation: removing the `extract_source` guard or the `PolicyMissingError` handler turns them red. Suite: 931 passed, 7 skipped; ruff clean.
