### PR TITLE
docs(#251): a marketing pass on the README — target reader, three differentiators, RAG/wiki table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # verinote
 
 [![ci](https://github.com/semantic-reasoning/verinote/actions/workflows/ci.yml/badge.svg)](https://github.com/semantic-reasoning/verinote/actions/workflows/ci.yml)
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
 **Ask your documents a question. Get an answer a deterministic engine has verified — with the source to prove it.**
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ judgment about that text — and tells you who made it.
 | What decides truth | the model | the last editor | a deterministic Datalog engine over facts you approved |
 | Provenance | retrieval cites chunks, but the answer text isn't bound to them | manual links that drift as pages are edited | every extracted fact is created with an evidence anchor, and missing evidence is itself flagged (`evidence_missing`); a verified answer echoes the fact and the sources that back it |
 | Stale facts | no lifecycle — an old chunk retrieves the same | silently overwritten or left contradictory | retired via `superseded`; single-valued conflicts are flagged, not overwritten |
-| Runs | usually a hosted vector DB / API | a hosted service | a local single-user web app with swappable LLM adapters |
+| Runs | usually a hosted vector DB / API | typically a shared page, self-hosted or hosted | a local single-user web app with swappable LLM adapters |
 
 Source-language facts still answer canonical questions through relation aliases;
 that mapping and the rest of the query path are in

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ stale, and lose the source that justified them — and who has to *trust* an ans
 not just read one. It runs as a local web app for a single user, on your own
 machine.
 
-verinote is an honest knowledge base that runs as a local web app. An LLM extracts
+verinote is an honest knowledge base. An LLM extracts
 source-backed candidate facts from your documents; a DuckDB-backed Datalog engine
 verifies them deterministically; and by default nothing becomes engine input until
 a human approves it.
@@ -74,7 +74,7 @@ judgment about that text — and tells you who made it.
 |---|---|---|---|
 | The answer is | generated — the model reads retrieved text and writes a reply | whatever a human last wrote (a plugin summarizes on top) | a deterministic engine result (`VERIFIED`) or explicitly unverified excerpts (`UNVERIFIED`) |
 | What decides truth | the model | the last editor | a deterministic Datalog engine over facts you approved |
-| Provenance | retrieval cites chunks, but the answer text isn't bound to them | manual links that drift as pages are edited | every fact carries recorded provenance; a verified answer echoes the fact and its sources |
+| Provenance | retrieval cites chunks, but the answer text isn't bound to them | manual links that drift as pages are edited | every extracted fact is created with an evidence anchor, and missing evidence is itself flagged (`evidence_missing`); a verified answer echoes the fact and the sources that back it |
 | Stale facts | no lifecycle — an old chunk retrieves the same | silently overwritten or left contradictory | retired via `superseded`; single-valued conflicts are flagged, not overwritten |
 | Runs | usually a hosted vector DB / API | a hosted service | a local single-user web app with swappable LLM adapters |
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 **Ask your documents a question. Get an answer a deterministic engine has verified — with the source to prove it.**
 
+<!-- TODO: demo.gif — Ask tab showing "VERIFIED — engine" (#212) -->
+
+For anyone whose notes, docs, and meeting minutes pile up until facts drift, go
+stale, and lose the source that justified them — and who has to *trust* an answer,
+not just read one. It runs as a local web app for a single user, on your own
+machine.
+
 verinote is an honest knowledge base that runs as a local web app. An LLM extracts
 source-backed candidate facts from your documents; a DuckDB-backed Datalog engine
 verifies them deterministically; and by default nothing becomes engine input until

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ Three rules keep it safe:
 What each file holds, why the DuckDB sidecar is data rather than a cache, and the
 exact failure modes are in [docs/operations.md](docs/operations.md).
 
-## Contributing & roadmap
+## Contributing
 
-Issues and feedback are welcome — the v1 vertical slice above is the current
-roadmap, and open questions are tracked in the
-[issue tracker](https://github.com/semantic-reasoning/verinote/issues). If you
-try verinote on a real document set, we would especially like to hear where
-extraction or verification surprised you.
+- **Try it.** Point verinote at a real document set and walk it through the
+  [Quickstart](#quickstart).
+- **Tell us where it surprised you.** Open an issue on the
+  [issue tracker](https://github.com/semantic-reasoning/verinote/issues) —
+  especially where extraction or verification did something you did not expect.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,19 +65,22 @@ CLI scaffolding (`verinote init`, `verinote seed`), the active-KB config file
 locations, and `VERINOTE_ROOT` precedence rules are covered in
 [docs/configuration.md](docs/configuration.md).
 
-## How is this different from RAG?
+## How is this different from RAG or a wiki?
 
-RAG retrieves text and hopes the model reads it correctly — the answer is still a
-generation. In verinote, an answer marked `VERIFIED` is not a generation: it is
-the output of a deterministic Datalog query over facts that passed the review
-gate, each with recorded provenance. The LLM's judgment is confined to proposing
-candidates; it never gets to decide what is true.
+Both retrieval-augmented generation and a wiki hand you text; verinote hands you a
+judgment about that text — and tells you who made it.
 
-Compared to a wiki (with or without LLM plugins), the difference is the review
-lifecycle and the audit log: every accept/reject decision is recorded, stale
-facts are retired via `superseded` rather than silently overwritten, and
-source-language facts still answer canonical English questions through relation
-aliases.
+| Axis | RAG | Wiki (± LLM plugins) | verinote |
+|---|---|---|---|
+| The answer is | generated — the model reads retrieved text and writes a reply | whatever a human last wrote (a plugin summarizes on top) | a deterministic engine result (`VERIFIED`) or explicitly unverified excerpts (`UNVERIFIED`) |
+| What decides truth | the model | the last editor | a deterministic Datalog engine over facts you approved |
+| Provenance | retrieval cites chunks, but the answer text isn't bound to them | manual links that drift as pages are edited | every fact carries recorded provenance; a verified answer echoes the fact and its sources |
+| Stale facts | no lifecycle — an old chunk retrieves the same | silently overwritten or left contradictory | retired via `superseded`; single-valued conflicts are flagged, not overwritten |
+| Runs | usually a hosted vector DB / API | a hosted service | a local single-user web app with swappable LLM adapters |
+
+Source-language facts still answer canonical questions through relation aliases;
+that mapping and the rest of the query path are in
+[docs/architecture.md](docs/architecture.md).
 
 ## Design (locked)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Three things set verinote apart:
    pointed at. By default that is Anthropic's or OpenAI's API for those
    adapters, and a server on your own machine for Ollama — but `VERINOTE_BASE_URL`
    redirects any of the three, in either direction. The Claude CLI adapter is the
-   exception: it shells out to the `claude` binary, which always talks to
-   Anthropic. No lock-in either way; that is a design principle, not a missing
-   feature.
+   exception: it shells out to the `claude` binary, so it goes wherever that CLI
+   is configured to talk to — Anthropic unless your environment redirects it. No
+   lock-in either way; that is a design principle, not a missing feature.
 
 When you ask a question, the answer arrives labeled with how much you can trust
 it: **`VERIFIED — engine`** when the Datalog engine proved it from facts you

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Three things set verinote apart:
    model never gets to decide what is true. When the engine cannot answer,
    verinote says so with `UNVERIFIED — source exploration` rather than faking it.
 3. **Local-first and vendor-neutral by design.** verinote is a local single-user
-   web app with swappable LLM adapters (Anthropic, Claude CLI, OpenAI, or local
-   Ollama). There is no cloud service and no lock-in — that is a design
-   principle, not a missing feature.
+   web app: your KB is a folder on your own machine, and there is no
+   verinote-hosted service to sign up for. The LLM adapters are swappable, and
+   which one you pick decides what leaves your machine — the Anthropic, OpenAI,
+   and Claude CLI adapters send document text and your questions to that
+   provider, while local Ollama keeps them on your own hardware. No lock-in
+   either way; that is a design principle, not a missing feature.
 
 When you ask a question, the answer arrives labeled with how much you can trust
 it: **`VERIFIED — engine`** when the Datalog engine proved it from facts you
@@ -70,13 +73,18 @@ locations, and `VERINOTE_ROOT` precedence rules are covered in
 Both retrieval-augmented generation and a wiki hand you text; verinote hands you a
 judgment about that text — and tells you who made it.
 
-| Axis | RAG | Wiki (± LLM plugins) | verinote |
+The comparison below is against the *common pattern*: a hosted RAG chat over
+retrieved chunks, and a free-text wiki. Self-hosted RAG closes the deployment
+gap, and citation-bound RAG closes part of the provenance gap — these axes
+describe where the usual defaults leave you, not a claim about every system.
+
+| Axis | RAG chat over chunks (typical) | Wiki (± LLM plugins) | verinote |
 |---|---|---|---|
 | The answer is | generated — the model reads retrieved text and writes a reply | whatever a human last wrote (a plugin summarizes on top) | a deterministic engine result (`VERIFIED`) or explicitly unverified excerpts (`UNVERIFIED`) |
-| What decides truth | the model | the last editor | a deterministic Datalog engine over facts you approved |
-| Provenance | retrieval cites chunks, but the answer text isn't bound to them | manual links that drift as pages are edited | every extracted fact is created with an evidence anchor, and missing evidence is itself flagged (`evidence_missing`); a verified answer echoes the fact and the sources that back it |
-| Stale facts | no lifecycle — an old chunk retrieves the same | silently overwritten or left contradictory | retired via `superseded`; single-valued conflicts are flagged, not overwritten |
-| Runs | usually a hosted vector DB / API | typically a shared page, self-hosted or hosted | a local single-user web app with swappable LLM adapters |
+| What decides truth | the model, unless the system is built to bind answers to citations | the last editor | a deterministic Datalog engine over facts you approved |
+| Provenance | retrieval cites chunks; without enforced citation binding, the answer text isn't tied to them | manual links that drift as pages are edited | every extracted fact is created with an evidence anchor, and missing evidence is itself flagged (`evidence_missing`); a verified answer echoes the fact and the sources that back it |
+| Stale facts | usually no lifecycle — an old chunk keeps retrieving until someone edits the corpus | silently overwritten or left contradictory | retired via `superseded`; single-valued conflicts are flagged, not overwritten |
+| Runs | commonly a hosted vector DB / API, though self-hosted stacks exist | typically a shared page, self-hosted or hosted | a local single-user web app with swappable LLM adapters |
 
 Source-language facts still answer canonical questions through relation aliases;
 that mapping and the rest of the query path are in
@@ -130,11 +138,16 @@ exact failure modes are in [docs/operations.md](docs/operations.md).
 
 ## Contributing
 
-- **Try it.** Point verinote at a real document set and walk it through the
-  [Quickstart](#quickstart).
+- **Try it.** Point verinote at your own document set and walk it through the
+  [Quickstart](#quickstart). Those documents stay in your KB folder; nothing
+  about them belongs in this repository.
 - **Tell us where it surprised you.** Open an issue on the
   [issue tracker](https://github.com/semantic-reasoning/verinote/issues) —
   especially where extraction or verification did something you did not expect.
+  **Keep real data out of it:** do not put real customer, company, person,
+  document, or source data in an issue, a PR, or the docs. If showing the bug
+  needs real input, reduce it to a synthetic minimal reproduction first. See
+  [Data Privacy](AGENTS.md#data-privacy).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ Three things set verinote apart:
 3. **Local-first and vendor-neutral by design.** verinote is a local single-user
    web app: your KB is a folder on your own machine, and there is no
    verinote-hosted service to sign up for. The LLM adapters are swappable, and
-   which one you pick decides what leaves your machine — the Anthropic, OpenAI,
-   and Claude CLI adapters send document text and your questions to that
-   provider, while local Ollama keeps them on your own hardware. No lock-in
-   either way; that is a design principle, not a missing feature.
+   which adapter *and endpoint* you configure decides what leaves your machine:
+   document text and your questions go to whatever endpoint that adapter is
+   pointed at. By default that is Anthropic's or OpenAI's API for those
+   adapters, and a server on your own machine for Ollama — but `VERINOTE_BASE_URL`
+   redirects any of the three, in either direction. The Claude CLI adapter is the
+   exception: it shells out to the `claude` binary, which always talks to
+   Anthropic. No lock-in either way; that is a design principle, not a missing
+   feature.
 
 When you ask a question, the answer arrives labeled with how much you can trust
 it: **`VERIFIED — engine`** when the Datalog engine proved it from facts you
@@ -81,7 +85,7 @@ describe where the usual defaults leave you, not a claim about every system.
 | Axis | RAG chat over chunks (typical) | Wiki (± LLM plugins) | verinote |
 |---|---|---|---|
 | The answer is | generated — the model reads retrieved text and writes a reply | whatever a human last wrote (a plugin summarizes on top) | a deterministic engine result (`VERIFIED`) or explicitly unverified excerpts (`UNVERIFIED`) |
-| What decides truth | the model, unless the system is built to bind answers to citations | the last editor | a deterministic Datalog engine over facts you approved |
+| What decides truth | the model — citation binding can hold it to retrieved text, but the model still writes the claim | the last editor | a deterministic Datalog engine over facts you approved |
 | Provenance | retrieval cites chunks; without enforced citation binding, the answer text isn't tied to them | manual links that drift as pages are edited | every extracted fact is created with an evidence anchor, and missing evidence is itself flagged (`evidence_missing`); a verified answer echoes the fact and the sources that back it |
 | Stale facts | usually no lifecycle — an old chunk keeps retrieving until someone edits the corpus | silently overwritten or left contradictory | retired via `superseded`; single-valued conflicts are flagged, not overwritten |
 | Runs | commonly a hosted vector DB / API, though self-hosted stacks exist | typically a shared page, self-hosted or hosted | a local single-user web app with swappable LLM adapters |

--- a/README.md
+++ b/README.md
@@ -25,20 +25,22 @@ free-text wiki drifts: facts go stale, contradict each other, and lose the link 
 whatever document justified them — and once you bolt an LLM on top, it happily
 summarizes the drift with full confidence.
 
-verinote keeps the knowledge base honest by splitting the work three ways:
+Three things set verinote apart:
 
-1. **The LLM only proposes.** It extracts candidate facts, each tied to a source
-   document (provider-agnostic: Anthropic, Claude CLI, OpenAI, or local Ollama).
-2. **The engine only verifies.** Confirmed facts load into DuckDB, where Datalog
-   policy and query rules check them deterministically. Because every fact is
-   re-checked by the engine, swapping to a cheaper or local model never
-   compromises correctness.
-3. **You decide.** A fact sits in the review tier (`candidate` or `needs_review`)
-   until you promote it to an engine status (`confirmed` or `accepted`);
-   `superseded` retires it. Not even seeded demo facts skip the queue. One
-   opt-in rule can promote corroborated, conflict-free facts for you — it is off
-   by default, and turning it on is you delegating the gate, not removing it
+1. **A human holds the gate.** Nothing becomes engine input until a person
+   promotes it from the review tier (`candidate`/`needs_review`) to an engine
+   status (`confirmed`/`accepted`) — and not even seeded demo facts skip the
+   queue. One opt-in rule can promote corroborated, conflict-free facts for you,
+   but turning it on is you delegating the gate, not removing it
    ([auto-accept](docs/configuration.md#auto-accept)).
+2. **`VERIFIED` is a deterministic proof, not a generation.** The label means a
+   deterministic Datalog query derived the answer from facts you approved; the
+   model never gets to decide what is true. When the engine cannot answer,
+   verinote says so with `UNVERIFIED — source exploration` rather than faking it.
+3. **Local-first and vendor-neutral by design.** verinote is a local single-user
+   web app with swappable LLM adapters (Anthropic, Claude CLI, OpenAI, or local
+   Ollama). There is no cloud service and no lock-in — that is a design
+   principle, not a missing feature.
 
 When you ask a question, the answer arrives labeled with how much you can trust
 it: **`VERIFIED — engine`** when the Datalog engine proved it from facts you


### PR DESCRIPTION
Closes #251.

PR #213(#211)이 README 를 독자의 첫 30초 중심으로 재구성한 위에, **마케팅/포지셔닝 레이어만** 얇게 얹었다. 구조 재배치는 하지 않았고, `README.md` 한 파일만 바뀐다.

모든 사실 주장은 `docs/functional-spec.md`(as-built 명세)에서 검증했다. verinote 의 브랜드가 "조용히 틀리는 것이 최악"이라는 정직성이므로, README 의 과장은 제품 철학 배반이라는 전제로 작업했다.

## 무엇을 왜 (전환/신뢰/스캔성)

- **배지 2개 추가** (신뢰) — License MPL-2.0, Python 3.11+. pyproject 값과 일치.
- **히어로에 타깃 독자 + 데모 슬롯** (전환/스캔성) — "누구를 위한 것인지"를 훅 아래 한 문단으로. `<!-- TODO: demo.gif (#212) -->` 슬롯은 #212 가 채운다.
- **Why 를 차별점 3축으로** (스캔성/신뢰) — (a) 사람이 게이트를 쥔다 (b) `VERIFIED` 는 생성이 아니라 결정론적 증명 (c) 로컬 우선 + 벤더 중립. 각 "주장 한 문장 + 근거 한 문장".
- **RAG 산문 → RAG vs 위키 vs verinote 3열 표** (스캔성) — 답의 성격 / 진실 판정 주체 / 프로버넌스 / 낡은 사실 / 실행 위치.
- **클로징을 CTA 2개로** (전환) — "Try it" + "Tell us where it surprised you". 로드맵은 Status 의 v1 slice 와 중복이라 제거.

## 정직성 가드 (전부 준수)

- confidence 를 신뢰 신호로 암시하지 않음 (명세 §3.4 — 신뢰는 서로 다른 출처 개수로만)
- 명세 밖 기능 발명 없음, "coming soon" 없음
- 비목표(클라우드/락인 없음)를 단점이 아니라 **설계 원칙**으로 포지셔닝 (§1.4)
- #185(`git clean` KB 파괴)·#156(사이드카 백업) 경고 그대로 보존
- `VERIFIED` 과대해석 없음 — `UNVERIFIED — source exploration` 라우트 명시 유지
- v0.0.1 early scaffold 표기 유지

## 리뷰

정직성 검증 중심으로 리뷰를 2회 돌렸다.
- **1차**: 전칭 프로버넌스 주장("every fact carries recorded provenance")이 명세 §3.4 의 `evidence_missing`/`unsupported` 라벨과 어긋난다는 MAJOR 1건 + 위키를 "hosted service" 로 단정한 MINOR + 히어로 중복 NIT. → "every *extracted* fact...evidence anchor, missing evidence flagged" 로 범위 한정, 위키 셀 완화, 중복 제거.
- **2차**: 1차 3건 전부 닫힘 확인, 수정이 새 과장·깨진 링크를 만들지 않음 확인. 머지 가능 판정.

## 유지 (건드리지 않음)

Quickstart, Design (locked), Status(v0.0.1), Your data lives in one folder(3규칙), License, Acknowledgements(factlog).

관련: #211(재구성, closed), #212(데모 이미지 슬롯 채우기).
