### PR TITLE
ci(#234): run the wirelog backend tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
-      - run: pip install -e ".[test]"
+      # Include the wirelog extra so pyrewire is present and the DuckDB/wirelog
+      # parity tests in tests/test_engine.py actually run instead of being
+      # importorskip'd — without it CI green-lights code it never executes.
+      - run: pip install -e ".[test,wirelog]"
       - run: pytest -q


### PR DESCRIPTION
Closes #234.

## Problem
`.github/workflows/ci.yml` installs `.[test]` only. `pyrewire` lives in a
separate `wirelog` extra, so it never reaches CI, and the 7 DuckDB/wirelog
parity tests in `tests/test_engine.py` guarded by `pytest.importorskip("pyrewire")`
were skipped on every run. CI was green-lighting a code path it never executed.

## Fix
Install `.[test,wirelog]` in the test job.

## Verification
- Without pyrewire: those 7 tests do not run (`90 passed, 7 skipped` per the issue).
- With the wirelog extra installed: `97 passed` — the 7 parity tests now execute.

Single-file change to the CI workflow; no production code touched.