### PR TITLE
docs(#211): put the answer first in the README, and move the manual into docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,14 +11,16 @@ venv/
 # verinote local state (a KB's data is local, like a working dir).
 #
 # The default KB lives here. It is USER DATA, not a repo artifact, so it is
-# never committed — and the only file in it this repo can regenerate is
-# `facts/query.dl`:
+# never committed. Almost none of it can be regenerated: `facts/query.dl` is
+# recompiled from your questions, and `policy/logic-policy.dl` can be re-scaffolded
+# back to the shipped default — never back to your edits. The rest is yours alone:
 #   data/kb.sqlite              every accept/reject decision + the audit log
 #   data/facts.duckdb           the canonical fact terms. NOT rebuildable from
 #                               kb.sqlite: the SQLite columns are display mirrors,
-#                               so a lost sidecar re-types compounds as strings
-#                               (#156). Ignored because it is user data, not
-#                               because it is disposable.
+#                               so the engine refuses to run on a lost sidecar
+#                               rather than re-type compounds as strings (#156).
+#                               Ignored because it is user data, not because it
+#                               is disposable.
 #   data/sources/, data/artifacts/
 #                               the ingested documents and their extracted text
 #   data/policy/*.dl            hand-written logic policy
@@ -27,8 +29,8 @@ venv/
 #   data/policy/prompts/, data/config.json
 #                               hand-written prompt overrides and settings
 # Back these up yourself, or keep the KB outside the working tree entirely
-# (`VERINOTE_ROOT=~/verinote-kb verinote init`). See README, "Your KB is not a
-# repo artifact". `git clean -fdx` deletes all of it.
+# (`VERINOTE_ROOT=~/verinote-kb verinote init`). See docs/operations.md.
+# `git clean -fdx` deletes all of it.
 /data/
 
 # Generated engine artifacts, anchored to the KB layout.

--- a/README.md
+++ b/README.md
@@ -2,42 +2,93 @@
 
 [![ci](https://github.com/semantic-reasoning/verinote/actions/workflows/ci.yml/badge.svg)](https://github.com/semantic-reasoning/verinote/actions/workflows/ci.yml)
 
-**Honest knowledge base.** An LLM extracts source-backed *candidate* facts from your
-documents; a deterministic DuckDB-backed Datalog engine verifies them; you keep a
-human review gate before any fact is promoted to engine input. Runs as a local web app.
+**Ask your documents a question. Get an answer a deterministic engine has verified — with the source to prove it.**
 
-> Borrows the *concept* of [factlog](https://github.com/semantic-reasoning/factlog)
-> (neurosymbolic: LLM extracts, a Datalog engine verifies) but is a
-> from-scratch implementation — no shared code.
+verinote is an honest knowledge base that runs as a local web app. An LLM extracts
+source-backed candidate facts from your documents; a DuckDB-backed Datalog engine
+verifies them deterministically; and by default nothing becomes engine input until
+a human approves it.
 
 ## Why
 
-A free-text wiki drifts: facts go stale, contradict each other, and lose their
-sources. verinote keeps the knowledge base *honest* by pairing a neural extractor
-with a symbolic verifier:
+Two hundred meeting notes, and nobody knows which decision is still current. Every
+free-text wiki drifts: facts go stale, contradict each other, and lose the link to
+whatever document justified them — and once you bolt an LLM on top, it happily
+summarizes the drift with full confidence.
 
-- **LLM extracts** source-backed candidate facts (provider-agnostic — see below).
-- **DuckDB-backed Datalog verifies** consistency deterministically. Because every fact is
-  re-checked by the engine, swapping to a cheaper or local model never compromises
-  correctness.
-- **You review.** Facts move `candidate → needs_review → confirmed/accepted`
-  through a human gate; `superseded` retires them.
+verinote keeps the knowledge base honest by splitting the work three ways:
+
+1. **The LLM only proposes.** It extracts candidate facts, each tied to a source
+   document (provider-agnostic: Anthropic, Claude CLI, OpenAI, or local Ollama).
+2. **The engine only verifies.** Confirmed facts load into DuckDB, where Datalog
+   policy and query rules check them deterministically. Because every fact is
+   re-checked by the engine, swapping to a cheaper or local model never
+   compromises correctness.
+3. **You decide.** A fact sits in the review tier (`candidate` or `needs_review`)
+   until you promote it to an engine status (`confirmed` or `accepted`);
+   `superseded` retires it. Not even seeded demo facts skip the queue. One
+   opt-in rule can promote corroborated, conflict-free facts for you — it is off
+   by default, and turning it on is you delegating the gate, not removing it
+   ([auto-accept](docs/configuration.md#auto-accept)).
+
+When you ask a question, the answer arrives labeled with how much you can trust
+it: **`VERIFIED — engine`** when the Datalog engine proved it from facts you
+approved, or **`UNVERIFIED — source exploration`** when verinote is only
+surfacing excerpts. The evidence block always comes first; commentary follows it.
+
+## Quickstart
+
+```bash
+pip install -e ".[anthropic,test]"   # pick the providers you use
+verinote ui                          # opens http://127.0.0.1:8731
+```
+
+On first launch verinote asks you to pick a KB folder (creating `kb.sqlite` if
+needed) and remembers it for next time.
+
+> **Keep your KB outside this working tree.** A KB is user data, not a repo
+> artifact. `VERINOTE_ROOT=~/verinote-kb verinote ui` is the safe habit — see
+> [Your data lives in one folder](#your-data-lives-in-one-folder).
+
+CLI scaffolding (`verinote init`, `verinote seed`), the active-KB config file
+locations, and `VERINOTE_ROOT` precedence rules are covered in
+[docs/configuration.md](docs/configuration.md).
+
+## How is this different from RAG?
+
+RAG retrieves text and hopes the model reads it correctly — the answer is still a
+generation. In verinote, an answer marked `VERIFIED` is not a generation: it is
+the output of a deterministic Datalog query over facts that passed the review
+gate, each with recorded provenance. The LLM's judgment is confined to proposing
+candidates; it never gets to decide what is true.
+
+Compared to a wiki (with or without LLM plugins), the difference is the review
+lifecycle and the audit log: every accept/reject decision is recorded, stale
+facts are retired via `superseded` rather than silently overwritten, and
+source-language facts still answer canonical English questions through relation
+aliases.
 
 ## Design (locked)
 
-| Concern        | Decision |
-|----------------|----------|
-| Logic engine   | **DuckDB-backed Datalog**. Confirmed rows load into in-memory DuckDB and non-recursive policy/query rules compile to SQL. |
-| LLM            | **Hand-rolled `LLMClient` adapters** (Anthropic / OpenAI / Ollama). No vendor lock-in. |
-| Web            | **FastAPI + HTMX + Jinja** — server-rendered partials, no JS build step. |
-| Storage        | **SQLite** owns KB metadata, source/run provenance, review lifecycle, audit log, and text display mirrors. **DuckDB** owns logical fact terms in `facts.duckdb`, runs verification, and attaches SQLite read-only for metadata analytics. `.dl` policy/query files remain editable inputs. |
+| Concern | Decision |
+|---|---|
+| Logic engine | **DuckDB-backed Datalog.** Confirmed rows load into in-memory DuckDB; non-recursive policy/query rules compile to SQL. |
+| LLM | **Hand-rolled `LLMClient` adapters** (Anthropic / Claude CLI / OpenAI / Ollama). No vendor lock-in. |
+| Web | **FastAPI + HTMX + Jinja** — server-rendered partials, no JS build step. |
+| Storage | **SQLite** owns KB metadata, source/run provenance, review lifecycle, the audit log, and the text display mirrors. **DuckDB** owns the canonical logical fact terms, runs verification, and attaches SQLite read-only for metadata analytics. `.dl` policy/query files stay editable inputs. |
+
+Internals — the SQLite/DuckDB fact-storage boundary, term typing (`StringLit` vs
+structural terms), relation canonicalization, and the Ask tab's evidence-first
+output contract — are documented in
+[docs/architecture.md](docs/architecture.md).
 
 ## Status
 
-Early scaffold (`v0.0.1`). Working today: SQLite store, LLM adapters, review queue,
-DuckDB-backed verification, question translation/repair, and local web UI.
+Early scaffold (`v0.0.1`). Working today: SQLite store, LLM adapters, review
+queue, DuckDB-backed verification, question translation/repair, and the local
+web UI.
 
-### v1 vertical slice
+**v1 vertical slice**
 
 1. Upload a text source → DB
 2. Auto-extract candidates via one LLM adapter
@@ -45,192 +96,41 @@ DuckDB-backed verification, question translation/repair, and local web UI.
 4. Load confirmed facts into DuckDB → run Datalog policy/query rules → show report
 5. Dashboard
 
-## Quickstart
+## Your data lives in one folder
 
-```bash
-pip install -e ".[anthropic,test]"   # pick the providers you use
-verinote ui        # launch the web app at http://localhost:8731
-```
+Three rules keep it safe:
 
-On first launch, if verinote cannot find an active KB, the web app opens a KB
-selection screen. Choose a KB folder there; if the folder has no `kb.sqlite`,
-verinote creates one. On later launches, the app opens that KB directly.
+1. **Keep the KB outside the repo.** `VERINOTE_ROOT=~/verinote-kb` in your shell
+   profile does it once for every command. A KB inside the working tree can be
+   committed by a stray `git add -A` or destroyed by `git clean -fdx`.
+2. **Back up the whole KB root, on your own schedule.** It is a plain folder:
+   `cp -a ~/verinote-kb ~/backups/verinote-kb-$(date +%F)`. verinote takes no
+   backups for you.
+3. **Never snapshot part of it.** `kb.sqlite` alone is not a backup. Without
+   `facts.duckdb` the engine refuses to run rather than guess at the fact terms,
+   and without `sources/` and `artifacts/` the provenance behind every confirmed
+   fact is gone.
 
-The active KB path is saved in a platform-native app config file:
+What each file holds, why the DuckDB sidecar is data rather than a cache, and the
+exact failure modes are in [docs/operations.md](docs/operations.md).
 
-- Windows: `%APPDATA%\verinote\app.json`
-- macOS: `~/Library/Application Support/verinote/app.json`
-- Linux/Unix: `${XDG_CONFIG_HOME:-~/.config}/verinote/app.json`
+## Contributing & roadmap
 
-`VERINOTE_ROOT` overrides the saved active KB and is still useful for scripts,
-tests, and one-off launches.
-
-```bash
-VERINOTE_ROOT=/path/to/kb verinote ui
-```
-
-You can also scaffold a KB explicitly. `init` and `seed` are *local* commands:
-they never write to the saved active KB. They target the root you name, else
-`VERINOTE_ROOT`, else `./data` in the current directory.
-
-```bash
-verinote init                 # ./data here (or $VERINOTE_ROOT if set)
-verinote init /path/to/kb     # a named root
-verinote seed /path/to/kb     # demo facts into an existing KB
-```
-
-Creating a KB does not make it the active one. Every other command still reads
-the saved active KB, so to work with the KB you just created either point
-`VERINOTE_ROOT` at it or select it in the UI:
-
-```bash
-VERINOTE_ROOT=/path/to/kb verinote status
-```
-
-Seeded demo facts land as `candidate`/`needs_review`, never as engine input —
-demo data has to pass through human review like anything else.
-
-DuckDB is a core dependency because it powers verification. The `analytics` extra is
-kept as a compatibility no-op; analytics uses the same DuckDB dependency. The
-`wirelog` extra installs the legacy `pyrewire` path for compatibility/debugging only.
-
-## Your KB is not a repo artifact
-
-A KB holds **user data**, so verinote never commits it. Treat the whole KB root
-as source: **the only file in it that can be rebuilt is `facts/query.dl`.**
-Everything else, if you lose it, is gone.
-
-| Path (KB root) | What it holds | Irreplaceable because |
-| --- | --- | --- |
-| `kb.sqlite` | facts, sources, questions | it records **every accept/reject decision and the full audit log** |
-| `facts.duckdb` | the canonical logical fact terms | see below — it is **not** rebuildable from `kb.sqlite` |
-| `sources/` | the documents you ingested, byte for byte | verinote never re-downloads them |
-| `artifacts/` | the extracted text of each source | `kb.sqlite` stores only its path and checksum, not the text |
-| `policy/logic-policy.dl` | your review rules | scaffolded by `init`, then hand-edited |
-| `policy/relation-aliases.md` | raw -> canonical relation names | hand-written |
-| `policy/typed-relations.md` | typed relation declarations | hand-written |
-| `policy/prompts/` | your prompt overrides | hand-written |
-| `config.json` | provider/model settings | hand-written |
-
-`init` writes a starting `logic-policy.dl` for you, but every edit you make to it
-afterwards is yours alone and is not reproducible from this repo — which is why
-it must stay committable rather than be swept up by a blanket `*.dl` ignore rule.
-
-**`facts.duckdb` is data, not a cache.** It owns the logical fact terms; the
-`facts.subject/relation/object` columns in `kb.sqlite` are display mirrors, and
-rendering a term into text is lossy. If the sidecar goes missing, the terms are
-*re-typed* from those mirrors rather than restored: a compound collapses into a
-string, and even a plain string gains the quotes it was rendered with.
-
-```text
-before:  Compound('person', (StringLit('Ada'),))   Atom('works_at')       StringLit('Acme')
-after:   StringLit('person("Ada")')                StringLit('works_at')  StringLit('"Acme"')
-```
-
-Rules that matched the structural terms stop firing, and the report still says
-the knowledge base is consistent. Silent re-typing on a lost sidecar is tracked
-in [#156](https://github.com/semantic-reasoning/verinote/issues/156) — until it
-is fixed, **back the sidecar up with the rest of the KB.**
-
-**Keep the KB outside this working tree.** The default root (`./data`) is a
-convenience for a first run, not a safe home:
-
-```bash
-VERINOTE_ROOT=~/verinote-kb verinote init   # scaffold a KB outside the repo
-VERINOTE_ROOT=~/verinote-kb verinote ui
-```
-
-`VERINOTE_ROOT` selects the KB root for every command, so exporting it once in
-your shell profile keeps all of your data out of this working tree.
-
-**If you do keep a KB inside the repo tree** (any path other than `data/`, e.g.
-`./my-kb`), a stray `git add -A` will commit most of it. Only the generated
-artifacts are ignored; the sources are not, and that is deliberate — the ignore
-rules match generated *paths*, never bare extensions, because a blanket `*.dl`
-rule is exactly what used to swallow hand-written policy. What gets staged:
-
-```text
-my-kb/sources/confidential.pdf        <- the document you ingested, byte for byte
-my-kb/artifacts/sources/1/<sha>.txt   <- its extracted text
-my-kb/policy/logic-policy.dl          <- your review rules
-my-kb/config.json                     <- your provider/model settings
-```
-
-So the exposure is not one policy file — it is **the documents themselves**, which
-is exactly what [AGENTS.md](AGENTS.md) forbids committing. Keep the KB outside
-the tree, or do not blind-add.
-
-**`git clean -fdx` deletes your KB.** Ignoring it does not save it: `-x` removes
-ignored files too, and user data cannot be committed to fix that. (Without `-x`,
-ignoring *does* protect the generated artifacts — but not `sources/` or
-`policy/`, which are not ignored.) Running it inside the working tree destroys
-the KB and its audit log with no undo. Moving the default root outside the
-working tree is tracked in
-[#185](https://github.com/semantic-reasoning/verinote/issues/185).
-
-**Backups are your responsibility.** verinote takes none. Copy **the whole KB
-root** — it is a plain folder — on your own schedule:
-
-```bash
-cp -a ~/verinote-kb ~/backups/verinote-kb-$(date +%F)
-```
-
-Do not snapshot only part of it. `kb.sqlite` alone is not a backup: without
-`facts.duckdb` the fact terms come back re-typed (see above), and without
-`sources/` and `artifacts/` the provenance behind every confirmed fact is gone.
-
-## Fact Storage Boundary
-
-Each KB stores two coordinated files under the KB root:
-
-- `kb.sqlite`: sources, extraction runs, review status, audit history, questions,
-  and the `facts.subject/relation/object` text columns used as display mirrors
-  and legacy backfill data.
-- `facts.duckdb`: canonical logical fact terms keyed by SQLite `facts.id`.
-
-Verification and report fact input read confirmed/accepted fact ids from SQLite,
-then load their logical terms from `facts.duckdb`. Source coverage, status counts,
-and analytics use SQLite metadata; relation analytics intentionally summarize the
-SQLite display mirror rather than acting as logical inference input.
-
-Plain extractor output remains `StringLit` by default, so text such as
-`person("Ada")` is not reinterpreted as a compound term. Source extraction can
-produce structural facts only by explicitly marking a slot as a term, for example
-`{"kind": "term", "value": "person(\"Ada\")"}`. Structural facts can also be
-entered through explicit term mode or `structural_term(...)`. Legacy SQLite rows
-without DuckDB term rows are backfilled as `StringLit` values the first time they
-are selected for verification.
-
-## Relation Canonicalization
-
-New extraction prefers stable English canonical relation labels such as `role`,
-`affiliation`, and `provides`. Source-language labels remain supported through
-`policy/relation-aliases.md`, where each line maps a source or local label to the
-canonical relation:
-
-```text
-- `역할` -> `role`
-- `제공 요소` -> `provides`
-```
-
-Subjects and objects preserve the source document's language and named-entity
-spelling. Relation aliases are used by extraction, query planning, trust views,
-and verification query expansion so older source-language facts can still answer
-canonical English questions.
-
-## Ask Output Order
-
-The Ask tab is evidence-first. Once a question is routed, verinote shows the
-answer block immediately under its route label (`VERIFIED — engine`,
-`VERIFIED — engine (negative)`, or `UNVERIFIED — source exploration`) before
-route reasons, query details, source tables, or excerpts.
-
-Treat that first block as the evidence. Any surrounding explanation must follow
-it and stay short; do not restate, translate, or summarize the block rows before
-the user has seen them.
+Issues and feedback are welcome — the v1 vertical slice above is the current
+roadmap, and open questions are tracked in the
+[issue tracker](https://github.com/semantic-reasoning/verinote/issues). If you
+try verinote on a real document set, we would especially like to hear where
+extraction or verification surprised you.
 
 ## License
 
 Mozilla Public License 2.0 — see [LICENSE](LICENSE). MPL-2.0 is a file-level
 copyleft: modifications to verinote's own source files stay open, while it can
 still be combined with proprietary code in separate files.
+
+## Acknowledgements
+
+verinote borrows its core concept from
+[factlog](https://github.com/semantic-reasoning/factlog) (neurosymbolic: an LLM
+extracts, a Datalog engine verifies) but is a from-scratch implementation with no
+shared code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,66 @@
+# Architecture
+
+## Fact storage boundary
+
+Each KB stores two coordinated files under the KB root:
+
+- **`kb.sqlite`** — sources, extraction runs, review status, audit history,
+  questions, and the `facts.subject/relation/object` text columns used as display
+  mirrors and legacy backfill data.
+- **`facts.duckdb`** — canonical logical fact terms, keyed by SQLite `facts.id`.
+
+Verification and report fact input read confirmed/accepted fact ids from SQLite,
+then load their logical terms from `facts.duckdb`. Source coverage, status counts,
+and analytics use SQLite metadata; relation analytics intentionally summarize the
+SQLite display mirror rather than acting as logical inference input.
+
+For those metadata aggregates, DuckDB **attaches the SQLite file read-only**
+(`ATTACH … (TYPE sqlite, READ_ONLY)`) rather than copying rows across the
+boundary — the same DuckDB dependency that backs the engine also serves analytics,
+and it can never write to the KB while doing so.
+
+Because the mirrors are lossy, the sidecar is data and not a cache — losing it is
+an unrecoverable failure, not a rebuild. See
+[operations.md](operations.md#factsduckdb-is-data-not-a-cache).
+
+## Term typing
+
+Plain extractor output remains `StringLit` by default, so text such as
+`person("Ada")` is **not** reinterpreted as a compound term. Source extraction can
+produce structural facts only by explicitly marking a slot as a term:
+
+```json
+{"kind": "term", "value": "person(\"Ada\")"}
+```
+
+Structural facts can also be entered through explicit term mode or
+`structural_term(...)`. Legacy SQLite rows without DuckDB term rows are backfilled
+as `StringLit` values the first time they are selected for verification.
+
+## Relation canonicalization
+
+New extraction prefers stable English canonical relation labels such as `role`,
+`affiliation`, and `provides`. Source-language labels remain supported through
+`policy/relation-aliases.md`, where each line maps a source or local label to the
+canonical relation:
+
+```text
+- `역할` -> `role`
+- `제공 요소` -> `provides`
+```
+
+Subjects and objects preserve the source document's language and named-entity
+spelling. Relation aliases are used by extraction, query planning, trust views, and
+verification query expansion, so older source-language facts can still answer
+canonical English questions.
+
+## Ask output order
+
+The Ask tab is evidence-first. Once a question is routed, verinote shows the answer
+block immediately under its route label — `VERIFIED — engine`,
+`VERIFIED — engine (negative)`, or `UNVERIFIED — source exploration` — before route
+reasons, query details, source tables, or excerpts.
+
+Treat that first block as the evidence. Any surrounding explanation must follow it
+and stay short; do not restate, translate, or summarize the block rows before the
+user has seen them.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,87 @@
+# Configuration
+
+## The active KB
+
+On first launch, if verinote cannot find an active KB, the web app opens a KB
+selection screen. Choose a KB folder there; if the folder has no `kb.sqlite`,
+verinote creates one. On later launches, the app opens that KB directly.
+
+The active KB path is saved in a platform-native app config file:
+
+| Platform | Path |
+|---|---|
+| Windows | `%APPDATA%\verinote\app.json` |
+| macOS | `~/Library/Application Support/verinote/app.json` |
+| Linux/Unix | `${XDG_CONFIG_HOME:-~/.config}/verinote/app.json` |
+
+`VERINOTE_ROOT` overrides the saved active KB and is still useful for scripts,
+tests, and one-off launches:
+
+```bash
+VERINOTE_ROOT=/path/to/kb verinote ui
+```
+
+## Scaffolding a KB from the CLI
+
+`init` and `seed` are *local* commands: they never write to the saved active KB.
+They target the root you name, else `VERINOTE_ROOT`, else `./data` in the current
+directory.
+
+```bash
+verinote init                 # ./data here (or $VERINOTE_ROOT if set)
+verinote init /path/to/kb     # a named root
+verinote seed /path/to/kb     # demo facts into an existing KB
+```
+
+Creating a KB does not make it the active one. Every other command still reads the
+saved active KB, so to work with the KB you just created, either point
+`VERINOTE_ROOT` at it or select it in the UI:
+
+```bash
+VERINOTE_ROOT=/path/to/kb verinote status
+```
+
+Seeded demo facts land as `candidate`/`needs_review`, never as engine input — demo
+data has to pass through human review like anything else.
+
+> Prefer a KB outside the working tree. See
+> [operations.md](operations.md#keep-the-kb-outside-the-working-tree).
+
+## Providers
+
+Provider choice lives in `config.json` (or `VERINOTE_PROVIDER`), and one adapter
+is selected from it: `anthropic`, `claudecli`, `openai`, or `ollama`. Install only
+the SDK you need — the LLM extras exist so the app installs without any single
+vendor's package:
+
+```bash
+pip install -e ".[anthropic]"   # or .[openai] — Ollama needs no SDK
+```
+
+## Auto-accept
+
+`auto_accept_recommendations` is the one setting that changes what verinote
+promises. It is **off by default**. With it on, extraction is followed by a rule
+(`corroborated_no_conflict`) that promotes eligible review-tier facts straight to
+`accepted` — an engine status — recorded with `actor="rule"` instead of a human
+click.
+
+The gate is still there: the rule only fires on facts that are corroborated and
+conflict-free, every promotion lands in the audit log, and you can still supersede
+anything it accepted. But while it is on, **"no fact reaches the engine without a
+human looking at it" is no longer true of your KB.** Turn it on when you trust the
+rule more than you value the click; leave it off if the audit trail must show a
+person behind every accepted fact.
+
+Set it in the Settings UI, in `config.json`, or via
+`VERINOTE_AUTO_ACCEPT_RECOMMENDATIONS`.
+
+## Optional extras
+
+| Extra | What it installs |
+|---|---|
+| `anthropic`, `openai` | the vendor SDK for that provider |
+| `ingest` | `python-docx` + `pypdf`, for binary source ingestion (docx/pdf → text) |
+| `test` | the test dependencies |
+| `analytics` | nothing — a **compatibility no-op**. DuckDB is a core dependency because it powers verification, and analytics uses that same dependency. |
+| `wirelog` | the legacy `pyrewire` path, for compatibility/debugging only |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,115 @@
+# Operating a verinote KB
+
+Your KB is user data. verinote never commits it, never backs it up, and — for the
+one file that matters most — cannot rebuild it. This page is what you need to know
+before you trust a KB with real documents.
+
+## Your KB is not a repo artifact
+
+Treat the whole KB root as source. Almost nothing in it can be regenerated, and
+the two things that can are not the things you care about: `facts/query.dl` is
+recompiled from your questions, and `policy/logic-policy.dl` can be re-scaffolded
+— but only back to the **shipped default**, not to whatever you edited it into.
+
+| Path (KB root) | What it holds | Irreplaceable because |
+|---|---|---|
+| `kb.sqlite` | facts, sources, questions | it records **every accept/reject decision and the full audit log** |
+| `facts.duckdb` | the canonical logical fact terms | see below — it is **not** rebuildable from `kb.sqlite` |
+| `sources/` | the documents you ingested, byte for byte | verinote never re-downloads them |
+| `artifacts/` | the extracted text of each source | `kb.sqlite` stores only its path and checksum, not the text. Re-derivable by re-ingesting — but only while `sources/` survives |
+| `policy/logic-policy.dl` | your review rules | scaffolded by `init`; `policy reset` only restores the default, never your edits |
+| `policy/relation-aliases.md` | raw → canonical relation names | written by hand or by the Settings UI |
+| `policy/typed-relations.md` | typed relation declarations | hand-written; nothing in verinote writes it |
+| `policy/prompts/` | your prompt overrides | written by hand or by the Prompts UI |
+| `config.json` | provider/model settings | written by hand or by the Settings UI |
+
+Every edit you make to `logic-policy.dl` is yours alone and is not reproducible
+from this repo — which is why it must stay committable rather than be swept up by
+a blanket `*.dl` ignore rule.
+
+## facts.duckdb is data, not a cache
+
+`facts.duckdb` owns the logical fact terms. The `facts.subject/relation/object`
+columns in `kb.sqlite` are **display mirrors**, and rendering a term into text is
+lossy: the compound `Compound('person', (StringLit('Ada'),))` renders as the text
+`person("Ada")`, which is indistinguishable from a plain string that happens to
+look like a compound. Rebuilding the terms from those mirrors would silently
+reinterpret structure as text, so verinote refuses to do it.
+
+Lose the sidecar and the engine stops instead of guessing:
+
+```text
+DuckDBFactTermStoreError: missing DuckDB fact terms for fact id(s): 1.
+Restore facts.duckdb from backup or re-enter the affected facts. Refusing to
+rebuild them from SQLite display text because that would reinterpret
+structural terms as strings.
+```
+
+That refusal is the resolution of
+[#156](https://github.com/semantic-reasoning/verinote/issues/156). Before it, a
+lost sidecar was silently re-typed — compounds collapsed into strings, rules that
+matched them stopped firing, and the report still called the knowledge base
+consistent. **The failure is loud now, but it is still not recoverable:** verinote
+can tell you the terms are gone; it cannot bring them back. Only your backup can.
+
+The one exception is a legacy KB whose facts predate the sidecar entirely (no
+fact-terms marker recorded in `kb.sqlite`). Those rows are backfilled as
+`StringLit` values the first time they are selected for verification, because
+there is no structure to lose. Once any fact has been written through the sidecar,
+the marker exists and the refusal above applies.
+
+**Back the sidecar up with the rest of the KB.**
+
+## Keep the KB outside the working tree
+
+The default root (`./data`) is a convenience for a first run, not a safe home:
+
+```bash
+VERINOTE_ROOT=~/verinote-kb verinote init   # scaffold a KB outside the repo
+VERINOTE_ROOT=~/verinote-kb verinote ui
+```
+
+`VERINOTE_ROOT` selects the KB root for every command, so exporting it once in
+your shell profile keeps all of your data out of the working tree.
+
+### A KB inside the repo tree gets committed
+
+If you keep a KB at any path other than `data/` — say `./my-kb` — a stray
+`git add -A` will commit most of it. Only the generated artifacts are ignored; the
+sources are not, and that is deliberate. The ignore rules match generated *paths*,
+never bare extensions, because a blanket `*.dl` rule is exactly what used to
+swallow hand-written policy. What gets staged:
+
+```text
+my-kb/sources/confidential.pdf        <- the document you ingested, byte for byte
+my-kb/artifacts/sources/1/<sha>.txt   <- its extracted text
+my-kb/policy/logic-policy.dl          <- your review rules
+my-kb/config.json                     <- your provider/model settings
+```
+
+So the exposure is not one policy file — it is **the documents themselves**, which
+is exactly what [AGENTS.md](../AGENTS.md) forbids committing. Keep the KB outside
+the tree, or do not blind-add.
+
+### `git clean -fdx` deletes your KB
+
+Ignoring it does not save it: `-x` removes ignored files too, and user data cannot
+be committed to fix that. (Without `-x`, ignoring *does* protect the generated
+artifacts — but not `sources/` or `policy/`, which are not ignored.) Running it
+inside the working tree destroys the KB and its audit log with no undo.
+
+Moving the default root outside the working tree is tracked in
+[#185](https://github.com/semantic-reasoning/verinote/issues/185).
+
+## Backups are your responsibility
+
+verinote takes none. Copy **the whole KB root** — it is a plain folder — on your
+own schedule:
+
+```bash
+cp -a ~/verinote-kb ~/backups/verinote-kb-$(date +%F)
+```
+
+Do not snapshot only part of it. `kb.sqlite` alone is not a backup: without
+`facts.duckdb` the engine refuses to run at all (see above), and without
+`sources/` and `artifacts/` the provenance behind every confirmed fact is gone.


### PR DESCRIPTION
Closes #211.

## Problem

The README was 236 lines, and **57% of it spoke to someone who had already adopted verinote**: 85 lines (36%) on how to lose your data, 50 lines (21%) on term typing and storage internals. The product's actual moment — you ask a question and get an answer labeled `VERIFIED — engine` — was written like a UI style guide and filed one section above the license.

## Change

Reordered around the reader's first 30 seconds (hook → problem → 3-line Quickstart → vs RAG/wiki → status → data safety in 3 rules → license/acknowledgements/CTA), and **moved, not deleted**, the rest into `docs/operations.md`, `docs/configuration.md`, and `docs/architecture.md`. README: 236 → 141 lines.

A semantic audit of the old README against the new tree found exactly one dropped fact — DuckDB attaching SQLite read-only for metadata analytics — restored in `docs/architecture.md` after re-confirming it against `store/analytics.py:72`.

## A lossless move preserves false statements too

So every checkable claim was re-verified against the code. **Four were wrong.**

**1. A lost `facts.duckdb` no longer lies — it refuses.** The README described silent re-typing (compounds collapsing into strings while the report still called the KB consistent) as a live defect *"tracked in #156 — until it is fixed."* **#156 is fixed.** Reproduced both halves on a scratch KB before rewriting:

\`\`\`
DuckDBFactTermStoreError: missing DuckDB fact terms for fact id(s): 1.
Restore facts.duckdb from backup or re-enter the affected facts. Refusing to
rebuild them from SQLite display text because that would reinterpret
structural terms as strings.
\`\`\`

The conclusion (back up the sidecar) survives; the reason changed from *it lies* to *it refuses*, which is a different instruction to the reader. The same stale claim in `.gitignore`'s comment block is corrected too — that comment also pointed at a README section this PR removes.

**2. "Nothing becomes engine input until a human approves it" is not unconditional.** With `auto_accept_recommendations` on (off by default), `corroborated_no_conflict` promotes review-tier facts straight to `accepted` with `actor=\"rule\"` and no human click (`pipeline/acceptance.py:62-75`, called from `web/app.py:330,707`). The landing page now says **by default**, and the setting gets its own section in `docs/configuration.md` instead of going unmentioned anywhere in the docs.

**3. `facts/query.dl` is not the only regenerable file in a KB.** `policy/logic-policy.dl` re-scaffolds from the shipped default (`policy_state.py:194`, `cli.py:85`) — just never back to *your edits*, which is the point the sentence was reaching for.

**4. Three KB files were labeled \"hand-written\"** that the Settings and Prompts UIs also write: `config.json`, `policy/relation-aliases.md`, `policy/prompts/`. (`policy/typed-relations.md` genuinely has no writer — that row was right.)

Smaller: the provider list omitted `claudecli`; the lifecycle was drawn as a chain (`candidate → needs_review → confirmed/accepted`) when the two review statuses are peers, not stages; the URL the CLI actually prints is `127.0.0.1`, not `localhost`.

## Verification

- \`pytest -q\` → **903 passed, 7 skipped**; \`ruff check verinote tests\` → clean. (No test reads the README, so nothing here could have been caught by CI — the claims were checked against the source by hand and by reproduction.)
- Every relative link and anchor in the four files resolves (checked programmatically).
- No open PR touches `README.md`, `docs/`, or `.gitignore` (#208/#209/#210 → zero file overlap); merges clean into `main`.

## Not in this PR

The Ask-tab screenshot (**#212**). The restructure opens the slot at the top of the README and deliberately leaves it empty rather than shipping a `TODO` placeholder.

The `ci` badge under the title was reviewed and left alone: it is a valid badge pointing at an active workflow, not a broken artifact.