### PR TITLE
fix(#256): honor llm_timeout_seconds in every adapter instead of only ollama

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -11,7 +11,7 @@ from verinote.llm.factory import get_client
 from verinote.prompts import save_prompt_override
 
 
-def _cfg(tmp_path, *, model: str = "") -> Config:
+def _cfg(tmp_path, *, model: str = "", llm_timeout_seconds: float = 600.0) -> Config:
     return Config(
         root=tmp_path,
         db_path=tmp_path / "kb.sqlite",
@@ -19,6 +19,7 @@ def _cfg(tmp_path, *, model: str = "") -> Config:
         model=model,
         api_key=None,
         base_url=None,
+        llm_timeout_seconds=llm_timeout_seconds,
     )
 
 
@@ -131,6 +132,31 @@ def test_claude_cli_uses_kb_prompt_overrides(tmp_path, monkeypatch):
     assert system.startswith("Custom extraction instructions.")
     assert "Schema contract:" in system
     assert '"facts"' in system
+
+
+# extract_facts drives the schema-constrained `_run` site; answer_question
+# drives the separate `_run_text` site. Both hardcoded timeout=180 before, so
+# each subprocess call site needs its own guard. 1234.0 differs from both the
+# 600.0 default and the old 180 hardcode.
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        lambda a: a.extract_facts(source_text="x"),
+        lambda a: a.answer_question(question="q", context="c"),
+    ],
+)
+def test_claude_cli_applies_configured_timeout(tmp_path, monkeypatch, invoke):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(returncode=0, stdout='{"facts":[]}', stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=1234.0)))
+
+    assert calls[0]["timeout"] == 1234.0
 
 
 def test_claude_cli_prompt_validation_error_is_llm_error(tmp_path):

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -11,7 +11,7 @@ from verinote.llm.openai_adapter import OpenAIAdapter
 from verinote.prompts import save_prompt_override
 
 
-def _cfg(tmp_path, *, provider: str) -> Config:
+def _cfg(tmp_path, *, provider: str, llm_timeout_seconds: float = 600.0) -> Config:
     return Config(
         root=tmp_path,
         db_path=tmp_path / "kb.sqlite",
@@ -19,7 +19,103 @@ def _cfg(tmp_path, *, provider: str) -> Config:
         model="model",
         api_key="key",
         base_url=None,
+        llm_timeout_seconds=llm_timeout_seconds,
     )
+
+
+# A distinctive value that is neither the 600.0 default nor the 180 the CLI
+# adapter used to hardcode, so a passing assertion can only mean the configured
+# timeout actually reached the client.
+_TIMEOUT = 1234.0
+
+_INTENT = {
+    "kind": "unknown_or_unsupported",
+    "subject": None,
+    "relation": None,
+    "object": None,
+    "relation_candidates": None,
+    "operator": None,
+    "value_type": None,
+    "value": None,
+    "reason": "unsupported",
+}
+
+_DATALOG = 'answer_q1(V) :- relation(V, "is_a", "x").'
+
+# One invocation per LLM method; each site constructs its own client, so a
+# single-method test would leave the other three sites unguarded.
+_INVOCATIONS = {
+    "extract_facts": lambda a: a.extract_facts(source_text="x"),
+    "translate_query": lambda a: a.translate_query(question="Who?", qid=1),
+    "extract_query_intent": lambda a: a.extract_query_intent(question="What?"),
+    "answer_question": lambda a: a.answer_question(question="q", context="c"),
+}
+
+
+def _openai_content(method: str) -> str:
+    import json
+
+    return {
+        "extract_facts": '{"facts":[]}',
+        "translate_query": json.dumps({"datalog": _DATALOG}),
+        "extract_query_intent": json.dumps(_INTENT),
+        "answer_question": "ok",
+    }[method]
+
+
+def _anthropic_content(method: str):
+    tool_input = {
+        "extract_facts": {"facts": []},
+        "translate_query": {"datalog": _DATALOG},
+        "extract_query_intent": _INTENT,
+    }
+    if method in tool_input:
+        return [SimpleNamespace(type="tool_use", input=tool_input[method])]
+    return [SimpleNamespace(type="text", text="ok")]
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_openai_adapter_applies_configured_timeout(tmp_path, monkeypatch, method):
+    recorded: dict = {}
+    content = _openai_content(method)
+
+    class _Completions:
+        def create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+            )
+
+    def _factory(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=_factory))
+
+    adapter = OpenAIAdapter(_cfg(tmp_path, provider="openai", llm_timeout_seconds=_TIMEOUT))
+    _INVOCATIONS[method](adapter)
+
+    assert recorded["timeout"] == _TIMEOUT
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_anthropic_adapter_applies_configured_timeout(tmp_path, monkeypatch, method):
+    recorded: dict = {}
+    content = _anthropic_content(method)
+
+    class _Messages:
+        def create(self, **kwargs):
+            return SimpleNamespace(content=content)
+
+    def _factory(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(messages=_Messages())
+
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(Anthropic=_factory))
+
+    adapter = AnthropicAdapter(_cfg(tmp_path, provider="anthropic", llm_timeout_seconds=_TIMEOUT))
+    _INVOCATIONS[method](adapter)
+
+    assert recorded["timeout"] == _TIMEOUT
 
 
 def test_openai_adapter_uses_kb_prompt_override(tmp_path, monkeypatch):

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -22,13 +22,24 @@ class AnthropicAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def _client(self):
+        """Build a client that honours the configured request timeout.
+
+        Every method routes through here so the timeout (and any future
+        client-wide setting) is applied at exactly one site.
+        """
         try:
             import anthropic
         except ImportError as exc:  # pragma: no cover - optional dep
             raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
