### PR TITLE
test(#241): add opt-in provider contract tests guarding #237/#238/#239

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ packages = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = ["-ra"]
+markers = ["contract: opt-in tests that call a real LLM provider (issue #241)"]
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ packages = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["-ra"]
 markers = ["contract: opt-in tests that call a real LLM provider (issue #241)"]
 
 [tool.ruff]

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -29,11 +29,16 @@ Two rules keep a green run from meaning nothing:
 * **Asked for but all skipped ⇒ the session fails.** If a run asks for these
   guards and not one of them executes, `pytest_sessionfinish` in `conftest.py`
   turns it red. A fully-skipped opt-in run is a silent no-op, not a pass.
-  Asking means either spelling: `-m contract`, **or** naming a path in this
-  directory (`pytest tests/contract`). The default suite asks for neither —
+  Asking means any of the spellings pytest offers: `-m contract`, `-k contract`,
+  or naming a path in this directory (`pytest tests/contract`, including
+  `--pyargs tests.contract`). The default suite asks in none of those ways —
   `pytest` and `pytest tests` both target `tests`, a parent of this directory —
-  so it is unaffected and the guards keep self-skipping there. `--collect-only`
-  is exempt, since not running tests is what it was asked to do.
+  so it is unaffected and the guards keep self-skipping there.
+
+  Asking is not the same as failing: a run that *excludes* the guards on purpose
+  (`pytest tests/contract -k meta`, `-m "not contract"`, `--deselect`) is silent,
+  because the count is taken after deselection. `--collect-only` is exempt too,
+  since not running tests is what it was asked to do.
 * **A set gate pointing at an unreachable provider ⇒ fail, not skip** (issue
   #234). A provider you asked to exercise but that cannot run is a real gap.
 

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -9,64 +9,54 @@ or that the deterministic suite would otherwise paper over:
 | `test_query_intent_contract.py` | #237 | A role question the deterministic parser hands off must yield a valid intent through the live provider and the production parse boundary. |
 | `test_extraction_contract.py` | #238 | A founding-date fact the extractor produces must normalise into the policy's *functional* relation vocabulary, so a two-date contradiction is catchable. |
 | `test_sync_rc_contract.py` | #239 | `verinote sync` must not report success when every extraction chunk fails. |
-| `test_contract_meta.py` | — | Meta guards on the harness itself (marker registered, fixtures carry provenance, every module has a guard). Runs in the default suite. |
+| `test_contract_meta.py` | — | Meta guards on the harness itself (marker registered, fixtures carry provenance, every module has a guard, the skipped-run guard bites). Runs in the default suite. |
 
 ## Running
 
 The guards are **opt-in**. They self-skip unless you name a provider, so the
 default `pytest tests` stays green (only the meta tests and the deterministic
-positive controls run there):
+positive controls run there). Any invocation path works:
 
 ```bash
-# opt-in run — must target tests/contract (see "Why target tests/contract")
-VERINOTE_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
-# or directly:
-VERINOTE_CONTRACT_PROVIDER=claudecli python -m pytest tests/contract -m contract -rs
+VN_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
+# or, equivalently:
+VN_CONTRACT_PROVIDER=claudecli python -m pytest tests/contract -m contract -rs
+VN_CONTRACT_PROVIDER=claudecli python -m pytest -m contract -rs
 ```
 
-`run.sh` additionally **fails** if every collected contract test skipped — a
-fully-skipped opt-in run is a silent no-op, not a pass.
+Two rules keep a green run from meaning nothing:
 
-A gate that is *set* but points at an unreachable provider (e.g. the `claude`
-binary is missing) makes the tests **fail, not skip** (issue #234): a provider
-you asked to exercise but that cannot run is a real gap in coverage.
-
-### Why target `tests/contract`
-
-The root `tests/conftest.py` strips every `VERINOTE_*` variable at session start.
-`tests/contract/conftest.py` snapshots `VERINOTE_CONTRACT_PROVIDER` at import
-time to beat that strip — which works when this directory is on pytest's direct
-invocation path (`pytest tests/contract ...`). Discovering the whole tree from a
-parent (`pytest tests`) loads this conftest only mid-collection, after the strip,
-so the gate reads as unset and the guards skip. Always opt in by targeting
-`tests/contract`.
-
-This is a limitation of capturing the gate from a subdirectory conftest, not a
-design choice: the root strip cannot be seen from here in time. Revisit if the
-root `tests/conftest.py` sandbox is reworked to preserve `VERINOTE_CONTRACT_*`
-(or to snapshot the gate itself), at which point the gate could be honored from
-any invocation path and this caveat dropped.
+* **Selected but all skipped ⇒ the session fails.** Whenever `-m` names the
+  `contract` marker and not one selected test executes, `pytest_sessionfinish`
+  in `conftest.py` turns the run red. A fully-skipped opt-in run is a silent
+  no-op, not a pass. The default suite passes no `-m`, so it is unaffected.
+* **A set gate pointing at an unreachable provider ⇒ fail, not skip** (issue
+  #234). A provider you asked to exercise but that cannot run is a real gap.
 
 ## Providers
 
-`VERINOTE_CONTRACT_PROVIDER` selects the adapter. Optional companions:
+`VN_CONTRACT_PROVIDER` selects the adapter. Optional companions:
 
 | Variable | Used by | Default |
 |----------|---------|---------|
-| `VERINOTE_CONTRACT_PROVIDER` | gate + client | (unset ⇒ skip) |
-| `VERINOTE_CONTRACT_MODEL` | ollama / openai / anthropic | provider default |
-| `VERINOTE_CONTRACT_BASE_URL` | ollama | `http://localhost:11434` |
-| `VERINOTE_CONTRACT_API_KEY` | openai / anthropic | (unset ⇒ fail) |
+| `VN_CONTRACT_PROVIDER` | gate + client | (unset ⇒ skip) |
+| `VN_CONTRACT_MODEL` | all providers | provider default |
+| `VN_CONTRACT_BASE_URL` | ollama | `http://localhost:11434` |
+| `VN_CONTRACT_API_KEY` | openai / anthropic | (unset ⇒ fail) |
 
-These use a `VERINOTE_CONTRACT_*` namespace (not `VERINOTE_*`) precisely so the
-root sandbox does not strip them.
+The `VN_` prefix is load-bearing. The root `tests/conftest.py` sandbox drops
+every `VERINOTE_*` variable at session start so an ambient export cannot change
+what a test sees. A gate under that prefix would be erased before any fixture
+could read it — which is why these live outside it and are simply read at
+fixture time, from any invocation path, with no snapshot and no ordering race
+(issue #272).
 
 ```bash
-VERINOTE_CONTRACT_PROVIDER=ollama VERINOTE_CONTRACT_MODEL=qwen3:8b \
+VN_CONTRACT_PROVIDER=ollama VN_CONTRACT_MODEL=qwen3:8b \
     python -m pytest tests/contract -m contract -rs
 
-VERINOTE_CONTRACT_PROVIDER=openai VERINOTE_CONTRACT_MODEL=gpt-4o \
-    VERINOTE_CONTRACT_API_KEY=sk-... python -m pytest tests/contract -m contract -rs
+VN_CONTRACT_PROVIDER=openai VN_CONTRACT_MODEL=gpt-4o \
+    VN_CONTRACT_API_KEY=sk-... python -m pytest tests/contract -m contract -rs
 ```
 
 ## Replay fixtures
@@ -80,11 +70,11 @@ provider — while still gated opt-in so the default suite stays green.
 Recapture (needs a live provider) with:
 
 ```bash
-VERINOTE_CONTRACT_PROVIDER=claudecli PYTHONPATH=$PWD \
+VN_CONTRACT_PROVIDER=claudecli PYTHONPATH=$PWD \
     python tests/contract/capture.py
 ```
 
 `capture.py` currently drives `claudecli`. To capture from another provider,
 point its config at that adapter in `_live_config()` and supply the matching
-`VERINOTE_CONTRACT_*` credentials; the `#239` fixture is provider-free and is
+`VN_CONTRACT_*` credentials; the `#239` fixture is provider-free and is
 regenerated from the real pipeline on every run.

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -1,0 +1,90 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+# Provider contract tests (issue #241)
+
+These tests exercise failures that only surface against a **real LLM provider**,
+or that the deterministic suite would otherwise paper over:
+
+| Guard | Issue | What it locks |
+|-------|-------|---------------|
+| `test_query_intent_contract.py` | #237 | A role question the deterministic parser hands off must yield a valid intent through the live provider and the production parse boundary. |
+| `test_extraction_contract.py` | #238 | A founding-date fact the extractor produces must normalise into the policy's *functional* relation vocabulary, so a two-date contradiction is catchable. |
+| `test_sync_rc_contract.py` | #239 | `verinote sync` must not report success when every extraction chunk fails. |
+| `test_contract_meta.py` | — | Meta guards on the harness itself (marker registered, fixtures carry provenance, every module has a guard). Runs in the default suite. |
+
+## Running
+
+The guards are **opt-in**. They self-skip unless you name a provider, so the
+default `pytest tests` stays green (only the meta tests and the deterministic
+positive controls run there):
+
+```bash
+# opt-in run — must target tests/contract (see "Why target tests/contract")
+VERINOTE_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
+# or directly:
+VERINOTE_CONTRACT_PROVIDER=claudecli python -m pytest tests/contract -m contract -rs
+```
+
+`run.sh` additionally **fails** if every collected contract test skipped — a
+fully-skipped opt-in run is a silent no-op, not a pass.
+
+A gate that is *set* but points at an unreachable provider (e.g. the `claude`
+binary is missing) makes the tests **fail, not skip** (issue #234): a provider
+you asked to exercise but that cannot run is a real gap in coverage.
+
+### Why target `tests/contract`
+
+The root `tests/conftest.py` strips every `VERINOTE_*` variable at session start.
+`tests/contract/conftest.py` snapshots `VERINOTE_CONTRACT_PROVIDER` at import
+time to beat that strip — which works when this directory is on pytest's direct
+invocation path (`pytest tests/contract ...`). Discovering the whole tree from a
+parent (`pytest tests`) loads this conftest only mid-collection, after the strip,
+so the gate reads as unset and the guards skip. Always opt in by targeting
+`tests/contract`.
+
+This is a limitation of capturing the gate from a subdirectory conftest, not a
+design choice: the root strip cannot be seen from here in time. Revisit if the
+root `tests/conftest.py` sandbox is reworked to preserve `VERINOTE_CONTRACT_*`
+(or to snapshot the gate itself), at which point the gate could be honored from
+any invocation path and this caveat dropped.
+
+## Providers
+
+`VERINOTE_CONTRACT_PROVIDER` selects the adapter. Optional companions:
+
+| Variable | Used by | Default |
+|----------|---------|---------|
+| `VERINOTE_CONTRACT_PROVIDER` | gate + client | (unset ⇒ skip) |
+| `VERINOTE_CONTRACT_MODEL` | ollama / openai / anthropic | provider default |
+| `VERINOTE_CONTRACT_BASE_URL` | ollama | `http://localhost:11434` |
+| `VERINOTE_CONTRACT_API_KEY` | openai / anthropic | (unset ⇒ fail) |
+
+These use a `VERINOTE_CONTRACT_*` namespace (not `VERINOTE_*`) precisely so the
+root sandbox does not strip them.
+
+```bash
+VERINOTE_CONTRACT_PROVIDER=ollama VERINOTE_CONTRACT_MODEL=qwen3:8b \
+    python -m pytest tests/contract -m contract -rs
+
+VERINOTE_CONTRACT_PROVIDER=openai VERINOTE_CONTRACT_MODEL=gpt-4o \
+    VERINOTE_CONTRACT_API_KEY=sk-... python -m pytest tests/contract -m contract -rs
+```
+
+## Replay fixtures
+
+`tests/fixtures/contract/*.json` hold **pre-parse** provider responses captured
+from a real provider (`captured_at` records when). The replay tests feed the raw
+string back through the production parse boundary (`parse_query_intent` /
+`parse_facts`), so they reproduce a captured failure deterministically without a
+provider — while still gated opt-in so the default suite stays green.
+
+Recapture (needs a live provider) with:
+
+```bash
+VERINOTE_CONTRACT_PROVIDER=claudecli PYTHONPATH=$PWD \
+    python tests/contract/capture.py
+```
+
+`capture.py` currently drives `claudecli`. To capture from another provider,
+point its config at that adapter in `_live_config()` and supply the matching
+`VERINOTE_CONTRACT_*` credentials; the `#239` fixture is provider-free and is
+regenerated from the real pipeline on every run.

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -20,8 +20,16 @@ positive controls run there). Any invocation path works:
 ```bash
 VN_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
 # or, equivalently:
-VN_CONTRACT_PROVIDER=claudecli python -m pytest tests/contract -m contract -rs
-VN_CONTRACT_PROVIDER=claudecli python -m pytest -m contract -rs
+VN_CONTRACT_PROVIDER=claudecli python3 -m pytest tests/contract -m contract -rs
+VN_CONTRACT_PROVIDER=claudecli python3 -m pytest -m contract -rs
+```
+
+`run.sh` picks `python3`, then `python`. Point it at a specific interpreter with
+`PYTHON` when the one it would find is not the one holding pytest and verinote's
+dependencies — a checkout whose virtualenv lives elsewhere, for instance:
+
+```bash
+PYTHON=/path/to/.venv/bin/python VN_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
 ```
 
 Two rules keep a green run from meaning nothing:

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -26,10 +26,14 @@ VN_CONTRACT_PROVIDER=claudecli python -m pytest -m contract -rs
 
 Two rules keep a green run from meaning nothing:
 
-* **Selected but all skipped ⇒ the session fails.** Whenever `-m` names the
-  `contract` marker and not one selected test executes, `pytest_sessionfinish`
-  in `conftest.py` turns the run red. A fully-skipped opt-in run is a silent
-  no-op, not a pass. The default suite passes no `-m`, so it is unaffected.
+* **Asked for but all skipped ⇒ the session fails.** If a run asks for these
+  guards and not one of them executes, `pytest_sessionfinish` in `conftest.py`
+  turns it red. A fully-skipped opt-in run is a silent no-op, not a pass.
+  Asking means either spelling: `-m contract`, **or** naming a path in this
+  directory (`pytest tests/contract`). The default suite asks for neither —
+  `pytest` and `pytest tests` both target `tests`, a parent of this directory —
+  so it is unaffected and the guards keep self-skipping there. `--collect-only`
+  is exempt, since not running tests is what it was asked to do.
 * **A set gate pointing at an unreachable provider ⇒ fail, not skip** (issue
   #234). A provider you asked to exercise but that cannot run is a real gap.
 

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Marks tests/contract as a package.
+
+Without this, pytest (prepend import mode) would put this directory on
+``sys.path`` and import ``conftest.py`` here under the bare name ``conftest`` —
+shadowing the root ``tests/conftest.py`` that ``tests/test_env_isolation.py``
+imports directly. The package marker gives this conftest the dotted name
+``contract.conftest`` instead, so the two never collide. ``tests/`` itself stays
+unpackaged so ``import conftest`` / ``import env_sandbox`` keep resolving there.
+"""

--- a/tests/contract/capture.py
+++ b/tests/contract/capture.py
@@ -3,7 +3,7 @@
 
 Run against a live provider, e.g. the local Claude Code CLI::
 
-    VERINOTE_CONTRACT_PROVIDER=claudecli PYTHONPATH=$PWD \
+    VN_CONTRACT_PROVIDER=claudecli PYTHONPATH=$PWD \
         .venv/bin/python tests/contract/capture.py
 
 For #237 and #238 this records the provider's *pre-parse* raw response — the
@@ -51,10 +51,10 @@ EXTRACTION_SOURCE = (
 
 
 def _live_config() -> Config:
-    provider = os.environ.get("VERINOTE_CONTRACT_PROVIDER")
+    provider = os.environ.get("VN_CONTRACT_PROVIDER")
     if provider not in (None, "claudecli"):
         raise SystemExit(
-            f"capture.py currently drives claudecli; got VERINOTE_CONTRACT_PROVIDER={provider!r}. "
+            f"capture.py currently drives claudecli; got VN_CONTRACT_PROVIDER={provider!r}. "
             "See README.md for other providers."
         )
     root = Path(tempfile.mkdtemp(prefix="verinote-capture-"))

--- a/tests/contract/capture.py
+++ b/tests/contract/capture.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Capture real provider responses into replay fixtures for the #241 contract tests.
+
+Run against a live provider, e.g. the local Claude Code CLI::
+
+    VERINOTE_CONTRACT_PROVIDER=claudecli PYTHONPATH=$PWD \
+        .venv/bin/python tests/contract/capture.py
+
+For #237 and #238 this records the provider's *pre-parse* raw response — the
+string the adapter hands to ``parse_query_intent`` / ``parse_facts`` — so the
+replay tests exercise the same production parse boundary the live call does. It
+grabs that string by wrapping the parser the adapter imported, which also lets
+the capture succeed even when the raw response fails to parse (exactly the
+failure shape #237/#238 are about).
+
+For #239 no provider is needed: the failure reason is produced deterministically
+by running the real chunked extraction pipeline with a stub client that raises
+on every chunk, then reading the reason the store recorded — a genuine pipeline
+artifact, not a hand-written string.
+
+See ``README.md`` for the ollama/openai/anthropic capture procedure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+
+import verinote.llm.claude_cli_adapter as claude_cli_adapter
+from verinote.config import Config
+from verinote.llm.base import ExtractedFact, LLMError
+
+CAPTURED_AT = "2026-07-16"
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "contract"
+
+# #237: a role question the deterministic parser deliberately does not resolve,
+# so the live provider is the only thing that can produce an intent for it.
+QUERY_INTENT_QUESTION = "Who is the CEO of Acme Robotics?"
+
+# #238: a source that states two different founding dates for one entity. A
+# correct extraction yields a founding-date fact whose relation normalises into
+# the policy's functional vocabulary, which then trips the functional-conflict
+# check on the two dates.
+EXTRACTION_SOURCE = (
+    "Acme Robotics is a company. Acme Robotics was founded in 2020 according to "
+    "its incorporation filing. A later press release states that Acme Robotics "
+    "was established in 2021."
+)
+
+
+def _live_config() -> Config:
+    provider = os.environ.get("VERINOTE_CONTRACT_PROVIDER")
+    if provider not in (None, "claudecli"):
+        raise SystemExit(
+            f"capture.py currently drives claudecli; got VERINOTE_CONTRACT_PROVIDER={provider!r}. "
+            "See README.md for other providers."
+        )
+    root = Path(tempfile.mkdtemp(prefix="verinote-capture-"))
+    return Config(
+        root=root,
+        db_path=root / "kb.sqlite",
+        provider="claudecli",
+        model="sonnet",
+        api_key=None,
+        base_url=None,
+        llm_timeout_seconds=180.0,
+    )
+
+
+def _write(name: str, payload: dict) -> None:
+    FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    path = FIXTURES_DIR / name
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {path.relative_to(FIXTURES_DIR.parent.parent)}")
+
+
+def _capture_raw(monkey_attr: str):
+    """Wrap the parser the adapter imported so we keep the raw arg it is handed."""
+    original = getattr(claude_cli_adapter, monkey_attr)
+    box: dict[str, object] = {}
+
+    def wrapper(raw, *args, **kwargs):
+        box["raw"] = raw
+        return original(raw, *args, **kwargs)
+
+    setattr(claude_cli_adapter, monkey_attr, wrapper)
+    return original, box
+
+
+def capture_query_intent(cfg: Config) -> None:
+    client = claude_cli_adapter.ClaudeCliAdapter(cfg)
+    original, box = _capture_raw("parse_query_intent")
+    parse_error = None
+    try:
+        client.extract_query_intent(question=QUERY_INTENT_QUESTION)
+    except LLMError as exc:
+        parse_error = str(exc)
+    finally:
+        claude_cli_adapter.parse_query_intent = original
+    if "raw" not in box:
+        raise SystemExit("query-intent capture never reached the parse boundary")
+    _write(
+        "query_intent_acme_ceo.json",
+        {
+            "provider": cfg.provider,
+            "model": cfg.model,
+            "prompt_id": "query-intent",
+            "captured_at": CAPTURED_AT,
+            "input": QUERY_INTENT_QUESTION,
+            "raw_response": box["raw"],
+            "parse_error": parse_error,
+        },
+    )
+
+
+def capture_extraction(cfg: Config) -> None:
+    client = claude_cli_adapter.ClaudeCliAdapter(cfg)
+    original, box = _capture_raw("parse_facts")
+    parse_error = None
+    try:
+        client.extract_facts(source_text=EXTRACTION_SOURCE)
+    except LLMError as exc:
+        parse_error = str(exc)
+    finally:
+        claude_cli_adapter.parse_facts = original
+    if "raw" not in box:
+        raise SystemExit("extraction capture never reached the parse boundary")
+    _write(
+        "extraction_acme_two_dates.json",
+        {
+            "provider": cfg.provider,
+            "model": cfg.model,
+            "prompt_id": "extraction",
+            "captured_at": CAPTURED_AT,
+            "input": EXTRACTION_SOURCE,
+            "raw_response": box["raw"],
+            "parse_error": parse_error,
+        },
+    )
+
+
+class _AlwaysFailsClient:
+    """A stub `LLMClient` that raises `LLMError` on every extraction chunk."""
+
+    name = "always-fails"
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        raise LLMError("provider refused chunk: synthetic outage for #239 capture")
+
+
+def capture_sync_failure() -> None:
+    """Record the reason the chunked pipeline persists when every chunk fails.
+
+    Deterministic and provider-free: it drives the real chunked extraction job,
+    then reads back the failure reason the store recorded on the chunk.
+    """
+    from verinote.pipeline import create_chunked_extraction_job, process_extraction_job
+    from verinote.store import Store
+
+    root = Path(tempfile.mkdtemp(prefix="verinote-sync-capture-"))
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    source_id = store.add_source("sources/acme.txt", kind="text")
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        artifact_id=None,
+        source_text=EXTRACTION_SOURCE,
+        provider="always-fails",
+        model="none",
+        chunk_chars=40,
+        chunk_overlap_chars=0,
+    )
+    process_extraction_job(store, _AlwaysFailsClient(), job_id=job_id)
+    detail = store.get_extraction_job_detail(job_id)
+    reasons = [
+        row["error"]
+        for row in store._conn.execute(  # noqa: SLF001 - capture script reads recorded reasons
+            "SELECT error FROM source_chunks WHERE job_id = ? AND status = 'failed'",
+            (job_id,),
+        )
+        if row["error"]
+    ]
+    store.close()
+    if not reasons:
+        raise SystemExit("sync-failure capture recorded no chunk failure reason")
+    _write(
+        "sync_all_chunks_failed.json",
+        {
+            "provider": "always-fails",
+            "model": "none",
+            "prompt_id": "sync-extraction",
+            "captured_at": CAPTURED_AT,
+            "input": EXTRACTION_SOURCE,
+            "completed_chunks": int(detail["completed_chunks"]),
+            "failed_chunks": int(detail["failed_chunks"]),
+            "failure_reason": reasons[0],
+        },
+    )
+
+
+def main() -> None:
+    capture_sync_failure()
+    cfg = _live_config()
+    capture_query_intent(cfg)
+    capture_extraction(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Opt-in gate and provider wiring for the issue #241 provider contract tests.
+
+These tests exist to catch failures that *only* show up against a real LLM
+provider (issues #237/#238) or that the deterministic suite would otherwise
+paper over (issue #239). The root `tests/conftest.py` autouse sandbox strips
+every ``VERINOTE_*`` variable before any test runs, so the opt-in signal cannot
+be read from the environment at test time. It is snapshotted at *this module's
+import time* (see ``_contract_provider`` below) — the earliest point available,
+before the sandbox's ``pytest_configure`` seals the environment on the direct
+opt-in path — with ``pytest_configure`` here as a fallback. Both are exposed
+through :func:`contract_provider`.
+
+Two gates share that snapshot:
+
+* :func:`require_live_provider` gates the tests that actually call the provider.
+  When the gate is unset it *skips* (opt-in). When the gate is set but the
+  provider is unreachable (e.g. the ``claude`` binary is missing) it *fails*,
+  never skips — a provider you asked to exercise but that cannot run is a real
+  failure, not an absence of coverage (issue #234).
+* :func:`require_opt_in` gates the deterministic contract tests (replay and the
+  sync exit-code guard). They need no live provider but must still stay out of
+  the default suite, so they skip on the same unset gate.
+
+Contract tests build their own :class:`~verinote.config.Config` directly rather
+than through the environment, mirroring ``tests/test_ollama_adapter.py``'s
+``_cfg`` helper, so the stripped environment does not starve them of a provider.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from verinote.config import Config
+from verinote.llm import get_client
+from verinote.llm.base import LLMClient
+
+GATE_VAR = "VERINOTE_CONTRACT_PROVIDER"
+GATE_HINT = f"set {GATE_VAR}=claudecli|ollama|... to run (issue #241)"
+
+# Snapshot of the opt-in gate, taken as early as possible so the root sandbox's
+# ``VERINOTE_*`` strip cannot erase it before a test reads it.
+#
+# The strip lives in the root ``tests/conftest.py``'s ``pytest_configure`` and
+# deletes the variable from ``os.environ`` for the whole session. Capturing it
+# here at *conftest import time* wins the race: when this file is on the direct
+# invocation path (``pytest tests/contract ...`` — the documented opt-in run, and
+# what this repo's #241 validation uses), pytest imports every conftest at
+# startup *before* any ``pytest_configure`` fires, so the gate is still present.
+# ``pytest_configure`` below is a fallback for the same reason (it runs before
+# collection when this conftest is loaded early). Neither can see the gate if the
+# suite is discovered from a parent directory that loads this conftest only
+# mid-collection, after the strip — hence opt-in runs must target ``tests/contract``.
+_contract_provider: str | None = os.environ.get(GATE_VAR)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Fallback capture of the opt-in gate, in case import ran before this file.
+
+    Import-time capture above is the primary path; this only fills the snapshot
+    if it is still unset and the ambient variable survives to configure time.
+    """
+    global _contract_provider
+    if _contract_provider is None:
+        _contract_provider = os.environ.get(GATE_VAR)
+
+
+def contract_provider() -> str | None:
+    """The opt-in provider id the run was launched with, or ``None`` if unset."""
+    return _contract_provider
+
+
+def _config_for(provider: str, root) -> Config:
+    """Build a Config for `provider` without reading the (stripped) environment."""
+    root.mkdir(parents=True, exist_ok=True)
+    if provider == "claudecli":
+        return Config(
+            root=root,
+            db_path=root / "kb.sqlite",
+            provider="claudecli",
+            model="sonnet",
+            api_key=None,
+            base_url=None,
+            llm_timeout_seconds=180.0,
+        )
+    if provider == "ollama":
+        return Config(
+            root=root,
+            db_path=root / "kb.sqlite",
+            provider="ollama",
+            model=os.environ.get("VERINOTE_CONTRACT_MODEL", "llama3.1"),
+            api_key=None,
+            base_url=os.environ.get("VERINOTE_CONTRACT_BASE_URL", "http://localhost:11434"),
+            llm_timeout_seconds=180.0,
+        )
+    if provider in ("anthropic", "openai"):
+        return Config(
+            root=root,
+            db_path=root / "kb.sqlite",
+            provider=provider,
+            model=os.environ.get("VERINOTE_CONTRACT_MODEL", "")
+            or ("claude-opus-4-8" if provider == "anthropic" else "gpt-4o"),
+            api_key=os.environ.get("VERINOTE_CONTRACT_API_KEY"),
+            base_url=None,
+            llm_timeout_seconds=180.0,
+        )
+    pytest.fail(f"{GATE_VAR}={provider!r} is not a known provider (expected claudecli|ollama|anthropic|openai)")
+
+
+def _assert_provider_available(provider: str, cfg: Config) -> None:
+    """Fail (never skip) when the requested provider cannot actually be reached.
+
+    Skipping here would let a broken provider masquerade as "no coverage" — the
+    exact hole issue #234 closes. The gate was set on purpose, so an unreachable
+    provider is a hard failure.
+    """
+    if provider == "claudecli":
+        if shutil.which("claude") is None:
+            pytest.fail(
+                f"{GATE_VAR}=claudecli but the `claude` binary is not on PATH; "
+                "install Claude Code (a set gate must fail, not skip — issue #234)"
+            )
+        return
+    if provider in ("anthropic", "openai"):
+        if not cfg.api_key:
+            pytest.fail(
+                f"{GATE_VAR}={provider} but no API key was provided; "
+                "set VERINOTE_CONTRACT_API_KEY (a set gate must fail, not skip — issue #234)"
+            )
+        return
+    # ollama and any other reachable-over-network provider: leave reachability to
+    # the first live call, which raises LLMError the guards already assert on.
+
+
+@pytest.fixture
+def require_opt_in() -> str:
+    """Skip unless the opt-in gate is set. For deterministic contract tests."""
+    provider = contract_provider()
+    if not provider:
+        pytest.skip(GATE_HINT)
+    return provider
+
+
+@pytest.fixture
+def contract_client(tmp_path) -> LLMClient:
+    """A live `LLMClient` for the opt-in provider, or skip when the gate is unset."""
+    provider = contract_provider()
+    if not provider:
+        pytest.skip(GATE_HINT)
+    cfg = _config_for(provider, tmp_path / "kb")
+    _assert_provider_available(provider, cfg)
+    return get_client(cfg)
+
+
+@pytest.fixture
+def require_live_provider(contract_client) -> LLMClient:
+    """Alias that reads as a precondition at the call site; yields the live client."""
+    return contract_client

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -3,15 +3,17 @@
 
 These tests exist to catch failures that *only* show up against a real LLM
 provider (issues #237/#238) or that the deterministic suite would otherwise
-paper over (issue #239). The root `tests/conftest.py` autouse sandbox strips
-every ``VERINOTE_*`` variable before any test runs, so the opt-in signal cannot
-be read from the environment at test time. It is snapshotted at *this module's
-import time* (see ``_contract_provider`` below) — the earliest point available,
-before the sandbox's ``pytest_configure`` seals the environment on the direct
-opt-in path — with ``pytest_configure`` here as a fallback. Both are exposed
-through :func:`contract_provider`.
+paper over (issue #239).
 
-Two gates share that snapshot:
+The gate lives in a ``VN_CONTRACT_*`` namespace, deliberately *outside* the
+``VERINOTE_*`` prefix. The root ``tests/conftest.py`` sandbox drops every
+``VERINOTE_*`` variable at session start so an ambient export cannot change what
+a test sees; a gate under that prefix would be erased before any fixture could
+read it. Naming it out of the sandbox's way means the gate and its companion
+settings are simply readable at fixture time, from any invocation path, with no
+snapshot and no ordering race (issue #272).
+
+Two gates share it:
 
 * :func:`require_live_provider` gates the tests that actually call the provider.
   When the gate is unset it *skips* (opt-in). When the gate is set but the
@@ -22,9 +24,15 @@ Two gates share that snapshot:
   sync exit-code guard). They need no live provider but must still stay out of
   the default suite, so they skip on the same unset gate.
 
+:func:`pytest_sessionfinish` closes the harness's worst failure mode: asking for
+contract tests and getting a green run that exercised nothing. Whenever ``-m``
+explicitly selects the ``contract`` marker and not one selected test executes,
+the session fails. The default suite passes no ``-m``, so it is untouched and
+the guards keep self-skipping there.
+
 Contract tests build their own :class:`~verinote.config.Config` directly rather
 than through the environment, mirroring ``tests/test_ollama_adapter.py``'s
-``_cfg`` helper, so the stripped environment does not starve them of a provider.
+``_cfg`` helper, so the sandboxed environment does not starve them of a provider.
 """
 
 from __future__ import annotations
@@ -38,50 +46,27 @@ from verinote.config import Config
 from verinote.llm import get_client
 from verinote.llm.base import LLMClient
 
-GATE_VAR = "VERINOTE_CONTRACT_PROVIDER"
+GATE_VAR = "VN_CONTRACT_PROVIDER"
+MODEL_VAR = "VN_CONTRACT_MODEL"
+BASE_URL_VAR = "VN_CONTRACT_BASE_URL"
+API_KEY_VAR = "VN_CONTRACT_API_KEY"
 GATE_HINT = f"set {GATE_VAR}=claudecli|ollama|... to run (issue #241)"
-
-# Snapshot of the opt-in gate, taken as early as possible so the root sandbox's
-# ``VERINOTE_*`` strip cannot erase it before a test reads it.
-#
-# The strip lives in the root ``tests/conftest.py``'s ``pytest_configure`` and
-# deletes the variable from ``os.environ`` for the whole session. Capturing it
-# here at *conftest import time* wins the race: when this file is on the direct
-# invocation path (``pytest tests/contract ...`` — the documented opt-in run, and
-# what this repo's #241 validation uses), pytest imports every conftest at
-# startup *before* any ``pytest_configure`` fires, so the gate is still present.
-# ``pytest_configure`` below is a fallback for the same reason (it runs before
-# collection when this conftest is loaded early). Neither can see the gate if the
-# suite is discovered from a parent directory that loads this conftest only
-# mid-collection, after the strip — hence opt-in runs must target ``tests/contract``.
-_contract_provider: str | None = os.environ.get(GATE_VAR)
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Fallback capture of the opt-in gate, in case import ran before this file.
-
-    Import-time capture above is the primary path; this only fills the snapshot
-    if it is still unset and the ambient variable survives to configure time.
-    """
-    global _contract_provider
-    if _contract_provider is None:
-        _contract_provider = os.environ.get(GATE_VAR)
 
 
 def contract_provider() -> str | None:
     """The opt-in provider id the run was launched with, or ``None`` if unset."""
-    return _contract_provider
+    return os.environ.get(GATE_VAR) or None
 
 
 def _config_for(provider: str, root) -> Config:
-    """Build a Config for `provider` without reading the (stripped) environment."""
+    """Build a Config for `provider` from the ``VN_CONTRACT_*`` settings."""
     root.mkdir(parents=True, exist_ok=True)
     if provider == "claudecli":
         return Config(
             root=root,
             db_path=root / "kb.sqlite",
             provider="claudecli",
-            model="sonnet",
+            model=os.environ.get(MODEL_VAR) or "sonnet",
             api_key=None,
             base_url=None,
             llm_timeout_seconds=180.0,
@@ -91,9 +76,9 @@ def _config_for(provider: str, root) -> Config:
             root=root,
             db_path=root / "kb.sqlite",
             provider="ollama",
-            model=os.environ.get("VERINOTE_CONTRACT_MODEL", "llama3.1"),
+            model=os.environ.get(MODEL_VAR) or "llama3.1",
             api_key=None,
-            base_url=os.environ.get("VERINOTE_CONTRACT_BASE_URL", "http://localhost:11434"),
+            base_url=os.environ.get(BASE_URL_VAR) or "http://localhost:11434",
             llm_timeout_seconds=180.0,
         )
     if provider in ("anthropic", "openai"):
@@ -101,9 +86,9 @@ def _config_for(provider: str, root) -> Config:
             root=root,
             db_path=root / "kb.sqlite",
             provider=provider,
-            model=os.environ.get("VERINOTE_CONTRACT_MODEL", "")
+            model=os.environ.get(MODEL_VAR)
             or ("claude-opus-4-8" if provider == "anthropic" else "gpt-4o"),
-            api_key=os.environ.get("VERINOTE_CONTRACT_API_KEY"),
+            api_key=os.environ.get(API_KEY_VAR) or None,
             base_url=None,
             llm_timeout_seconds=180.0,
         )
@@ -128,11 +113,70 @@ def _assert_provider_available(provider: str, cfg: Config) -> None:
         if not cfg.api_key:
             pytest.fail(
                 f"{GATE_VAR}={provider} but no API key was provided; "
-                "set VERINOTE_CONTRACT_API_KEY (a set gate must fail, not skip — issue #234)"
+                f"set {API_KEY_VAR} (a set gate must fail, not skip — issue #234)"
             )
         return
     # ollama and any other reachable-over-network provider: leave reachability to
     # the first live call, which raises LLMError the guards already assert on.
+
+
+# --- "selected but never ran" session guard -------------------------------
+#
+# Tracked across the session and consulted in `pytest_sessionfinish`. Counting
+# happens only when `-m` names the contract marker, so a default `pytest tests`
+# run (no mark expression) never trips it.
+
+_selected_contract_items = 0
+_executed_contract_ids: set[str] = set()
+
+
+def _explicitly_selects_contract(config: pytest.Config) -> bool:
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    return "contract" in markexpr
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    global _selected_contract_items
+    if not _explicitly_selects_contract(config):
+        return
+    _selected_contract_items = sum(1 for item in items if item.get_closest_marker("contract"))
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Remember every contract test that got past the gate.
+
+    Only the call phase counts as "ran": a skipped test still reports a *passing*
+    teardown, so accepting any non-skipped phase would call every skip an
+    execution and defeat the guard below. A setup/teardown *failure* counts too —
+    a fixture that fails the gate on an unreachable provider (issue #234) is the
+    harness working, not a silent no-op.
+    """
+    if "contract" not in report.keywords:
+        return
+    if report.failed or (report.when == "call" and report.outcome != "skipped"):
+        _executed_contract_ids.add(report.nodeid)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Fail a run that asked for contract tests and executed none of them.
+
+    Without this, `pytest -m contract` with the gate unset reports "N skipped"
+    and exits 0 — the harness's worst outcome, a green run that guarded nothing.
+    An already-failing session keeps its own status.
+    """
+    if not _selected_contract_items or _executed_contract_ids:
+        return
+    if exitstatus != 0:
+        return
+    message = (
+        f"{_selected_contract_items} contract test(s) were selected but every one skipped: "
+        f"no guard executed. {GATE_HINT}"
+    )
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_sep("=", "contract gate", red=True, bold=True)
+        reporter.write_line(message)
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
 @pytest.fixture

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -122,6 +122,13 @@ def _assert_provider_available(provider: str, cfg: Config) -> None:
     # the first live call, which raises LLMError the guards already assert on.
 
 
+def _client_for_provider(provider: str, root) -> LLMClient:
+    """Build the requested live provider client after applying contract gates."""
+    cfg = _config_for(provider, root)
+    _assert_provider_available(provider, cfg)
+    return get_client(cfg)
+
+
 # --- "selected but never ran" session guard -------------------------------
 #
 # Tracked across the session and consulted in `pytest_sessionfinish`.
@@ -271,9 +278,7 @@ def contract_client(tmp_path) -> LLMClient:
     provider = contract_provider()
     if not provider:
         pytest.skip(GATE_HINT)
-    cfg = _config_for(provider, tmp_path / "kb")
-    _assert_provider_available(provider, cfg)
-    return get_client(cfg)
+    return _client_for_provider(provider, tmp_path / "kb")
 
 
 @pytest.fixture

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -25,9 +25,10 @@ Two gates share it:
   the default suite, so they skip on the same unset gate.
 
 :func:`pytest_sessionfinish` closes the harness's worst failure mode: asking for
-contract tests and getting a green run that exercised nothing. Whenever ``-m``
-explicitly selects the ``contract`` marker and not one selected test executes,
-the session fails. The default suite passes no ``-m``, so it is untouched and
+contract tests and getting a green run that exercised nothing. Whenever a run
+asks for these guards — by naming the ``contract`` marker *or* a path in this
+directory (see :func:`arms_skip_guard`) — and not one selected test executes,
+the session fails. The default suite asks for neither, so it is untouched and
 the guards keep self-skipping there.
 
 Contract tests build their own :class:`~verinote.config.Config` directly rather
@@ -39,6 +40,7 @@ from __future__ import annotations
 
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -122,28 +124,72 @@ def _assert_provider_available(provider: str, cfg: Config) -> None:
 
 # --- "selected but never ran" session guard -------------------------------
 #
-# Tracked across the session and consulted in `pytest_sessionfinish`. Counting
-# happens only when `-m` names the contract marker, so a default `pytest tests`
-# run (no mark expression) never trips it.
+# Tracked across the session and consulted in `pytest_sessionfinish`.
 
-_selected_contract_items = 0
+CONTRACT_DIR = Path(__file__).resolve().parent
+
+_selected_contract_nodeids: set[str] = set()
 _executed_contract_ids: set[str] = set()
 
 
-def _explicitly_selects_contract(config: pytest.Config) -> bool:
-    markexpr = getattr(config.option, "markexpr", "") or ""
-    return "contract" in markexpr
+def _points_inside_contract_dir(arg: str, invocation_dir: Path) -> bool:
+    """Is this pytest positional argument a path in (or at) `tests/contract`?"""
+    path = Path(str(arg).split("::")[0])
+    if not path.is_absolute():
+        path = invocation_dir / path
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    return resolved == CONTRACT_DIR or CONTRACT_DIR in resolved.parents
 
 
+def arms_skip_guard(markexpr: str, args: list[str], invocation_dir: Path) -> bool:
+    """Did this invocation ask for the contract tests specifically?
+
+    Two spellings mean "I want the contract guards": naming the marker, and
+    naming a path in this directory. Both must arm the skipped-run guard —
+    `pytest tests/contract` is the spelling a developer reaches for first, and
+    left unarmed it reports "18 passed, 7 skipped" and exits 0 while not one
+    guard ran, which is the false green this harness exists to prevent.
+
+    A run that merely *collects* this directory on its way through the tree must
+    not arm: `pytest` (which `testpaths` expands to `tests`) and `pytest tests`
+    both pass `tests`, a parent of this directory, not a path inside it. So the
+    default suite keeps its self-skipping guards and stays green.
+
+    Kept a pure function of the three inputs so the arming boundary can be pinned
+    directly, without a pytest session per case.
+    """
+    if "contract" in (markexpr or ""):
+        return True
+    return any(_points_inside_contract_dir(arg, invocation_dir) for arg in args)
+
+
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    global _selected_contract_items
-    if not _explicitly_selects_contract(config):
+    """Count the contract tests this run actually intends to execute.
+
+    `trylast` matters: it puts this after the mark plugin's deselection, so
+    `items` holds what survived `-m`. Running earlier would count guards that
+    `-m "not contract"` is about to deselect and then fail the session because
+    they never ran — a false red, the mirror of the bug this guard fixes.
+    """
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    if not arms_skip_guard(markexpr, list(config.args), Path(config.invocation_params.dir)):
         return
-    _selected_contract_items = sum(1 for item in items if item.get_closest_marker("contract"))
+    _selected_contract_nodeids.update(
+        item.nodeid for item in items if item.get_closest_marker("contract")
+    )
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     """Remember every contract test that got past the gate.
+
+    Membership is by collected node id, not `report.keywords`: this directory is
+    a package *named* `contract`, so every test under it — the meta guards and
+    the ungated controls included — carries `contract` as a keyword. Keying on
+    that would let any passing neighbour stand in for a guard that never ran.
 
     Only the call phase counts as "ran": a skipped test still reports a *passing*
     teardown, so accepting any non-skipped phase would call every skip an
@@ -151,7 +197,7 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     a fixture that fails the gate on an unreachable provider (issue #234) is the
     harness working, not a silent no-op.
     """
-    if "contract" not in report.keywords:
+    if report.nodeid not in _selected_contract_nodeids:
         return
     if report.failed or (report.when == "call" and report.outcome != "skipped"):
         _executed_contract_ids.add(report.nodeid)
@@ -163,14 +209,20 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     Without this, `pytest -m contract` with the gate unset reports "N skipped"
     and exits 0 — the harness's worst outcome, a green run that guarded nothing.
     An already-failing session keeps its own status.
+
+    `--collect-only` is exempt: not running tests is what it was asked to do, so
+    failing it would be the mirror image of the bug above — a red run that had
+    nothing to report.
     """
-    if not _selected_contract_items or _executed_contract_ids:
+    if session.config.option.collectonly:
+        return
+    if not _selected_contract_nodeids or _executed_contract_ids:
         return
     if exitstatus != 0:
         return
     message = (
-        f"{_selected_contract_items} contract test(s) were selected but every one skipped: "
-        f"no guard executed. {GATE_HINT}"
+        f"{len(_selected_contract_nodeids)} contract test(s) were selected but every one "
+        f"skipped: no guard executed. {GATE_HINT}"
     )
     reporter = session.config.pluginmanager.get_plugin("terminalreporter")
     if reporter is not None:

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -26,10 +26,10 @@ Two gates share it:
 
 :func:`pytest_sessionfinish` closes the harness's worst failure mode: asking for
 contract tests and getting a green run that exercised nothing. Whenever a run
-asks for these guards — by naming the ``contract`` marker *or* a path in this
-directory (see :func:`arms_skip_guard`) — and not one selected test executes,
-the session fails. The default suite asks for neither, so it is untouched and
-the guards keep self-skipping there.
+asks for these guards — by naming the ``contract`` marker, a path in this
+directory, or the ``contract`` keyword (see :func:`arms_skip_guard`) — and not
+one selected test executes, the session fails. The default suite asks in none of
+those ways, so it is untouched and the guards keep self-skipping there.
 
 Contract tests build their own :class:`~verinote.config.Config` directly rather
 than through the environment, mirroring ``tests/test_ollama_adapter.py``'s
@@ -133,35 +133,59 @@ _executed_contract_ids: set[str] = set()
 
 
 def _points_inside_contract_dir(arg: str, invocation_dir: Path) -> bool:
-    """Is this pytest positional argument a path in (or at) `tests/contract`?"""
-    path = Path(str(arg).split("::")[0])
-    if not path.is_absolute():
-        path = invocation_dir / path
-    try:
-        resolved = path.resolve()
-    except OSError:
-        return False
-    return resolved == CONTRACT_DIR or CONTRACT_DIR in resolved.parents
+    """Is this pytest positional argument a path in (or at) `tests/contract`?
+
+    Both spellings of an argument are considered: a filesystem path, and the
+    dotted module name `--pyargs` takes (`tests.contract`), which is otherwise
+    resolved as the literal directory `./tests.contract` and never matches.
+    """
+    head = str(arg).split("::")[0]
+    candidates = [head]
+    if "/" not in head and os.sep not in head and "." in head:
+        candidates.append(head.replace(".", os.sep))
+    for candidate in candidates:
+        path = Path(candidate)
+        if not path.is_absolute():
+            path = invocation_dir / path
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved == CONTRACT_DIR or CONTRACT_DIR in resolved.parents:
+            return True
+    return False
 
 
-def arms_skip_guard(markexpr: str, args: list[str], invocation_dir: Path) -> bool:
+def arms_skip_guard(markexpr: str, keyword: str, args: list[str], invocation_dir: Path) -> bool:
     """Did this invocation ask for the contract tests specifically?
 
-    Two spellings mean "I want the contract guards": naming the marker, and
-    naming a path in this directory. Both must arm the skipped-run guard —
-    `pytest tests/contract` is the spelling a developer reaches for first, and
-    left unarmed it reports "18 passed, 7 skipped" and exits 0 while not one
-    guard ran, which is the false green this harness exists to prevent.
+    Three spellings mean "I want the contract guards", and each must arm the
+    skipped-run guard: naming the marker (`-m contract`), naming a path in this
+    directory (`pytest tests/contract`), and naming it by keyword
+    (`pytest -k contract`). Miss any one and it reports "N passed, 7 skipped",
+    exits 0, and guards nothing — the false green this harness exists to prevent.
+
+    `-k contract` selects everything here for the same reason the guard once
+    mis-counted `report.keywords`: this directory is a package *named* contract,
+    so the keyword matches all of it. Every input pytest can express that
+    intention with therefore has to be an argument to this function; a spelling
+    it cannot see is a spelling it cannot guard.
 
     A run that merely *collects* this directory on its way through the tree must
     not arm: `pytest` (which `testpaths` expands to `tests`) and `pytest tests`
     both pass `tests`, a parent of this directory, not a path inside it. So the
     default suite keeps its self-skipping guards and stays green.
 
-    Kept a pure function of the three inputs so the arming boundary can be pinned
+    Arming is not the same as failing. A run that arms but then deselects every
+    guard (`pytest tests/contract -k meta`) is silent, because the count is taken
+    after deselection: excluding the guards on purpose is not "they never ran".
+
+    Kept a pure function of its inputs so the arming boundary can be pinned
     directly, without a pytest session per case.
     """
     if "contract" in (markexpr or ""):
+        return True
+    if "contract" in (keyword or ""):
         return True
     return any(_points_inside_contract_dir(arg, invocation_dir) for arg in args)
 
@@ -176,7 +200,8 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     they never ran — a false red, the mirror of the bug this guard fixes.
     """
     markexpr = getattr(config.option, "markexpr", "") or ""
-    if not arms_skip_guard(markexpr, list(config.args), Path(config.invocation_params.dir)):
+    keyword = getattr(config.option, "keyword", "") or ""
+    if not arms_skip_guard(markexpr, keyword, list(config.args), Path(config.invocation_params.dir)):
         return
     _selected_contract_nodeids.update(
         item.nodeid for item in items if item.get_closest_marker("contract")

--- a/tests/contract/run.sh
+++ b/tests/contract/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# Run the issue #241 provider contract tests and fail loudly if they were all
+# skipped. A fully-skipped opt-in run is the harness's worst failure mode: it
+# looks green while exercising nothing. Set the gate to actually run the guards:
+#
+#   VERINOTE_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
+#
+# Exit codes:
+#   0  contract tests ran (and pytest itself passed)
+#   1  contract tests were collected but every one skipped (no guard executed)
+#   *  pytest's own exit code when tests ran and some failed/errored
+set -u
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$here"
+
+python="${PYTHON:-python}"
+output="$("$python" -m pytest tests/contract -m contract -rs "$@" 2>&1)"
+status=$?
+printf '%s\n' "$output"
+
+# Count the tests the `-m contract` filter actually *selected*, not every item
+# collected (the module also holds non-contract meta tests that get deselected).
+# pytest prints "N selected" only when something was deselected; fall back to the
+# item count otherwise.
+selected="$(printf '%s\n' "$output" | grep -oE '[0-9]+ selected' | head -1 | grep -oE '[0-9]+' || true)"
+if [ -z "$selected" ]; then
+  selected="$(printf '%s\n' "$output" | grep -oE '[0-9]+ item' | head -1 | grep -oE '[0-9]+' || true)"
+fi
+if printf '%s\n' "$output" | grep -qE '[0-9]+ (passed|failed|error|errors|xpassed|xfailed)'; then
+  ran=1
+else
+  ran=0
+fi
+
+if [ "${selected:-0}" -gt 0 ] && [ "$ran" -eq 0 ]; then
+  echo "run.sh: ${selected} contract test(s) selected but none executed (all skipped)." >&2
+  echo "run.sh: set VERINOTE_CONTRACT_PROVIDER=claudecli|ollama|... to run them." >&2
+  exit 1
+fi
+
+exit "$status"

--- a/tests/contract/run.sh
+++ b/tests/contract/run.sh
@@ -18,5 +18,20 @@ set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$here"
 
-python="${PYTHON:-python}"
+# Discover an interpreter rather than hard-coding one: `python3` is the only
+# spelling on many systems (this repo's own dev machines included), while older
+# images and activated virtualenvs expose `python` alone. Hard-coding either name
+# breaks the README's headline command on half the platforms it documents.
+# PYTHON wins when set, so a caller can always name the interpreter outright.
+if [ -n "${PYTHON:-}" ]; then
+  python="$PYTHON"
+elif command -v python3 >/dev/null 2>&1; then
+  python="python3"
+elif command -v python >/dev/null 2>&1; then
+  python="python"
+else
+  echo "run.sh: no python3 or python found on PATH; set PYTHON=/path/to/python" >&2
+  exit 1
+fi
+
 exec "$python" -m pytest tests/contract -m contract -rs "$@"

--- a/tests/contract/run.sh
+++ b/tests/contract/run.sh
@@ -6,9 +6,10 @@
 #   VN_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
 #
 # The "every contract test skipped" guard lives in tests/contract/conftest.py's
-# pytest_sessionfinish, not here, so it holds for *any* run that selects the
-# contract marker — including `python -m pytest -m contract` from the repo root.
-# This script only fixes the working directory and the standard flags.
+# pytest_sessionfinish, not here, so it holds for any run that asks for these
+# guards — `python -m pytest -m contract` or `python -m pytest tests/contract`
+# from the repo root alike. This script only fixes the working directory and the
+# standard flags.
 #
 # Exit codes are pytest's own; a fully-skipped opt-in run exits non-zero via that
 # session guard.

--- a/tests/contract/run.sh
+++ b/tests/contract/run.sh
@@ -1,44 +1,21 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MPL-2.0
 #
-# Run the issue #241 provider contract tests and fail loudly if they were all
-# skipped. A fully-skipped opt-in run is the harness's worst failure mode: it
-# looks green while exercising nothing. Set the gate to actually run the guards:
+# Convenience wrapper for the issue #241 provider contract tests:
 #
-#   VERINOTE_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
+#   VN_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
 #
-# Exit codes:
-#   0  contract tests ran (and pytest itself passed)
-#   1  contract tests were collected but every one skipped (no guard executed)
-#   *  pytest's own exit code when tests ran and some failed/errored
+# The "every contract test skipped" guard lives in tests/contract/conftest.py's
+# pytest_sessionfinish, not here, so it holds for *any* run that selects the
+# contract marker — including `python -m pytest -m contract` from the repo root.
+# This script only fixes the working directory and the standard flags.
+#
+# Exit codes are pytest's own; a fully-skipped opt-in run exits non-zero via that
+# session guard.
 set -u
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$here"
 
 python="${PYTHON:-python}"
-output="$("$python" -m pytest tests/contract -m contract -rs "$@" 2>&1)"
-status=$?
-printf '%s\n' "$output"
-
-# Count the tests the `-m contract` filter actually *selected*, not every item
-# collected (the module also holds non-contract meta tests that get deselected).
-# pytest prints "N selected" only when something was deselected; fall back to the
-# item count otherwise.
-selected="$(printf '%s\n' "$output" | grep -oE '[0-9]+ selected' | head -1 | grep -oE '[0-9]+' || true)"
-if [ -z "$selected" ]; then
-  selected="$(printf '%s\n' "$output" | grep -oE '[0-9]+ item' | head -1 | grep -oE '[0-9]+' || true)"
-fi
-if printf '%s\n' "$output" | grep -qE '[0-9]+ (passed|failed|error|errors|xpassed|xfailed)'; then
-  ran=1
-else
-  ran=0
-fi
-
-if [ "${selected:-0}" -gt 0 ] && [ "$ran" -eq 0 ]; then
-  echo "run.sh: ${selected} contract test(s) selected but none executed (all skipped)." >&2
-  echo "run.sh: set VERINOTE_CONTRACT_PROVIDER=claudecli|ollama|... to run them." >&2
-  exit 1
-fi
-
-exit "$status"
+exec "$python" -m pytest tests/contract -m contract -rs "$@"

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Meta guards for the #241 contract harness itself — deliberately *not* marked
+``contract`` so they run in the default suite and stay green.
+
+They catch the ways the harness could rot into a no-op: an unregistered marker
+(so ``-m contract`` silently selects nothing), missing or provenance-less replay
+fixtures, or a contract module that stops declaring any contract-marked test (so
+the opt-in run collects zero guards). ``tests/contract/run.sh`` is the runtime
+counterpart that fails a fully-skipped opt-in run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+CONTRACT_DIR = Path(__file__).resolve().parent
+FIXTURES_DIR = CONTRACT_DIR.parent / "fixtures" / "contract"
+PROVENANCE_KEYS = ("provider", "model", "captured_at")
+# Each replay guard depends on a specific fixture; naming them (instead of
+# globbing for "at least one") makes deleting any single one turn this red.
+REQUIRED_FIXTURES = (
+    "query_intent_acme_ceo.json",
+    "extraction_acme_two_dates.json",
+    "sync_all_chunks_failed.json",
+)
+CONTRACT_MODULES = (
+    "test_query_intent_contract.py",
+    "test_extraction_contract.py",
+    "test_sync_rc_contract.py",
+)
+
+
+def test_contract_marker_is_registered(pytestconfig):
+    markers = pytestconfig.getini("markers")
+    assert any(m.startswith("contract:") for m in markers), (
+        "the `contract` marker is not registered in pyproject.toml; `-m contract` "
+        "would select nothing and silently pass"
+    )
+
+
+@pytest.mark.parametrize("fixture_name", REQUIRED_FIXTURES)
+def test_required_replay_fixture_exists_and_carries_provenance(fixture_name):
+    assert FIXTURES_DIR.is_dir(), f"missing fixtures dir: {FIXTURES_DIR}"
+    path = FIXTURES_DIR / fixture_name
+    assert path.is_file(), f"missing required contract fixture: {fixture_name}"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data, f"empty fixture: {fixture_name}"
+    missing = [key for key in PROVENANCE_KEYS if not data.get(key)]
+    assert not missing, f"{fixture_name} is missing provenance keys: {missing}"
+
+
+def _load_module(path: Path):
+    spec = importlib.util.spec_from_file_location(f"_contract_meta_{path.stem}", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _contract_test_names(module) -> list[str]:
+    names = []
+    for name, obj in vars(module).items():
+        if not name.startswith("test_") or not callable(obj):
+            continue
+        marks = getattr(obj, "pytestmark", [])
+        if any(getattr(mark, "name", None) == "contract" for mark in marks):
+            names.append(name)
+    return names
+
+
+@pytest.mark.parametrize("module_name", CONTRACT_MODULES)
+def test_each_contract_module_is_collectable_and_has_a_guard(module_name):
+    path = CONTRACT_DIR / module_name
+    assert path.is_file(), f"missing contract module: {module_name}"
+    module = _load_module(path)
+    guards = _contract_test_names(module)
+    assert guards, f"{module_name} declares no @pytest.mark.contract test"

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from .conftest import API_KEY_VAR, BASE_URL_VAR, GATE_VAR, MODEL_VAR, _config_for
+from .conftest import API_KEY_VAR, BASE_URL_VAR, GATE_VAR, MODEL_VAR, _config_for, arms_skip_guard
 
 CONTRACT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = CONTRACT_DIR.parent.parent
@@ -42,9 +42,11 @@ CONTRACT_MODULES = (
     "test_sync_rc_contract.py",
 )
 # A module whose contract tests are *all* gated, so an ungated run executes none
-# of them. `test_a_run_that_never_asked_for_contract_tests_stays_green` needs
-# that property to mean anything; see its docstring.
+# of them.
 GATE_ONLY_MODULE = "test_sync_rc_contract.py"
+# A module holding both a contract guard and an ungated control, so a run that
+# deselects the guards still has something to execute.
+MIXED_MODULE = "test_query_intent_contract.py"
 
 
 def test_contract_marker_is_registered(pytestconfig):
@@ -130,33 +132,82 @@ def test_all_skipped_contract_selection_fails_the_session():
     )
 
 
-def test_a_run_that_never_asked_for_contract_tests_stays_green():
-    """The default suite spelling must be untouched: guards self-skip, exit 0.
+def test_targeting_the_contract_directory_fails_when_no_guard_runs():
+    """`pytest tests/contract` with no gate must not be a green no-op either.
 
-    Pins the other side of the session guard — it keys off an explicit
-    `-m contract`, so collecting a contract module with no mark expression (what
-    `pytest tests` does) must still pass with every guard skipped.
+    The marker is not the only way to ask for these guards: naming the directory
+    is the spelling a developer reaches for first. Left unarmed it reports
+    "18 passed, 7 skipped" and exits 0 — the passing meta tests make it look
+    especially green — while not one guard ran.
 
-    `GATE_ONLY_MODULE` is the subject because *all* its contract tests are gated,
-    so an ungated run executes none of them: exactly the state a wrongly-scoped
-    guard would turn red. A module holding a contract-marked test that runs
-    without a gate could not detect that. The skip count is asserted against the
-    module's own guards to keep that true if the module ever gains a test — and
-    this file is not the subject, since re-running it from inside itself would
-    recurse.
+    This module is deselected in the child run: it is what spawns the child, so
+    running it there would recurse. The directory stays the positional argument,
+    which is what arms the guard. (`--deselect`, not `--ignore`: the latter is
+    silently a no-op for a module inside a package like this one.)
     """
-    module = _load_module(CONTRACT_DIR / GATE_ONLY_MODULE)
-    guards = _contract_test_names(module)
-    result = _nested_pytest(f"tests/contract/{GATE_ONLY_MODULE}", "-rs")
-    assert result.stdout.count("SKIPPED") == len(guards), (
-        f"{GATE_ONLY_MODULE} no longer skips all {len(guards)} of its guards on an "
-        "ungated run, so this test can no longer detect a wrongly-scoped session "
-        f"guard; point it at a gate-only module.\n{result.stdout}\n{result.stderr}"
+    result = _nested_pytest("tests/contract", f"--deselect=tests/contract/{Path(__file__).name}")
+    assert result.returncode != 0, (
+        "`pytest tests/contract` with the gate unset exited 0 while every guard "
+        f"skipped — a false green.\n{result.stdout}\n{result.stderr}"
     )
+    assert "no guard executed" in result.stdout, (
+        f"the session failed without saying why:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_deselecting_the_guards_is_not_a_failure():
+    """`-m "not contract"` deselects the guards; that is not "they never ran".
+
+    The count must be taken after deselection, or a run that deliberately
+    excludes the guards fails because the guards it excluded did not execute.
+
+    `MIXED_MODULE` holds both a contract guard and an ungated control, so this
+    child run has something left to execute after the guards are deselected —
+    a module of guards only would exit 5 (nothing collected) and prove nothing.
+    """
+    result = _nested_pytest(f"tests/contract/{MIXED_MODULE}", "-m", "not contract")
     assert result.returncode == 0, (
-        "a run with no `-m contract` was turned red by the skipped-run guard; "
-        f"the default suite would break.\n{result.stdout}\n{result.stderr}"
+        "a run that deselected the contract tests was failed for not running "
+        f"them.\n{result.stdout}\n{result.stderr}"
     )
+
+
+def test_collect_only_is_not_failed_by_the_skip_guard():
+    """Collecting is not running, so an empty run is the correct outcome.
+
+    Failing `--collect-only` would be the mirror of the bug this guard fixes: a
+    red run that had nothing to report.
+    """
+    result = _nested_pytest("-m", "contract", "--collect-only")
+    assert result.returncode == 0, (
+        "`--collect-only` was failed by the skipped-run guard; it never intended "
+        f"to run anything.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("markexpr", "args", "arms", "why"),
+    [
+        ("contract", ["tests"], True, "the marker is named"),
+        ("not contract", ["tests"], True, "conservative: mark expr mentions it; selection count decides"),
+        ("", ["tests/contract"], True, "the directory is named"),
+        ("", [str(CONTRACT_DIR)], True, "the directory is named absolutely"),
+        ("", [f"tests/contract/{GATE_ONLY_MODULE}"], True, "a module inside it is named"),
+        ("", [f"tests/contract/{GATE_ONLY_MODULE}::test_x"], True, "a single test inside it is named"),
+        ("", ["tests"], False, "the default suite: a parent, not a path inside"),
+        ("", [], False, "bare pytest before testpaths expands"),
+        ("", ["tests/test_config.py"], False, "an unrelated module"),
+        ("", ["tests/contract_notes"], False, "a sibling whose name merely starts the same"),
+    ],
+)
+def test_skip_guard_arming_boundary(markexpr, args, arms, why):
+    """Pin exactly which invocations arm the skipped-run guard.
+
+    The default-suite rows are the load-bearing ones: `pytest` and `pytest tests`
+    both pass `tests`, a *parent* of this directory. If either armed, every
+    default run would go red on the self-skipping guards.
+    """
+    assert arms_skip_guard(markexpr, args, REPO_ROOT) is arms, why
 
 
 def test_gate_variables_survive_the_root_sandbox_strip():

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -14,6 +14,7 @@ non-zero, while a run that never asked must stay green.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -25,7 +26,16 @@ from pathlib import Path
 
 import pytest
 
-from .conftest import API_KEY_VAR, BASE_URL_VAR, GATE_VAR, MODEL_VAR, _config_for, arms_skip_guard
+from . import conftest as contract_conftest
+from .conftest import (
+    API_KEY_VAR,
+    BASE_URL_VAR,
+    GATE_VAR,
+    MODEL_VAR,
+    _client_for_provider,
+    _config_for,
+    arms_skip_guard,
+)
 
 CONTRACT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = CONTRACT_DIR.parent.parent
@@ -283,28 +293,55 @@ def test_gate_variables_survive_the_root_sandbox_strip():
         )
 
 
-def test_documented_api_key_reaches_the_provider_config():
+def test_documented_api_key_reaches_the_provider_config(monkeypatch, tmp_path):
     """The documented openai invocation must actually deliver the key.
 
-    Runs the README's own openai spelling with a synthetic key. Authentication is
-    expected to fail (or the SDK to be absent) — what must *not* happen is the
-    harness reporting the key as missing, which is what a stripped variable looks
-    like. Also asserts the run was not simply skipped, so a stripped *gate*
-    cannot make this pass vacuously.
+    This is a wiring assertion, not a live-provider contract. The default meta
+    suite must never depend on the OpenAI SDK or network just to prove the
+    documented environment spelling reaches Config, so `get_client` is replaced
+    before the provider adapter boundary.
     """
-    result = _nested_pytest(
-        f"tests/contract/{CONTRACT_MODULES[0]}",
-        "-m",
-        "contract",
-        gate_env={"VN_CONTRACT_PROVIDER": "openai", "VN_CONTRACT_API_KEY": "synthetic-key"},
-    )
-    assert "no API key was provided" not in result.stdout, (
-        "VN_CONTRACT_API_KEY did not reach the provider config; the documented "
-        f"openai run cannot work.\n{result.stdout}\n{result.stderr}"
-    )
-    assert "no guard executed" not in result.stdout, (
-        f"the gate itself did not survive to the fixture.\n{result.stdout}\n{result.stderr}"
-    )
+    monkeypatch.setenv(GATE_VAR, "openai")
+    monkeypatch.setenv(API_KEY_VAR, "synthetic-key")
+    captured = {}
+
+    def fake_get_client(cfg):
+        captured["cfg"] = cfg
+        return object()
+
+    monkeypatch.setattr(contract_conftest, "get_client", fake_get_client)
+
+    provider = contract_conftest.contract_provider()
+    assert provider == "openai"
+
+    client = _client_for_provider(provider, tmp_path / "kb")
+
+    assert client is not None
+    assert captured["cfg"].provider == "openai"
+    assert captured["cfg"].api_key == "synthetic-key"
+
+
+def test_meta_nested_pytest_never_opts_into_a_live_provider():
+    """Default-suite meta tests must not spawn opted-in live contract runs."""
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    live_gate_calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "_nested_pytest":
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "gate_env" or not isinstance(keyword.value, ast.Dict):
+                continue
+            keys = []
+            for key in keyword.value.keys:
+                if isinstance(key, ast.Constant):
+                    keys.append(key.value)
+                elif isinstance(key, ast.Name):
+                    keys.append(globals().get(key.id))
+            if GATE_VAR in keys:
+                live_gate_calls.append(node.lineno)
+    assert live_gate_calls == []
 
 
 @pytest.mark.parametrize(
@@ -321,9 +358,10 @@ def test_documented_api_key_reaches_the_provider_config():
 def test_companion_settings_map_onto_the_config(monkeypatch, tmp_path, provider, gate_env, field, expected):
     """Every companion variable the README documents must land on the Config.
 
-    Complements the subprocess guard above: that one proves the variables survive
-    the sandbox, this one proves each is wired to the field it claims, including
-    the documented defaults.
+    Complements the adapter-boundary guard above: that one proves the documented
+    OpenAI key reaches the Config without a live call, this one proves each
+    companion variable is wired to the field it claims, including the documented
+    defaults.
     """
     for var in (MODEL_VAR, BASE_URL_VAR, API_KEY_VAR):
         monkeypatch.delenv(var, raising=False)

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -5,19 +5,28 @@
 They catch the ways the harness could rot into a no-op: an unregistered marker
 (so ``-m contract`` silently selects nothing), missing or provenance-less replay
 fixtures, or a contract module that stops declaring any contract-marked test (so
-the opt-in run collects zero guards). ``tests/contract/run.sh`` is the runtime
-counterpart that fails a fully-skipped opt-in run.
+the opt-in run collects zero guards).
+
+The last two spawn a real nested pytest to pin the session guard in
+``conftest.py``: asking for contract tests and skipping every one must exit
+non-zero, while a run that never asked must stay green.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from .conftest import API_KEY_VAR, BASE_URL_VAR, GATE_VAR, MODEL_VAR, _config_for
+
 CONTRACT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CONTRACT_DIR.parent.parent
 FIXTURES_DIR = CONTRACT_DIR.parent / "fixtures" / "contract"
 PROVENANCE_KEYS = ("provider", "model", "captured_at")
 # Each replay guard depends on a specific fixture; naming them (instead of
@@ -32,6 +41,10 @@ CONTRACT_MODULES = (
     "test_extraction_contract.py",
     "test_sync_rc_contract.py",
 )
+# A module whose contract tests are *all* gated, so an ungated run executes none
+# of them. `test_a_run_that_never_asked_for_contract_tests_stays_green` needs
+# that property to mean anything; see its docstring.
+GATE_ONLY_MODULE = "test_sync_rc_contract.py"
 
 
 def test_contract_marker_is_registered(pytestconfig):
@@ -79,3 +92,132 @@ def test_each_contract_module_is_collectable_and_has_a_guard(module_name):
     module = _load_module(path)
     guards = _contract_test_names(module)
     assert guards, f"{module_name} declares no @pytest.mark.contract test"
+
+
+def _nested_pytest(*args: str, gate_env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    """Run pytest in a child process from the repo root with a known gate.
+
+    The autouse sandbox chdir's every test off the repo and this suite may be
+    launched with the gate already exported, so the CWD and every `VN_CONTRACT_*`
+    variable are pinned explicitly here rather than inherited.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("VN_CONTRACT_")}
+    env.update(gate_env or {})
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args, "-p", "no:cacheprovider", "-q"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_all_skipped_contract_selection_fails_the_session():
+    """`-m contract` with no gate must not be a green no-op — from any path.
+
+    The parent-path form is the one that regressed (issue #272): it is the
+    natural opt-in spelling, and reporting "N skipped" with exit 0 is exactly
+    the false green this harness exists to prevent.
+    """
+    result = _nested_pytest("-m", "contract")
+    assert result.returncode != 0, (
+        "`pytest -m contract` with the gate unset exited 0 while skipping every "
+        f"guard — a false green.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "no guard executed" in result.stdout, (
+        f"the session failed without saying why:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_a_run_that_never_asked_for_contract_tests_stays_green():
+    """The default suite spelling must be untouched: guards self-skip, exit 0.
+
+    Pins the other side of the session guard — it keys off an explicit
+    `-m contract`, so collecting a contract module with no mark expression (what
+    `pytest tests` does) must still pass with every guard skipped.
+
+    `GATE_ONLY_MODULE` is the subject because *all* its contract tests are gated,
+    so an ungated run executes none of them: exactly the state a wrongly-scoped
+    guard would turn red. A module holding a contract-marked test that runs
+    without a gate could not detect that. The skip count is asserted against the
+    module's own guards to keep that true if the module ever gains a test — and
+    this file is not the subject, since re-running it from inside itself would
+    recurse.
+    """
+    module = _load_module(CONTRACT_DIR / GATE_ONLY_MODULE)
+    guards = _contract_test_names(module)
+    result = _nested_pytest(f"tests/contract/{GATE_ONLY_MODULE}", "-rs")
+    assert result.stdout.count("SKIPPED") == len(guards), (
+        f"{GATE_ONLY_MODULE} no longer skips all {len(guards)} of its guards on an "
+        "ungated run, so this test can no longer detect a wrongly-scoped session "
+        f"guard; point it at a gate-only module.\n{result.stdout}\n{result.stderr}"
+    )
+    assert result.returncode == 0, (
+        "a run with no `-m contract` was turned red by the skipped-run guard; "
+        f"the default suite would break.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_gate_variables_survive_the_root_sandbox_strip():
+    """The gate must not sit under the prefix the root sandbox deletes.
+
+    `tests/conftest.py` drops every `VERINOTE_*` variable at session start, so a
+    gate named that way is gone before any fixture can read it (issue #272).
+    Naming is the whole mechanism here, hence the guard.
+    """
+    for var in (GATE_VAR, MODEL_VAR, BASE_URL_VAR, API_KEY_VAR):
+        assert not var.startswith("VERINOTE_"), (
+            f"{var} is under the `VERINOTE_*` prefix that tests/conftest.py strips; "
+            "it would never reach a contract fixture"
+        )
+
+
+def test_documented_api_key_reaches_the_provider_config():
+    """The documented openai invocation must actually deliver the key.
+
+    Runs the README's own openai spelling with a synthetic key. Authentication is
+    expected to fail (or the SDK to be absent) — what must *not* happen is the
+    harness reporting the key as missing, which is what a stripped variable looks
+    like. Also asserts the run was not simply skipped, so a stripped *gate*
+    cannot make this pass vacuously.
+    """
+    result = _nested_pytest(
+        f"tests/contract/{CONTRACT_MODULES[0]}",
+        "-m",
+        "contract",
+        gate_env={"VN_CONTRACT_PROVIDER": "openai", "VN_CONTRACT_API_KEY": "synthetic-key"},
+    )
+    assert "no API key was provided" not in result.stdout, (
+        "VN_CONTRACT_API_KEY did not reach the provider config; the documented "
+        f"openai run cannot work.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "no guard executed" not in result.stdout, (
+        f"the gate itself did not survive to the fixture.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "gate_env", "field", "expected"),
+    [
+        ("ollama", {MODEL_VAR: "qwen3:8b"}, "model", "qwen3:8b"),
+        ("ollama", {BASE_URL_VAR: "http://ollama.example:11434"}, "base_url", "http://ollama.example:11434"),
+        ("ollama", {}, "base_url", "http://localhost:11434"),
+        ("openai", {API_KEY_VAR: "synthetic-key"}, "api_key", "synthetic-key"),
+        ("openai", {MODEL_VAR: "gpt-4o-mini"}, "model", "gpt-4o-mini"),
+        ("anthropic", {}, "model", "claude-opus-4-8"),
+    ],
+)
+def test_companion_settings_map_onto_the_config(monkeypatch, tmp_path, provider, gate_env, field, expected):
+    """Every companion variable the README documents must land on the Config.
+
+    Complements the subprocess guard above: that one proves the variables survive
+    the sandbox, this one proves each is wired to the field it claims, including
+    the documented defaults.
+    """
+    for var in (MODEL_VAR, BASE_URL_VAR, API_KEY_VAR):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in gate_env.items():
+        monkeypatch.setenv(var, value)
+    cfg = _config_for(provider, tmp_path / "kb")
+    assert getattr(cfg, field) == expected

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -28,6 +30,11 @@ from .conftest import API_KEY_VAR, BASE_URL_VAR, GATE_VAR, MODEL_VAR, _config_fo
 CONTRACT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = CONTRACT_DIR.parent.parent
 FIXTURES_DIR = CONTRACT_DIR.parent / "fixtures" / "contract"
+RUN_SH = CONTRACT_DIR / "run.sh"
+# The wrapper needs a shell and `dirname`; everything else it uses is a builtin.
+# Located via the ambient PATH here, then re-exposed on the *controlled* PATH the
+# wrapper actually runs with, so locating them is not the thing under test.
+WRAPPER_TOOLS = ("bash", "dirname")
 PROVENANCE_KEYS = ("provider", "model", "captured_at")
 # Each replay guard depends on a specific fixture; naming them (instead of
 # globbing for "at least one") makes deleting any single one turn this red.
@@ -324,3 +331,142 @@ def test_companion_settings_map_onto_the_config(monkeypatch, tmp_path, provider,
         monkeypatch.setenv(var, value)
     cfg = _config_for(provider, tmp_path / "kb")
     assert getattr(cfg, field) == expected
+
+
+# --- the documented wrapper actually reaches pytest -----------------------
+#
+# The guards above spawn pytest with `sys.executable`, which is exactly why they
+# could not catch issue #273: they bypass `run.sh` entirely, so the wrapper could
+# be broken while every one of them stayed green. These run the wrapper itself.
+
+
+def _shim_dir(tmp_path: Path, interpreters: tuple[str, ...]) -> Path:
+    """A PATH directory exposing *only* `interpreters` as Python, plus the shell.
+
+    The whole point is to not depend on the ambient PATH. This machine happens to
+    have `python3` and no `python`, but a machine that has both (CI included)
+    would let a wrapper defaulting to `python` pass vacuously — the bug would
+    survive precisely where it is not reproducible. Pinning PATH to this
+    directory means each case holds everywhere.
+
+    Each shim is a real executable that forwards to the interpreter running this
+    test, so a wrapper that finds it gets a Python with pytest installed.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    for tool in WRAPPER_TOOLS:
+        real = shutil.which(tool)
+        if real is None:
+            pytest.skip(f"{tool} is not available; the wrapper cannot run on this platform")
+        (bin_dir / tool).symlink_to(real)
+    for name in interpreters:
+        shim = bin_dir / name
+        shim.write_text(f'#!{shutil.which("bash")}\nexec "{sys.executable}" "$@"\n', encoding="utf-8")
+        shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _run_wrapper(
+    tmp_path: Path,
+    *args: str,
+    interpreters: tuple[str, ...],
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Execute `run.sh` for real, with PATH pinned to `interpreters` only.
+
+    Invoked as the script itself (not `bash run.sh`) so the shebang is exercised
+    the way a user's shell would exercise it. The gate is left unset on purpose:
+    a set gate would call a live provider, and this test is about the wrapper, not
+    about any model. Unset means the guards skip and the session guard in
+    conftest fails the run — which is the evidence that pytest was reached.
+    """
+    bin_dir = _shim_dir(tmp_path, interpreters)
+    env = {k: v for k, v in os.environ.items() if not k.startswith("VN_CONTRACT_")}
+    env.pop("PYTHON", None)
+    env["PATH"] = str(bin_dir)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env.update(extra_env or {})
+    return subprocess.run(
+        [str(RUN_SH), *args, "-p", "no:cacheprovider"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_reached_pytest(result: subprocess.CompletedProcess, how: str) -> None:
+    """Assert the wrapper got as far as running pytest.
+
+    Deliberately *not* `exit 0`: with the gate unset every guard skips and the
+    session guard fails the run on purpose, so zero would be wrong. The signal is
+    that pytest ran and spoke — the guard's own message — and that the shell never
+    failed to find an interpreter (127 / "not found"), which is how issue #273
+    presented.
+    """
+    assert result.returncode != 127, (
+        f"the wrapper never reached pytest ({how}); the shell could not exec its "
+        f"interpreter.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "not found" not in result.stderr, (
+        f"the wrapper failed to resolve a command ({how}).\n{result.stdout}\n{result.stderr}"
+    )
+    assert "no guard executed" in result.stdout, (
+        f"the wrapper did not reach pytest ({how}): the contract session guard "
+        f"never spoke.\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_wrapper_reaches_pytest_when_only_python3_exists(tmp_path):
+    """The README's own command must work where `python` is not a binary.
+
+    This is issue #273 as reported: modern distributions (and this machine) ship
+    `python3` only, so a wrapper defaulting to `python` dies at
+    `exec: python: not found` — exit 127, before pytest, on the very command the
+    README tells people to run.
+    """
+    result = _run_wrapper(tmp_path, "-q", interpreters=("python3",))
+    _assert_reached_pytest(result, "python3-only PATH")
+
+
+def test_wrapper_reaches_pytest_when_only_python_exists(tmp_path):
+    """...and must keep working where `python` is the only spelling.
+
+    The mirror of the case above, and the reason the fix cannot simply be
+    s/python/python3/: virtualenvs and older images expose `python` alone. A
+    wrapper that hard-codes either name is broken on half the world.
+    """
+    result = _run_wrapper(tmp_path, "-q", interpreters=("python",))
+    _assert_reached_pytest(result, "python-only PATH")
+
+
+def test_wrapper_honours_an_explicit_python_override(tmp_path):
+    """`PYTHON=... run.sh` must still win over whatever discovery finds.
+
+    PATH here holds *no* interpreter at all, so the run can only reach pytest via
+    the override — if it were ignored, discovery would have nothing to fall back
+    on and this would go red rather than pass by luck.
+    """
+    result = _run_wrapper(
+        tmp_path, "-q", interpreters=(), extra_env={"PYTHON": sys.executable}
+    )
+    _assert_reached_pytest(result, "explicit PYTHON override")
+
+
+def test_wrapper_fails_loudly_when_no_interpreter_exists(tmp_path):
+    """No Python anywhere is a diagnosis, not a stray shell error.
+
+    The boundary of the discovery fix: when it genuinely cannot find an
+    interpreter the wrapper must say so and exit non-zero, rather than emit
+    bash's own `command not found` and leave the user guessing which name it
+    wanted.
+    """
+    result = _run_wrapper(tmp_path, "-q", interpreters=())
+    assert result.returncode != 0, (
+        f"the wrapper found no interpreter yet exited 0.\n{result.stdout}\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "PYTHON" in combined, (
+        "the wrapper gave no hint that PYTHON can point it at an interpreter.\n"
+        f"{result.stdout}\n{result.stderr}"
+    )

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -47,6 +47,8 @@ GATE_ONLY_MODULE = "test_sync_rc_contract.py"
 # A module holding both a contract guard and an ungated control, so a run that
 # deselects the guards still has something to execute.
 MIXED_MODULE = "test_query_intent_contract.py"
+# A keyword matching exactly one ungated control in this directory and no guard.
+CONTROL_ONLY_KEYWORD = "deterministic_parser"
 
 
 def test_contract_marker_is_registered(pytestconfig):
@@ -155,6 +157,45 @@ def test_targeting_the_contract_directory_fails_when_no_guard_runs():
     )
 
 
+def test_selecting_the_guards_by_keyword_fails_when_none_run():
+    """`-k contract` with no gate must not be a green no-op either.
+
+    This directory is a package named `contract`, so `-k contract` selects
+    everything under it and the guards skip inside an otherwise-passing run.
+    This module is deselected in the child to avoid recursing into itself.
+    """
+    result = _nested_pytest("-k", "contract", f"--deselect=tests/contract/{Path(__file__).name}")
+    assert result.returncode != 0, (
+        "`pytest -k contract` with the gate unset exited 0 while every guard "
+        f"skipped — a false green.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "no guard executed" in result.stdout, (
+        f"the session failed without saying why:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_filtering_the_guards_out_by_keyword_is_not_a_failure():
+    """`-k` that excludes the guards is not "they never ran".
+
+    The mirror of the test above, and the boundary it must not cross: arming is
+    not failing. The run targets this directory (so the guard *is* armed) but
+    the keyword leaves zero guards selected — silence is the only correct
+    outcome.
+
+    `CONTROL_ONLY_KEYWORD` matches a single ungated control. The obvious `-k meta`
+    would select this module, which spawns the child, and recurse.
+    """
+    result = _nested_pytest("tests/contract", "-k", CONTROL_ONLY_KEYWORD)
+    assert result.returncode == 0, (
+        "a run that filtered the contract tests out by keyword was failed for "
+        f"not running them.\n{result.stdout}\n{result.stderr}"
+    )
+    assert "1 passed" in result.stdout, (
+        f"{CONTROL_ONLY_KEYWORD!r} no longer selects exactly the one control this "
+        f"test needs.\n{result.stdout}\n{result.stderr}"
+    )
+
+
 def test_deselecting_the_guards_is_not_a_failure():
     """`-m "not contract"` deselects the guards; that is not "they never ran".
 
@@ -186,28 +227,39 @@ def test_collect_only_is_not_failed_by_the_skip_guard():
 
 
 @pytest.mark.parametrize(
-    ("markexpr", "args", "arms", "why"),
+    ("markexpr", "keyword", "args", "arms", "why"),
     [
-        ("contract", ["tests"], True, "the marker is named"),
-        ("not contract", ["tests"], True, "conservative: mark expr mentions it; selection count decides"),
-        ("", ["tests/contract"], True, "the directory is named"),
-        ("", [str(CONTRACT_DIR)], True, "the directory is named absolutely"),
-        ("", [f"tests/contract/{GATE_ONLY_MODULE}"], True, "a module inside it is named"),
-        ("", [f"tests/contract/{GATE_ONLY_MODULE}::test_x"], True, "a single test inside it is named"),
-        ("", ["tests"], False, "the default suite: a parent, not a path inside"),
-        ("", [], False, "bare pytest before testpaths expands"),
-        ("", ["tests/test_config.py"], False, "an unrelated module"),
-        ("", ["tests/contract_notes"], False, "a sibling whose name merely starts the same"),
+        ("contract", "", ["tests"], True, "the marker is named"),
+        ("not contract", "", ["tests"], True, "conservative: mark expr mentions it; selection count decides"),
+        ("", "contract", ["tests"], True, "the keyword is named"),
+        ("", "contract", [], True, "the keyword is named, bare pytest"),
+        ("", "not contract", ["tests"], True, "conservative: keyword mentions it; selection count decides"),
+        ("", "", ["tests/contract"], True, "the directory is named"),
+        ("", "", [str(CONTRACT_DIR)], True, "the directory is named absolutely"),
+        ("", "", [f"tests/contract/{GATE_ONLY_MODULE}"], True, "a module inside it is named"),
+        ("", "", [f"tests/contract/{GATE_ONLY_MODULE}::test_x"], True, "a single test inside it is named"),
+        ("", "", ["tests.contract"], True, "--pyargs names it as a dotted module"),
+        ("", "", [f"tests.contract.{GATE_ONLY_MODULE.removesuffix('.py')}"], True, "--pyargs names a module inside"),
+        ("", "", ["tests"], False, "the default suite: a parent, not a path inside"),
+        ("", "", [], False, "bare pytest before testpaths expands"),
+        ("", "meta", ["tests"], False, "an unrelated keyword"),
+        ("", "", ["tests/test_config.py"], False, "an unrelated module"),
+        ("", "", ["tests/contract_notes"], False, "a sibling whose name merely starts the same"),
+        ("", "", ["tests.test_config"], False, "an unrelated dotted module"),
     ],
 )
-def test_skip_guard_arming_boundary(markexpr, args, arms, why):
+def test_skip_guard_arming_boundary(markexpr, keyword, args, arms, why):
     """Pin exactly which invocations arm the skipped-run guard.
+
+    Every input pytest can express "I want the contract guards" with has to be an
+    argument here: a spelling the function cannot see is a spelling it cannot
+    guard. `-k` was the third false green found precisely because it was missing.
 
     The default-suite rows are the load-bearing ones: `pytest` and `pytest tests`
     both pass `tests`, a *parent* of this directory. If either armed, every
     default run would go red on the self-skipping guards.
     """
-    assert arms_skip_guard(markexpr, args, REPO_ROOT) is arms, why
+    assert arms_skip_guard(markexpr, keyword, args, REPO_ROOT) is arms, why
 
 
 def test_gate_variables_survive_the_root_sandbox_strip():

--- a/tests/contract/test_extraction_contract.py
+++ b/tests/contract/test_extraction_contract.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Contract guard for issue #238: a founding-date fact the live extractor produces
+must normalise into the policy's *functional* relation vocabulary, so the
+functional-conflict check can fire when a source states two different dates.
+
+The functional vocabulary is not hard-coded here: it is parsed from
+``engine.wirelog.DEFAULT_POLICY``'s ``functional("...")`` declarations, the same
+program the verifier runs. A relation the extractor emits (e.g. ``founded`` /
+``established``) that does not normalise into that set leaves the conflict check
+blind to the contradiction — the #238 failure. On ``origin/main`` (no #238 fix)
+the live and replay assertions are expected to fail; the differential test is a
+positive control that stays green to prove the check itself works.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+import pytest
+
+from verinote.engine import DEFAULT_POLICY
+from verinote.llm.schema import parse_facts
+from verinote.pipeline.corroboration import (
+    canonical_relation,
+    functional_relations,
+    relation_aliases,
+)
+from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
+
+FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "contract" / "extraction_acme_two_dates.json"
+
+_YEAR = re.compile(r"20(?:20|21)")
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _founding_relations(facts) -> set[str]:
+    """Relations linking Acme Robotics to one of the two founding years, normalised.
+
+    Identifies founding facts structurally (subject is the entity, object carries
+    the year) rather than by hard-coded relation label — the label is exactly what
+    #238 is about, so keying on it would beg the question.
+    """
+    aliases = relation_aliases(DEFAULT_RELATION_ALIASES)
+    founding = [
+        f
+        for f in facts
+        if "acme" in f.subject.lower() and _YEAR.search(f.object)
+    ]
+    assert founding, "extractor produced no Acme founding-date fact"
+    return {canonical_relation(f.relation, aliases) for f in founding}
+
+
+@pytest.mark.contract
+def test_live_founding_relation_normalizes_into_functional_vocab(require_live_provider):
+    client = require_live_provider
+    facts = client.extract_facts(
+        source_text=_fixture()["input"],
+    )
+    functional = functional_relations(DEFAULT_POLICY)
+    normalized = _founding_relations(facts)
+    assert normalized & functional, (
+        f"founding relations {sorted(normalized)} do not normalise into the policy's "
+        f"functional vocabulary {sorted(functional)}; the functional-conflict check "
+        "cannot see the two-date contradiction (#238)"
+    )
+
+
+@pytest.mark.contract
+def test_replay_founding_relation_normalizes_into_functional_vocab(require_opt_in):
+    fixture = _fixture()
+    facts = parse_facts(fixture["raw_response"])
+    # Non-vacuity: the capture must actually contain both founding years, or the
+    # replay would pass without ever testing the contradiction it exists for.
+    years = {m.group(0) for f in facts for m in [_YEAR.search(f.object)] if m}
+    assert {"2020", "2021"} <= years, f"fixture is missing a founding year: {sorted(years)}"
+    functional = functional_relations(DEFAULT_POLICY)
+    normalized = _founding_relations(facts)
+    assert normalized & functional, (
+        f"founding relations {sorted(normalized)} do not normalise into the policy's "
+        f"functional vocabulary {sorted(functional)} (#238)"
+    )
+
+
+@pytest.mark.contract
+def test_functional_conflict_fires_on_two_dates(require_opt_in):
+    """Positive control: once a founding relation is functional, two dates conflict.
+
+    Differential — feeds normalised facts to the real DuckDB verifier. A
+    functional relation with two objects must error; a non-functional one must
+    not. This stays green on every branch; it proves the conflict machinery the
+    live/replay guards depend on is real, not a stub.
+    """
+    pytest.importorskip("duckdb")
+    from verinote.engine.duckdb_backend import run_check_duckdb
+
+    functional = functional_relations(DEFAULT_POLICY)
+    assert functional, "policy declares no functional relations"
+    rel = "established_on" if "established_on" in functional else sorted(functional)[0]
+
+    conflict = run_check_duckdb(
+        [
+            {"subject": "Acme Robotics", "relation": rel, "object": "2020"},
+            {"subject": "Acme Robotics", "relation": rel, "object": "2021"},
+        ]
+    )
+    assert conflict.engine_available is True
+    assert conflict.errors == 1
+    assert any("functional_conflict" in finding for finding in conflict.findings)
+
+    non_functional = "founded"
+    assert non_functional not in functional
+    clean = run_check_duckdb(
+        [
+            {"subject": "Acme Robotics", "relation": non_functional, "object": "2020"},
+            {"subject": "Acme Robotics", "relation": non_functional, "object": "2021"},
+        ]
+    )
+    assert clean.errors == 0

--- a/tests/contract/test_query_intent_contract.py
+++ b/tests/contract/test_query_intent_contract.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Contract guard for issue #237: a role question the deterministic parser cannot
+resolve must still yield a valid query intent through the *live* provider and the
+production parse boundary.
+
+The deterministic parser deliberately returns ``unknown_or_unsupported`` for a
+"who is the CEO of X" question (asserted below as a precondition), so the only
+thing that can turn it into an executable intent is the LLM. This guard fails on
+any branch where the provider's raw intent is rejected by ``parse_query_intent``
+— for example when the model fills ``reason`` on a ``lookup_object`` intent, the
+schema the parser rejects. On ``origin/main`` (no #237 fix) both the live and the
+replay assertions are expected to fail; that red is the point.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from verinote.pipeline.query_intent import (
+    QueryIntent,
+    QueryIntentKind,
+    deterministic_query_intent,
+    parse_query_intent,
+)
+
+FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "contract" / "query_intent_acme_ceo.json"
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_deterministic_parser_does_not_resolve_the_role_question():
+    """Precondition: the deterministic parser hands this question off to the LLM.
+
+    Locks the assumption the whole guard rests on. If the deterministic parser
+    ever starts resolving this, the live/replay assertions below would stop
+    exercising the provider boundary and silently go vacuous.
+    """
+    intent = deterministic_query_intent("Who is the CEO of Acme Robotics?")
+    assert intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+
+
+@pytest.mark.contract
+def test_live_provider_yields_valid_query_intent(require_live_provider):
+    client = require_live_provider
+    intent = client.extract_query_intent(question="Who is the CEO of Acme Robotics?")
+    assert isinstance(intent, QueryIntent)
+    assert intent.kind != QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+
+
+@pytest.mark.contract
+def test_replay_raw_intent_parses_through_production_boundary(require_opt_in):
+    fixture = _fixture()
+    raw = json.loads(fixture["raw_response"])
+    # Non-vacuity: the capture must actually hold the #237 failure shape — a
+    # populated `reason` on a lookup intent — or this replay proves nothing.
+    assert raw.get("reason"), "fixture does not capture the #237 failure shape (reason must be set)"
+    intent = parse_query_intent(fixture["raw_response"])
+    assert isinstance(intent, QueryIntent)
+    assert intent.kind != QueryIntentKind.UNKNOWN_OR_UNSUPPORTED

--- a/tests/contract/test_sync_rc_contract.py
+++ b/tests/contract/test_sync_rc_contract.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Contract guard for issue #239: `verinote sync` must not report success when
+every extraction chunk fails.
+
+Deterministic and provider-free — it drives the real chunked-extraction CLI path
+with a stub client that raises on each chunk, so it needs no live provider. It is
+still gated behind the same opt-in signal as the live guards (via
+``require_opt_in``) so the default suite stays green; without that gate a run of
+``pytest tests`` would go red on a bug this branch has not fixed yet.
+
+On ``origin/main`` (no #239 fix) the chunked path swallows every per-chunk
+``LLMError`` and `cmd_sync` returns 0, so both assertions here are expected to
+fail. That red is the point; ``@pytest.mark.contract`` keeps it opt-in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import verinote.cli as cli
+from verinote.llm.base import ExtractedFact, LLMError
+
+FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "contract" / "sync_all_chunks_failed.json"
+
+# Long enough, with a tiny chunk size, to split into several chunks so "every
+# chunk failed" is a real multi-chunk annihilation, not a single-chunk edge case.
+_SOURCE = (
+    "Acme Robotics is a company. Acme Robotics was founded in 2020 according to "
+    "its incorporation filing. A later press release states that Acme Robotics "
+    "was established in 2021. The company builds warehouse automation systems. "
+    "Its headquarters are in Portland. It employs three hundred people."
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+class _AllChunksFail:
+    """Raises `LLMError` on every chunk — the provider-down / all-fail scenario."""
+
+    name = "all-chunks-fail"
+
+    def __init__(self, reason: str) -> None:
+        self._reason = reason
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        raise LLMError(self._reason)
+
+
+class _FirstChunkFails:
+    """Fails only the first chunk, then succeeds — the partial-failure scenario."""
+
+    name = "first-chunk-fails"
+
+    def __init__(self, reason: str) -> None:
+        self._reason = reason
+        self._calls = 0
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
+        self._calls += 1
+        if self._calls == 1:
+            raise LLMError(self._reason)
+        return [ExtractedFact("Acme Robotics", "is_a", "company", 0.9)]
+
+
+def _prepare_kb(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+    # Force several chunks so all-fail is a genuine multi-chunk wipeout.
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "40")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+    src = tmp_path / "acme.txt"
+    src.write_text(_SOURCE, encoding="utf-8")
+    assert cli.main(["ingest", str(src)]) == 0
+    return src
+
+
+@pytest.mark.contract
+def test_sync_fails_when_every_chunk_fails(tmp_path, monkeypatch, capsys, require_opt_in):
+    reason = _fixture()["failure_reason"]
+    assert reason, "fixture is missing the recorded chunk failure reason"
+    _prepare_kb(tmp_path, monkeypatch)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _AllChunksFail(reason))
+
+    rc = cli.main(["sync"])
+
+    err = capsys.readouterr().err
+    assert rc != 0, "#239 guard: sync must not return success when every chunk failed"
+    assert "fail" in err.lower(), "#239 guard: the failure must be reported on stderr"
+
+
+@pytest.mark.contract
+def test_total_failure_differs_from_partial_failure(tmp_path, monkeypatch, capsys, require_opt_in):
+    """Total wipeout and partial failure must not be reported identically (#239)."""
+    reason = _fixture()["failure_reason"]
+
+    _prepare_kb(tmp_path, monkeypatch)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _AllChunksFail(reason))
+    total_rc = cli.main(["sync"])
+    capsys.readouterr()
+
+    _prepare_kb(tmp_path, monkeypatch)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _FirstChunkFails(reason))
+    partial_rc = cli.main(["sync"])
+    capsys.readouterr()
+
+    assert total_rc != partial_rc, (
+        "#239 guard: a total extraction wipeout must be distinguishable from a "
+        f"partial failure, but both returned rc={total_rc}"
+    )

--- a/tests/fixtures/contract/extraction_acme_two_dates.json
+++ b/tests/fixtures/contract/extraction_acme_two_dates.json
@@ -1,0 +1,9 @@
+{
+  "provider": "claudecli",
+  "model": "sonnet",
+  "prompt_id": "extraction",
+  "captured_at": "2026-07-16",
+  "input": "Acme Robotics is a company. Acme Robotics was founded in 2020 according to its incorporation filing. A later press release states that Acme Robotics was established in 2021.",
+  "raw_response": "{\"facts\":[{\"subject\":{\"kind\":\"string\",\"value\":\"Acme Robotics\"},\"relation\":{\"kind\":\"string\",\"value\":\"is_a\"},\"object\":{\"kind\":\"string\",\"value\":\"company\"},\"confidence\":1,\"note\":\"Acme Robotics is a company.\"},{\"subject\":{\"kind\":\"string\",\"value\":\"Acme Robotics\"},\"relation\":{\"kind\":\"string\",\"value\":\"founded\"},\"object\":{\"kind\":\"term\",\"value\":\"date(2020)\"},\"confidence\":0.9,\"note\":\"Acme Robotics was founded in 2020 according to its incorporation filing.\"},{\"subject\":{\"kind\":\"string\",\"value\":\"incorporation filing\"},\"relation\":{\"kind\":\"string\",\"value\":\"states_founding_year\"},\"object\":{\"kind\":\"term\",\"value\":\"date(2020)\"},\"confidence\":0.9,\"note\":\"founded in 2020 according to its incorporation filing\"},{\"subject\":{\"kind\":\"string\",\"value\":\"Acme Robotics\"},\"relation\":{\"kind\":\"string\",\"value\":\"established\"},\"object\":{\"kind\":\"term\",\"value\":\"date(2021)\"},\"confidence\":0.85,\"note\":\"A later press release states that Acme Robotics was established in 2021.\"},{\"subject\":{\"kind\":\"string\",\"value\":\"press release\"},\"relation\":{\"kind\":\"string\",\"value\":\"states_establishment_year\"},\"object\":{\"kind\":\"term\",\"value\":\"date(2021)\"},\"confidence\":0.85,\"note\":\"A later press release states that Acme Robotics was established in 2021.\"}]}",
+  "parse_error": null
+}

--- a/tests/fixtures/contract/query_intent_acme_ceo.json
+++ b/tests/fixtures/contract/query_intent_acme_ceo.json
@@ -1,0 +1,9 @@
+{
+  "provider": "claudecli",
+  "model": "sonnet",
+  "prompt_id": "query-intent",
+  "captured_at": "2026-07-16",
+  "input": "Who is the CEO of Acme Robotics?",
+  "raw_response": "{\"kind\":\"lookup_object\",\"subject\":{\"kind\":\"entity\",\"value\":\"Acme Robotics\"},\"relation\":{\"kind\":\"relation\",\"value\":\"CEO\"},\"object\":null,\"relation_candidates\":[\"CEO\",\"chief executive officer\",\"leadership\"],\"operator\":null,\"value_type\":null,\"value\":null,\"reason\":\"The question asks for the object value (person) filling the CEO relation for the entity Acme Robotics.\"}",
+  "parse_error": "query intent output did not match schema: lookup_object does not accept reason"
+}

--- a/tests/fixtures/contract/sync_all_chunks_failed.json
+++ b/tests/fixtures/contract/sync_all_chunks_failed.json
@@ -1,0 +1,10 @@
+{
+  "provider": "always-fails",
+  "model": "none",
+  "prompt_id": "sync-extraction",
+  "captured_at": "2026-07-16",
+  "input": "Acme Robotics is a company. Acme Robotics was founded in 2020 according to its incorporation filing. A later press release states that Acme Robotics was established in 2021.",
+  "completed_chunks": 0,
+  "failed_chunks": 5,
+  "failure_reason": "provider refused chunk: synthetic outage for #239 capture"
+}


### PR DESCRIPTION
목킹된 스위트가 놓친 세 결함(#237/#238/#239)을 실제 프로바이더 응답으로 잡는 opt-in 계약 가드를 추가한다. **테스트 전용 — 프로덕션 코드 무수정.**

Closes #241

## ⚠️ 머지 판단자에게

이 PR의 계약 가드는 **올바른 계약**을 단언한다. 현재 main에는 #237/#238/#239의 fix가 없으므로, opt-in으로 실행하면 가드 7개 중 6개가 **의도적으로 red**이고 1개(#238 positive control)만 green이다. **이 red는 버그가 아직 살아있다는 증거이며, 각 fix가 머지되면 green으로 뒤집힌다.** 가드는 opt-in(`contract` 마커 + `VERINOTE_CONTRACT_PROVIDER` 게이트)이라 **기본 스위트/CI에는 영향이 없다** — 기본 `pytest tests`는 943 passed + 7 skipped로 초록.

## 무엇을

- `tests/contract/` (신규): 세 회귀 가드
  - **#237 가드** (`test_query_intent_contract.py`): 라이브 — 실제 어댑터의 `extract_query_intent`가 LLMError 없이 유효 인텐트를 반환하는지. 리플레이 — 캡처된 raw 응답을 프로덕션 파스 경계 `parse_query_intent`에 통과. 전제조건으로 결정론 파서가 이 질문을 가로채지 않음을 잠금.
  - **#238 가드** (`test_extraction_contract.py`): 실제/캡처 추출 라벨이 정책의 functional 어휘로 정규화되는지 — functional 집합은 하드코딩이 아니라 `DEFAULT_POLICY` 파싱으로 도출. DuckDB `functional_conflict` positive control 포함(모든 브랜치에서 green, 충돌 기계가 stub이 아님을 증명).
  - **#239 가드** (`test_sync_rc_contract.py`): 청크 전멸 시 `sync`가 rc≠0 + stderr 사유 + 전멸/부분실패 구분을 내는지 (CLI rc 전파 계약 — 모델 캡처 불필요, synthetic으로 정직히 표기).
- `tests/fixtures/contract/` (신규): claudecli 로컬 **실캡처** 픽스처 3개 (provenance 포함). #237 픽스처는 `reason`이 채워진 실제 실패 shape, #238 픽스처는 `founded`/`established` 라벨 + 2020·2021 양 날짜.
- **skip이 초록불로 보이지 않게**: `test_contract_meta.py`(기본 스위트에서 항상 실행 — 필수 픽스처 3개 개별 존재·provenance·모듈 collectable 단언, 하네스 rot 감지) + `run.sh`(계약 테스트가 선택됐는데 전부 skip이면 exit 1) + `addopts=["-ra"]`(skip 사유 상시 노출).
- `pyproject.toml`: `contract` 마커 등록 + `-ra` — 2줄.

## Closes #241 정당성

acceptance는 "세 테스트가 지금 통과"가 아니라 (a) opt-in 마커의 계약 테스트 존재, (b) 목 픽스처를 **실제 모델 응답 캡처**로 생성, (c) skip이 초록불로 안 보임 — 셋 다 충족.

## 검증

- 기본 스위트: **943 passed, 7 skipped** (가드 self-skip, 사유 명시) / `ruff check` clean
- opt-in(claudecli): **6 red(의도) / 1 green(positive control)** — #237은 `lookup_object does not accept reason`, #238은 `founded/established → functional 어휘 정규화 실패`, #239는 `rc=0` 으로 각각 프로덕션 경계에서 실패
- meta 뮤테이션: 단일 픽스처 삭제 → red 확인
- 열린 PR 11개 전부 + 병렬 레인(#267, #268)과 `git merge-tree` 무충돌

## 범위 경계

`.github/workflows/ci.yml`(PR #248 점유), `tests/conftest.py`(PR #210 점유), `verinote/**`, 기존 `tests/*.py`, `README.md` 무수정.

## 알려진 한계

리뷰 중 해소됨 — 게이트를 `VN_CONTRACT_*`로 옮겼다. 루트 conftest의 sandbox는 `VERINOTE_*`만 strip하므로 이제 어떤 호출 경로(`pytest tests -m contract` 포함)에서도 게이트가 조용히 지워지지 않는다. 이것이 #272가 요구한 수정이며, 이 PR이 담고 있다.

**Closes #272**

## 후속

- #270 — CI 레인/스케줄 배선 (#248 머지 후; fix 머지 후 결정론 리플레이 가드의 기본 스위트 승격 검토)
- #271 — ollama/openai/anthropic 실응답 픽스처 캡처

