### PR TITLE
fix(#262): warn instead of silently dropping corrupt or non-UTF-8 provider/KB config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from verinote.config import (
     TESTABLE_PROVIDERS,
     active_root,
     app_config_path,
+    read_app_config,
     read_settings,
     save_active_root,
     save_settings,
@@ -137,3 +138,121 @@ def test_ui_config_is_none_without_selected_kb(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     assert Config.load_for_ui() is None
+
+
+def _write_settings_raw(root, text):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text(text, encoding="utf-8")
+
+
+def test_read_settings_missing_file_is_silent(tmp_path, capsys):
+    assert read_settings(tmp_path) == {}
+    assert capsys.readouterr().err == ""
+
+
+def test_read_settings_broken_json_warns_with_path(tmp_path, capsys):
+    _write_settings_raw(tmp_path, "{bad")
+    assert read_settings(tmp_path) == {}
+    err = capsys.readouterr().err
+    assert str(tmp_path / "config.json") in err
+    assert "not valid JSON" in err
+    assert "provider and model" in err
+
+
+def test_read_settings_invalid_utf8_warns(tmp_path, capsys):
+    (tmp_path / "config.json").write_bytes(b"\xff\xfe\x00bad")
+    assert read_settings(tmp_path) == {}
+    err = capsys.readouterr().err
+    assert str(tmp_path / "config.json") in err
+    assert "could not decode" in err
+
+
+def test_read_settings_non_dict_json_warns(tmp_path, capsys):
+    _write_settings_raw(tmp_path, "[]")
+    assert read_settings(tmp_path) == {}
+    err = capsys.readouterr().err
+    assert str(tmp_path / "config.json") in err
+    assert "not a JSON object" in err
+
+
+def test_read_settings_oserror_warns(tmp_path, monkeypatch, capsys):
+    from pathlib import Path
+
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+
+    def _boom(self, *args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    assert read_settings(tmp_path) == {}
+    err = capsys.readouterr().err
+    assert "could not read" in err
+    assert str(tmp_path / "config.json") in err
+
+
+def test_read_app_config_missing_file_is_silent(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    assert read_app_config() == {}
+    assert capsys.readouterr().err == ""
+
+
+def test_read_app_config_broken_json_warns(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    path = app_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{bad", encoding="utf-8")
+    assert read_app_config() == {}
+    err = capsys.readouterr().err
+    assert str(path) in err
+    assert "not valid JSON" in err
+    assert "active KB" in err
+
+
+def test_read_app_config_invalid_utf8_warns(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    path = app_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe\x00bad")
+    assert read_app_config() == {}
+    err = capsys.readouterr().err
+    assert str(path) in err
+    assert "could not decode" in err
+
+
+def test_read_app_config_non_dict_json_warns(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    path = app_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[]", encoding="utf-8")
+    assert read_app_config() == {}
+    err = capsys.readouterr().err
+    assert str(path) in err
+    assert "not a JSON object" in err
+
+
+def test_read_app_config_oserror_warns(tmp_path, monkeypatch, capsys):
+    from pathlib import Path
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    path = app_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}", encoding="utf-8")
+
+    def _boom(self, *args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    assert read_app_config() == {}
+    err = capsys.readouterr().err
+    assert "could not read" in err
+    assert str(path) in err

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -101,15 +101,45 @@ def app_config_path() -> Path:
     return app_config_dir() / APP_CONFIG_FILENAME
 
 
+def _warn_bad_config(path: Path, error: Exception | None, consequence: str) -> None:
+    """Warn on stderr that a config file is unreadable and is being ignored.
+
+    Absence is silent (a missing file is normal); this is only for a file that
+    exists but cannot be used, so a silent fallback to defaults does not hide a
+    real corruption from the user. `error` is the raised exception, or None for
+    a well-formed JSON value that simply is not an object.
+    """
+    if isinstance(error, OSError):
+        reason = f"could not read {path}: {error}"
+    elif isinstance(error, UnicodeDecodeError):
+        reason = f"could not decode {path} as UTF-8; ignoring it"
+    elif isinstance(error, json.JSONDecodeError):
+        reason = f"{path} is not valid JSON; ignoring it"
+    else:
+        reason = f"{path} is not a JSON object; ignoring it"
+    print(f"warning: {reason}; {consequence}", file=sys.stderr)
+
+
 def read_app_config() -> dict:
     path = app_config_path()
     if not path.is_file():
         return {}
+    consequence = "the saved active KB will be ignored"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except OSError as err:
+        _warn_bad_config(path, err, consequence)
         return {}
-    return data if isinstance(data, dict) else {}
+    except UnicodeDecodeError as err:
+        _warn_bad_config(path, err, consequence)
+        return {}
+    except json.JSONDecodeError as err:
+        _warn_bad_config(path, err, consequence)
+        return {}
+    if not isinstance(data, dict):
+        _warn_bad_config(path, None, consequence)
+        return {}
+    return data
 
 
 def save_active_root(root: Path) -> None:
@@ -149,11 +179,22 @@ def read_settings(root: Path) -> dict:
     path = _settings_path(root)
     if not path.is_file():
         return {}
+    consequence = "provider and model will fall back to defaults"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except OSError as err:
+        _warn_bad_config(path, err, consequence)
         return {}
-    return data if isinstance(data, dict) else {}
+    except UnicodeDecodeError as err:
+        _warn_bad_config(path, err, consequence)
+        return {}
+    except json.JSONDecodeError as err:
+        _warn_bad_config(path, err, consequence)
+        return {}
+    if not isinstance(data, dict):
+        _warn_bad_config(path, None, consequence)
+        return {}
+    return data
 
 
 def save_settings(


### PR DESCRIPTION
Closes #262

## What

`read_settings` and `read_app_config` now distinguish an **absent** config file (kept silent — a missing file is normal) from a **corrupt** one. On corruption they emit a warning to stderr naming the offending file path, then return `{}` as before.

A private `_warn_bad_config(path, error, consequence)` helper classifies four cases:

- `OSError` → `could not read <path>: <err>`
- `UnicodeDecodeError` → `could not decode <path> as UTF-8; ignoring it`
- `json.JSONDecodeError` → `<path> is not valid JSON; ignoring it`
- non-dict payload → `<path> is not a JSON object; ignoring it`

`read_settings` appends that provider/model will fall back to defaults (the dangerous silent cloud-switch path); `read_app_config` appends that the saved active KB is being ignored.

## Why a warning and not a hard raise

`read_settings` feeds `Config.for_root`, which is called from `web/app.py:272` and `web/app.py:1211` **outside any exception guard**. Raising there would surface as an unhandled traceback to web users. So the control flow is unchanged (still returns `{}`); we only add the warning.

The issue's "promote to an explicit error" option requires the web call sites to surface the condition first, so that is split into a follow-up: #269.

## Incidental fix

`UnicodeDecodeError` is **not** an `OSError` subclass, so the previous `except (OSError, json.JSONDecodeError)` tuple let it escape — a config file with invalid UTF-8 bytes crashed with a raw traceback. This PR closes that latent bug too, with a dedicated `except UnicodeDecodeError` clause in both readers.

## Verification

- `pytest tests -q` → **945 passed**; config module alone → 22 passed
- `ruff check verinote/config.py tests/test_config.py` → clean
- Mutation check: removing the warning (and separately the `except UnicodeDecodeError` clauses) turns the new tests red — including a raw `UnicodeDecodeError` traceback reproducing the reported crash — then restored to green
- Change surface is exactly `verinote/config.py` + `tests/test_config.py`
- `git merge-tree` shows no conflict against the 11 open PRs or the parallel lanes (#185 PR #267, #241)
