### PR TITLE
fix(#214): stop `git add -A` from committing the agent worktrees as gitlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,24 @@ venv/
 **/kb.sqlite-wal
 **/kb.sqlite-shm
 
+# Agent tooling state, anchored to the repo root.
+#
+# This repo is developed from linked git worktrees under `.claude/worktrees/`.
+# Each one is a git repository, so `git add -A` at the root does not stage their
+# contents — it stages the worktrees themselves as gitlinks (`warning: adding
+# embedded git repository`, and it is only a warning: the add succeeds). The
+# resulting commit carries four pointers that no clone can resolve. `.omc/` is
+# session telemetry: local paths and counters, worthless in history.
+#
+# ANCHORED, not blanket, for the same reason as the block above: a bare
+# `.claude/` would swallow `.claude/agents/`, `.claude/skills/` and a shared
+# `.claude/settings.json` — committable project config, the exact class of file
+# the old `*.dl` rule used to eat. `settings.local.json` is the personal half of
+# that directory and is named for it. See tests/test_gitignore.py.
+/.omc/
+/.claude/worktrees/
+/.claude/settings.local.json
+
 # tooling
 .pytest_cache/
 .ruff_cache/

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -10,6 +10,12 @@ then falls back to the shipped default policy or refuses to run outright (#155),
 which is why these tests pin the ignore rules rather than the engine's reaction
 to a policy that is already gone.
 
+The same split now covers agent tooling state (#214). This repo is developed from
+linked worktrees under `.claude/worktrees/`, which `git add -A` stages as gitlinks
+no clone can resolve — so they must be ignored, while `.claude/agents/`,
+`.claude/skills/` and a shared `.claude/settings.json` must not be. A blanket
+`.claude/` would take both, which is the `*.dl` mistake one directory over.
+
 These tests assert both directions with `git check-ignore`'s exit status
 (0 = ignored, 1 = not ignored). It is pattern-based, so it works for paths that
 do not exist on disk. Asserting only one direction would be vacuous: emptying
@@ -66,6 +72,32 @@ ARTIFACT_PATHS = [
     "some/other/kb/kb.sqlite-shm",
 ]
 
+# Agent tooling state: local, per-session, must stay ignored.
+#
+# The worktree entry is the sharp one. `.claude/worktrees/<issue>` is a linked git
+# worktree, so `git add -A` stages it as a gitlink rather than as files — a commit
+# that no clone can resolve. git only *warns* about that; the add succeeds.
+AGENT_STATE_PATHS = [
+    ".claude/worktrees/issue-1/verinote/cli.py",
+    ".claude/worktrees/issue-1/README.md",
+    ".claude/settings.local.json",
+    ".omc/project-memory.json",
+    ".omc/state/sessions/abc/mission-state.json",
+    ".omc/sessions/abc.json",
+]
+
+# Shared agent config: committable, and threatened by the obvious over-broad fix.
+#
+# These are the reason the rules above are anchored. A bare `.claude/` would ignore
+# every one of them — the same failure as the old `*.dl` glob, one directory over.
+# This half is not decoration: it fails the moment someone "simplifies" the three
+# anchored rules into one.
+AGENT_SHARED_PATHS = [
+    ".claude/agents/dev-reviewer.md",
+    ".claude/skills/run/SKILL.md",
+    ".claude/settings.json",
+]
+
 
 @pytest.fixture(scope="module")
 def gitignore_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
@@ -103,6 +135,37 @@ def test_hand_written_sources_are_not_ignored(gitignore_repo: Path, path: str) -
 def test_generated_kb_artifacts_stay_ignored(gitignore_repo: Path, path: str) -> None:
     assert _check_ignore(gitignore_repo, path) == 0, (
         f"{path} is a generated artifact and must stay ignored"
+    )
+
+
+@pytest.mark.parametrize("path", AGENT_STATE_PATHS)
+def test_agent_tooling_state_stays_ignored(gitignore_repo: Path, path: str) -> None:
+    assert _check_ignore(gitignore_repo, path) == 0, (
+        f"{path} is agent tooling state and must stay ignored. A linked worktree "
+        "under .claude/worktrees/ is staged by `git add -A` as an embedded git "
+        "repository — a gitlink no clone can resolve."
+    )
+
+
+@pytest.mark.parametrize("path", AGENT_SHARED_PATHS)
+def test_shared_agent_config_is_not_ignored(gitignore_repo: Path, path: str) -> None:
+    assert _check_ignore(gitignore_repo, path) == 1, (
+        f"{path} is shared, hand-written project config and must stay committable. "
+        "Ignoring `.claude/` wholesale swallows it — the same mistake the bare "
+        "`*.dl` glob made with hand-written policy."
+    )
+
+
+def test_no_agent_state_is_tracked() -> None:
+    """Non-vacuity guard: the ignore rules match what is actually in the tree."""
+    proc = subprocess.run(
+        ["git", "ls-files", ".omc/", ".claude/worktrees/", ".claude/settings.local.json"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    )
+    assert proc.stdout.decode().strip() == "", (
+        "agent tooling state is tracked by git; it must never enter history"
     )
 
 


### PR DESCRIPTION
Closes #214.

## Problem

This repo is developed from linked git worktrees under `.claude/worktrees/`. Each one is a git repository, so `git add -A` at the root does not stage their *files* — it stages the worktrees themselves as **gitlinks**:

```
$ git add -An            # before
warning: adding embedded git repository: .claude/worktrees/issue-176-engine-status
warning: adding embedded git repository: .claude/worktrees/issue-183-review-statuses
warning: adding embedded git repository: .claude/worktrees/issue-198-env-sandbox
warning: adding embedded git repository: .claude/worktrees/issue-211-readme
```

git only **warns**; the add succeeds. The resulting commit carries four pointers no clone can resolve. `.omc/` rides along as 48 files of session telemetry.

This is not hypothetical — it fired while preparing #213, where `.omc/` state landed in the index and had to be backed out by hand.

## Change

Three anchored rules:

```gitignore
/.omc/
/.claude/worktrees/
/.claude/settings.local.json
```

**Measured at the repo root:** 71 staged paths → **4**, embedded-repo warnings 4 → **0**. The 4 that remain are genuine untracked docs (`CLAUDE.md`, `docs/*.md`), so the rule is not over-broad either.

## Why anchored, not `.claude/`

Because a blanket `.claude/` would swallow `.claude/agents/`, `.claude/skills/`, and a shared `.claude/settings.json` — committable, hand-written project config. That is precisely the `*.dl` mistake of #159, one directory over: an ignored file cannot be `git add`-ed without `-f`, so it never enters history, and nothing regenerates it. `.gitignore` already states the doctrine (*"Match generated paths, never bare extensions"*); this follows it.

## Tests

`tests/test_gitignore.py` already asserts both directions with `git check-ignore`. Extended with the same shape, and **both halves are non-vacuous — verified, not assumed**:

| Mutation | Result |
|---|---|
| drop the three rules (the state before this PR) | the **6 agent-state** tests fail |
| "simplify" them into a blanket `.claude/` | **exactly the 3 shared-config** tests fail, nothing else |

The second row is the point: the un-ignored half is a real regression lock, not decoration. It fails the moment someone collapses the three rules into one.

Plus a non-vacuity guard (`test_no_agent_state_is_tracked`) that no `.omc/` or worktree path is *actually* tracked, mirroring the existing `data/` guard.

## Scope note

`.omc/` was inspected before being ignored: session ids, agent counters, cooldown timestamps. **No transcripts and no document text**, so this is not an AGENTS.md data-leak fix — just noise and a footgun.

`CLAUDE.md` sits untracked at the root while `AGENTS.md` is tracked. Whether it should be committed or ignored is a separate judgement call and is left alone here.

## Verification

- `pytest -q` → **913 passed, 7 skipped** (903 + 10 new); `ruff check verinote tests` → clean.
- **#213 also touches `.gitignore`** (the KB comment block, lines 11–32) — different region, no overlap. 3-way merge of the two branches simulated: **clean**, in either order. No other open PR touches these files.