### PR TITLE
fix(#227): say that the confidence chart is the model's opinion, not a verdict

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1686,6 +1686,34 @@ def test_analytics_page_renders(tmp_path):
         assert "DuckDB isn't installed" in r.text
 
 
+def test_confidence_chart_is_captioned_as_not_a_trust_signal(tmp_path):
+    """The confidence buckets are the LLM's opinion of itself, and the page says so.
+
+    Rendered *above* the numbers: a reader who meets the buckets first has already
+    decided what they mean, and "lots of 0.9s" reads as "this KB is trustworthy" —
+    the exact inference verinote exists to refuse.
+    """
+    from verinote.store.analytics import duckdb_available
+
+    if not duckdb_available():
+        pytest.skip("analytics page is disabled without DuckDB")
+
+    c = _client(tmp_path)
+    c.app.state.store.add_fact("A", "is_a", "B", status="confirmed", confidence=0.95)
+    body = c.get("/analytics").text
+
+    disclaimer = "verinote never uses it to decide what is true"
+    assert disclaimer in body
+    # Only the confidence table carries it; the deterministic breakdowns do not.
+    assert body.count(disclaimer) == 1
+    # heading, then the disclaimer, then the buckets — in that order.
+    assert (
+        body.index("Confidence distribution")
+        < body.index(disclaimer)
+        < body.index("0.9–1.0")
+    )
+
+
 def test_add_question_persists(tmp_path):
     c = _client(tmp_path)
     r = c.post("/questions", data={"text": "Where was Ada born?"}, follow_redirects=False)

--- a/verinote/web/templates/analytics.html
+++ b/verinote/web/templates/analytics.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Analytics — verinote{% endblock %}
-{% macro breakdown(title, rows, label) %}
+{% macro breakdown(title, rows, label, caption=None) %}
 <h2>{{ title }}</h2>
+{# The caption sits above the numbers on purpose: a reader who meets the buckets
+   first has already decided what they mean. #}
+{% if caption %}<p class="muted">{{ caption }}</p>{% endif %}
 {% if rows %}
 <table class="counts">
   <thead><tr><th>{{ label }}</th><th>facts</th></tr></thead>
@@ -27,6 +30,11 @@
 {{ breakdown("By status", a.by_status, "status") }}
 {{ breakdown("By relation", a.by_relation, "relation") }}
 {{ breakdown("By source", a.by_source, "source") }}
-{{ breakdown("Confidence distribution", a.by_confidence, "bucket") }}
+{% set confidence_caption %}
+  LLM self-reported confidence. verinote never uses it to decide what is true —
+  trust comes from corroboration across distinct sources and from your review
+  decisions. A knowledge base full of high-confidence facts is not a verified one.
+{% endset %}
+{{ breakdown("Confidence distribution", a.by_confidence, "bucket", confidence_caption) }}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Closes #227.

## Problem

`analytics.html` renders a **Confidence distribution** table (`0.0–0.5` … `0.9–1.0`) sitting next to three deterministic breakdowns — By status, By relation, By source — with **nothing to tell them apart**.

But those buckets are not a verinote judgement. They are the **LLM's self-report about itself**, and verinote does not use the value to decide anything: trust comes from corroboration across distinct sources and from a human's review decision. A reader who sees a wall of 0.9s concludes *"this knowledge base is trustworthy"* — the exact inference this product exists to refuse.

The provenance page already captions the same number `model metadata only` (`provenance.html:157`). The page that **aggregates** it, where the misreading actually happens, said nothing.

## Change

One caption, on the confidence table only:

> LLM self-reported confidence. verinote never uses it to decide what is true — trust comes from corroboration across distinct sources and from your review decisions. A knowledge base full of high-confidence facts is not a verified one.

**Above the buckets, not below them.** A reader who meets the numbers first has already decided what they mean; the disclaimer has to arrive before the data, not after it. This is the same evidence-ordering principle the Ask tab is held to.

The `breakdown` macro grows an optional `caption` parameter, so the three deterministic breakdowns stay uncaptioned — the disclaimer belongs to this table alone, and the test pins that (`body.count(disclaimer) == 1`). No CSS: it reuses the existing `.muted` class.

## Tests

`test_confidence_chart_is_captioned_as_not_a_trust_signal` asserts presence, exclusivity, and **order** (`"Confidence distribution"` → disclaimer → `"0.9–1.0"`).

**Non-vacuous — verified by mutation, not assumed:**

| Mutation | Result |
|---|---|
| drop the caption (the state before this PR) | new test fails |
| move the caption below the table | new test fails |

The order half matters: a caption that renders under the numbers would pass a naive `in body` assertion while doing nothing for the reader.

`pytest -q` → **911 passed**; `ruff check verinote tests` → clean.

## Conflicts

None. Touches `analytics.html` (no open PR touches it) and appends one test to `test_web.py` far from #209's hunks. Merge simulated against **all six open PRs (#208, #209, #210, #213, #215, #218) and `main` — clean in every case**, in any order.

## Not in this PR

The bar-chart rendering (#227 mentions it as optional) and the review queue's `confidence` sort option. This is the honesty fix only; visualization can follow once the design tokens land (#226).