### PR TITLE
fix(#233): stop a rejected row from offering a one-click way back

### DIFF
--- a/tests/test_review_actions.py
+++ b/tests/test_review_actions.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MPL-2.0
+"""What a fact row offers a reviewer, per status.
+
+The row template is the UI contract for review decisions. A rejected fact
+(`superseded`) has left the KB by a human's deliberate act; the row that comes
+back from that decision must not offer a one-click way back in. Undo, if it is
+ever wanted, has to be its own explicit and audited action -- not the same
+`needs_review ⇄ confirmed` button the reviewer just used.
+
+The control cases matter as much: strip the buttons from the review tier and
+review becomes impossible.
+"""
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from verinote.config import Config  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+REVERT_ACTIONS = ("toggle", "accept")
+ALL_ACTIONS = ("toggle", "accept", "reject", "edit")
+
+
+def _client(tmp_path) -> TestClient:
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    app = create_app(cfg)
+    client = TestClient(app)
+    client.fact_id = app.state.store.add_fact(
+        "A", "is_a", "B", status="needs_review", confidence=0.9
+    )
+    return client
+
+
+def _offered(body: str, fact_id: int) -> set[str]:
+    """The fact-level actions a row body wires up, by endpoint."""
+    return {
+        action
+        for action in ALL_ACTIONS
+        if f"/facts/{fact_id}/{action}" in body
+    }
+
+
+def test_rejected_row_offers_no_way_back(tmp_path):
+    c = _client(tmp_path)
+    body = c.post(f"/facts/{c.fact_id}/reject").text
+
+    assert "superseded" in body
+    assert _offered(body, c.fact_id) & set(REVERT_ACTIONS) == set()
+
+
+def test_rejected_row_offers_no_fact_actions_at_all(tmp_path):
+    # reject is a no-op on an already-rejected fact, and amend leaves the status
+    # alone -- neither has a meaning here, so neither is drawn.
+    c = _client(tmp_path)
+    body = c.post(f"/facts/{c.fact_id}/reject").text
+
+    assert _offered(body, c.fact_id) == set()
+
+
+def test_rejected_row_stays_inspectable(tmp_path):
+    # A rejected fact is still evidence: the trust dossier stays reachable.
+    c = _client(tmp_path)
+    body = c.post(f"/facts/{c.fact_id}/reject").text
+
+    assert f"/facts/{c.fact_id}/provenance" in body
+    assert "badge badge-superseded" in body
+
+
+def test_rejected_row_stays_stripped_when_re_rendered(tmp_path):
+    # Not a property of the reject response: any render of a superseded row.
+    c = _client(tmp_path)
+    c.post(f"/facts/{c.fact_id}/reject")
+    body = c.get(f"/facts/{c.fact_id}/row").text
+
+    assert "superseded" in body
+    assert _offered(body, c.fact_id) == set()
+
+
+def test_review_tier_row_keeps_every_action(tmp_path):
+    # Control: without these, the queue cannot be reviewed at all.
+    c = _client(tmp_path)
+    body = c.get(f"/facts/{c.fact_id}/row").text
+
+    assert "needs_review" in body
+    assert _offered(body, c.fact_id) == set(ALL_ACTIONS)
+
+
+def test_queued_row_in_the_review_page_keeps_every_action(tmp_path):
+    c = _client(tmp_path)
+    body = c.get("/review").text
+
+    assert _offered(body, c.fact_id) == set(ALL_ACTIONS)
+
+
+def test_engine_tier_row_keeps_every_action(tmp_path):
+    # Control: a confirmed fact is still demotable -- this issue is about
+    # rejection, not about freezing the engine tier.
+    c = _client(tmp_path)
+    body = c.post(f"/facts/{c.fact_id}/accept").text
+
+    assert "confirmed" in body
+    assert _offered(body, c.fact_id) == set(ALL_ACTIONS)

--- a/tests/test_review_actions.py
+++ b/tests/test_review_actions.py
@@ -7,8 +7,13 @@ back from that decision must not offer a one-click way back in. Undo, if it is
 ever wanted, has to be its own explicit and audited action -- not the same
 `needs_review ⇄ confirmed` button the reviewer just used.
 
-The control cases matter as much: strip the buttons from the review tier and
-review becomes impossible.
+The control cases matter as much: strip the buttons from a status the reviewer
+still has to act on and review becomes impossible. So the controls run over
+*every* status in the two tiers -- read from the tier accessors at call time,
+not copied here -- and not just the one status a hand-written case happened to
+pick. `candidate` in particular is what extraction stamps on a new fact, so it
+is the bulk of the queue; a control that only looked at `needs_review` would
+watch the buttons vanish from most of the review page and still pass.
 """
 import pytest
 
@@ -16,10 +21,20 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from verinote.config import Config  # noqa: E402
+from verinote.store.tiers import engine_statuses, review_statuses  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
 REVERT_ACTIONS = ("toggle", "accept")
 ALL_ACTIONS = ("toggle", "accept", "reject", "edit")
+
+
+def actionable_statuses() -> list[str]:
+    """Every status a reviewer must still be able to act on, at call time.
+
+    Widening a tier widens this control set with it, so a new status arrives
+    with the buttons already guarded.
+    """
+    return sorted(review_statuses() | engine_statuses())
 
 
 def _client(tmp_path) -> TestClient:
@@ -33,7 +48,8 @@ def _client(tmp_path) -> TestClient:
     )
     app = create_app(cfg)
     client = TestClient(app)
-    client.fact_id = app.state.store.add_fact(
+    client.store = app.state.store
+    client.fact_id = client.store.add_fact(
         "A", "is_a", "B", status="needs_review", confidence=0.9
     )
     return client
@@ -63,6 +79,10 @@ def test_rejected_row_offers_no_fact_actions_at_all(tmp_path):
     body = c.post(f"/facts/{c.fact_id}/reject").text
 
     assert _offered(body, c.fact_id) == set()
+    # ...and the row says why it is empty. This sentence is the only thing left
+    # where four buttons were: drop it and the reviewer is looking at a blank
+    # cell with no account of what happened to it.
+    assert "rejected — no further action" in body
 
 
 def test_rejected_row_stays_inspectable(tmp_path):
@@ -84,27 +104,21 @@ def test_rejected_row_stays_stripped_when_re_rendered(tmp_path):
     assert _offered(body, c.fact_id) == set()
 
 
-def test_review_tier_row_keeps_every_action(tmp_path):
-    # Control: without these, the queue cannot be reviewed at all.
+@pytest.mark.parametrize("status", actionable_statuses())
+def test_actionable_row_keeps_every_action(tmp_path, status):
+    # Control, over both tiers: strip these and the queue cannot be reviewed
+    # (review tier) or a promoted fact can never be demoted again (engine
+    # tier). This issue is about rejection, not about freezing anything else.
     c = _client(tmp_path)
-    body = c.get(f"/facts/{c.fact_id}/row").text
+    fact_id = c.store.add_fact("C", "is_a", "D", status=status, confidence=0.9)
+    body = c.get(f"/facts/{fact_id}/row").text
 
-    assert "needs_review" in body
-    assert _offered(body, c.fact_id) == set(ALL_ACTIONS)
+    assert status in body
+    assert _offered(body, fact_id) == set(ALL_ACTIONS)
 
 
 def test_queued_row_in_the_review_page_keeps_every_action(tmp_path):
     c = _client(tmp_path)
     body = c.get("/review").text
 
-    assert _offered(body, c.fact_id) == set(ALL_ACTIONS)
-
-
-def test_engine_tier_row_keeps_every_action(tmp_path):
-    # Control: a confirmed fact is still demotable -- this issue is about
-    # rejection, not about freezing the engine tier.
-    c = _client(tmp_path)
-    body = c.post(f"/facts/{c.fact_id}/accept").text
-
-    assert "confirmed" in body
     assert _offered(body, c.fact_id) == set(ALL_ACTIONS)

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -51,16 +51,26 @@
     {% endif %}
   </td>
   <td class="actions">
+    {# A rejected fact was put out of the KB by a human decision. None of the
+       fact actions mean anything on it, and two of them (toggle, accept) would
+       silently undo that decision in one click -- so the row that comes back
+       from a reject offers no way back. Reinstating a rejected fact, if it is
+       ever wanted, has to be its own explicit and audited action. The trust
+       dossier stays reachable: a rejected fact is still evidence. #}
     <a class="btn ghost" href="/facts/{{ f['id'] }}/provenance" title="inspect trust dossier">Inspect</a>
-    <button hx-post="/facts/{{ f['id'] }}/toggle"
-            hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML"
-            title="needs_review ⇄ confirmed">⇄ toggle</button>
-    <button hx-post="/facts/{{ f['id'] }}/accept"
-            hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">✓ accept</button>
-    <button hx-post="/facts/{{ f['id'] }}/reject"
-            hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML"
-            class="danger">✗ reject</button>
-    <button hx-get="/facts/{{ f['id'] }}/edit"
-            hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">✎ edit</button>
+    {% if f['status'] == 'superseded' %}
+      <span class="muted">rejected — no further action</span>
+    {% else %}
+      <button hx-post="/facts/{{ f['id'] }}/toggle"
+              hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML"
+              title="needs_review ⇄ confirmed">⇄ toggle</button>
+      <button hx-post="/facts/{{ f['id'] }}/accept"
+              hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">✓ accept</button>
+      <button hx-post="/facts/{{ f['id'] }}/reject"
+              hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML"
+              class="danger">✗ reject</button>
+      <button hx-get="/facts/{{ f['id'] }}/edit"
+              hx-target="#fact-{{ f['id'] }}" hx-swap="outerHTML">✎ edit</button>
+    {% endif %}
   </td>
 </tr>

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -58,6 +58,21 @@
        ever wanted, has to be its own explicit and audited action. The trust
        dossier stays reachable: a rejected fact is still evidence. #}
     <a class="btn ghost" href="/facts/{{ f['id'] }}/provenance" title="inspect trust dossier">Inspect</a>
+    {# FAIL-OPEN, knowingly and only for now. This asks "is it superseded?" and
+       hides the buttons if so; it does not ask "is it in the review or engine
+       tier?" and show them only then. Today those are the same question --
+       superseded is the one status outside both tiers -- but the day a status
+       is added (retracted, archived, ...) it lands in the else branch and gets
+       the full set back, toggle and accept included: the one-click way back
+       into the KB that #233 closed reopens by itself, silently.
+
+       The condition has to be inverted to
+         if is_review_eligible(f['status']) or is_engine_input(f['status'])
+       over the call-time tier accessors in verinote/store/tiers.py. That needs
+       the callables handed to Jinja (templates.env.globals / the row context)
+       in verinote/web/app.py, which PR #209 currently holds -- so it is not
+       done here. This literal is also the 6th hardcopy of the status
+       vocabulary tracked by #191; see the note there. #}
     {% if f['status'] == 'superseded' %}
       <span class="muted">rejected — no further action</span>
     {% else %}


### PR DESCRIPTION
## 문제

`partials/fact_row.html` 이 상태를 보지 않고 toggle/accept/reject/edit 를 무조건 그렸다. `✗ reject` 를 누르면 HTMX 가 그 행을 제자리 교체하는데, 돌아온 행에 `⇄ toggle` 과 `✓ accept` 가 그대로 살아 있었다 — 사람의 거부가 **한 클릭 거리**에서 되돌려졌다.

## 변경

`superseded` 행에서는 사실 액션 네 개를 모두 그리지 않고, `rejected — no further action` 이라는 muted 힌트만 남긴다. `Inspect`(provenance) 는 유지한다 — 거부된 사실도 여전히 증거이고 조사 대상이다.

액션별 근거:

| 액션 | superseded 행에서 | 왜 |
|---|---|---|
| `⇄ toggle` | 제거 | 거부를 조용히 되돌린다 (이슈의 핵심) |
| `✓ accept` | 제거 | 거부를 조용히 되돌린다 |
| `✗ reject` | 제거 | 이미 거부된 사실에 무의미한 no-op |
| `✎ edit` | 제거 | `amend_fact` 는 status 를 건드리지 않으므로 부활 경로는 아니지만, 재승인이 없는 이상 거부된 사실을 고칠 의미가 없다 |
| `Inspect` | 유지 | 감사·조사용 trust dossier 는 계속 닿아야 한다 |

되돌리기 기능은 이 PR 에서 만들지 않았다 (범위 밖). Acceptance 대로, 되돌리기를 원한다면 `needs_review ⇄ confirmed` 라벨의 같은 버튼이 아니라 **명시적이고 감사되는 별도 동작**이어야 한다.

리뷰 티어(`candidate`/`needs_review`)와 엔진 티어(`confirmed`/`accepted`)의 버튼은 **그대로 둔다.** 앞은 없으면 리뷰가 불가능해지고, 뒤는 강등(demote)이 정당한 동작이다. 이 이슈는 거부 뒤집기이지 엔진 티어 동결이 아니다. **네 상태 전부가 대조군 테스트로 지켜진다** (아래 테스트 절 참고 — 초판에서는 `needs_review` 와 `confirmed` 두 개만 지켰고, `candidate`/`accepted` 에서 버튼이 전멸해도 스위트가 초록이었다).

CSS 는 건드리지 않았다 — 기존 `.muted` 클래스를 재사용했다.

## 가드가 fail-open 이다 (알고 남긴 부채, #191)

이 PR 의 가드는 `{% if f['status'] == 'superseded' %}` — **"superseded 면 숨긴다"** 이지 **"두 티어에 속할 때만 보여준다"** 가 아니다. 오늘은 superseded 가 두 티어 밖의 유일한 상태라 동치지만, 상태가 하나 추가되면(`retracted`, `archived`, …) 그 행은 else 로 떨어져 toggle/accept 를 포함한 버튼 전체를 **기본값으로 되찾는다.** 이 이슈가 막은 부활 경로가 새 상태에서 조용히 다시 열린다 — 안전하지 않은 방향으로 실패한다.

올바른 형태는 조건을 뒤집는 것이다:

```jinja
{% if is_review_eligible(f['status']) or is_engine_input(f['status']) %}  ← 버튼
{% else %}                                                                ← muted
```

`verinote/store/tiers.py` 의 call-time 접근자를 Jinja 에 넘겨야 하고(`templates.env.globals` 또는 행 컨텍스트), 그건 `web/app.py` 수정을 뜻한다 — **PR #209 가 그 파일을 잡고 있어 이번 PR 에서는 하지 않는다.** 대신 템플릿에 이 성질과 이유를 주석으로 남겼다.

또한 이 리터럴은 **상태 어휘 하드코딩의 6번째 사본**이다 (#191). 단순 중복이 아니라 fail-open 가드라는 점을 [#191 에 코멘트](https://github.com/semantic-reasoning/verinote/issues/191)로 남겼다.

## 부분 수정임을 밝힌다

이 PR 이 닫는 것은 **정규 UI 경로** 하나다. 같은 계약의 나머지 두 층은 아직 열려 있다:

- #231 — `store/db.py` `toggle_review` 가 `superseded` 를 `confirmed` 로 오분기
- #232 — `web/app.py` 의 `accept` 가 현재 상태를 읽지 않음

따라서 오래된 탭, 폼 재전송, 직접 POST 같은 **비정규 경로로는 여전히 거부된 사실을 부활시킬 수 있다.** 세 층이 다 막혀야 경로가 닫힌다.

## 테스트

`tests/test_review_actions.py` (신규, 9개 = 5 + 파라미터 4):

거부 행:

- `test_rejected_row_offers_no_way_back` — reject 응답 행에 toggle/accept 없음
- `test_rejected_row_offers_no_fact_actions_at_all` — 사실 액션 4개 모두 없음 **+ `rejected — no further action` 문구 유지** (버튼이 사라진 이유를 알려주는 유일한 어포던스)
- `test_rejected_row_stays_inspectable` — provenance 링크 + `superseded` 배지 유지
- `test_rejected_row_stays_stripped_when_re_rendered` — reject 응답만의 성질이 아니라 `superseded` 행 렌더 전체의 성질

대조군:

- `test_actionable_row_keeps_every_action[candidate|needs_review|confirmed|accepted]` — **두 티어 전체를 파라미터화.** 상태 목록을 테스트에 복사하지 않고 `review_statuses() | engine_statuses()` call-time 접근자로 읽으므로, 티어가 넓어지면 대조군도 따라 넓어진다.
- `test_queued_row_in_the_review_page_keeps_every_action` — `/review` 큐 렌더도 동일

뮤테이션으로 non-vacuous 확인 (`pytest tests/test_review_actions.py`):

| 뮤테이션 | 결과 |
|---|---|
| 가드 통째로 제거 (수정 되돌리기 → superseded 행에 버튼 부활) | **3 failed**, 6 passed |
| 조건 → `('superseded', 'candidate')` (candidate 행 버튼 전멸) | **1 failed**, 8 passed |
| 조건 → `('superseded', 'accepted')` (accepted 행 버튼 전멸) | **1 failed**, 8 passed |
| `rejected — no further action` 문구 삭제 | **1 failed**, 8 passed |

아래 두 뮤테이션은 초판 스위트에서 **0 caught** 였다 — 대조군 파라미터화로 잡히게 됐다.

전체 스위트 **919 passed**, `ruff check .` **All checks passed**.

Closes #233
