### PR TITLE
fix(#167): dedupe findings and answers by tuple, not by rendered string

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -228,3 +228,31 @@ def test_search_source_excerpts_reads_latest_text_artifact(tmp_path):
     excerpts = search_source_excerpts(store, root=tmp_path, question="샘플항목")
 
     assert [item.path for item in excerpts] == [f"artifacts/sources/{sid}/text.txt"]
+
+
+def test_ask_grounding_table_shows_a_comma_answer_in_its_source_form(tmp_path):
+    """Ask's Answer cell is one value, not a comma-delimited list.
+
+    `/report` joins a question's answers with `, `, so the answer renderer
+    escapes a value's own surface comma as `\\,` (issue #167) -- otherwise one
+    answer `검토자, 팀장` reads as two. Ask reuses `trace_query_answers()` for
+    grounding (`AskGroundingFact.answer`, rendered as a single table cell in
+    `web/templates/ask.html`), and there is no join to defend against: the cell
+    holds exactly one value. Carrying the report's escape into it puts a
+    backslash on screen that is in neither the source text nor the `object`
+    column beside it, so the same fact contradicts itself across one row.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플인물", "역할", "검토자, 팀장", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
+    )
+
+    assert result.route == "engine"
+    fact = result.grounding_facts[0]
+    # The Answer cell and the Object cell beside it are the same value, and it
+    # is the source's value: no report-join escape reaches this screen.
+    assert fact.answer == "검토자, 팀장"
+    assert fact.object == "검토자, 팀장"

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -702,3 +702,106 @@ def test_duckdb_backend_plain_string_answers_stay_unquoted():
 
     assert rep.answers == ["q1: Gadget Works"]
     assert '"' not in rep.answers[0]
+
+
+_DUP_POLICY = (
+    ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+    ".decl error_dup(subject: symbol, object: symbol)\n"
+    'error_dup(S, O) :- relation(S, "flag", O).\n'
+)
+_ROLE_QUERY = (
+    ".decl answer_q1(value: symbol)\n"
+    'answer_q1(O) :- relation("Subj", "role", O).\n'
+)
+
+
+def _c(functor, *args):
+    return Compound(functor, tuple(args))
+
+
+def test_duckdb_backend_counts_distinct_tuples_that_render_alike():
+    """Two policy violations that happen to render the same must stay two.
+
+    ``("A B", "flag", "C")`` and ``("A", "flag", "B C")`` are different tuples,
+    but the old rendered-string dedupe collapsed them into a single "1 error"
+    (issue #167). The count is what the user trusts, so it must reflect tuples.
+    """
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": "A B", "relation": "flag", "object": "C"},
+            {"subject": "A", "relation": "flag", "object": "B C"},
+        ],
+        policy_dl=_DUP_POLICY,
+    )
+
+    assert rep.ok is False
+    assert rep.errors == 2
+    assert len(rep.findings) == 2
+
+
+def test_duckdb_backend_finding_columns_cannot_forge_each_other():
+    """A space in one column may not blur into the column boundary.
+
+    Without escaping, ``("A B", "C")`` and ``("A", "B C")`` both render
+    ``A B C`` and become indistinguishable. Multi-column findings must render so
+    the two tuples read differently.
+    """
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": "A B", "relation": "flag", "object": "C"},
+            {"subject": "A", "relation": "flag", "object": "B C"},
+        ],
+        policy_dl=_DUP_POLICY,
+    )
+
+    assert sorted(rep.findings) == ["ERROR dup: A B\\ C", "ERROR dup: A\\ B C"]
+    assert len(set(rep.findings)) == 2
+
+
+def test_duckdb_backend_answer_comma_cannot_forge_two_answers():
+    """One value containing a comma must not read as two answers.
+
+    ``Analytical Engine, Ltd`` is a single answer; joined answers use ``, `` as
+    the separator, so the value's own comma is escaped to stay distinguishable
+    from a two-answer list (issue #167).
+    """
+    _duckdb()
+    query = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "worked_at", O).\n'
+    )
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "worked_at", "object": "Analytical Engine, Ltd"}],
+        query_dl=query,
+    )
+
+    assert rep.answers == ["q1: Analytical Engine\\, Ltd"]
+    # It must not read as the two-answer list ``Analytical Engine`` + ``Ltd``.
+    assert rep.answers != ["q1: Analytical Engine, Ltd"]
+
+
+def test_duckdb_backend_answers_keep_distinct_tuples_that_render_alike():
+    """Two different answer tuples that used to render alike must both survive.
+
+    A compound ``pair(a, b)`` and the *string* ``"pair(a, b)"`` are different
+    answers: one is a structured term, one is a text value that merely looks like
+    it. Under the old renderer both printed ``pair(a, b)`` and ``set()`` on that
+    text dropped one answer entirely. Deduping on the tuple keeps both, and the
+    string's surface comma is escaped so the two are no longer even confusable
+    (issue #167).
+    """
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": "Subj", "relation": "role", "object": _c("pair", Atom("a"), Atom("b"))},
+            {"subject": "Subj", "relation": "role", "object": "pair(a, b)"},
+        ],
+        query_dl=_ROLE_QUERY,
+    )
+
+    # Compound comma stays bare; the string's comma is escaped. Two answers, not
+    # one. Reverting the fix (set() on rendered text) collapses these to a single
+    # "q1: pair(a, b)".
+    assert rep.answers == ["q1: pair(a, b), pair(a\\, b)"]

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -805,3 +805,54 @@ def test_duckdb_backend_answers_keep_distinct_tuples_that_render_alike():
     # one. Reverting the fix (set() on rendered text) collapses these to a single
     # "q1: pair(a, b)".
     assert rep.answers == ["q1: pair(a, b), pair(a\\, b)"]
+
+
+_PAIR_QUERY = (
+    ".decl answer_q1(left: symbol, right: symbol)\n"
+    'answer_q1(S, O) :- relation(S, "pair", O).\n'
+)
+
+
+def test_duckdb_backend_multi_column_answer_columns_cannot_forge_each_other():
+    """A multi-column answer must guard its column boundary like a finding.
+
+    Answers join columns with a bare space too, so without escaping
+    ``("A B", "C")`` and ``("A", "B C")`` both read ``A B C`` and become
+    indistinguishable inside the ``, ``-joined answer list (issue #167).
+    Reverting the multi-column space escape collapses both rows to ``A B C``.
+    """
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": "A B", "relation": "pair", "object": "C"},
+            {"subject": "A", "relation": "pair", "object": "B C"},
+        ],
+        query_dl=_PAIR_QUERY,
+    )
+
+    assert rep.answers == ["q1: A B\\ C, A\\ B C"]
+    # The two tuples must not read alike (the pre-fix bug produced 'A B C, A B C').
+    assert rep.answers != ["q1: A B C, A B C"]
+
+
+def test_duckdb_backend_collapses_representation_twins_into_one_finding():
+    """Same value, different storage encoding, is one violation -- not two.
+
+    ``Atom("x")`` and ``StringLit("x")`` are stored as different JSON terms, so
+    ``SELECT DISTINCT`` keeps both, but the engine treats them as equal
+    (``term_compare_key`` maps both to ``s:x``). The report must dedupe on that
+    compare-key tuple, so this pair collapses into a single finding. Reverting
+    ``_dedupe_rows_by_compare_key`` yields two identical findings instead.
+    """
+    _duckdb()
+    rep = run_check_duckdb(
+        [
+            {"subject": Atom("x"), "relation": "flag", "object": "y"},
+            {"subject": "x", "relation": "flag", "object": "y"},
+        ],
+        policy_dl=_DUP_POLICY,
+    )
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert rep.findings == ["ERROR dup: x y"]

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 from verinote.pipeline.query import query_path
 from verinote.pipeline.report_trace import report_trace
+from verinote.pipeline.verify import verify
 from verinote.store import Store, db as store_db
 
 
@@ -48,6 +49,48 @@ def test_report_trace_links_direct_answers_to_engine_facts_and_evidence(tmp_path
     assert [fact.id for fact in answer.facts] == [fact_id]
     assert answer.facts[0].source == "sources/sample.txt"
     assert answer.facts[0].evidence == "Sample Person was born in Sample City."
+
+
+def test_report_answer_and_trace_render_a_comma_value_the_same_way(tmp_path):
+    """/report shows one answer twice; both renderings must agree.
+
+    "Query answers" (`rep.answers`, rendered by the engine backend) and
+    "Traceability" (`trace.answers`, rendered by report_trace) are two views of
+    the same derived answer on the same page. The backend escapes a surface
+    comma as `\\,` so a value cannot forge two answers across the `, ` join
+    (issue #167); if the trace renders the same value its own way, the page
+    shows `Analytical Engine\\, Ltd` in one section and the ambiguous
+    `Analytical Engine, Ltd` in the other, and the ambiguity this PR removed is
+    simply reintroduced one section lower.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/org.txt")
+    s.add_fact(
+        "Ada",
+        "works_at",
+        "Analytical Engine, Ltd",
+        status="confirmed",
+        source_id=source_id,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "works_at", O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+    trace = report_trace(s)
+
+    # The escaped comma is what keeps this one answer from reading as two.
+    assert rep.answers == ["q1: Analytical Engine\\, Ltd"]
+    assert [(a.qid, a.value) for a in trace.answers] == [
+        ("1", "Analytical Engine\\, Ltd")
+    ]
+    # ...and the two sections agree: the answer line is exactly the traced
+    # values joined the way the backend joins them, so a renderer change that
+    # reaches only one of the two sections fails here.
+    assert rep.answers == ["q1: " + ", ".join(a.value for a in trace.answers)]
 
 
 def test_report_trace_ignores_invalid_relation_alias_policy(tmp_path):

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-from verinote.engine.terms import Atom
+from verinote.engine.terms import Atom, Compound, StringLit
 from verinote.pipeline.query import query_path
 from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.verify import verify
@@ -284,4 +284,79 @@ def test_report_trace_joins_a_repeated_variable_on_engine_equality(tmp_path):
     assert rep.answers == ["q1: ada"]
     assert [(a.qid, a.value, tuple(f.id for f in a.facts)) for a in trace.answers] == [
         ("1", "ada", (fact_id,))
+    ]
+
+
+def test_report_trace_keeps_render_alike_structural_answers_separate(tmp_path):
+    """Trace identity must not collapse distinct answers that render alike.
+
+    `Compound("f", (Atom("x"),))` and `StringLit("f(x)")` both display as
+    `f(x)`, but the engine compare key keeps them distinct because compound
+    identity is structural. Grouping trace matches by rendered text merged their
+    provenance into one row even though the report answers preserve two tuples.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/render-alike.txt")
+    compound_fact = s.add_fact(
+        "s",
+        "r",
+        Compound("f", (Atom("x"),)),
+        status="confirmed",
+        source_id=source_id,
+    )
+    string_fact = s.add_fact(
+        "s",
+        "r",
+        StringLit("f(x)"),
+        status="confirmed",
+        source_id=source_id,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("s", "r", O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+    trace = report_trace(s)
+
+    assert rep.answers == ["q1: f(x), f(x)"]
+    assert [(a.qid, a.value, [fact.id for fact in a.facts]) for a in trace.answers] == [
+        ("1", "f(x)", [compound_fact]),
+        ("1", "f(x)", [string_fact]),
+    ]
+
+
+def test_report_trace_dedupes_render_alike_heads_by_engine_identity(tmp_path):
+    """Trace row dedupe must preserve distinct head values with the same facts.
+
+    A constant compound head and a constant string head can render the same
+    `f(x)` while depending on the same body fact. Deduping traced rows by the
+    rendered answer and fact ids alone would hide one of the engine answers.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/render-alike-heads.txt")
+    fact_id = s.add_fact(
+        "s",
+        "r",
+        "anchor",
+        status="confirmed",
+        source_id=source_id,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(f(x)) :- relation("s", "r", "anchor").\n'
+        'answer_q1("f(x)") :- relation("s", "r", "anchor").\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+    trace = report_trace(s)
+
+    assert rep.answers == ["q1: f(x), f(x)"]
+    assert [(a.qid, a.value, [fact.id for fact in a.facts]) for a in trace.answers] == [
+        ("1", "f(x)", [fact_id]),
+        ("1", "f(x)", [fact_id]),
     ]

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
+from verinote.engine.terms import Atom
 from verinote.pipeline.query import query_path
 from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.verify import verify
@@ -212,3 +213,75 @@ def test_report_trace_excluded_count_follows_review_statuses(tmp_path, monkeypat
 
     assert trace.excluded_review_count == 2
     assert trace.excluded_by_status == (("candidate", 1), ("superseded", 1))
+
+
+def test_report_trace_matches_engine_equal_representation_twins(tmp_path):
+    """Trace matching must use the engine's equality, not dataclass equality.
+
+    The DuckDB backend compares body constants and variable joins on
+    `term_compare_key`, so `Atom("x")` and `StringLit("x")` are one value to the
+    engine (both map to `s:x`). `report_trace` matched query terms against fact
+    terms with dataclass `==`, which separates the two. The result was an answer
+    on `/report` with an empty Traceability row: the engine derived it, but the
+    trace could name no fact behind it -- exactly the provenance the report
+    exists to show.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/twins.txt")
+    fact_id = s.add_fact(
+        Atom("x"),
+        "role",
+        "Chief",
+        status="confirmed",
+        source_id=source_id,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("x", "role", O).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+    trace = report_trace(s)
+
+    # The engine answers, because `"x"` and the stored `x` are one value to it.
+    assert rep.answers == ["q1: Chief"]
+    # ...so the trace must name the fact behind that answer.
+    assert [(a.qid, a.value) for a in trace.answers] == [("1", "Chief")]
+    assert [fact.id for fact in trace.answers[0].facts] == [fact_id]
+
+
+def test_report_trace_joins_a_repeated_variable_on_engine_equality(tmp_path):
+    """A repeated query variable must join the way the engine joins it.
+
+    The DuckDB backend joins a repeated variable on the compare-key column
+    (`__cmp_<column> = __cmp_<column>`), so a fact whose subject is `Atom("ada")`
+    and whose object is `StringLit("ada")` satisfies `relation(S, _, S)`. Trace
+    matching bound `S` to the subject term and compared the object with
+    dataclass `==`, so the twins never joined and the answer lost its
+    provenance.
+    """
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/twins.txt")
+    fact_id = s.add_fact(
+        Atom("ada"),
+        "same_as",
+        "ada",
+        status="confirmed",
+        source_id=source_id,
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(S) :- relation(S, "same_as", S).\n',
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+    trace = report_trace(s)
+
+    assert rep.answers == ["q1: ada"]
+    assert [(a.qid, a.value, tuple(f.id for f in a.facts)) for a in trace.answers] == [
+        ("1", "ada", (fact_id,))
+    ]

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -32,6 +32,7 @@ from verinote.engine.terms import (
     Term,
     Var,
     escape_string_value,
+    render_answer_value,
     render_term,
 )
 from verinote.engine.wirelog import CheckReport, DEFAULT_POLICY, NO_FINDINGS_TEXT
@@ -541,27 +542,8 @@ def _render_finding_row(row: tuple[object, ...]) -> str:
 def _render_answer_row(row: tuple[object, ...]) -> str:
     """Render one answer tuple, guarding column boundaries like a finding row."""
     return _join_row_columns(
-        [_render_answer_value(duckdb_value_to_term(value)) for value in row]
+        [render_answer_value(duckdb_value_to_term(value)) for value in row]
     )
-
-
-def _render_answer_value(term: Term) -> str:
-    """Render one answer value so a comma inside it cannot forge two answers.
-
-    Multiple answers for a question are joined with ``, ``. A ``StringLit`` whose
-    surface text already contains a comma (e.g. ``Analytical Engine, Ltd``) would
-    then be indistinguishable from two separate answers (issue #167), so we
-    escape those surface commas as ``\\,``. Backslash is escaped first by
-    :func:`escape_string_value`, so ``\\,`` round-trips unambiguously.
-
-    A ``Compound`` is rendered by :func:`render_term`. Its ``, `` separators are
-    structural, not surface text, and callers (and tests such as
-    ``role(person("Ada"), "PI")``) depend on that rendering staying intact, so we
-    must not touch a compound's commas.
-    """
-    if isinstance(term, StringLit):
-        return escape_string_value(term.value).replace(",", "\\,")
-    return render_term(term)
 
 
 def _render_output_term(term: Term) -> str:

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -422,24 +422,29 @@ def _collect_report(
         ).fetchall()
         if not declarations[name].columns:
             rows = [() for _row in rows]
-        rendered_rows = [_render_row(row) for row in rows]
+        rows = _dedupe_rows_by_compare_key(rows)
         if name.startswith(_ERROR_PREFIX):
-            errors.extend(
-                f"{name[len(_ERROR_PREFIX) :]}: {row}" for row in rendered_rows
-            )
+            label = name[len(_ERROR_PREFIX) :]
+            errors.extend(f"{label}: {_render_finding_row(row)}" for row in rows)
         elif name.startswith(_WARN_PREFIX):
-            warnings.extend(
-                f"{name[len(_WARN_PREFIX) :]}: {row}" for row in rendered_rows
-            )
+            label = name[len(_WARN_PREFIX) :]
+            warnings.extend(f"{label}: {_render_finding_row(row)}" for row in rows)
         elif name.startswith(_ANSWER_PREFIX):
-            if rendered_rows:
+            if rows:
                 qid = name[len(_ANSWER_PREFIX) :]
-                answers_by_q.setdefault(qid, []).extend(rendered_rows)
+                answers_by_q.setdefault(qid, []).extend(
+                    _render_answer_row(row) for row in rows
+                )
 
-    errors = sorted(set(errors))
-    warnings = sorted(set(warnings))
+    # Rows are deduped by their compare-key tuple (see
+    # `_dedupe_rows_by_compare_key`), so each survivor is a semantically distinct
+    # tuple. We must NOT dedupe again on the rendered string: two different
+    # tuples can render alike, and collapsing them here would hide real
+    # violations (issue #167). Sort only, never set().
+    errors = sorted(errors)
+    warnings = sorted(warnings)
     answers = [
-        f"q{qid}: {', '.join(sorted(set(vals)))}"
+        f"q{qid}: {', '.join(sorted(vals))}"
         for qid, vals in sorted(answers_by_q.items())
     ]
     findings = [f"ERROR {e}" for e in errors] + [f"WARN {w}" for w in warnings]
@@ -480,8 +485,71 @@ def _render_fact_input(facts: list[Mapping[str, object]]) -> str:
     return "\n".join(sorted(set(lines)))
 
 
-def _render_row(row: tuple[object, ...]) -> str:
-    return " ".join(_render_output_term(duckdb_value_to_term(value)) for value in row)
+def _dedupe_rows_by_compare_key(
+    rows: list[tuple[object, ...]],
+) -> list[tuple[object, ...]]:
+    """Drop rows that are the same tuple under the engine's equality.
+
+    ``SELECT DISTINCT`` only removes rows that are identical in their *typed
+    storage* (the JSON term encoding), so ``Atom("ada")`` and ``StringLit("ada")``
+    survive as two rows even though the engine treats them as equal
+    (`term_compare_key` maps both to ``s:ada``). Deduping on the compare-key
+    tuple collapses those representation twins into one finding/answer, while
+    still keeping genuinely different tuples such as ``("A B", "C")`` and
+    ``("A", "B C")`` apart -- which is the whole point of issue #167. Order is
+    preserved so the later sort is stable and deterministic.
+    """
+    seen: set[tuple[str, ...]] = set()
+    deduped: list[tuple[object, ...]] = []
+    for row in rows:
+        key = tuple(term_compare_key(duckdb_value_to_term(value)) for value in row)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped
+
+
+def _render_finding_row(row: tuple[object, ...]) -> str:
+    """Render one finding tuple so its columns cannot be forged into each other.
+
+    Columns are joined by a bare space. A single-column row is rendered
+    verbatim (its own spaces are kept), because there is no neighbouring column
+    for a space to blur into. But once a row has two or more columns, a bare
+    space inside a value would be indistinguishable from the column separator --
+    ``("A B", "C")`` and ``("A", "B C")`` would both read ``A B C`` and collapse
+    into one finding (issue #167). So for multi-column rows we escape the spaces
+    *inside* each rendered value as ``\\ `` and keep the column separator bare.
+    Backslash is already escaped by :func:`escape_string_value`, so ``\\ ``
+    round-trips back to an in-value space with no ambiguity.
+    """
+    values = [_render_output_term(duckdb_value_to_term(value)) for value in row]
+    if len(values) <= 1:
+        return " ".join(values)
+    return " ".join(value.replace(" ", "\\ ") for value in values)
+
+
+def _render_answer_row(row: tuple[object, ...]) -> str:
+    return " ".join(_render_answer_value(duckdb_value_to_term(value)) for value in row)
+
+
+def _render_answer_value(term: Term) -> str:
+    """Render one answer value so a comma inside it cannot forge two answers.
+
+    Multiple answers for a question are joined with ``, ``. A ``StringLit`` whose
+    surface text already contains a comma (e.g. ``Analytical Engine, Ltd``) would
+    then be indistinguishable from two separate answers (issue #167), so we
+    escape those surface commas as ``\\,``. Backslash is escaped first by
+    :func:`escape_string_value`, so ``\\,`` round-trips unambiguously.
+
+    A ``Compound`` is rendered by :func:`render_term`. Its ``, `` separators are
+    structural, not surface text, and callers (and tests such as
+    ``role(person("Ada"), "PI")``) depend on that rendering staying intact, so we
+    must not touch a compound's commas.
+    """
+    if isinstance(term, StringLit):
+        return escape_string_value(term.value).replace(",", "\\,")
+    return render_term(term)
 
 
 def _render_output_term(term: Term) -> str:

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -510,27 +510,39 @@ def _dedupe_rows_by_compare_key(
     return deduped
 
 
-def _render_finding_row(row: tuple[object, ...]) -> str:
-    """Render one finding tuple so its columns cannot be forged into each other.
+def _join_row_columns(values: list[str]) -> str:
+    """Join already-rendered column values so no column can forge another.
 
-    Columns are joined by a bare space. A single-column row is rendered
-    verbatim (its own spaces are kept), because there is no neighbouring column
-    for a space to blur into. But once a row has two or more columns, a bare
-    space inside a value would be indistinguishable from the column separator --
+    Columns are joined by a bare space. A single-column row is emitted verbatim
+    (its own spaces are kept), because with no neighbouring column a space cannot
+    blur into a boundary. But once a row has two or more columns, a bare space
+    inside a value would be indistinguishable from the column separator --
     ``("A B", "C")`` and ``("A", "B C")`` would both read ``A B C`` and collapse
-    into one finding (issue #167). So for multi-column rows we escape the spaces
+    into one row (issue #167). So for multi-column rows we escape the spaces
     *inside* each rendered value as ``\\ `` and keep the column separator bare.
     Backslash is already escaped by :func:`escape_string_value`, so ``\\ ``
     round-trips back to an in-value space with no ambiguity.
+
+    Both findings and answers share this rule so a multi-column answer is guarded
+    exactly like a multi-column finding.
     """
-    values = [_render_output_term(duckdb_value_to_term(value)) for value in row]
     if len(values) <= 1:
         return " ".join(values)
     return " ".join(value.replace(" ", "\\ ") for value in values)
 
 
+def _render_finding_row(row: tuple[object, ...]) -> str:
+    """Render one finding tuple so its columns cannot be forged into each other."""
+    return _join_row_columns(
+        [_render_output_term(duckdb_value_to_term(value)) for value in row]
+    )
+
+
 def _render_answer_row(row: tuple[object, ...]) -> str:
-    return " ".join(_render_answer_value(duckdb_value_to_term(value)) for value in row)
+    """Render one answer tuple, guarding column boundaries like a finding row."""
+    return _join_row_columns(
+        [_render_answer_value(duckdb_value_to_term(value)) for value in row]
+    )
 
 
 def _render_answer_value(term: Term) -> str:

--- a/verinote/engine/duckdb_terms.py
+++ b/verinote/engine/duckdb_terms.py
@@ -17,7 +17,32 @@ import re
 from typing import Any
 
 from verinote.engine.datalog import Declaration
-from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Term, Var
+from verinote.engine.terms import (
+    Atom,
+    Compound,
+    NumberLit,
+    StringLit,
+    Term,
+    Var,
+    term_compare_key,
+)
+
+# Re-exported for the backend, which reads storage encoding and equality from
+# one place. `term_compare_key` itself belongs to `engine.terms`: it is the term
+# language's equality, not this module's storage encoding, and non-DuckDB
+# callers (`pipeline.report_trace`) must be able to ask what the engine calls
+# equal without importing a storage backend.
+__all__ = [
+    "DUCKDB_TERM_SQL_TYPE",
+    "DuckDBTermError",
+    "create_decl_table_sql",
+    "create_relation_table_sql",
+    "create_term_table_sql",
+    "duckdb_value_to_term",
+    "term_compare_key",
+    "term_eq_sql",
+    "term_to_duckdb_value",
+]
 
 DUCKDB_TERM_SQL_TYPE = "VARCHAR"
 
@@ -55,26 +80,6 @@ def duckdb_value_to_term(value: object) -> Term:
 def term_eq_sql(left_expr: str, right_expr: str) -> str:
     """Return SQL comparing two physical DuckDB term expressions."""
     return f"{left_expr} = {right_expr}"
-
-
-def term_compare_key(term: Term) -> str:
-    """Return the human-surface comparison key used by the inference engine.
-
-    Storage remains type-tagged via `term_to_duckdb_value`; this key is only for
-    Datalog equality so equivalent UI/display values do not occupy separate
-    universes merely because one was entered as a structural term.
-    """
-    if isinstance(term, Atom):
-        return f"s:{term.name}"
-    if isinstance(term, StringLit):
-        return f"s:{term.value}"
-    if isinstance(term, NumberLit):
-        return f"s:{term.value}"
-    if isinstance(term, Compound):
-        return f"c:{term_to_duckdb_value(term)}"
-    if isinstance(term, Var):
-        return f"v:{term.name}"
-    raise TypeError(f"not a term: {term!r}")
 
 
 def create_term_table_sql(table_name: str, columns: tuple[str, ...]) -> str:

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -200,6 +200,32 @@ def escape_string_value(value: str) -> str:
     return "".join(out)
 
 
+def render_answer_value(term: Term) -> str:
+    """Render one answer value so a comma inside it cannot forge two answers.
+
+    This is the single owner of "how does one answer value reach a reader", so
+    the two places /report shows the same answer cannot drift apart. The engine
+    backend renders the "Query answers" line and `pipeline.report_trace` renders
+    the "Traceability" section; when each escaped in its own way the one answer
+    `Analytical Engine, Ltd` appeared escaped in one section and ambiguous in the
+    other (issue #167).
+
+    Multiple answers for a question are joined with `, `. A `StringLit` whose
+    surface text already contains a comma would then be indistinguishable from
+    two separate answers, so those surface commas are escaped as `\\,`.
+    Backslash is escaped first by `escape_string_value`, so `\\,` round-trips
+    unambiguously.
+
+    A `Compound` is rendered by `render_term`. Its `, ` separators are
+    structural, not surface text, and callers (and tests such as
+    `role(person("Ada"), "PI")`) depend on that rendering staying intact, so a
+    compound's commas are left alone.
+    """
+    if isinstance(term, StringLit):
+        return escape_string_value(term.value).replace(",", "\\,")
+    return render_term(term)
+
+
 def _unicode_escape(ch: str) -> str:
     code = ord(ch)
     if code <= 0xFFFF:

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -200,15 +200,40 @@ def escape_string_value(value: str) -> str:
     return "".join(out)
 
 
+def render_display_value(term: Term) -> str:
+    """Render one value the way a reader should see it standing on its own.
+
+    This is `render_term` with the quotes taken off a `StringLit`: a value shown
+    in its own right (an Ask grounding cell) is text the source said, not
+    Datalog syntax the reader must un-quote. Control characters still go through
+    `escape_string_value`, because a value able to start a new line can forge a
+    line wherever it is shown.
+
+    What it deliberately does *not* do is escape surface commas. That escape
+    belongs to `render_answer_value` below and exists only to defend the `, `
+    join between answers. Where there is no join there is nothing to defend, and
+    the backslash would be a character the reader's source never contained --
+    which is what made an Ask Answer cell disagree with the `object` column
+    printed beside it (issue #167).
+    """
+    if isinstance(term, StringLit):
+        return escape_string_value(term.value)
+    return render_term(term)
+
+
 def render_answer_value(term: Term) -> str:
     """Render one answer value so a comma inside it cannot forge two answers.
 
-    This is the single owner of "how does one answer value reach a reader", so
-    the two places /report shows the same answer cannot drift apart. The engine
-    backend renders the "Query answers" line and `pipeline.report_trace` renders
-    the "Traceability" section; when each escaped in its own way the one answer
-    `Analytical Engine, Ltd` appeared escaped in one section and ambiguous in the
-    other (issue #167).
+    This is the single owner of "how does one answer reach a reader *through the
+    `, ` join*", so the two places /report shows the same answer cannot drift
+    apart. The engine backend renders the "Query answers" line and
+    `pipeline.report_trace` renders the "Traceability" section; when each escaped
+    in its own way the one answer `Analytical Engine, Ltd` appeared escaped in
+    one section and ambiguous in the other (issue #167).
+
+    Use `render_display_value` instead wherever a value is shown alone rather
+    than joined; this function's escape is a property of the join, not of the
+    value.
 
     Multiple answers for a question are joined with `, `. A `StringLit` whose
     surface text already contains a comma would then be indistinguishable from
@@ -222,7 +247,7 @@ def render_answer_value(term: Term) -> str:
     compound's commas are left alone.
     """
     if isinstance(term, StringLit):
-        return escape_string_value(term.value).replace(",", "\\,")
+        return render_display_value(term).replace(",", "\\,")
     return render_term(term)
 
 

--- a/verinote/engine/terms.py
+++ b/verinote/engine/terms.py
@@ -153,6 +153,46 @@ def canonical_term_key(term: Term) -> str:
     raise TypeError(f"not a term: {term!r}")
 
 
+def term_compare_key(term: Term) -> str:
+    """Return the equality key the inference engine compares terms on.
+
+    This is the single owner of "when are two terms one value?", and every
+    consumer must ask it rather than reach for dataclass `==`. The engine's
+    equality is *human-surface* equality for leaves: `Atom("x")`, `StringLit("x")`
+    and `NumberLit(5)`/`StringLit("5")` are one value, so an entry that happened
+    to be stored as a structural term does not occupy a universe of its own.
+    Storage stays type-tagged and lossless (`term_to_duckdb_value`); this key is
+    only for equality.
+
+    It lives here, beside the term model, rather than in `duckdb_terms` where it
+    started: it is the semantics of the term language itself, not of one
+    backend's storage. `pipeline.report_trace` needs the same rule to match a
+    query against a fact -- and a pipeline module importing a backend's storage
+    encoder to learn what equality means is a layering inversion, the same one
+    that moved `bare_label` here.
+
+    Compounds compare structurally, on `canonical_term_key`: `f(Atom("x"))` and
+    `f(StringLit("x"))` stay distinct, which is the pre-existing behaviour and is
+    preserved here deliberately -- only the leaf twins collapse.
+    """
+    if isinstance(term, Atom):
+        return f"s:{term.name}"
+    if isinstance(term, StringLit):
+        return f"s:{term.value}"
+    if isinstance(term, NumberLit):
+        return f"s:{term.value}"
+    if isinstance(term, Compound):
+        return f"c:{canonical_term_key(term)}"
+    if isinstance(term, Var):
+        return f"v:{term.name}"
+    raise TypeError(f"not a term: {term!r}")
+
+
+def terms_equal(left: Term, right: Term) -> bool:
+    """Return whether the engine treats two terms as the same value."""
+    return term_compare_key(left) == term_compare_key(right)
+
+
 def escape_string_value(value: str) -> str:
     """Escape backslashes, line-breaking characters and bidi controls.
 

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -326,9 +326,21 @@ def _render_row(row: Iterable[object]) -> str:
 
     Values go through `escape_string_value` for the same reason the DuckDB
     backend does it: an unescaped line break inside a value would let that value
-    forge extra `ERROR `/`WARN ` lines in the report body. Escaping has exactly
-    one owner (`verinote.engine.terms`), so this legacy path cannot drift away
-    from the production one.
+    forge extra `ERROR `/`WARN ` lines in the report body. *Control-character*
+    escaping has exactly one owner (`verinote.engine.terms`), so on that question
+    this legacy path cannot drift away from the production one.
+
+    The shared ownership stops there, and answers on this path really do drift.
+    The production answer path escapes a value's surface commas via
+    `terms.render_answer_value`, so one value cannot forge two answers across the
+    `, ` join that `run_check` uses below (#167); this path does not, so a legacy
+    answer `q1: A, B` stays ambiguous between one value and two.
+
+    Sharing that renderer is not a swap: it takes a `Term`, while pyrewire hands
+    this path bare values that are `str()`-ed here, so sharing would mean
+    asserting that every legacy value is a string literal. That is a rendering
+    change on a path CI cannot execute at all (pyrewire is absent there, #234),
+    so it is left alone deliberately rather than changed blind.
     """
     return " ".join(escape_string_value(str(value)) for value in row)
 

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -200,7 +200,13 @@ def _engine_source_facts(store: Store, query_dl: str) -> list[AskGroundingFact]:
             seen.add(key)
             facts.append(
                 AskGroundingFact(
-                    answer=answer.value,
+                    # `display_value`, not `value`: ask.html renders this as a
+                    # single table cell, not as an entry in the report's
+                    # `, `-joined answer line, so the join's comma escape has
+                    # nothing to defend here and would only contradict the
+                    # `object` cell printed beside it (issue #167). `seen` still
+                    # keys on `value`, the answer's identity.
+                    answer=answer.display_value,
                     subject=fact.subject,
                     relation=fact.relation,
                     object=fact.object,

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -19,6 +19,7 @@ from verinote.engine.terms import (
     Var,
     render_answer_value,
     render_display_value,
+    term_compare_key,
     terms_equal,
 )
 from verinote.pipeline.corroboration import CorroborationPolicyError
@@ -47,9 +48,9 @@ class AnswerTrace:
 
     `value` is the answer as /report writes it -- the same rendering the engine
     backend uses for the "Query answers" line, so the "Traceability" section
-    below it shows that answer the same way and the two can be matched to each
-    other (issue #167). It is the answer's identity here: grouping and dedupe
-    key on it.
+    below it shows that answer the same way. It is a rendered value, not the
+    trace identity: grouping and dedupe key on the engine compare key before
+    this dataclass is created, because distinct answers can render alike.
 
     `display_value` is the same answer standing on its own, without the escape
     that only the report's `, ` join needs. Ask puts one answer in one table
@@ -126,8 +127,8 @@ def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
         if relation_atom is None:
             continue
         matches = _match_relation_atom(relation_atom, facts, rule.head.args)
-        for value, (display_value, fact_ids) in sorted(matches.items()):
-            key = (qid, value, tuple(sorted(fact_ids)))
+        for identity, (value, display_value, fact_ids) in sorted(matches.items()):
+            key = (qid, identity, tuple(sorted(fact_ids)))
             if key in seen:
                 continue
             seen.add(key)
@@ -170,18 +171,18 @@ def _match_relation_atom(
     atom: AtomExpr,
     facts: list[dict[str, object]],
     head_args: tuple[Term, ...],
-) -> dict[str, tuple[str, set[int]]]:
+) -> dict[str, tuple[str, str, set[int]]]:
     """Group matching facts by answer value.
 
-    Keyed on `render_answer_value` -- the report's rendering -- because that is
-    the answer's identity on /report, and two terms the engine calls one answer
-    (`Atom("x")` and `StringLit("x")`) must land in one group rather than two
-    rows naming the same value. The display form rides along per group; it is a
-    function of the same term, so every member of a group agrees on it.
+    Keyed on `term_compare_key`, not on either display rendering. Two terms the
+    engine calls one answer (`Atom("x")` and `StringLit("x")`) must land in one
+    group rather than two rows naming the same value, while structurally distinct
+    answers that render alike (`f(x)` as a compound versus a string) must keep
+    separate provenance rows. The renderings ride along as payload, not identity.
     """
     if len(head_args) != 1:
         return {}
-    matches: dict[str, tuple[str, set[int]]] = {}
+    matches: dict[str, tuple[str, str, set[int]]] = {}
     for fact in facts:
         bindings: dict[str, Term] = {}
         if not _match_term(atom.args[0], fact["subject"], bindings):
@@ -194,9 +195,10 @@ def _match_relation_atom(
         if value is None:
             continue
         group = matches.setdefault(
-            render_answer_value(value), (render_display_value(value), set())
+            term_compare_key(value),
+            (render_answer_value(value), render_display_value(value), set()),
         )
-        group[1].add(int(fact["id"]))
+        group[2].add(int(fact["id"]))
     return matches
 
 

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -13,7 +13,7 @@ from verinote.engine.datalog import (
     DatalogValidationError,
     parse_and_validate_program,
 )
-from verinote.engine.terms import Compound, StringLit, Term, Var, render_term
+from verinote.engine.terms import Compound, Term, Var, render_answer_value
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.trust import fact_trust_summary
@@ -162,7 +162,7 @@ def _match_relation_atom(
         value = _head_value(head_args[0], bindings)
         if value is None:
             continue
-        matches.setdefault(_render_answer_value(value), set()).add(int(fact["id"]))
+        matches.setdefault(render_answer_value(value), set()).add(int(fact["id"]))
     return matches
 
 
@@ -205,12 +205,6 @@ def _trace_fact(
         evidence=evidence,
         conflicted=conflicted,
     )
-
-
-def _render_answer_value(term: Term) -> str:
-    if isinstance(term, StringLit):
-        return term.value
-    return render_term(term)
 
 
 def _has_vars(term: Term) -> bool:

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -19,6 +19,7 @@ from verinote.engine.terms import (
     Var,
     render_answer_value,
     render_display_value,
+    terms_equal,
 )
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query import load_query
@@ -200,6 +201,17 @@ def _match_relation_atom(
 
 
 def _match_term(pattern: Term, value: object, bindings: dict[str, Term]) -> bool:
+    """Match one query term against one fact term, the way the engine matches.
+
+    Equality is `terms_equal` (the engine's compare-key), not dataclass `==`.
+    The DuckDB backend compiles a body constant to `__cmp_<col> = ?` bound with
+    `term_compare_key`, and a repeated variable to `__cmp_a = __cmp_b`, so
+    `Atom("x")` and `StringLit("x")` are one value to it -- and to the legacy
+    wirelog path too, which renders both to `"x"` before pyrewire sees them.
+    Dataclass `==` splits that pair, so the trace found no fact behind an answer
+    the engine had just derived, and /report showed provenance-less answers
+    (issue #167).
+    """
     if not isinstance(value, Term):
         return False
     if isinstance(pattern, Var):
@@ -207,8 +219,8 @@ def _match_term(pattern: Term, value: object, bindings: dict[str, Term]) -> bool
         if bound is None:
             bindings[pattern.name] = value
             return True
-        return bound == value
-    return pattern == value
+        return terms_equal(bound, value)
+    return terms_equal(pattern, value)
 
 
 def _head_value(term: Term, bindings: dict[str, Term]) -> Term | None:

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -13,7 +13,13 @@ from verinote.engine.datalog import (
     DatalogValidationError,
     parse_and_validate_program,
 )
-from verinote.engine.terms import Compound, Term, Var, render_answer_value
+from verinote.engine.terms import (
+    Compound,
+    Term,
+    Var,
+    render_answer_value,
+    render_display_value,
+)
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query import load_query
 from verinote.pipeline.trust import fact_trust_summary
@@ -36,8 +42,23 @@ class TraceFact:
 
 @dataclass(frozen=True)
 class AnswerTrace:
+    """One traced answer, in the two forms its two readers need.
+
+    `value` is the answer as /report writes it -- the same rendering the engine
+    backend uses for the "Query answers" line, so the "Traceability" section
+    below it shows that answer the same way and the two can be matched to each
+    other (issue #167). It is the answer's identity here: grouping and dedupe
+    key on it.
+
+    `display_value` is the same answer standing on its own, without the escape
+    that only the report's `, ` join needs. Ask puts one answer in one table
+    cell with no join, so it reads this one; showing `value` there printed a
+    backslash the `object` cell beside it did not have.
+    """
+
     qid: str
     value: str
+    display_value: str
     facts: tuple[TraceFact, ...]
     conflicted: bool
 
@@ -104,7 +125,7 @@ def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
         if relation_atom is None:
             continue
         matches = _match_relation_atom(relation_atom, facts, rule.head.args)
-        for value, fact_ids in sorted(matches.items()):
+        for value, (display_value, fact_ids) in sorted(matches.items()):
             key = (qid, value, tuple(sorted(fact_ids)))
             if key in seen:
                 continue
@@ -118,6 +139,7 @@ def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
                 AnswerTrace(
                     qid=qid,
                     value=value,
+                    display_value=display_value,
                     facts=trace_facts,
                     conflicted=any(fact.conflicted for fact in trace_facts),
                 )
@@ -147,10 +169,18 @@ def _match_relation_atom(
     atom: AtomExpr,
     facts: list[dict[str, object]],
     head_args: tuple[Term, ...],
-) -> dict[str, set[int]]:
+) -> dict[str, tuple[str, set[int]]]:
+    """Group matching facts by answer value.
+
+    Keyed on `render_answer_value` -- the report's rendering -- because that is
+    the answer's identity on /report, and two terms the engine calls one answer
+    (`Atom("x")` and `StringLit("x")`) must land in one group rather than two
+    rows naming the same value. The display form rides along per group; it is a
+    function of the same term, so every member of a group agrees on it.
+    """
     if len(head_args) != 1:
         return {}
-    matches: dict[str, set[int]] = {}
+    matches: dict[str, tuple[str, set[int]]] = {}
     for fact in facts:
         bindings: dict[str, Term] = {}
         if not _match_term(atom.args[0], fact["subject"], bindings):
@@ -162,7 +192,10 @@ def _match_relation_atom(
         value = _head_value(head_args[0], bindings)
         if value is None:
             continue
-        matches.setdefault(render_answer_value(value), set()).add(int(fact["id"]))
+        group = matches.setdefault(
+            render_answer_value(value), (render_display_value(value), set())
+        )
+        group[1].add(int(fact["id"]))
     return matches
 
 


### PR DESCRIPTION
## Problem

Engine reports deduped findings and answers by their **rendered string**, not by
their tuple, so distinct policy violations that happen to render the same collapsed
into one finding (`duckdb_backend._collect_report`):

- Policy `error_dup(subject, object)`, facts `("A B","flag","C")` and `("A","flag","B C")`
  both render `A B C`; `errors = sorted(set(errors))` reported **1 error** for **2 violations**.
- Answers had the same class of bug plus a comma ambiguity: a single value
  `("Ada","worked_at","Analytical Engine, Ltd")` rendered `q1: Analytical Engine, Ltd`,
  indistinguishable from a two-answer list, because answers are joined with `, `.

## Fix

- **Dedupe on the compare-key tuple, not the rendered string.** `SELECT DISTINCT` only
  removes rows identical in their *typed storage*, so `Atom("ada")` and `StringLit("ada")`
  survive as two rows even though the engine treats them as equal. A new
  `_dedupe_rows_by_compare_key` collapses those representation twins into one
  finding/answer (keeping the existing atom/string equality test green) while keeping
  genuinely different tuples apart. The now-redundant-and-harmful `set()` on rendered
  text is removed.
- **Findings render so columns cannot forge each other** (`_render_finding_row`): a
  single-column row is verbatim; a multi-column row escapes in-value spaces as `\ ` and
  keeps the column separator bare, so `("A B","C")` → `A\ B C` and `("A","B C")` → `A B\ C`
  read differently. Backslash is already escaped by `escape_string_value`, so `\ ` round-trips.
- **Answers escape a StringLit's surface commas** as `\,` so one value cannot forge two
  answers. Compound structural commas (`role(person("Ada"), "PI")`) are left intact.
- **One shared owner for answer rendering** (review follow-up). The escape above first
  lived privately in `duckdb_backend`, while `pipeline.report_trace` kept its own private
  renderer that returned `term.value` raw — so `/report` showed the same answer escaped
  under "Query answers" and ambiguous under "Traceability". The renderer now lives in
  `verinote.engine.terms` as `render_answer_value`. Both the DuckDB backend and
  `report_trace` call it. Extending the escaping-ownership rule that `terms` already
  carries was preferred over introducing a separate structured answer identity, which
  would have added a new concept to solve a drift the rule already covers.

- **The report's join escape stays out of surfaces that do not join** (2nd review
  follow-up). The `\,` escape is a property of the `, ` join between answers, not of the
  value. Ask renders one answer per table cell and joins nothing, so carrying the escape
  there put a backslash in the Answer cell that the `object`/evidence cells beside it did
  not have. `terms.render_display_value` now renders a value standing alone, and
  `render_answer_value` is that plus the join escape, so the two cannot drift.
  `AnswerTrace` carries both: `value` stays the report rendering and the answer's
  identity (grouping, dedupe and the report/traceability match are unchanged), while
  `display_value` is what Ask reads.
- **Trace matching uses the engine's equality** (2nd review follow-up). `_match_term()`
  compared with dataclass `==`, which splits pairs both engines call one value, so a fact
  stored as `Atom("x")` answered `relation("x","role",O)` in the engine while the trace
  found nothing behind it — an answer printed with no provenance. It now matches on the
  engine compare key. That key moves from `engine.duckdb_terms` to `engine.terms` (the
  term language's equality, not one backend's storage encoding; `duckdb_terms`
  re-exports it), so the pipeline no longer imports a storage backend to learn what
  equality means. Compounds still compare structurally; only leaf twins collapse.

## Behavior change (breaking for rendered text)

Rendered finding/answer strings change for values that contain spaces (multi-column
findings) or commas (string answers): e.g. `ERROR dup: A B C` becomes `ERROR dup: A\ B C`,
and `q1: Analytical Engine, Ltd` becomes `q1: Analytical Engine\, Ltd`. Findings/answer
**counts** now reflect distinct tuples rather than distinct rendered strings.

Beyond the report body, the shared renderer means the `\,` escaping reaches **two
further user-visible surfaces**, and deliberately does **not** reach a third:

1. **`/report` "Traceability"** (`report.html` renders `AnswerTrace.value`). Previously
   showed the raw value while "Query answers" showed the escaped one; that disagreement
   on one page is the bug the first review follow-up fixes. Escaped, and matched to the
   "Query answers" line above it.
2. **`/ask` answer body, when the source trace is empty** (`ask.html` renders
   `{{ result.answer }}`). `_render_engine_answer_body` normally restates the verified
   triples and never shows the raw answer value, but with no source facts it falls back
   to rendering `rep.answers` with the `q<id>: ` prefix stripped. This branch is named in
   the code — it carries the warning `"source trace unavailable for this verified query
   shape"`. Still escaped: this fallback prints the joined answer line.
3. **`/ask` "Verified source facts" table** — **not** escaped (2nd review follow-up).
   `ask.html` renders `{{ fact.answer }}` from `AskGroundingFact.answer` as a single
   table cell, with no join to defend; escaping it contradicted the `object` cell printed
   beside it. It now reads `AnswerTrace.display_value`, so a comma answer shows in its
   source form: `AskGroundingFact.answer == 'Analytical Engine, Ltd'`. An earlier version
   of this description claimed the escape here was intended; that was wrong, and the
   escape is removed rather than justified.

**Not fixed here:** the legacy `wirelog.run_check` answer path uses the same `, ` join
without the comma escape, so a legacy `q1: A, B` stays ambiguous. It has no production
caller (`engine/__init__.py` re-exports it; only tests call it), and CI cannot execute it
at all — `pyrewire` lives in the `wirelog` extra while CI installs only `.[test]` (#234).
Its `_render_row` also takes bare pyrewire values rather than `Term`s. Rather than change
the rendering of an unreachable, untested-in-CI path blind, its docstring — which used to
over-claim that this path "cannot drift away from the production one" — is corrected to
say exactly what is shared (control-character escaping) and what is not (the answer comma
escape), and why.

## Tests

Four tests in `tests/test_duckdb_backend.py`, each verified to go **red** when the
fix is reverted to the original code:

1. `counts_distinct_tuples_that_render_alike` — the repro: `errors == 2`, `len(findings) == 2`.
2. `finding_columns_cannot_forge_each_other` — the two findings render differently.
3. `answer_comma_cannot_forge_two_answers` — a comma value stays one escaped answer.
4. `answers_keep_distinct_tuples_that_render_alike` — a compound `pair(a, b)` and the
   string `"pair(a, b)"` stay two distinct answers (they collapsed to one before).

Plus one integration test in `tests/test_report_trace.py` for the first review follow-up:

5. `report_answer_and_trace_render_a_comma_value_the_same_way` — one store, one
   comma-and-space answer value, `verify()` and `report_trace()` run together; asserts
   both the concrete escaped rendering and that the two `/report` sections agree.

Plus three for the second review follow-up (each confirmed red before its fix):

6. `test_ask.py::ask_grounding_table_shows_a_comma_answer_in_its_source_form` — the Ask
   Answer cell and the `object` cell beside it hold the same, unescaped, source value.
7. `test_report_trace.py::report_trace_matches_engine_equal_representation_twins` — a
   fact stored as `Atom("x")`; asserts the engine answers **and** the trace names the
   fact behind that answer.
8. `test_report_trace.py::report_trace_joins_a_repeated_variable_on_engine_equality` —
   `relation(S, "same_as", S)` over a subject/object twin pair; pins the bound-variable
   branch of the matcher.

## Verification

- `pytest -q` (full suite, worktree code on `PYTHONPATH`): **1035 passed, 0 skipped**.
  `duckdb` 1.5.4 and `fastapi` 0.139.0 are both installed here and really ran — nothing
  DuckDB-related was skipped into a false green.
- `ruff check .`: all checks passed.
- Full suite with `pyrewire` hidden (CI blind spot, #234): **1028 passed, 7 skipped** —
  the 7 are `tests/test_engine.py`'s `importorskip("pyrewire")` wirelog tests, which CI
  skips too. No new test depends on `pyrewire`.
- Both engines checked directly for the compare-key question, rather than assumed: DuckDB
  maps `Atom("x")` and `StringLit("x")` to the same key `s:x`, and wirelog's `compile_dl`
  renders both to `relation("x", ...)` before pyrewire sees them (a plain `str` subject is
  stored as `StringLit`, and both display as `x`). The two engines **agree**, so aligning
  the trace to the compare key aligns it with both — there is no engine divergence to
  report.
- Mutation (each reverted in isolation, rest of the tree intact):
  - `ask.py` `display_value` → `value`: only the Ask grounding test goes red.
  - `_match_term` bound-variable branch → `==`: only the repeated-variable test goes red.
  - `_match_term` constant branch → `==`: only the twin-subject test goes red.
    The two matcher tests therefore pin two different branches, not one.
  - `render_display_value` given the comma escape: the Ask test goes red (and the
    report-consistency test too, since `render_answer_value` builds on it and would
    double-escape).
  - `AnswerTrace.value` switched to the display rendering: the earlier review's
    report/traceability agreement test goes red — the identity the first review asked for
    is still pinned.
- Both commits verified independently: `a0822ae` alone is green (1033 passed — the two
  tests added by `f7f0f8c` do not exist yet), so the history bisects.

Closes #167

