### PR TITLE
fix(#231): close the review-gate holes — superseded promotion, blind accept/reject, and dormant auto-accept

### DIFF
--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -12,15 +12,20 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from verinote.config import Config  # noqa: E402
+from verinote.pipeline import acceptance  # noqa: E402
 from verinote.store import Store  # noqa: E402
 from verinote.store.db import ENGINE_STATUSES  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
 
-def _store(tmp_path) -> Store:
-    s = Store(tmp_path / "kb.sqlite")
+def _store_at(db_path) -> Store:
+    s = Store(db_path)
     s.init_schema()
     return s
+
+
+def _store(tmp_path) -> Store:
+    return _store_at(tmp_path / "kb.sqlite")
 
 
 def _auto_accept_client(tmp_path):
@@ -185,3 +190,162 @@ def test_accept_route_without_promotions_keeps_single_row_swap(tmp_path):
     assert store.get_fact(acted)["status"] == "confirmed"
     # Nothing else was eligible, so no full refresh — the row swap stands.
     assert "HX-Refresh" not in resp.headers
+
+
+# --- #263 review: a decision must not be undone by the pass that follows it ---
+
+
+def _corroborated_pair(store: Store, *, acted_status: str, sibling_status: str):
+    """Two facts stating the same triple from two analysed sources.
+
+    That is exactly the shape auto-accept calls eligible, so either fact is a
+    promotion candidate the moment it sits in the review tier.
+    """
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    job_a = _done_job(store, source_a)
+    job_b = _done_job(store, source_b)
+    acted = store.add_fact(
+        "Report", "author", "Kim",
+        status=acted_status, source_id=source_a, job_id=job_a,
+    )
+    sibling = store.add_fact(
+        "Report", "author", "Kim",
+        status=sibling_status, source_id=source_b, job_id=job_b,
+    )
+    return acted, sibling
+
+
+def test_toggle_demotion_is_not_undone_by_auto_accept(tmp_path):
+    # A human demoting a confirmed fact is an explicit decision. Auto-accept
+    # runs in the same request for the siblings it may unblock, and it must not
+    # use that pass to shove the demoted fact straight back up to `accepted`.
+    client, store = _auto_accept_client(tmp_path)
+    acted, _sibling = _corroborated_pair(
+        store, acted_status="confirmed", sibling_status="confirmed"
+    )
+
+    resp = client.post(f"/facts/{acted}/toggle")
+
+    assert resp.status_code == 200
+    assert store.get_fact(acted)["status"] == "needs_review"
+    # The demotion stands in the audit trail too: no rule undid it.
+    assert "auto_accepted" not in _actions(store, acted)
+
+
+def test_toggle_demotion_still_lets_auto_accept_promote_siblings(tmp_path):
+    # Regression guard: excusing the acted fact must not switch auto-accept off
+    # for everyone else. Demoting the engine-tier fact frees the single-valued
+    # slot its sibling was conflicting on, so the sibling becomes eligible.
+    client, store = _auto_accept_client(tmp_path)
+    acted, sibling = _corroborated_pair(
+        store, acted_status="confirmed", sibling_status="needs_review"
+    )
+
+    resp = client.post(f"/facts/{acted}/toggle")
+
+    assert resp.status_code == 200
+    assert store.get_fact(acted)["status"] == "needs_review"
+    assert store.get_fact(sibling)["status"] == "accepted"
+    # A sibling moved, and a single-row swap cannot show it.
+    assert resp.headers.get("HX-Refresh") == "true"
+
+
+def test_toggle_promotion_still_works_under_auto_accept(tmp_path):
+    # The other direction of the toggle keeps promoting, as before.
+    client, store = _auto_accept_client(tmp_path)
+    store_fact = store.add_fact("Solo", "author", "Han", status="needs_review")
+
+    resp = client.post(f"/facts/{store_fact}/toggle")
+
+    assert resp.status_code == 200
+    assert store.get_fact(store_fact)["status"] == "confirmed"
+
+
+def test_toggle_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
+    """A toggle that read `needs_review` must not write `confirmed` over a
+    rejection that landed after that read.
+
+    The two `Store` objects are the point: `Store._lock` only serialises writers
+    sharing one instance, and a real deployment has several connections on one
+    SQLite file. So the guard has to live in the write itself, conditional on
+    the status the toggle actually observed.
+    """
+    db = tmp_path / "kb.sqlite"
+    toggling = _store_at(db)
+    rejecting = _store_at(db)
+    fact_id = toggling.add_fact("Report", "author", "Kim", status="needs_review")
+
+    real_get_fact = toggling.get_fact
+    interleaved = []
+
+    def reject_once_after_the_read(target_id: int):
+        row = real_get_fact(target_id)
+        if not interleaved:
+            interleaved.append(True)
+            # The other connection's human presses reject in this window.
+            rejecting.reject_fact(fact_id)
+        return row
+
+    toggling.get_fact = reject_once_after_the_read
+    row = toggling.toggle_review(fact_id)
+
+    assert interleaved, "the reject never landed — the test proves nothing"
+    # The rejection is terminal: the stale toggle target loses.
+    assert rejecting.get_fact(fact_id)["status"] == "superseded"
+    assert row["status"] == "superseded"
+    # And the losing toggle logged no `toggled` row for a write it never made.
+    assert "toggled" not in _actions(rejecting, fact_id)
+
+
+def test_auto_accept_cannot_overwrite_a_reject_that_lands_after_the_snapshot(tmp_path):
+    """Auto-accept recommends from a snapshot; a human can reject in the gap
+    between that snapshot and the write. The write must re-check, not assume."""
+    client, store = _auto_accept_client(tmp_path)
+    acted, sibling = _corroborated_pair(
+        store, acted_status="needs_review", sibling_status="confirmed"
+    )
+
+    real_recommendations = acceptance.accept_recommendations
+    rejected_in_the_gap = []
+
+    def reject_after_recommending(target_store):
+        recommendations = real_recommendations(target_store)
+        if not rejected_in_the_gap:
+            rejected_in_the_gap.append(True)
+            # The human rejects while the rule is still holding a stale snapshot
+            # that says "eligible".
+            target_store.reject_fact(acted)
+        return recommendations
+
+    acceptance.accept_recommendations = reject_after_recommending
+    try:
+        applied = acceptance.apply_auto_accept_recommendations(store)
+    finally:
+        acceptance.accept_recommendations = real_recommendations
+
+    assert rejected_in_the_gap, "the reject never landed — the test proves nothing"
+    # superseded is terminal: no rule may take a fact out of it.
+    assert store.get_fact(acted)["status"] == "superseded"
+    assert acted not in [rec.fact_id for rec in applied]
+    # The refused promotion leaves no audit trail claiming it happened.
+    assert "auto_accepted" not in _actions(store, acted)
+    assert not [
+        e for e in store.fact_events(acted) if e["event_type"] == "auto_accept_applied"
+    ]
+    assert store.get_fact(sibling)["status"] == "confirmed"
+
+
+def test_auto_accept_still_promotes_an_eligible_fact(tmp_path):
+    # Regression guard: the re-check must not block the promotions auto-accept
+    # exists to make.
+    client, store = _auto_accept_client(tmp_path)
+    acted, _sibling = _corroborated_pair(
+        store, acted_status="needs_review", sibling_status="confirmed"
+    )
+
+    applied = acceptance.apply_auto_accept_recommendations(store)
+
+    assert [rec.fact_id for rec in applied] == [acted]
+    assert store.get_fact(acted)["status"] == "accepted"
+    assert "auto_accepted" in _actions(store, acted)

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -601,6 +601,23 @@ def test_toggle_on_a_superseded_fact_does_not_run_auto_accept(tmp_path):
     _assert_untouched(store, eligible, resp)
 
 
+def test_accept_all_on_a_source_with_nothing_to_confirm_does_not_run_auto_accept(
+    tmp_path,
+):
+    # The bulk route carries the same contract: no fact was confirmed, so no
+    # decision was made and the rule has nothing new to act on.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    empty_source = store.add_source("sources/empty.txt")
+
+    resp = client.post(f"/sources/{empty_source}/accept-all")
+
+    assert resp.status_code == 200  # 303 followed to /sources
+    assert store.get_fact(eligible)["status"] == "needs_review"
+    assert "auto_accepted" not in _actions(store, eligible)
+    assert not _auto_accept_events(store, eligible)
+
+
 def test_reject_that_really_transitions_still_runs_auto_accept(tmp_path):
     # Over-fix guard: only no-ops are filtered. A reject that actually moves a
     # fact is a decision, and the rule still runs for the siblings it unblocks.

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -422,3 +422,71 @@ def test_auto_accept_still_promotes_an_eligible_fact(tmp_path):
     assert [rec.fact_id for rec in applied] == [acted]
     assert store.get_fact(acted)["status"] == "accepted"
     assert "auto_accepted" in _actions(store, acted)
+
+
+# --- the other two routes that hand facts to the rule ---------------------
+
+
+def test_amend_lets_the_rule_promote_the_amended_fact(tmp_path):
+    """An amend decides the fact's content, not its tier, so the rule may act on
+    the amended fact itself — the opposite of a toggle demotion.
+
+    This is that distinction as a worked example: the fact's object is a typo
+    that keeps it from matching the second source. Correcting it *is*
+    corroboration arriving, so promoting on it is the recommender working, not a
+    decision being undone.
+    """
+    client, store = _auto_accept_client(tmp_path)
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    job_a = _done_job(store, source_a)
+    job_b = _done_job(store, source_b)
+    acted = store.add_fact(
+        "Report", "author", "Kimm",  # the typo: no support while it stands
+        status="needs_review", source_id=source_a, job_id=job_a,
+    )
+    store.add_fact(
+        "Report", "author", "Kim",
+        status="confirmed", source_id=source_b, job_id=job_b,
+    )
+    # Nothing is eligible yet: the typo means the two sources disagree.
+    assert store.get_fact(acted)["status"] == "needs_review"
+
+    resp = client.post(
+        f"/facts/{acted}/amend",
+        data={"subject": "Report", "relation": "author", "object": "Kim"},
+    )
+
+    assert resp.status_code == 200
+    assert store.get_fact(acted)["object"] == "Kim"
+    # The correction brought the second source's support with it.
+    assert store.get_fact(acted)["status"] == "accepted"
+    assert "auto_accepted" in _actions(store, acted)
+
+
+def test_accept_all_promotes_a_corroborated_fact_in_another_source(tmp_path):
+    """Bulk-confirming one source is a decision too, and it corroborates facts
+    outside that source — so it hands them to the rule like the single-fact
+    routes do."""
+    client, store = _auto_accept_client(tmp_path)
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    job_a = _done_job(store, source_a)
+    job_b = _done_job(store, source_b)
+    bulk = store.add_fact(
+        "Report", "author", "Kim",
+        status="needs_review", source_id=source_a, job_id=job_a,
+    )
+    elsewhere = store.add_fact(
+        "Report", "author", "Kim",
+        status="needs_review", source_id=source_b, job_id=job_b,
+    )
+
+    resp = client.post(f"/sources/{source_a}/accept-all")
+
+    assert resp.status_code == 200  # 303 followed to /sources
+    assert store.get_fact(bulk)["status"] == "confirmed"
+    # The fact in the *other* source was corroborated by the bulk accept, and
+    # the route runs the rule so it doesn't sit in the queue until the next job.
+    assert store.get_fact(elsewhere)["status"] == "accepted"
+    assert "auto_accepted" in _actions(store, elsewhere)

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -334,6 +334,43 @@ def test_accept_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
     assert "accepted" not in _actions(rejecting, fact_id)
 
 
+def test_auto_accept_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
+    """The rule's own version of the cross-connection race.
+
+    The pass-level test below hands `auto_accept_fact` a fact that is already
+    superseded by the time it is called, so the tier pre-check alone turns it
+    away and the conditional write never has to do anything. This test opens the
+    window the pre-check cannot see: the reject lands *after* the tier read, on
+    another connection, where `self._lock` has no say. Only the status condition
+    on the UPDATE stops the rule overwriting a human's rejection here.
+    """
+    db = tmp_path / "kb.sqlite"
+    accepting = _store_at(db)
+    rejecting = _store_at(db)
+    fact_id = accepting.add_fact("Report", "author", "Kim", status="needs_review")
+
+    real_get_fact = accepting.get_fact
+    interleaved = []
+
+    def reject_once_after_the_read(target_id: int):
+        row = real_get_fact(target_id)
+        if not interleaved:
+            interleaved.append(True)
+            # The other connection's human presses reject in this window.
+            rejecting.reject_fact(fact_id)
+        return row
+
+    accepting.get_fact = reject_once_after_the_read
+    row = accepting.auto_accept_fact(fact_id, rule_name="corroborated_no_conflict")
+
+    assert interleaved, "the reject never landed — the test proves nothing"
+    # The rejection is terminal: no rule may take a fact out of superseded.
+    assert rejecting.get_fact(fact_id)["status"] == "superseded"
+    # None is how the caller learns to skip both `applied` and the audit event.
+    assert row is None
+    assert "auto_accepted" not in _actions(rejecting, fact_id)
+
+
 def test_auto_accept_cannot_overwrite_a_reject_that_lands_after_the_snapshot(tmp_path):
     """Auto-accept recommends from a snapshot; a human can reject in the gap
     between that snapshot and the write. The write must re-check, not assume."""

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -389,6 +389,76 @@ def test_auto_accept_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_pat
     assert "auto_accepted" not in _actions(rejecting, fact_id)
 
 
+def test_reject_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
+    """The same window again, in `reject_fact` — the one write of the four that
+    still landed unconditionally.
+
+    Reject's own pre-check ("is it already superseded?") is a read, so a reject
+    arriving on another connection lands after it just as it does for accept and
+    toggle. The second write agrees about the *status*, so no state is corrupted
+    here — but it still reports `changed=True` for a transition it did not make,
+    which is exactly the claim the route turns into an auto-accept pass, and it
+    files a second `rejected` row for one human decision.
+    """
+    db = tmp_path / "kb.sqlite"
+    rejecting = _store_at(db)
+    other = _store_at(db)
+    fact_id = rejecting.add_fact("Report", "author", "Kim", status="needs_review")
+
+    real_get_fact = rejecting.get_fact
+    interleaved = []
+
+    def reject_once_after_the_read(target_id: int):
+        row = real_get_fact(target_id)
+        if not interleaved:
+            interleaved.append(True)
+            # The other connection's human presses reject in this window.
+            other.reject_fact(fact_id)
+        return row
+
+    rejecting.get_fact = reject_once_after_the_read
+    decision = rejecting.reject_fact(fact_id)
+
+    assert interleaved, "the reject never landed — the test proves nothing"
+    assert other.get_fact(fact_id)["status"] == "superseded"
+    assert decision.fact["status"] == "superseded"
+    # The loser reports its loss, so the route above it skips the follow-on pass.
+    assert decision.changed is False
+    # One human decision, one audit row — the loser wrote nothing to log.
+    assert _actions(other, fact_id).count("rejected") == 1
+
+
+def test_a_reject_that_loses_the_race_does_not_run_auto_accept(tmp_path):
+    """The route-level consequence: the losing reject decided nothing, so the
+    rule must not act on a transition that already belonged to someone else."""
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact("Ledger", "owner", "Park", status="needs_review")
+    other = _store_at(tmp_path / "kb.sqlite")
+
+    real_get_fact = store.get_fact
+    interleaved = []
+
+    def reject_once_after_the_read(target_id: int):
+        row = real_get_fact(target_id)
+        if not interleaved and target_id == target:
+            interleaved.append(True)
+            other.reject_fact(target)
+        return row
+
+    store.get_fact = reject_once_after_the_read
+    try:
+        resp = client.post(f"/facts/{target}/reject")
+    finally:
+        store.get_fact = real_get_fact
+
+    assert interleaved, "the reject never landed — the test proves nothing"
+    assert resp.status_code == 200
+    assert store.get_fact(target)["status"] == "superseded"
+    assert _actions(store, target).count("rejected") == 1
+    _assert_untouched(store, eligible, resp)
+
+
 def test_auto_accept_cannot_overwrite_a_reject_that_lands_after_the_snapshot(tmp_path):
     """Auto-accept recommends from a snapshot; a human can reject in the gap
     between that snapshot and the write. The write must re-check, not assume."""

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -298,6 +298,42 @@ def test_toggle_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
     assert "toggled" not in _actions(rejecting, fact_id)
 
 
+def test_accept_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
+    """The same window `toggle_review` had, in `accept_fact`.
+
+    Checking the tier before the write only settles the race for callers sharing
+    this instance's lock. A reject arriving on another connection to the same KB
+    lands between that check and the write, and a blind write would then take a
+    fact back out of `superseded` — the one thing the review gate promises can't
+    happen.
+    """
+    db = tmp_path / "kb.sqlite"
+    accepting = _store_at(db)
+    rejecting = _store_at(db)
+    fact_id = accepting.add_fact("Report", "author", "Kim", status="needs_review")
+
+    real_get_fact = accepting.get_fact
+    interleaved = []
+
+    def reject_once_after_the_read(target_id: int):
+        row = real_get_fact(target_id)
+        if not interleaved:
+            interleaved.append(True)
+            # The other connection's human presses reject in this window.
+            rejecting.reject_fact(fact_id)
+        return row
+
+    accepting.get_fact = reject_once_after_the_read
+    row = accepting.accept_fact(fact_id)
+
+    assert interleaved, "the reject never landed — the test proves nothing"
+    # The rejection is terminal: the stale accept loses.
+    assert rejecting.get_fact(fact_id)["status"] == "superseded"
+    assert row["status"] == "superseded"
+    # And the losing accept logged no `accepted` row for a write it never made.
+    assert "accepted" not in _actions(rejecting, fact_id)
+
+
 def test_auto_accept_cannot_overwrite_a_reject_that_lands_after_the_snapshot(tmp_path):
     """Auto-accept recommends from a snapshot; a human can reject in the gap
     between that snapshot and the write. The write must re-check, not assume."""

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -671,6 +671,47 @@ def test_toggle_on_a_superseded_fact_does_not_run_auto_accept(tmp_path):
     _assert_untouched(store, eligible, resp)
 
 
+def test_missing_amend_target_does_not_run_auto_accept(tmp_path):
+    # A stale inline-edit POST for a fact that no longer exists writes nothing,
+    # so it must not become an excuse to promote unrelated eligible facts.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+
+    resp = client.post(
+        "/facts/999999/amend",
+        data={"subject": "Ledger", "relation": "owner", "object": "Park"},
+    )
+
+    assert resp.status_code == 200
+    _assert_untouched(store, eligible, resp)
+
+
+def test_replayed_amend_does_not_run_auto_accept(tmp_path):
+    # Reposting the same content is not a new human decision. It must not log an
+    # amendment, rewrite timestamps, or run the auto-accept pass.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact(
+        "Ledger", "owner", "Park", status="needs_review", note="unchanged"
+    )
+    before = dict(store.get_fact(target))
+
+    resp = client.post(
+        f"/facts/{target}/amend",
+        data={
+            "subject": "Ledger",
+            "relation": "owner",
+            "object": "Park",
+            "note": "unchanged",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert dict(store.get_fact(target)) == before
+    assert "amended" not in _actions(store, target)
+    _assert_untouched(store, eligible, resp)
+
+
 def test_accept_all_on_a_source_with_nothing_to_confirm_does_not_run_auto_accept(
     tmp_path,
 ):

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Review-gate transition guards (#231, #232, #257).
+
+These tests pin the rule that a human's rejection is terminal: neither a toggle
+nor an accept may revive a `superseded` fact, and the status-changing web routes
+apply auto-accept so a decision on one fact reveals promotions of its siblings.
+"""
+
+from verinote.store import Store
+from verinote.store.db import ENGINE_STATUSES
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _actions(store: Store, fact_id: int) -> list[str]:
+    return [row["action"] for row in store.fact_log(fact_id)]
+
+
+# --- #231: toggle_review must not promote superseded ----------------------
+
+
+def test_toggle_leaves_superseded_untouched_and_unlogged(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/a.txt")
+    fact_id = s.add_fact(
+        "Report", "published_year", "2024", status="superseded", source_id=source_id
+    )
+    log_before = _actions(s, fact_id)
+
+    row = s.toggle_review(fact_id)
+
+    # The rejected fact stays rejected — no revival to confirmed.
+    assert row is not None
+    assert row["status"] == "superseded"
+    assert s.get_fact(fact_id)["status"] == "superseded"
+    # No audit noise: the no-op toggle writes no `toggled` row.
+    assert _actions(s, fact_id) == log_before
+    assert "toggled" not in _actions(s, fact_id)
+    # And it never becomes engine input.
+    engine_ids = {r["id"] for r in s.facts(statuses=ENGINE_STATUSES)}
+    assert fact_id not in engine_ids
+
+
+def test_toggle_still_flips_review_and_engine_tiers(tmp_path):
+    # Regression guard: the superseded fix must not freeze the normal toggle.
+    s = _store(tmp_path)
+    review_id = s.add_fact("Report", "author", "Kim", status="needs_review")
+    engine_id = s.add_fact("Report", "author", "Lee", status="confirmed")
+
+    assert s.toggle_review(review_id)["status"] == "confirmed"
+    assert s.toggle_review(engine_id)["status"] == "needs_review"

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -6,14 +6,49 @@ nor an accept may revive a `superseded` fact, and the status-changing web routes
 apply auto-accept so a decision on one fact reveals promotions of its siblings.
 """
 
-from verinote.store import Store
-from verinote.store.db import ENGINE_STATUSES
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from verinote.config import Config  # noqa: E402
+from verinote.store import Store  # noqa: E402
+from verinote.store.db import ENGINE_STATUSES  # noqa: E402
+from verinote.web import create_app  # noqa: E402
 
 
 def _store(tmp_path) -> Store:
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
     return s
+
+
+def _auto_accept_client(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+        auto_accept_recommendations=True,
+    )
+    client = TestClient(create_app(cfg))
+    return client, client.app.state.store
+
+
+def _done_job(store: Store, source_id: int) -> int:
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id, source_id=source_id, chunks=["body"]
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_done(chunk_id, candidates=1)
+    store.finish_extraction_job(job_id)
+    return job_id
 
 
 def _actions(store: Store, fact_id: int) -> list[str]:
@@ -105,3 +140,48 @@ def test_double_reject_logs_once(tmp_path):
 
     # A repeat reject on an already-superseded fact writes no duplicate audit row.
     assert _actions(s, fact_id).count("rejected") == 1
+
+
+# --- #257: decision routes apply auto-accept and refresh siblings ---------
+
+
+def test_accept_route_promotes_a_corroborated_sibling_and_refreshes(tmp_path):
+    client, store = _auto_accept_client(tmp_path)
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    job_a = _done_job(store, source_a)
+    job_b = _done_job(store, source_b)
+    acted = store.add_fact(
+        "Report", "author", "Kim",
+        status="needs_review", source_id=source_a, job_id=job_a,
+    )
+    sibling = store.add_fact(
+        "Report", "author", "Kim",
+        status="needs_review", source_id=source_b, job_id=job_b,
+    )
+
+    resp = client.post(f"/facts/{acted}/accept")
+
+    assert resp.status_code == 200
+    # The acted fact is confirmed by the route; auto-accept then promotes the
+    # corroborating sibling, which a single-row swap can't show — hence a refresh.
+    assert store.get_fact(acted)["status"] == "confirmed"
+    assert store.get_fact(sibling)["status"] == "accepted"
+    assert resp.headers.get("HX-Refresh") == "true"
+
+
+def test_accept_route_without_promotions_keeps_single_row_swap(tmp_path):
+    client, store = _auto_accept_client(tmp_path)
+    source = store.add_source("sources/solo.txt")
+    job = _done_job(store, source)
+    acted = store.add_fact(
+        "Solo", "author", "Han",
+        status="needs_review", source_id=source, job_id=job,
+    )
+
+    resp = client.post(f"/facts/{acted}/accept")
+
+    assert resp.status_code == 200
+    assert store.get_fact(acted)["status"] == "confirmed"
+    # Nothing else was eligible, so no full refresh — the row swap stands.
+    assert "HX-Refresh" not in resp.headers

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -71,11 +71,14 @@ def test_toggle_leaves_superseded_untouched_and_unlogged(tmp_path):
     )
     log_before = _actions(s, fact_id)
 
-    row = s.toggle_review(fact_id)
+    decision = s.toggle_review(fact_id)
 
     # The rejected fact stays rejected — no revival to confirmed.
-    assert row is not None
-    assert row["status"] == "superseded"
+    assert decision.fact is not None
+    assert decision.fact["status"] == "superseded"
+    # And the store says so: no transition happened, so a caller owes it no
+    # follow-on effects.
+    assert decision.changed is False
     assert s.get_fact(fact_id)["status"] == "superseded"
     # No audit noise: the no-op toggle writes no `toggled` row.
     assert _actions(s, fact_id) == log_before
@@ -91,8 +94,11 @@ def test_toggle_still_flips_review_and_engine_tiers(tmp_path):
     review_id = s.add_fact("Report", "author", "Kim", status="needs_review")
     engine_id = s.add_fact("Report", "author", "Lee", status="confirmed")
 
-    assert s.toggle_review(review_id)["status"] == "confirmed"
-    assert s.toggle_review(engine_id)["status"] == "needs_review"
+    for fact_id, expected in ((review_id, "confirmed"), (engine_id, "needs_review")):
+        decision = s.toggle_review(fact_id)
+        assert decision.fact["status"] == expected
+        # A real flip is reported as one.
+        assert decision.changed is True
 
 
 # --- #232: accept/reject are transition-aware, not blind writes -----------
@@ -102,10 +108,13 @@ def test_reject_then_accept_keeps_a_fact_superseded(tmp_path):
     s = _store(tmp_path)
     fact_id = s.add_fact("Report", "author", "Kim", status="needs_review")
 
-    assert s.reject_fact(fact_id)["status"] == "superseded"
+    rejected = s.reject_fact(fact_id)
+    assert rejected.fact["status"] == "superseded"
+    assert rejected.changed is True
     # The whole point of the gate: accept must not resurrect a rejection.
     reaccepted = s.accept_fact(fact_id)
-    assert reaccepted["status"] == "superseded"
+    assert reaccepted.fact["status"] == "superseded"
+    assert reaccepted.changed is False
     assert s.get_fact(fact_id)["status"] == "superseded"
     # One rejection logged, and no `accepted` row from the refused accept.
     actions = _actions(s, fact_id)
@@ -118,10 +127,13 @@ def test_reaccepting_a_confirmed_fact_is_a_silent_noop(tmp_path):
     fact_id = s.add_fact("Report", "author", "Kim", status="confirmed")
     log_before = _actions(s, fact_id)
 
-    row = s.accept_fact(fact_id)
+    decision = s.accept_fact(fact_id)
 
-    assert row["status"] == "confirmed"
-    # No write, no audit growth — accept only moves review-tier rows.
+    assert decision.fact["status"] == "confirmed"
+    # No write, no audit growth — accept only moves review-tier rows. The
+    # `changed=False` is what lets a caller tell this apart from a real accept
+    # that happens to land on the same status.
+    assert decision.changed is False
     assert _actions(s, fact_id) == log_before
 
 
@@ -131,8 +143,10 @@ def test_accept_promotes_a_review_fact(tmp_path):
     candidate = s.add_fact("Report", "author", "Kim", status="candidate")
     needs = s.add_fact("Report", "author", "Lee", status="needs_review")
 
-    assert s.accept_fact(candidate)["status"] == "confirmed"
-    assert s.accept_fact(needs)["status"] == "confirmed"
+    for fact_id in (candidate, needs):
+        decision = s.accept_fact(fact_id)
+        assert decision.fact["status"] == "confirmed"
+        assert decision.changed is True
     assert _actions(s, candidate) == ["accepted"]
 
 
@@ -288,12 +302,14 @@ def test_toggle_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
         return row
 
     toggling.get_fact = reject_once_after_the_read
-    row = toggling.toggle_review(fact_id)
+    decision = toggling.toggle_review(fact_id)
 
     assert interleaved, "the reject never landed — the test proves nothing"
     # The rejection is terminal: the stale toggle target loses.
     assert rejecting.get_fact(fact_id)["status"] == "superseded"
-    assert row["status"] == "superseded"
+    assert decision.fact["status"] == "superseded"
+    # The loser reports its loss, so the route above it skips the follow-on pass.
+    assert decision.changed is False
     # And the losing toggle logged no `toggled` row for a write it never made.
     assert "toggled" not in _actions(rejecting, fact_id)
 
@@ -324,12 +340,14 @@ def test_accept_cannot_overwrite_a_reject_that_lands_mid_transition(tmp_path):
         return row
 
     accepting.get_fact = reject_once_after_the_read
-    row = accepting.accept_fact(fact_id)
+    decision = accepting.accept_fact(fact_id)
 
     assert interleaved, "the reject never landed — the test proves nothing"
     # The rejection is terminal: the stale accept loses.
     assert rejecting.get_fact(fact_id)["status"] == "superseded"
-    assert row["status"] == "superseded"
+    assert decision.fact["status"] == "superseded"
+    # The loser reports its loss, so the route above it skips the follow-on pass.
+    assert decision.changed is False
     # And the losing accept logged no `accepted` row for a write it never made.
     assert "accepted" not in _actions(rejecting, fact_id)
 
@@ -490,3 +508,109 @@ def test_accept_all_promotes_a_corroborated_fact_in_another_source(tmp_path):
     # the route runs the rule so it doesn't sit in the queue until the next job.
     assert store.get_fact(elsewhere)["status"] == "accepted"
     assert "auto_accepted" in _actions(store, elsewhere)
+
+
+# --- #263 review 2: a no-op / replayed POST is not a review decision ---------
+
+
+def _eligible_pair(store: Store):
+    """One confirmed fact and one review-tier fact stating the same triple from
+    two analysed sources: the review-tier one is already auto-accept eligible.
+
+    It is the tripwire for these tests — if a route runs the rule at all, this
+    fact moves to `accepted`.
+    """
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    job_a = _done_job(store, source_a)
+    job_b = _done_job(store, source_b)
+    store.add_fact(
+        "Report", "author", "Kim",
+        status="confirmed", source_id=source_a, job_id=job_a,
+    )
+    eligible = store.add_fact(
+        "Report", "author", "Kim",
+        status="needs_review", source_id=source_b, job_id=job_b,
+    )
+    return eligible
+
+
+def _auto_accept_events(store: Store, fact_id: int) -> list:
+    return [
+        e for e in store.fact_events(fact_id) if e["event_type"] == "auto_accept_applied"
+    ]
+
+
+def _assert_untouched(store: Store, eligible: int, resp) -> None:
+    assert store.get_fact(eligible)["status"] == "needs_review"
+    assert "auto_accepted" not in _actions(store, eligible)
+    assert not _auto_accept_events(store, eligible)
+    assert "HX-Refresh" not in resp.headers
+
+
+def test_replayed_accept_does_not_run_auto_accept(tmp_path):
+    # A second /accept on an already-confirmed fact writes nothing: the human
+    # made no new decision in this request, so nothing may be promoted off it.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact("Ledger", "owner", "Park", status="confirmed")
+
+    resp = client.post(f"/facts/{target}/accept")
+
+    assert resp.status_code == 200
+    assert store.get_fact(target)["status"] == "confirmed"
+    _assert_untouched(store, eligible, resp)
+
+
+def test_accept_on_a_superseded_fact_does_not_run_auto_accept(tmp_path):
+    # Accept refuses to revive a rejection, so it is a no-op here too.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact("Ledger", "owner", "Park", status="superseded")
+
+    resp = client.post(f"/facts/{target}/accept")
+
+    assert resp.status_code == 200
+    assert store.get_fact(target)["status"] == "superseded"
+    _assert_untouched(store, eligible, resp)
+
+
+def test_replayed_reject_does_not_run_auto_accept(tmp_path):
+    # Reject is terminal and idempotent; the replay decides nothing.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact("Ledger", "owner", "Park", status="superseded")
+
+    resp = client.post(f"/facts/{target}/reject")
+
+    assert resp.status_code == 200
+    assert store.get_fact(target)["status"] == "superseded"
+    _assert_untouched(store, eligible, resp)
+
+
+def test_toggle_on_a_superseded_fact_does_not_run_auto_accept(tmp_path):
+    # A toggle that hits the no-revival guard writes nothing either.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact("Ledger", "owner", "Park", status="superseded")
+
+    resp = client.post(f"/facts/{target}/toggle")
+
+    assert resp.status_code == 200
+    assert store.get_fact(target)["status"] == "superseded"
+    _assert_untouched(store, eligible, resp)
+
+
+def test_reject_that_really_transitions_still_runs_auto_accept(tmp_path):
+    # Over-fix guard: only no-ops are filtered. A reject that actually moves a
+    # fact is a decision, and the rule still runs for the siblings it unblocks.
+    client, store = _auto_accept_client(tmp_path)
+    eligible = _eligible_pair(store)
+    target = store.add_fact("Ledger", "owner", "Park", status="needs_review")
+
+    resp = client.post(f"/facts/{target}/reject")
+
+    assert resp.status_code == 200
+    assert store.get_fact(target)["status"] == "superseded"
+    assert store.get_fact(eligible)["status"] == "accepted"
+    assert resp.headers.get("HX-Refresh") == "true"

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -53,3 +53,55 @@ def test_toggle_still_flips_review_and_engine_tiers(tmp_path):
 
     assert s.toggle_review(review_id)["status"] == "confirmed"
     assert s.toggle_review(engine_id)["status"] == "needs_review"
+
+
+# --- #232: accept/reject are transition-aware, not blind writes -----------
+
+
+def test_reject_then_accept_keeps_a_fact_superseded(tmp_path):
+    s = _store(tmp_path)
+    fact_id = s.add_fact("Report", "author", "Kim", status="needs_review")
+
+    assert s.reject_fact(fact_id)["status"] == "superseded"
+    # The whole point of the gate: accept must not resurrect a rejection.
+    reaccepted = s.accept_fact(fact_id)
+    assert reaccepted["status"] == "superseded"
+    assert s.get_fact(fact_id)["status"] == "superseded"
+    # One rejection logged, and no `accepted` row from the refused accept.
+    actions = _actions(s, fact_id)
+    assert actions.count("rejected") == 1
+    assert "accepted" not in actions
+
+
+def test_reaccepting_a_confirmed_fact_is_a_silent_noop(tmp_path):
+    s = _store(tmp_path)
+    fact_id = s.add_fact("Report", "author", "Kim", status="confirmed")
+    log_before = _actions(s, fact_id)
+
+    row = s.accept_fact(fact_id)
+
+    assert row["status"] == "confirmed"
+    # No write, no audit growth — accept only moves review-tier rows.
+    assert _actions(s, fact_id) == log_before
+
+
+def test_accept_promotes_a_review_fact(tmp_path):
+    # Regression guard: the transition checks must not block the real accept.
+    s = _store(tmp_path)
+    candidate = s.add_fact("Report", "author", "Kim", status="candidate")
+    needs = s.add_fact("Report", "author", "Lee", status="needs_review")
+
+    assert s.accept_fact(candidate)["status"] == "confirmed"
+    assert s.accept_fact(needs)["status"] == "confirmed"
+    assert _actions(s, candidate) == ["accepted"]
+
+
+def test_double_reject_logs_once(tmp_path):
+    s = _store(tmp_path)
+    fact_id = s.add_fact("Report", "author", "Kim", status="needs_review")
+
+    s.reject_fact(fact_id)
+    s.reject_fact(fact_id)
+
+    # A repeat reject on an already-superseded fact writes no duplicate audit row.
+    assert _actions(s, fact_id).count("rejected") == 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -125,7 +125,11 @@ def test_compile_dl_escapes_quotes(tmp_path):
 def test_amend_fact_persists_and_audits(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("A", "is_a", "B", status="needs_review", note="orig")
-    after = s.amend_fact(fid, subject="A2", relation="became", obj="C", note="fixed")
+    decision = s.amend_fact(
+        fid, subject="A2", relation="became", obj="C", note="fixed"
+    )
+    after = decision.fact
+    assert decision.changed is True
     assert (after["subject"], after["relation"], after["object"], after["note"]) == (
         "A2",
         "became",
@@ -137,7 +141,24 @@ def test_amend_fact_persists_and_audits(tmp_path):
 
 def test_amend_missing_fact_returns_none(tmp_path):
     s = _store(tmp_path)
-    assert s.amend_fact(999, subject="x", relation="y", obj="z") is None
+    decision = s.amend_fact(999, subject="x", relation="y", obj="z")
+
+    assert decision.fact is None
+    assert decision.changed is False
+
+
+def test_replayed_amend_writes_no_audit_event(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "is_a", "B", status="needs_review", note="orig")
+    before = dict(s.get_fact(fid))
+
+    decision = s.amend_fact(fid, subject="A", relation="is_a", obj="B", note="orig")
+
+    assert decision.fact is not None
+    assert decision.changed is False
+    assert dict(decision.fact) == before
+    assert dict(s.get_fact(fid)) == before
+    assert s.fact_log(fid) == []
 
 
 def test_delete_source_removes_source_facts_and_terms(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -17,10 +17,10 @@ def test_toggle_promotes_and_reverts(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
 
-    row = s.toggle_review(fid)
+    row = s.toggle_review(fid).fact
     assert row["status"] == "confirmed"
 
-    row = s.toggle_review(fid)
+    row = s.toggle_review(fid).fact
     assert row["status"] == "needs_review"
 
 

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -131,14 +131,16 @@ def test_amend_fact_updates_sqlite_duckdb_terms_and_audit(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("A", "r", "B", status="needs_review")
 
-    after = s.amend_fact(
+    decision = s.amend_fact(
         fid,
         subject=Compound("person", (StringLit("Ada"),)),
         relation=Atom("born_year"),
         obj=NumberLit(1815),
         note="fixed",
     )
+    after = decision.fact
 
+    assert decision.changed is True
     assert (after["subject"], after["relation"], after["object"], after["note"]) == (
         'person("Ada")',
         "born_year",
@@ -169,6 +171,31 @@ def test_amend_fact_keeps_term_syntax_strings_as_stringlit(tmp_path):
         StringLit("born_in"),
         StringLit('city("London")'),
     )
+
+
+def test_replayed_structural_amend_writes_no_audit_event(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact(
+        Compound("person", (StringLit("Ada"),)),
+        Atom("born_year"),
+        NumberLit(1815),
+        note="verified",
+    )
+    before = dict(s.get_fact(fid))
+    before_terms = s.get_fact_terms(fid)
+
+    decision = s.amend_fact(
+        fid,
+        subject=Compound("person", (StringLit("Ada"),)),
+        relation=Atom("born_year"),
+        obj=NumberLit(1815),
+        note="verified",
+    )
+
+    assert decision.changed is False
+    assert dict(decision.fact) == before
+    assert s.get_fact_terms(fid) == before_terms
+    assert s.fact_log(fid) == []
 
 
 def test_backfill_fact_terms_migrates_legacy_sqlite_text_as_stringlit(tmp_path):

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -60,8 +60,16 @@ def accept_recommendations_for(
     return recommendations
 
 
-def apply_auto_accept_recommendations(store: Store) -> list[AcceptRecommendation]:
+def apply_auto_accept_recommendations(
+    store: Store, *, exclude_fact_ids: Iterable[int] = ()
+) -> list[AcceptRecommendation]:
     """Promote every eligible candidate to `accepted` — never on a halted KB.
+
+    `exclude_fact_ids` holds facts a human has just decided on in this same
+    request. The rule still runs for everything else, because that decision may
+    have unblocked siblings; it just doesn't get to re-decide the fact the human
+    aimed at. Without this, demoting a corroborated fact to the review tier hands
+    it straight back to the rule that promotes corroborated review-tier facts.
 
     A halted KB already stops this today, but only by COINCIDENCE: `_engine` builds
     its single-valued set from `store_functional_relations`, which calls
@@ -77,17 +85,16 @@ def apply_auto_accept_recommendations(store: Store) -> list[AcceptRecommendation
     a policy deleted after the final chunk's write boundary lands exactly here.
     """
     assert_writable(store)
+    excluded = {int(fact_id) for fact_id in exclude_fact_ids}
     applied = []
     for recommendation in accept_recommendations(store).values():
-        if not recommendation.eligible:
+        if not recommendation.eligible or recommendation.fact_id in excluded:
             continue
-        store.set_status(
-            recommendation.fact_id,
-            "accepted",
-            action="auto_accepted",
-            actor="rule",
-            rule_name=RULE_NAME,
-        )
+        # Eligibility came off a snapshot; `auto_accept_fact` re-checks the tier
+        # at the write and returns None if a human decided first. Their decision
+        # wins, and the audit event below is skipped along with the write.
+        if store.auto_accept_fact(recommendation.fact_id, rule_name=RULE_NAME) is None:
+            continue
         store.add_fact_event(
             fact_id=recommendation.fact_id,
             event_type="auto_accept_applied",

--- a/verinote/store/__init__.py
+++ b/verinote/store/__init__.py
@@ -3,6 +3,7 @@
 
 from verinote.store.db import (
     DEFAULT_REVIEW_PAGE_SIZE,
+    FactDecision,
     POLICY_MARKER_KEY,
     REVIEW_PAGE_SIZES,
     ReviewQueuePage,
@@ -21,6 +22,7 @@ from verinote.store.tiers import (
 # accessors above instead — they resolve `db.ENGINE_STATUSES` at call time.
 __all__ = [
     "Store",
+    "FactDecision",
     "POLICY_MARKER_KEY",
     "engine_statuses",
     "review_statuses",

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1226,6 +1226,56 @@ class Store:
             return row
         return self.set_status(fact_id, new_status, action="toggled")
 
+    def accept_fact(self, fact_id: int) -> sqlite3.Row | None:
+        """Promote a review-queue fact to confirmed (a human's accept).
+
+        Only review-tier rows (candidate/needs_review) move. A row that is
+        already confirmed/accepted needs no write, and a superseded row stays
+        superseded: a human's rejection is terminal, so accept must never revive
+        it. Non-moving calls return the current row without touching the audit
+        log, and the read and the write share `self._lock` so the decision can't
+        race a concurrent status change.
+        """
+        with self._lock:
+            before = self.get_fact(fact_id)
+            if before is None:
+                return None
+            if before["status"] not in REVIEW_STATUSES:
+                return before
+            self._conn.execute(
+                "UPDATE facts SET status = 'confirmed', updated_at = datetime('now') "
+                "WHERE id = ?",
+                (fact_id,),
+            )
+            after = self.get_fact(fact_id)
+            self._log(fact_id, "accepted", before, after)
+            return after
+
+    def reject_fact(self, fact_id: int) -> sqlite3.Row | None:
+        """Supersede a fact (a human's reject); the terminal review decision.
+
+        Any non-superseded status moves to superseded. A superseded row is left
+        untouched and unlogged so repeat rejects don't pile duplicate audit rows.
+        There is deliberately no transition out of superseded here — this route
+        is the one that puts a fact into the terminal state, never the one that
+        takes it out. Read and write share `self._lock` for the same reason
+        accept does.
+        """
+        with self._lock:
+            before = self.get_fact(fact_id)
+            if before is None:
+                return None
+            if before["status"] == "superseded":
+                return before
+            self._conn.execute(
+                "UPDATE facts SET status = 'superseded', updated_at = datetime('now') "
+                "WHERE id = ?",
+                (fact_id,),
+            )
+            after = self.get_fact(fact_id)
+            self._log(fact_id, "rejected", before, after)
+            return after
+
     def amend_fact(
         self,
         fact_id: int,

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1254,20 +1254,30 @@ class Store:
         already confirmed/accepted needs no write, and a superseded row stays
         superseded: a human's rejection is terminal, so accept must never revive
         it. Non-moving calls return the current row without touching the audit
-        log, and the read and the write share `self._lock` so the decision can't
-        race a concurrent status change.
+        log.
+
+        The tier check before the write only settles the race for callers
+        sharing this instance's lock; a reject arriving on another connection to
+        the same KB lands in the window between the two. So, as in
+        `toggle_review` and `auto_accept_fact`, the write is conditional on the
+        status this call actually observed, and a lost race writes nothing.
         """
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
                 return None
-            if before["status"] not in REVIEW_STATUSES:
+            observed = before["status"]
+            if observed not in REVIEW_STATUSES:
                 return before
-            self._conn.execute(
+            cursor = self._conn.execute(
                 "UPDATE facts SET status = 'confirmed', updated_at = datetime('now') "
-                "WHERE id = ?",
-                (fact_id,),
+                "WHERE id = ? AND status = ?",
+                (fact_id, observed),
             )
+            if cursor.rowcount == 0:
+                # Someone moved the fact between the read and the write; their
+                # decision stands, and this stale accept writes nothing.
+                return self.get_fact(fact_id)
             after = self.get_fact(fact_id)
             self._log(fact_id, "accepted", before, after)
             return after

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1387,14 +1387,24 @@ class Store:
         relation: object,
         obj: object,
         note: str = "",
-    ) -> sqlite3.Row | None:
-        """Correct a fact's (subject, relation, object, note); audit as `amended`."""
+    ) -> FactDecision:
+        """Correct a fact's (subject, relation, object, note); audit as `amended`.
+
+        An amend is a decision only when it changes stored content. A missing
+        target or an exact replay writes nothing, logs nothing, and returns
+        `changed=False` so callers do not run follow-on effects for a request
+        that made no decision.
+        """
         with self._lock:
             from verinote.store.duckdb_fact_terms import fact_term_token
 
             before = self.get_fact(fact_id)
             if before is None:
-                return None
+                return FactDecision.unchanged(None)
+            previous_terms = self.fact_terms.get_fact_terms(fact_id)
+            requested_terms = _stored_fact_terms(subject, relation, obj)
+            if previous_terms == requested_terms and before["note"] == note:
+                return FactDecision.unchanged(before)
             token = fact_term_token(subject, relation, obj)
             self._conn.execute("BEGIN")
             try:
@@ -1420,7 +1430,7 @@ class Store:
             self.fact_terms.put_fact_terms(
                 fact_id, subject, relation, obj, term_token=token
             )
-            return after
+            return FactDecision(fact=after, changed=True)
 
     # --- questions -------------------------------------------------------
     def add_question(self, text: str) -> int:
@@ -1865,6 +1875,12 @@ def _display_fact_value(value: object) -> str:
     if isinstance(value, (Atom, Compound, NumberLit, StringLit, Var)):
         return render_term(value)
     return str(value)
+
+
+def _stored_fact_terms(subject: object, relation: object, obj: object):
+    from verinote.store.duckdb_fact_terms import _coerce_term
+
+    return (_coerce_term(subject), _coerce_term(relation), _coerce_term(obj))
 
 
 def _json_payload(value: dict[str, object] | sqlite3.Row | None) -> str | None:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1315,20 +1315,33 @@ class Store:
         untouched and unlogged so repeat rejects don't pile duplicate audit rows.
         There is deliberately no transition out of superseded here — this route
         is the one that puts a fact into the terminal state, never the one that
-        takes it out. Read and write share `self._lock` for the same reason
-        accept does.
+        takes it out.
+
+        That "already superseded?" check is a read, so it settles the race only
+        for callers sharing this instance's lock; a reject arriving on another
+        connection to the same KB lands in the window after it. Two rejects agree
+        about the status, so no state is corrupted — but the loser would still
+        claim `changed=True` for a transition it did not make, and the route
+        above turns that claim into an auto-accept pass. So, as in the three
+        writes around it, the UPDATE is conditional on the status this call
+        observed, and a lost race writes nothing and logs nothing.
         """
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
                 return FactDecision.unchanged(None)
-            if before["status"] == "superseded":
+            observed = before["status"]
+            if observed == "superseded":
                 return FactDecision.unchanged(before)
-            self._conn.execute(
+            cursor = self._conn.execute(
                 "UPDATE facts SET status = 'superseded', updated_at = datetime('now') "
-                "WHERE id = ?",
-                (fact_id,),
+                "WHERE id = ? AND status = ?",
+                (fact_id, observed),
             )
+            if cursor.rowcount == 0:
+                # Someone moved the fact between the read and the write; their
+                # decision stands, and this stale reject writes nothing.
+                return FactDecision.unchanged(self.get_fact(fact_id))
             after = self.get_fact(fact_id)
             self._log(fact_id, "rejected", before, after)
             return FactDecision(fact=after, changed=True)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1213,18 +1213,39 @@ class Store:
         rows (candidate/needs_review) promote to confirmed. A superseded fact is
         a human's terminal rejection, so a toggle leaves it untouched and
         unlogged rather than reviving it to confirmed.
+
+        The target status is derived from a status this transition then *writes
+        conditionally on*, so a toggle can only ever commit the flip it actually
+        read. Holding `self._lock` is not enough on its own: the lock serialises
+        writers sharing this instance, but a KB is one SQLite file that several
+        connections open, and a reject arriving from any of them must win over a
+        toggle target computed before it landed. When the row has moved
+        underneath, the current row is returned unchanged and nothing is logged
+        — the toggle simply didn't happen.
         """
-        row = self.get_fact(fact_id)
-        if row is None:
-            return None
-        status = row["status"]
-        if status in ENGINE_STATUSES:
-            new_status = "needs_review"
-        elif status in REVIEW_STATUSES:
-            new_status = "confirmed"
-        else:  # superseded (or any terminal status): no revival path
-            return row
-        return self.set_status(fact_id, new_status, action="toggled")
+        with self._lock:
+            before = self.get_fact(fact_id)
+            if before is None:
+                return None
+            observed = before["status"]
+            if observed in ENGINE_STATUSES:
+                new_status = "needs_review"
+            elif observed in REVIEW_STATUSES:
+                new_status = "confirmed"
+            else:  # superseded (or any terminal status): no revival path
+                return before
+            cursor = self._conn.execute(
+                "UPDATE facts SET status = ?, updated_at = datetime('now') "
+                "WHERE id = ? AND status = ?",
+                (new_status, fact_id, observed),
+            )
+            if cursor.rowcount == 0:
+                # Someone moved the fact between the read and the write; their
+                # decision stands, and this stale toggle writes nothing.
+                return self.get_fact(fact_id)
+            after = self.get_fact(fact_id)
+            self._log(fact_id, "toggled", before, after)
+            return after
 
     def accept_fact(self, fact_id: int) -> sqlite3.Row | None:
         """Promote a review-queue fact to confirmed (a human's accept).
@@ -1274,6 +1295,39 @@ class Store:
             )
             after = self.get_fact(fact_id)
             self._log(fact_id, "rejected", before, after)
+            return after
+
+    def auto_accept_fact(self, fact_id: int, *, rule_name: str) -> sqlite3.Row | None:
+        """Promote a review-queue fact to `accepted` (a rule's decision).
+
+        The caller recommends from a snapshot, so by the time this write runs a
+        human may have rejected the fact — and a rule must never take a fact out
+        of `superseded`. The status condition lives in the UPDATE itself rather
+        than in a check before it, because the competing decision can arrive on
+        another connection to the same KB, where this instance's lock has no say.
+
+        Returns None when the fact has left the review tier, so the caller can
+        tell a promotion it made from one it declined and skip the audit event
+        for a write that never happened.
+        """
+        with self._lock:
+            before = self.get_fact(fact_id)
+            if before is None:
+                return None
+            observed = before["status"]
+            if observed not in REVIEW_STATUSES:
+                return None
+            cursor = self._conn.execute(
+                "UPDATE facts SET status = 'accepted', updated_at = datetime('now') "
+                "WHERE id = ? AND status = ?",
+                (fact_id, observed),
+            )
+            if cursor.rowcount == 0:
+                return None
+            after = self.get_fact(fact_id)
+            self._log(
+                fact_id, "auto_accepted", before, after, actor="rule", rule_name=rule_name
+            )
             return after
 
     def amend_fact(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1207,11 +1207,23 @@ class Store:
                 raise
 
     def toggle_review(self, fact_id: int) -> sqlite3.Row | None:
-        """needs_review/candidate -> confirmed, and confirmed -> needs_review."""
+        """Flip a fact between the engine and review tiers.
+
+        Engine rows (confirmed/accepted) drop back to needs_review; review-queue
+        rows (candidate/needs_review) promote to confirmed. A superseded fact is
+        a human's terminal rejection, so a toggle leaves it untouched and
+        unlogged rather than reviving it to confirmed.
+        """
         row = self.get_fact(fact_id)
         if row is None:
             return None
-        new_status = "needs_review" if row["status"] in ENGINE_STATUSES else "confirmed"
+        status = row["status"]
+        if status in ENGINE_STATUSES:
+            new_status = "needs_review"
+        elif status in REVIEW_STATUSES:
+            new_status = "confirmed"
+        else:  # superseded (or any terminal status): no revival path
+            return row
         return self.set_status(fact_id, new_status, action="toggled")
 
     def amend_fact(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -26,6 +26,32 @@ POLICY_MARKER_KEY = "policy.logic"
 FACT_TERMS_MARKER_KEY = "fact_terms.duckdb"
 ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
+
+
+@dataclass(frozen=True)
+class FactDecision:
+    """The outcome of a review decision: the fact's row, and whether it moved.
+
+    `changed` is False for the two ways a decision writes nothing — the fact was
+    already in the status being asked for (a replayed or no-op POST), or a
+    competing decision won the race and this one's conditional UPDATE matched no
+    row. Either way `fact` is the fact's *current* row, not the hoped-for one.
+
+    Callers need this told to them rather than inferred, because a decision's
+    follow-on effects (auto-accept, audit events) are owed to a state transition,
+    not to the arrival of a request. Only the store can answer: it is what holds
+    the lock across the read and the conditional write, so the transition is
+    reported from inside the window where the race is settled. A caller trying to
+    work it out by reading the status before and after would be reintroducing the
+    unsynchronised read this class exists alongside the fix for.
+    """
+
+    fact: sqlite3.Row | None
+    changed: bool
+
+    @classmethod
+    def unchanged(cls, fact: sqlite3.Row | None) -> "FactDecision":
+        return cls(fact=fact, changed=False)
 REVIEW_PAGE_SIZES = (25, 50, 100)
 DEFAULT_REVIEW_PAGE_SIZE = 50
 DEFAULT_REVIEW_SORT = "newest"
@@ -1206,7 +1232,7 @@ class Store:
                 self._rollback_quietly()
                 raise
 
-    def toggle_review(self, fact_id: int) -> sqlite3.Row | None:
+    def toggle_review(self, fact_id: int) -> FactDecision:
         """Flip a fact between the engine and review tiers.
 
         Engine rows (confirmed/accepted) drop back to needs_review; review-queue
@@ -1221,19 +1247,19 @@ class Store:
         connections open, and a reject arriving from any of them must win over a
         toggle target computed before it landed. When the row has moved
         underneath, the current row is returned unchanged and nothing is logged
-        — the toggle simply didn't happen.
+        — the toggle simply didn't happen, which the `FactDecision` says.
         """
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
-                return None
+                return FactDecision.unchanged(None)
             observed = before["status"]
             if observed in ENGINE_STATUSES:
                 new_status = "needs_review"
             elif observed in REVIEW_STATUSES:
                 new_status = "confirmed"
             else:  # superseded (or any terminal status): no revival path
-                return before
+                return FactDecision.unchanged(before)
             cursor = self._conn.execute(
                 "UPDATE facts SET status = ?, updated_at = datetime('now') "
                 "WHERE id = ? AND status = ?",
@@ -1242,19 +1268,19 @@ class Store:
             if cursor.rowcount == 0:
                 # Someone moved the fact between the read and the write; their
                 # decision stands, and this stale toggle writes nothing.
-                return self.get_fact(fact_id)
+                return FactDecision.unchanged(self.get_fact(fact_id))
             after = self.get_fact(fact_id)
             self._log(fact_id, "toggled", before, after)
-            return after
+            return FactDecision(fact=after, changed=True)
 
-    def accept_fact(self, fact_id: int) -> sqlite3.Row | None:
+    def accept_fact(self, fact_id: int) -> FactDecision:
         """Promote a review-queue fact to confirmed (a human's accept).
 
         Only review-tier rows (candidate/needs_review) move. A row that is
         already confirmed/accepted needs no write, and a superseded row stays
         superseded: a human's rejection is terminal, so accept must never revive
-        it. Non-moving calls return the current row without touching the audit
-        log.
+        it. Non-moving calls return the current row with `changed=False` and
+        without touching the audit log.
 
         The tier check before the write only settles the race for callers
         sharing this instance's lock; a reject arriving on another connection to
@@ -1265,10 +1291,10 @@ class Store:
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
-                return None
+                return FactDecision.unchanged(None)
             observed = before["status"]
             if observed not in REVIEW_STATUSES:
-                return before
+                return FactDecision.unchanged(before)
             cursor = self._conn.execute(
                 "UPDATE facts SET status = 'confirmed', updated_at = datetime('now') "
                 "WHERE id = ? AND status = ?",
@@ -1277,12 +1303,12 @@ class Store:
             if cursor.rowcount == 0:
                 # Someone moved the fact between the read and the write; their
                 # decision stands, and this stale accept writes nothing.
-                return self.get_fact(fact_id)
+                return FactDecision.unchanged(self.get_fact(fact_id))
             after = self.get_fact(fact_id)
             self._log(fact_id, "accepted", before, after)
-            return after
+            return FactDecision(fact=after, changed=True)
 
-    def reject_fact(self, fact_id: int) -> sqlite3.Row | None:
+    def reject_fact(self, fact_id: int) -> FactDecision:
         """Supersede a fact (a human's reject); the terminal review decision.
 
         Any non-superseded status moves to superseded. A superseded row is left
@@ -1295,9 +1321,9 @@ class Store:
         with self._lock:
             before = self.get_fact(fact_id)
             if before is None:
-                return None
+                return FactDecision.unchanged(None)
             if before["status"] == "superseded":
-                return before
+                return FactDecision.unchanged(before)
             self._conn.execute(
                 "UPDATE facts SET status = 'superseded', updated_at = datetime('now') "
                 "WHERE id = ?",
@@ -1305,7 +1331,7 @@ class Store:
             )
             after = self.get_fact(fact_id)
             self._log(fact_id, "rejected", before, after)
-            return after
+            return FactDecision(fact=after, changed=True)
 
     def auto_accept_fact(self, fact_id: int, *, rule_name: str) -> sqlite3.Row | None:
         """Promote a review-queue fact to `accepted` (a rule's decision).

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1051,6 +1051,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             obj=object_value,
             note=note,
         )
+        # The rule may act on the amended fact itself, unlike a toggle demotion.
+        # An amend decides the fact's content, not its tier: correcting a term so
+        # it finally matches a second source's wording *is* corroboration
+        # arriving, and promoting on it is the recommender working as intended.
         return _row_after_decision(request, amended, fact_id)
 
     @app.get("/facts/{fact_id}/provenance", response_class=HTMLResponse)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -934,10 +934,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/sources/{source_id}/accept-all", response_class=HTMLResponse)
     def accept_all_source_facts(request: Request, source_id: int):
-        _active_store().accept_review_facts_for_source(source_id)
+        accepted = _active_store().accept_review_facts_for_source(source_id)
         # Bulk-confirming a source can corroborate facts elsewhere; the redirect
-        # reloads the page so no HX-Refresh header is needed here.
-        _maybe_apply_auto_accept()
+        # reloads the page so no HX-Refresh header is needed here. `accepted` is
+        # the same transition test the single-fact routes apply: a source with
+        # nothing left in the review tier confirms nothing, so the POST decided
+        # nothing and the rule stays out of it.
+        if accepted:
+            _maybe_apply_auto_accept()
         return RedirectResponse("/sources", status_code=303)
 
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -328,15 +328,37 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         recommendation = recommendations.get(int(fact["id"])) if fact else None
         return {"f": view, "trust": trust, "recommendation": recommendation}
 
-    def _maybe_apply_auto_accept() -> None:
+    def _maybe_apply_auto_accept() -> list:
         if _active_cfg().auto_accept_recommendations:
-            apply_auto_accept_recommendations(_active_store())
+            return apply_auto_accept_recommendations(_active_store())
+        return []
 
     def _row(request: Request, fact):
         # Starlette's current API is TemplateResponse(request, name, context).
         return templates.TemplateResponse(
             request, "partials/fact_row.html", _fact_row_context(fact)
         )
+
+    def _row_after_decision(request: Request, fact, acted_fact_id: int | None):
+        """Render the acted row, running auto-accept for the corroboration it
+        may have unblocked.
+
+        A human decision changes the corroboration landscape, so re-run the
+        recommender here just as the extraction worker does. When it promotes
+        *other* facts, a single-row HTMX swap can't reveal them, so ask the
+        client for a full refresh; when nothing (or only the acted fact) moved,
+        the row swap is enough. The acted row is re-read afterwards so it
+        reflects an auto-accept that landed on the fact itself.
+        """
+        applied = _maybe_apply_auto_accept()
+        if acted_fact_id is not None:
+            refreshed = _active_store().get_fact(acted_fact_id)
+            if refreshed is not None:
+                fact = refreshed
+        response = _row(request, fact)
+        if any(rec.fact_id != acted_fact_id for rec in applied):
+            response.headers["HX-Refresh"] = "true"
+        return response
 
     def _fact_edit_context(fact, *, error: str | None = None):
         kinds = {"subject": "string", "relation": "string", "object": "string"}
@@ -890,6 +912,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.post("/sources/{source_id}/accept-all", response_class=HTMLResponse)
     def accept_all_source_facts(request: Request, source_id: int):
         _active_store().accept_review_facts_for_source(source_id)
+        # Bulk-confirming a source can corroborate facts elsewhere; the redirect
+        # reloads the page so no HX-Refresh header is needed here.
+        _maybe_apply_auto_accept()
         return RedirectResponse("/sources", status_code=303)
 
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
@@ -954,15 +979,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)
     def toggle(request: Request, fact_id: int):
-        return _row(request, _active_store().toggle_review(fact_id))
+        return _row_after_decision(request, _active_store().toggle_review(fact_id), fact_id)
 
     @app.post("/facts/{fact_id}/accept", response_class=HTMLResponse)
     def accept(request: Request, fact_id: int):
-        return _row(request, _active_store().accept_fact(fact_id))
+        return _row_after_decision(request, _active_store().accept_fact(fact_id), fact_id)
 
     @app.post("/facts/{fact_id}/reject", response_class=HTMLResponse)
     def reject(request: Request, fact_id: int):
-        return _row(request, _active_store().reject_fact(fact_id))
+        # Reject runs auto-accept too: removing a fact's support (or freeing a
+        # single-valued slot it conflicted on) also reshapes corroboration, so
+        # keeping the trigger here matches the other decision routes.
+        return _row_after_decision(request, _active_store().reject_fact(fact_id), fact_id)
 
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):
@@ -1007,7 +1035,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             obj=object_value,
             note=note,
         )
-        return _row(request, amended)
+        return _row_after_decision(request, amended, fact_id)
 
     @app.get("/facts/{fact_id}/provenance", response_class=HTMLResponse)
     def provenance(request: Request, fact_id: int):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1088,7 +1088,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # An amend decides the fact's content, not its tier: correcting a term so
         # it finally matches a second source's wording *is* corroboration
         # arriving, and promoting on it is the recommender working as intended.
-        return _row_after_decision(request, amended, fact_id)
+        return _row_after_decision(
+            request, amended.fact, fact_id, decided=amended.changed
+        )
 
     @app.get("/facts/{fact_id}/provenance", response_class=HTMLResponse)
     def provenance(request: Request, fact_id: int):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -86,6 +86,7 @@ from verinote.store import (
     REVIEW_PAGE_SIZES,
     ReviewQueuePage,
     Store,
+    review_statuses,
 )
 # Imported as a module, not `from ... import ENGINE_STATUSES`: the tier must be
 # read at call time so the web layer cannot pin a stale copy of the constant.
@@ -328,9 +329,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         recommendation = recommendations.get(int(fact["id"])) if fact else None
         return {"f": view, "trust": trust, "recommendation": recommendation}
 
-    def _maybe_apply_auto_accept() -> list:
+    def _maybe_apply_auto_accept(exclude_fact_ids: tuple[int, ...] = ()) -> list:
         if _active_cfg().auto_accept_recommendations:
-            return apply_auto_accept_recommendations(_active_store())
+            return apply_auto_accept_recommendations(
+                _active_store(), exclude_fact_ids=exclude_fact_ids
+            )
         return []
 
     def _row(request: Request, fact):
@@ -339,7 +342,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             request, "partials/fact_row.html", _fact_row_context(fact)
         )
 
-    def _row_after_decision(request: Request, fact, acted_fact_id: int | None):
+    def _row_after_decision(
+        request: Request, fact, acted_fact_id: int | None, *, rule_may_act: bool = True
+    ):
         """Render the acted row, running auto-accept for the corroboration it
         may have unblocked.
 
@@ -349,8 +354,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         client for a full refresh; when nothing (or only the acted fact) moved,
         the row swap is enough. The acted row is re-read afterwards so it
         reflects an auto-accept that landed on the fact itself.
+
+        `rule_may_act=False` bars the rule from the acted fact while still
+        letting it promote everything else — for the one decision that parks a
+        fact back in the tier auto-accept harvests from (see `toggle`).
         """
-        applied = _maybe_apply_auto_accept()
+        excluded = () if rule_may_act or acted_fact_id is None else (acted_fact_id,)
+        applied = _maybe_apply_auto_accept(excluded)
         if acted_fact_id is not None:
             refreshed = _active_store().get_fact(acted_fact_id)
             if refreshed is not None:
@@ -979,7 +989,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)
     def toggle(request: Request, fact_id: int):
-        return _row_after_decision(request, _active_store().toggle_review(fact_id), fact_id)
+        toggled = _active_store().toggle_review(fact_id)
+        # A demotion parks the fact in exactly the tier auto-accept promotes
+        # from, so an unrestricted pass would undo the user's click inside their
+        # own request. The demotion is the decision; the rule may act on the
+        # siblings it unblocks, but not on this fact.
+        demoted = toggled is not None and toggled["status"] in review_statuses()
+        return _row_after_decision(request, toggled, fact_id, rule_may_act=not demoted)
 
     @app.post("/facts/{fact_id}/accept", response_class=HTMLResponse)
     def accept(request: Request, fact_id: int):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -958,11 +958,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/facts/{fact_id}/accept", response_class=HTMLResponse)
     def accept(request: Request, fact_id: int):
-        return _row(request, _active_store().set_status(fact_id, "confirmed", action="accepted"))
+        return _row(request, _active_store().accept_fact(fact_id))
 
     @app.post("/facts/{fact_id}/reject", response_class=HTMLResponse)
     def reject(request: Request, fact_id: int):
-        return _row(request, _active_store().set_status(fact_id, "superseded", action="rejected"))
+        return _row(request, _active_store().reject_fact(fact_id))
 
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -343,7 +343,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
 
     def _row_after_decision(
-        request: Request, fact, acted_fact_id: int | None, *, rule_may_act: bool = True
+        request: Request,
+        fact,
+        acted_fact_id: int | None,
+        *,
+        rule_may_act: bool = True,
+        decided: bool = True,
     ):
         """Render the acted row, running auto-accept for the corroboration it
         may have unblocked.
@@ -355,12 +360,20 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         the row swap is enough. The acted row is re-read afterwards so it
         reflects an auto-accept that landed on the fact itself.
 
+        `decided=False` means the POST changed nothing — a replayed accept on an
+        already-confirmed fact, a toggle a reject beat to the row. The follow-on
+        pass is owed to a *transition*, not to a request arriving: with no new
+        human decision there is no newly unblocked corroboration, and running the
+        rule anyway would promote siblings and stamp `auto_accepted` audit events
+        off a click the user may have made hours ago (or never made — HTMX and
+        browsers both retry). Such a request only re-renders the row.
+
         `rule_may_act=False` bars the rule from the acted fact while still
         letting it promote everything else — for the one decision that parks a
         fact back in the tier auto-accept harvests from (see `toggle`).
         """
         excluded = () if rule_may_act or acted_fact_id is None else (acted_fact_id,)
-        applied = _maybe_apply_auto_accept(excluded)
+        applied = _maybe_apply_auto_accept(excluded) if decided else []
         if acted_fact_id is not None:
             refreshed = _active_store().get_fact(acted_fact_id)
             if refreshed is not None:
@@ -994,19 +1007,35 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # from, so an unrestricted pass would undo the user's click inside their
         # own request. The demotion is the decision; the rule may act on the
         # siblings it unblocks, but not on this fact.
-        demoted = toggled is not None and toggled["status"] in review_statuses()
-        return _row_after_decision(request, toggled, fact_id, rule_may_act=not demoted)
+        demoted = (
+            toggled.changed
+            and toggled.fact is not None
+            and toggled.fact["status"] in review_statuses()
+        )
+        return _row_after_decision(
+            request,
+            toggled.fact,
+            fact_id,
+            rule_may_act=not demoted,
+            decided=toggled.changed,
+        )
 
     @app.post("/facts/{fact_id}/accept", response_class=HTMLResponse)
     def accept(request: Request, fact_id: int):
-        return _row_after_decision(request, _active_store().accept_fact(fact_id), fact_id)
+        accepted = _active_store().accept_fact(fact_id)
+        return _row_after_decision(
+            request, accepted.fact, fact_id, decided=accepted.changed
+        )
 
     @app.post("/facts/{fact_id}/reject", response_class=HTMLResponse)
     def reject(request: Request, fact_id: int):
         # Reject runs auto-accept too: removing a fact's support (or freeing a
         # single-valued slot it conflicted on) also reshapes corroboration, so
         # keeping the trigger here matches the other decision routes.
-        return _row_after_decision(request, _active_store().reject_fact(fact_id), fact_id)
+        rejected = _active_store().reject_fact(fact_id)
+        return _row_after_decision(
+            request, rejected.fact, fact_id, decided=rejected.changed
+        )
 
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):


### PR DESCRIPTION
Closes #231, closes #232, closes #257.

리뷰 게이트의 세 구멍을 한 번에 닫는다 — 셋은 같은 계약(사람의 거부는 종착 상태이고, 리뷰 결정은 약속된 후속 효과를 가진다)의 상보적 계층이라 한 PR로 묶었다.

## 무엇을 고치나

**#231 — store 계층** (`9329d42`): `toggle_review`의 이진 else가 superseded를 confirmed로 승격시켰다. 3-tier 명시 분기로 교체: ENGINE({confirmed,accepted})→needs_review, REVIEW({candidate,needs_review})→confirmed, superseded→무변경·무로그.

**#232 — 전이 규칙** (`077f1de`): accept/reject 라우트가 현재 상태를 읽지 않고 무조건 write 했다(오래된 탭/재전송으로 거부 사실 부활). 정책을 store의 원자 메서드 `accept_fact`/`reject_fact`로 내려 `self._lock` 아래 read-then-write로 처리(TOCTOU 차단), 라우트는 얇게 위임:
- accept: REVIEW에서만 → confirmed. confirmed/accepted/superseded는 무변경·무로그.
- reject: superseded 외 전부 → superseded. superseded 재-reject만 무로그 no-op(감사 로그 중복 방지).
- 불변식: **이 라우트들로는 superseded에서 나가는 길이 없다.** (#233/PR #236의 템플릿 버튼 숨김에 대한 서버측 backstop)

**#257 — auto-accept 배선** (`defa4fe`): `_maybe_apply_auto_accept`가 정의만 되고 호출이 없어 auto-accept가 추출 후에만 돌았다. `_row_after_decision` 헬퍼로 toggle/accept/reject/amend에 배선(accept-all은 redirect 경로에서 직접 호출). 지금 액션한 fact 외의 행이 승격된 경우에만 `HX-Refresh: true`로 전체 새로고침을 유도하고, 아니면 기존 단일 행 스왑 유지. 워커 경로는 그대로. reject에도 돌리는 이유: 거부 역시 corroboration 지형을 바꾼다(승격 전용이므로 방금 거부한 사실이 부활할 수는 없음 — recommender가 superseded를 ineligible 처리).

## 검증

- 전체 `pytest`: 926 passed, 7 skipped. `ruff check`: clean.
- 신규 테스트는 `tests/test_review_gate.py` 한 파일에만 추가 — 열린 PR(#209/#229/#236)이 점유한 test_web.py/test_store.py/test_review_actions.py/fact_row.html 무접촉.
- 뮤테이션 검증 5회: 각 가드를 되돌리면 해당 테스트가 red (superseded 토글 가드, accept 가드, reject 중복 로그 가드, auto-accept 배선, HX-Refresh 조건).

## 범위 밖 (후속)

auto-accept는 승격 전용이라 근거를 잃은 accepted 사실의 강등 경로가 없다 — 기존 시맨틱으로, 별도 이슈로 파일링.