+        return anthropic.Anthropic(
+            api_key=self.cfg.api_key,
+            base_url=self.cfg.base_url,
+            timeout=self.cfg.llm_timeout_seconds,
+        )
 
-        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        client = self._client()
         tool = {
             "name": "emit_facts",
             "description": "Return the extracted facts.",
@@ -54,12 +65,7 @@ class AnthropicAdapter:
         raise LLMError("anthropic response contained no tool_use block")
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
-        try:
-            import anthropic
-        except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
-
-        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = self._client()
         tool = {
             "name": "emit_query",
             "description": "Return the Datalog query line.",
@@ -86,12 +92,7 @@ class AnthropicAdapter:
         raise LLMError("anthropic response contained no tool_use block")
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
-        try:
-            import anthropic
-        except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
-
-        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = self._client()
         tool = {
             "name": "emit_query_intent",
             "description": "Return the structured query intent.",
@@ -117,12 +118,7 @@ class AnthropicAdapter:
         raise LLMError("anthropic response contained no tool_use block")
 
     def answer_question(self, *, question: str, context: str) -> str:
-        try:
-            import anthropic
-        except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
-
-        client = anthropic.Anthropic(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = self._client()
         try:
             msg = client.messages.create(
                 model=self.cfg.model,

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -43,7 +43,14 @@ class ExtractedFact:
 
 @runtime_checkable
 class LLMClient(Protocol):
-    """Every provider adapter implements this; callers depend only on it."""
+    """Every provider adapter implements this; callers depend only on it.
+
+    Timeout contract: every adapter MUST apply ``cfg.llm_timeout_seconds`` to
+    each outbound call it makes -- the remote HTTP request for the cloud/local
+    SDK adapters, or the subprocess run for the CLI adapter -- so no method can
+    block indefinitely on a stuck provider. A bounded wait is part of the
+    contract, not a per-adapter option.
+    """
 
     name: str
 

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -101,7 +101,7 @@ class ClaudeCliAdapter:
                     cwd=tmpdir,
                     stdin=subprocess.DEVNULL,
                     text=True,
-                    timeout=180,
+                    timeout=self.cfg.llm_timeout_seconds,
                 )
         except FileNotFoundError as exc:
             raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
@@ -136,7 +136,7 @@ class ClaudeCliAdapter:
                     cwd=tmpdir,
                     stdin=subprocess.DEVNULL,
                     text=True,
-                    timeout=180,
+                    timeout=self.cfg.llm_timeout_seconds,
                 )
         except FileNotFoundError as exc:
             raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -22,14 +22,25 @@ class OpenAIAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+    def _client(self):
+        """Build a client that honours the configured request timeout.
+
+        Every method routes through here so the timeout (and any future
+        client-wide setting) is applied at exactly one site. The base_url
+        also makes this work against any OpenAI-compatible endpoint.
+        """
         try:
             from openai import OpenAI
         except ImportError as exc:  # pragma: no cover - optional dep
             raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
+        return OpenAI(
+            api_key=self.cfg.api_key,
+            base_url=self.cfg.base_url,
+            timeout=self.cfg.llm_timeout_seconds,
+        )
 
-        # base_url makes this work against any OpenAI-compatible endpoint too.
-        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        client = self._client()
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
@@ -53,12 +64,7 @@ class OpenAIAdapter:
         return parse_facts(resp.choices[0].message.content or "")
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
-        try:
-            from openai import OpenAI
-        except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
-
-        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = self._client()
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
@@ -85,12 +91,7 @@ class OpenAIAdapter:
         return parse_query(resp.choices[0].message.content or "")
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
-        try:
-            from openai import OpenAI
-        except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
-
-        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = self._client()
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
@@ -119,12 +120,7 @@ class OpenAIAdapter:
         return parse_query_intent(resp.choices[0].message.content or "")
 
     def answer_question(self, *, question: str, context: str) -> str:
-        try:
-            from openai import OpenAI
-        except ImportError as exc:  # pragma: no cover - optional dep
-            raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
-
-        client = OpenAI(api_key=self.cfg.api_key, base_url=self.cfg.base_url)
+        client = self._client()
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,


### PR DESCRIPTION
Closes #256.

## 무엇을 고치나

`Config.llm_timeout_seconds`(`VERINOTE_LLM_TIMEOUT`, 기본 600s)를 존중하는 어댑터가 4개 중 ollama 하나뿐이었다:

- **anthropic / openai**: 4개 메서드(extract_facts / translate_query / extract_query_intent / answer_question)가 각자 client 를 만들면서 전부 timeout 미전달 — SDK 기본값이 조용히 적용. 이슈는 2사이트를 지목했지만 실제로는 **메서드별 중복 생성으로 8사이트**였다.
- **claude_cli**: `subprocess.run(..., timeout=180)` 하드코딩 2곳 — 설정 기본값(600)보다 짧고 올릴 수단이 없었다.

수정 (`a56243a`, atomic 1커밋):

- anthropic/openai 의 중복 client 생성을 어댑터당 `_client()` 헬퍼 하나로 통합하고 거기서 `timeout=self.cfg.llm_timeout_seconds` 적용 — 이번 드리프트의 근본원인(4x 중복 생성자)을 단일 사이트로 봉쇄. ImportError→`LLMError("... SDK not installed ...")` 계약과 api_key/base_url 전달 시맨틱은 그대로.
- claude_cli 두 사이트를 `timeout=self.cfg.llm_timeout_seconds` 로 — **동작 변경: CLI 요청 상한 180s → 설정값(기본 600s)**.
- ollama 는 무접촉 (기존 준수).
- `base.py` `LLMClient` 클래스 docstring 에 timeout 계약 명시: 모든 어댑터는 원격/서브프로세스 호출에 `cfg.llm_timeout_seconds` 를 적용해야 한다.

## 검증

- 전체 `pytest`: 928 passed, 7 skipped. `ruff check`: clean.
- 테스트: cloud 2종 × 4메서드 파라미터라이즈 + claude_cli 2경로 — 구별값 1234.0(기본 600·구 180 과 모두 다름)이 생성자/서브프로세스 kwargs 로 도달하는지 단언.
- 뮤테이션 검증: 각 어댑터의 timeout 을 되돌리면 해당 테스트만 red (사이트별 독립 가드 — 리뷰어·아키텍트가 각각 독립 재현).
- PR #249 점유 영역(schema.py 및 4개 테스트 파일) 무접촉.

## 범위 밖 (후속)

실제 SDK 생성자 계약(mock 아닌)과 전 어댑터 공통 conformance 하니스는 #241 범위 — 해당 이슈에 코멘트로 연결.
