### PR TITLE
fix(#255): make the inference cache reload exception-safe, and stop blaming engine bugs on the policy

### DIFF
--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -46,7 +46,7 @@ def test_cache_reloads_after_a_failed_reload(monkeypatch):
         monkeypatch.setattr(duckdb_backend, "_load_relation_facts", raising_load)
         failed = cache.run_check(_OTHER_FACTS)
         assert failed.ok is False
-        assert failed.findings == [f"ERROR engine error: {boom}"]
+        assert failed.findings == [f"ERROR internal engine error: {boom}"]
 
         # 3) Undo the injection and re-run the SAME conflict facts on the SAME
         #    cache instance. The reload must run again (the base relation was

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Guards for the DuckDB inference cache's fingerprint/relation invariant.
+
+The base `relation` table and its fingerprint must stay in sync even when a
+reload fails partway. If a reload raises after the DELETE, the fingerprint must
+be left invalid so that a later run with the *same* facts reloads instead of
+trusting a now-empty table and reporting a false "consistent" result.
+"""
+
+import pytest
+
+import verinote.engine.duckdb_backend as duckdb_backend
+from verinote.engine.duckdb_backend import DuckDBInferenceCache
+
+# Same subject established on two different dates: the default policy's
+# functional-conflict rule flags this, so a correctly loaded relation yields
+# ok is False. An empty/unloaded relation would silently report ok is True.
+_CONFLICT_FACTS = [
+    {"subject": "Org", "relation": "established_on", "object": "2020"},
+    {"subject": "Org", "relation": "established_on", "object": "2021"},
+]
+_OTHER_FACTS = [{"subject": "Org", "relation": "is_a", "object": "company"}]
+
+
+def _duckdb():
+    return pytest.importorskip("duckdb")
+
+
+def test_cache_reloads_after_a_failed_reload(monkeypatch):
+    _duckdb()
+    cache = DuckDBInferenceCache()
+    try:
+        # 1) Load the conflict facts cleanly: the conflict is detected.
+        first = cache.run_check(_CONFLICT_FACTS)
+        assert first.ok is False
+        assert first.findings == ["ERROR functional_conflict: Org established_on"]
+
+        # 2) Inject a one-shot failure into the reload triggered by different
+        #    facts. The DELETE clears the base relation, then the load raises,
+        #    so the run returns a fail-closed engine error.
+        boom = "injected reload failure"
+
+        def raising_load(con, facts):
+            raise RuntimeError(boom)
+
+        monkeypatch.setattr(duckdb_backend, "_load_relation_facts", raising_load)
+        failed = cache.run_check(_OTHER_FACTS)
+        assert failed.ok is False
+        assert failed.findings == [f"ERROR engine error: {boom}"]
+
+        # 3) Undo the injection and re-run the SAME conflict facts on the SAME
+        #    cache instance. The reload must run again (the base relation was
+        #    emptied by the failed run), so the conflict is detected once more.
+        monkeypatch.undo()
+        again = cache.run_check(_CONFLICT_FACTS)
+        assert again.ok is False
+        assert again.findings == ["ERROR functional_conflict: Org established_on"]
+    finally:
+        cache.close()

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -129,6 +129,10 @@ class DuckDBInferenceCache:
                 self._reset_derived_tables()
                 fingerprint = _relation_fingerprint(fact_rows)
                 if fingerprint != self._relation_fingerprint:
+                    # Invalidate before mutating: if the reload fails partway,
+                    # the stale fingerprint must not let a later run with the
+                    # same facts skip reloading a now-empty/corrupt relation.
+                    self._relation_fingerprint = None
                     con.execute('DELETE FROM "relation"')
                     _load_relation_facts(con, fact_rows)
                     self._relation_fingerprint = fingerprint

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -154,8 +154,10 @@ class DuckDBInferenceCache:
                     policy_dl=policy,
                     query_dl=query_dl,
                 )
-        except Exception as exc:
+        except DuckDBBackendError as exc:
             return _engine_error(str(exc))
+        except Exception as exc:
+            return _internal_engine_error(exc)
 
     def _reset_derived_tables(self) -> None:
         assert self._con is not None
@@ -185,6 +187,24 @@ def _engine_error(message: str, *, engine_available: bool = True) -> CheckReport
         text=f"backend: DuckDB\n\npolicy/engine error: {message}",
         findings=[f"ERROR engine error: {message}"],
         engine_available=engine_available,
+    )
+
+
+def _internal_engine_error(exc: Exception) -> CheckReport:
+    """Fail-closed report for a backend failure that is not a policy fault.
+
+    A `DuckDBBackendError` means the policy/query could not be compiled and is
+    surfaced via `_engine_error`. Any other exception is an internal engine
+    failure, so its message must not read as if the user's policy were at fault.
+    """
+    message = f"internal engine error: {exc}"
+    return CheckReport(
+        ok=False,
+        errors=1,
+        warnings=0,
+        text=f"backend: DuckDB\n\n{message}",
+        findings=[f"ERROR {message}"],
+        engine_available=True,
     )
 
 


### PR DESCRIPTION
Closes #255.

## 무엇을 고치나

`DuckDBInferenceCache.run_check` 의 캐시 재적재가 예외에 원자적이지 않았다: `DELETE FROM "relation"` 후 `_load_relation_facts` 가 던지면 광역 except 가 오류 리포트만 반환하고 `self._relation_fingerprint` 는 옛 값으로 남는다. 이후 **같은** 사실집합으로 재검증하면 fingerprint 일치로 재적재를 건너뛰고, 빈 relation 테이블 위에서 정책이 돌아 "no findings — knowledge base is consistent" 가 나온다 — 검증 게이트의 fail-open. `Store.inference_cache` 가 Store 수명 내내 유지되므로 웹 프로세스에선 재시작 전까지 오염이 지속된다.

**커밋 1 (`0c3ce21`)**: 재적재 분기에서 DELETE 직전 `self._relation_fingerprint = None` 으로 무효화하고, 적재가 완전히 성공한 뒤에만 새 값을 기록. 실패 시 fp=None 이라 다음 run 이 반드시 재적재한다. fingerprint 계산은 DELETE 전에 끝나므로(형상 오류는 앞에서 안전하게 터짐) 무효화가 계산을 방해하지 않는다.

**커밋 2 (`0c93bf2`)**: 같은 블록의 광역 `except Exception` 이 엔진 내부 버그까지 "policy/engine error" 로 사용자 정책 탓으로 표기하던 것을 분리 — 정책 컴파일이 던지는 `DuckDBBackendError` 만 정책 오류로, 나머지는 신규 `_internal_engine_error` ("internal engine error: ...") 로. 두 경로 모두 ok=False fail-closed 유지.

## 검증

- 전체 `pytest`: 919 passed, 7 skipped. `ruff check`: clean.
- 신규 테스트는 `tests/test_inference_cache.py` 한 파일 — 같은 캐시 인스턴스로 3단계(정상 conflict 검출 → 적재 실패 주입 → 같은 사실집합 재검증에서 conflict 재검출)를 재현해 오염 지속 시나리오를 가둔다.
- 뮤테이션 검증: 무효화 라인을 제거하면 3단계가 ok=True("consistent") 로 red — 원버그 정확 재현. except 분리를 되돌리면 라벨 테스트 red.
- PR #253(#167) 점유 영역(`_collect_report`, `tests/test_duckdb_backend.py`) 무접촉 — 머지 순서 무관.
