### PR TITLE
fix(#247): refuse status/coverage on an absent or unusable KB instead of scaffolding one

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1119,6 +1119,26 @@ def _partial_schema_db(root: Path) -> Path:
     return db
 
 
+def _core_tables_with_idless_facts_db(root: Path) -> Path:
+    """Core table names are not enough when `facts` lacks its row identity."""
+    root.mkdir(parents=True, exist_ok=True)
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            subject TEXT, relation TEXT, object TEXT, status TEXT
+        );
+        CREATE TABLE sources (id INTEGER PRIMARY KEY, path TEXT NOT NULL UNIQUE);
+        CREATE TABLE runs (id INTEGER PRIMARY KEY);
+        CREATE TABLE review_log (id INTEGER PRIMARY KEY);
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
 def test_read_only_commands_still_accept_a_kb_predating_the_later_tables(
     tmp_path, monkeypatch, capsys
 ):
@@ -1202,3 +1222,33 @@ def test_read_only_commands_refuse_a_partial_schema_instead_of_completing_it(
     tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
     conn.close()
     assert tables == {"facts"}
+
+
+@pytest.mark.parametrize("command", ["status", "coverage"])
+def test_read_only_commands_refuse_core_tables_when_facts_lacks_id(
+    command, tmp_path, monkeypatch, capsys
+):
+    """`facts.id` is part of the oldest KB identity, not a migratable column.
+
+    Without this guard, a file with verinote-looking core table names but no
+    `facts.id` reaches `_store().init_schema()`, gains later migration tables,
+    and then fails deeper in a command that was supposed to read only.
+    """
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "idless-facts"
+    db = _core_tables_with_idless_facts_db(root)
+    before = db.read_bytes()
+    before_mtime = db.stat().st_mtime_ns
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main([command]) == 1
+
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+    assert "is not a verinote KB" in err
+    assert db.read_bytes() == before
+    assert db.stat().st_mtime_ns == before_mtime
+    conn = sqlite3.connect(db)
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert tables == {"facts", "review_log", "runs", "sources"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -918,3 +919,74 @@ def test_coverage_rejects_a_corrupt_db_file_without_a_traceback(
 
     assert db.read_bytes() == b"not sqlite"  # file left untouched, no traceback
     assert "is not a verinote KB" in capsys.readouterr().err
+
+
+def _alien_facts_db(root: Path) -> Path:
+    """A readable SQLite file holding a `facts` table that is not verinote's.
+
+    The shape a half-finished script or an unrelated project leaves behind: the
+    table name matches, so a name-only probe calls it a KB, but none of the
+    columns the KB is made of are there.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE facts (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    return db
+
+
+@pytest.mark.parametrize("command", ["status", "coverage"])
+def test_read_only_commands_refuse_a_foreign_facts_table_without_touching_it(
+    command, tmp_path, monkeypatch, capsys
+):
+    """A `facts` table alone is not a KB, and the file is not ours to migrate.
+
+    Probing for the *name* `facts` let this file through as healthy. `_store()`
+    then ran `init_schema()` on it, which failed on the mismatched table with a
+    raw `sqlite3.OperationalError` — but only after `CREATE TABLE IF NOT EXISTS`
+    had already added six tables to a file the user asked us to *read*. A
+    diagnosis that half-migrates whatever it is pointed at is worse than one that
+    refuses: the write is the damage, and the traceback merely reports it.
+    """
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "alien"
+    db = _alien_facts_db(root)
+    before = db.read_bytes()
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main([command]) == 1
+
+    assert db.read_bytes() == before  # not one byte of a file we were asked to read
+    assert sorted(p.name for p in root.iterdir()) == ["kb.sqlite"]  # no -wal, no policy
+    err = capsys.readouterr().err
+    assert "is not a verinote KB" in err
+    assert "Traceback" not in err
+
+
+def test_read_only_commands_still_accept_a_kb_predating_the_job_id_column(
+    tmp_path, monkeypatch, capsys
+):
+    """The other edge of the same check: it must not reject KBs migration exists to fix.
+
+    `facts.job_id` is added by `_ensure_schema_migrations()`, so a KB written
+    before that column existed is *valid* and self-heals on open. Demanding the
+    current schema's full column set here would refuse those KBs outright — which
+    is why the guard asks only for the columns every verinote KB has ever had.
+    """
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "legacy"
+    root.mkdir()
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    store.close()
+    conn = sqlite3.connect(root / "kb.sqlite")
+    conn.execute("ALTER TABLE facts DROP COLUMN job_id")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main(["status"]) == 0
+
+    assert "KB:" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -856,3 +856,65 @@ def test_seed_accepts_a_kb_whose_path_holds_a_uri_metacharacter(tmp_path, monkey
     store = Store(root / "kb.sqlite")
     assert len(store.facts()) == len(cli._DEMO_FACTS)
     store.close()
+
+
+def test_status_on_absent_kb_refuses_and_creates_nothing(tmp_path, monkeypatch, capsys):
+    """A read-only diagnosis must not scaffold a fresh KB at a mistyped path."""
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["status"]) == 1
+
+    assert not (workdir / "data").exists()  # no KB was created behind our back
+    err = capsys.readouterr().err
+    assert "no KB" in err
+    assert str(workdir / "data") in err
+
+
+def test_coverage_on_absent_kb_refuses_and_creates_nothing(tmp_path, monkeypatch, capsys):
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["coverage"]) == 1
+
+    assert not (workdir / "data").exists()
+    err = capsys.readouterr().err
+    assert "no KB" in err
+    assert str(workdir / "data") in err
+
+
+def test_status_rejects_an_empty_db_file_instead_of_creating_a_schema(
+    tmp_path, monkeypatch, capsys
+):
+    """`kb.sqlite` existing is not enough: status reads an *initialised* KB."""
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "broken"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    db.write_bytes(b"")
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main(["status"]) == 1
+
+    assert db.read_bytes() == b""  # no schema was created behind our back
+    assert "is not a verinote KB" in capsys.readouterr().err
+
+
+def test_coverage_rejects_a_corrupt_db_file_without_a_traceback(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "corrupt"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    db.write_bytes(b"not sqlite")
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main(["coverage"]) == 1
+
+    assert db.read_bytes() == b"not sqlite"  # file left untouched, no traceback
+    assert "is not a verinote KB" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -992,6 +992,28 @@ def test_read_only_commands_still_accept_a_kb_predating_the_job_id_column(
     assert "KB:" in capsys.readouterr().out
 
 
+def _alien_sources_db(root: Path) -> Path:
+    """A verinote `facts` table beside somebody else's `sources` table.
+
+    Passes the `facts` probe, then fails deeper in on `SELECT ... ORDER BY path`.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY, subject TEXT, relation TEXT,
+            object TEXT, status TEXT
+        );
+        CREATE TABLE sources (nonsense TEXT);
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
 @pytest.mark.parametrize("command", ["status", "coverage"])
 def test_read_only_commands_diagnose_an_alien_table_past_the_facts_probe(
     command, tmp_path, monkeypatch, capsys
@@ -1015,19 +1037,7 @@ def test_read_only_commands_diagnose_an_alien_table_past_the_facts_probe(
     """
     _isolated(monkeypatch, tmp_path)
     root = tmp_path / "alien-sources"
-    root.mkdir()
-    conn = sqlite3.connect(root / "kb.sqlite")
-    conn.executescript(
-        """
-        CREATE TABLE facts (
-            id INTEGER PRIMARY KEY, subject TEXT, relation TEXT,
-            object TEXT, status TEXT
-        );
-        CREATE TABLE sources (nonsense TEXT);
-        """
-    )
-    conn.commit()
-    conn.close()
+    _alien_sources_db(root)
     monkeypatch.setenv("VERINOTE_ROOT", str(root))
 
     assert cli.main([command]) == 1
@@ -1035,4 +1045,49 @@ def test_read_only_commands_diagnose_an_alien_table_past_the_facts_probe(
     out = capsys.readouterr()
     assert "Traceback" not in out.err
     assert "cannot read the KB" in out.err
-    assert "may already have been modified" in out.err  # the write is not hidden
+    # The message may not pin the blame on the KB: a `DatabaseError` here is just
+    # as likely to be verinote's own SQL bug, and telling *that* user to restore a
+    # healthy KB from backup is worse advice than the traceback this replaced.
+    assert "or a bug in verinote" in out.err
+    # So the one check the code cannot make is handed to the user, and the restore
+    # advice waits behind it rather than being an unconditional imperative.
+    assert "opens with another verinote version" in out.err
+    assert "do not restore anything" in out.err
+
+
+def test_the_two_refusal_paths_do_not_borrow_each_others_diagnosis(
+    tmp_path, monkeypatch, capsys
+):
+    """The probe refusal and the wrap diagnosis describe different worlds.
+
+    The probe refuses *before* anything opens the KB read-write, so that file is
+    provably untouched. The wrap only ever fires after `_store()` has already
+    written. Leaking the wrap's "restore from backup" into the probe's path would
+    tell a user to recover a file nothing has touched; leaking the probe's flat
+    "not a verinote KB" into the wrap's path would state a cause we cannot know.
+    """
+    _isolated(monkeypatch, tmp_path)
+    probe_root = tmp_path / "probe"
+    probe_db = _alien_facts_db(probe_root)
+    before = probe_db.read_bytes()
+    monkeypatch.setenv("VERINOTE_ROOT", str(probe_root))
+
+    assert cli.main(["status"]) == 1
+
+    probe_err = capsys.readouterr().err
+    assert probe_db.read_bytes() == before  # nothing to restore, and we say nothing
+    assert "is not a verinote KB" in probe_err
+    assert "backup" not in probe_err
+    assert "bug in verinote" not in probe_err
+
+    wrap_root = tmp_path / "wrap"
+    _alien_sources_db(wrap_root)
+    monkeypatch.setenv("VERINOTE_ROOT", str(wrap_root))
+
+    assert cli.main(["status"]) == 1
+
+    wrap_err = capsys.readouterr().err
+    assert "cannot read the KB" in wrap_err
+    assert "is not a verinote KB" not in wrap_err
+
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -990,3 +990,49 @@ def test_read_only_commands_still_accept_a_kb_predating_the_job_id_column(
     assert cli.main(["status"]) == 0
 
     assert "KB:" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("command", ["status", "coverage"])
+def test_read_only_commands_diagnose_an_alien_table_past_the_facts_probe(
+    command, tmp_path, monkeypatch, capsys
+):
+    """The probe checks `facts`; the KB is made of more tables than that.
+
+    A file whose `facts` table is verinote's but whose `sources` table is
+    somebody else's gets past the probe and blows up deeper in
+    (`no such column: path`). Tightening the probe to every table's columns
+    would be the schema-drift trap the probe is shaped to avoid, so instead the
+    read-only commands own their contract at the boundary: a diagnosis reports,
+    it does not traceback.
+
+    LIMITATION, on purpose: this closes the traceback, *not* the write. By the
+    time the error surfaces, `_store()` has already run `init_schema()` and the
+    file has grown. Only refusing to open the KB read-write would fix that, and
+    that is issue #291 — `_store()` writes unconditionally, so today even a
+    healthy `status` writes. This test deliberately asserts nothing about the
+    file's bytes: pinning today's damage would be a test of the bug, and it must
+    not go red when #291 stops the write.
+    """
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "alien-sources"
+    root.mkdir()
+    conn = sqlite3.connect(root / "kb.sqlite")
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY, subject TEXT, relation TEXT,
+            object TEXT, status TEXT
+        );
+        CREATE TABLE sources (nonsense TEXT);
+        """
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main([command]) == 1
+
+    out = capsys.readouterr()
+    assert "Traceback" not in out.err
+    assert "cannot read the KB" in out.err
+    assert "may already have been modified" in out.err  # the write is not hidden

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -995,7 +995,13 @@ def test_read_only_commands_still_accept_a_kb_predating_the_job_id_column(
 def _alien_sources_db(root: Path) -> Path:
     """A verinote `facts` table beside somebody else's `sources` table.
 
-    Passes the `facts` probe, then fails deeper in on `SELECT ... ORDER BY path`.
+    Passes the probe, then fails deeper in on `SELECT ... ORDER BY path`.
+
+    The core tables are all present and only `sources`' *columns* are alien, which
+    is what keeps this file past the probe: the probe asks which tables are there,
+    not what every column of each one looks like — checking that would be the
+    schema-drift trap it is shaped to avoid. So this file is exactly the case the
+    probe cannot catch by construction, which is why the wrap has to.
     """
     root.mkdir(parents=True, exist_ok=True)
     db = root / "kb.sqlite"
@@ -1007,6 +1013,8 @@ def _alien_sources_db(root: Path) -> Path:
             object TEXT, status TEXT
         );
         CREATE TABLE sources (nonsense TEXT);
+        CREATE TABLE runs (id INTEGER PRIMARY KEY);
+        CREATE TABLE review_log (id INTEGER PRIMARY KEY);
         """
     )
     conn.commit()
@@ -1091,3 +1099,106 @@ def test_the_two_refusal_paths_do_not_borrow_each_others_diagnosis(
     assert "is not a verinote KB" not in wrap_err
 
 
+def _partial_schema_db(root: Path) -> Path:
+    """A verinote-shaped `facts` table and nothing else — not a KB.
+
+    Every column the identity probe asks for is here, so a facts-only probe
+    calls this a KB. But no verinote KB has ever consisted of `facts` alone:
+    `sources`, `runs` and `review_log` have been in `schema.sql` since the
+    initial commit, so a file missing them was never written by verinote.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts (id INTEGER PRIMARY KEY, subject TEXT, "
+        "relation TEXT, object TEXT, status TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_read_only_commands_still_accept_a_kb_predating_the_later_tables(
+    tmp_path, monkeypatch, capsys
+):
+    """The other edge of the core-table check, and the one that bounds its reach.
+
+    `schema.sql` grew from four tables to eleven, and `init_schema()` runs it on
+    every open — so `CREATE TABLE IF NOT EXISTS` is how `kb_meta`, `fact_events`
+    and the rest reach KBs written before they existed. Demanding the *current*
+    table set here would refuse those KBs outright, which is why the check asks
+    only for the four tables the schema has had since its initial commit.
+
+    So this is a KB from before any of the later tables existed: it must still
+    open and self-heal, exactly as the missing-column case above does. The
+    sibling test proves a `facts` table alone is refused; this one proves the
+    refusal stops there and does not reach real KBs.
+    """
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "ancient"
+    root.mkdir()
+    conn = sqlite3.connect(root / "kb.sqlite")
+    conn.executescript(
+        """
+        CREATE TABLE sources (
+            id INTEGER PRIMARY KEY, path TEXT NOT NULL UNIQUE,
+            added_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE runs (
+            id INTEGER PRIMARY KEY, started_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY, subject TEXT NOT NULL, relation TEXT NOT NULL,
+            object TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'candidate'
+        );
+        CREATE TABLE review_log (
+            id INTEGER PRIMARY KEY, fact_id INTEGER NOT NULL,
+            action TEXT NOT NULL, at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main(["status"]) == 0
+
+    assert "KB:" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("command", ["status", "coverage"])
+def test_read_only_commands_refuse_a_partial_schema_instead_of_completing_it(
+    command, tmp_path, monkeypatch, capsys
+):
+    """A file with only `facts` must not be finished into a KB and reported healthy.
+
+    The identity probe reads the `facts` columns, which this file has, so it used
+    to get through — and then `_store()` ran `init_schema()`, whose
+    `CREATE TABLE IF NOT EXISTS` *completed* the rest of the schema. The command
+    then found a coherent (empty) KB and reported rc=0. That is the worst of both
+    outcomes this PR exists to prevent: a read-only diagnosis wrote to the file,
+    and then vouched for what it had just written.
+    """
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    db = _partial_schema_db(root)
+    before = db.read_bytes()
+    before_mtime = db.stat().st_mtime_ns
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main([command]) == 1
+
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+    assert "is not a verinote KB" in err
+    # The probe refuses before anything opens the file read-write, so the bytes
+    # *and* the mtime are the evidence that nothing ran `init_schema()` here.
+    assert db.read_bytes() == before
+    assert db.stat().st_mtime_ns == before_mtime
+    # The tables `init_schema()` would have added are the tell: if any of these
+    # exist, the read-only command wrote the schema it then reported on.
+    conn = sqlite3.connect(db)
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert tables == {"facts"}

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -161,12 +161,21 @@ def _seed(store: Store) -> None:
         store.add_fact(subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note)
 
 
-# The two ways an existing `kb.sqlite` can fail to be a usable KB. They are not
+# The three ways an existing `kb.sqlite` can fail to be a usable KB. They are not
 # interchangeable: `init`'s whole job is to put a schema into a database that has
-# none, so only the *unreadable* one may stop it. `seed` must refuse both — it
-# fills an existing KB and never creates one.
+# none, so only the *unreadable* one may stop it. `seed` must refuse all three —
+# it fills an existing KB and never creates one.
 KB_UNREADABLE = "not a readable SQLite database"
 KB_NO_SCHEMA = "no `facts` table"
+KB_ALIEN_FACTS = "its `facts` table is not verinote's"
+
+# What a `facts` table must have for the file to be a verinote KB at all. This is
+# deliberately *not* the current schema's column set: `_ensure_schema_migrations()`
+# adds columns (`job_id`) to KBs written before they existed, so requiring today's
+# full set would refuse the very KBs migration exists to repair. These four are the
+# fact itself — every verinote KB has always had them, and no migration adds them —
+# so the check stays put as the schema grows around it.
+_KB_FACTS_IDENTITY_COLUMNS = frozenset({"subject", "relation", "object", "status"})
 
 
 def _kb_schema_problem(db_path: Path) -> str | None:
@@ -176,6 +185,12 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     would let `seed` silently create a schema (it must only fill an existing KB)
     or blow up with a raw `sqlite3` traceback.
 
+    Matching the table *name* alone is not enough either. `init_schema()` is
+    `CREATE TABLE IF NOT EXISTS`, so it skips a `facts` table it did not write and
+    then fails on the mismatch — after having added the rest of the schema to a
+    file the caller only meant to read. Checking the columns keeps that write from
+    ever starting.
+
     The path is percent-encoded via `Path.as_uri()` before it goes into the
     SQLite URI. Interpolating it raw truncates any root holding a `?` or `#` at
     that character, which both misreports a healthy KB as schema-less *and*
@@ -184,15 +199,21 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     try:
         uri = f"{db_path.resolve().as_uri()}?mode=ro"
         conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
         try:
             row = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'facts'"
             ).fetchone()
+            if not row:
+                return KB_NO_SCHEMA
+            columns = {c["name"] for c in conn.execute("PRAGMA table_info(facts)")}
         finally:
             conn.close()
     except sqlite3.DatabaseError:
         return KB_UNREADABLE
-    return None if row else KB_NO_SCHEMA
+    if not _KB_FACTS_IDENTITY_COLUMNS <= columns:
+        return KB_ALIEN_FACTS
+    return None
 
 
 def _require_existing_kb(cfg: Config) -> int | None:

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -195,6 +195,22 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     return None if row else KB_NO_SCHEMA
 
 
+def _require_existing_kb(cfg: Config) -> int | None:
+    """Refuse a read-only diagnosis when no usable KB is there, rather than
+    scaffolding one. `_store()` calls `init_schema()`, so without this a mistyped
+    root becomes a fresh empty KB that then reports as a healthy `0 facts` one —
+    the same reason `seed` guards its own path before opening the store.
+    """
+    if not cfg.db_path.is_file():
+        print(f"no KB at {cfg.root}", file=sys.stderr)
+        return 1
+    problem = _kb_schema_problem(cfg.db_path)
+    if problem is not None:
+        print(f"{cfg.db_path} is not a verinote KB ({problem})", file=sys.stderr)
+        return 1
+    return None
+
+
 def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
     if not cfg.db_path.is_file():
         print(
@@ -463,6 +479,9 @@ def _print_policy_state(store: Store) -> bool:
 def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.engine import coverage
 
+    refusal = _require_existing_kb(cfg)
+    if refusal is not None:
+        return refusal
     store = _store(cfg)
     cov = coverage(store, root=cfg.root)
     halted = _print_policy_state(store)
@@ -493,6 +512,9 @@ def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
 
 
 def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
+    refusal = _require_existing_kb(cfg)
+    if refusal is not None:
+        return refusal
     store = _store(cfg)
     counts = store.status_counts()
     print(f"KB: {cfg.root}")

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -161,13 +161,14 @@ def _seed(store: Store) -> None:
         store.add_fact(subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note)
 
 
-# The three ways an existing `kb.sqlite` can fail to be a usable KB. They are not
+# The four ways an existing `kb.sqlite` can fail to be a usable KB. They are not
 # interchangeable: `init`'s whole job is to put a schema into a database that has
-# none, so only the *unreadable* one may stop it. `seed` must refuse all three —
+# none, so only the *unreadable* one may stop it. `seed` must refuse all four —
 # it fills an existing KB and never creates one.
 KB_UNREADABLE = "not a readable SQLite database"
 KB_NO_SCHEMA = "no `facts` table"
 KB_ALIEN_FACTS = "its `facts` table is not verinote's"
+KB_PARTIAL_SCHEMA = "it has a `facts` table but is missing the rest of a KB"
 
 # What a `facts` table must have for the file to be a verinote KB at all. This is
 # deliberately *not* the current schema's column set: `_ensure_schema_migrations()`
@@ -176,6 +177,20 @@ KB_ALIEN_FACTS = "its `facts` table is not verinote's"
 # fact itself — every verinote KB has always had them, and no migration adds them —
 # so the check stays put as the schema grows around it.
 _KB_FACTS_IDENTITY_COLUMNS = frozenset({"subject", "relation", "object", "status"})
+
+# The tables that make the file a KB rather than a `facts` table someone left in a
+# database. Same principle as the columns above, one level up, and chosen the same
+# way: these four are every table `schema.sql` has had since the initial commit, so
+# no KB verinote has ever written can lack them.
+#
+# This is deliberately *not* derived from today's `schema.sql`. `init_schema()` runs
+# that script on every open, which makes `CREATE TABLE IF NOT EXISTS` the migration
+# that adds new tables to old KBs — `kb_meta`, `fact_evidence`, `fact_events`,
+# `source_artifacts`, `extraction_jobs`, `source_chunks` and `questions` all arrived
+# that way. Deriving the set would therefore refuse exactly the KBs that migration
+# exists to repair. The intersection over the schema's history is the part that has
+# never been a migration's job, and only that part can be demanded up front.
+_KB_CORE_TABLES = frozenset({"facts", "review_log", "runs", "sources"})
 
 
 def _kb_schema_problem(db_path: Path) -> str | None:
@@ -191,6 +206,12 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     file the caller only meant to read. Checking the columns keeps that write from
     ever starting.
 
+    The columns alone are not enough either, and for the mirror-image reason. A
+    file holding nothing but a verinote-shaped `facts` table does not fail the
+    mismatch: `IF NOT EXISTS` *completes* it into a real schema, and the read-only
+    command then reports rc=0 on a KB it just wrote itself. Requiring the core
+    tables refuses that file while it is still only a `facts` table.
+
     The path is percent-encoded via `Path.as_uri()` before it goes into the
     SQLite URI. Interpolating it raw truncates any root holding a `?` or `#` at
     that character, which both misreports a healthy KB as schema-less *and*
@@ -201,18 +222,25 @@ def _kb_schema_problem(db_path: Path) -> str | None:
         conn = sqlite3.connect(uri, uri=True)
         conn.row_factory = sqlite3.Row
         try:
-            row = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'facts'"
-            ).fetchone()
-            if not row:
+            tables = {
+                r["name"]
+                for r in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+            }
+            if "facts" not in tables:
                 return KB_NO_SCHEMA
             columns = {c["name"] for c in conn.execute("PRAGMA table_info(facts)")}
         finally:
             conn.close()
     except sqlite3.DatabaseError:
         return KB_UNREADABLE
+    # `facts` is asked about first, and separately: "this is not verinote's `facts`"
+    # is a sharper answer than "tables are missing" for a file that is somebody
+    # else's, and it stays the answer it was before the core-table check existed.
     if not _KB_FACTS_IDENTITY_COLUMNS <= columns:
         return KB_ALIEN_FACTS
+    missing = _KB_CORE_TABLES - tables
+    if missing:
+        return f"{KB_PARTIAL_SCHEMA} (no {', '.join('`' + t + '`' for t in sorted(missing))})"
     return None
 
 

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -512,12 +512,22 @@ def _unusable_kb(cfg: Config, exc: sqlite3.DatabaseError) -> int:
     even a healthy `status` writes — and until it lands, saying so is the honest
     move. A user who is told the file is untouched, when it is not, cannot make
     the one decision that matters here: whether to restore from backup.
+
+    The message must not blame the KB, though, because we cannot see from here
+    whether it earned the blame: a `DatabaseError` this deep is just as easily
+    verinote's own SQL bug, and then the KB is healthy and "restore from backup"
+    is worse counsel than the traceback this replaced — a traceback at least
+    points at *us*. We cannot make that call in code, but the user can (does this
+    KB open with another build?), so the restore advice waits behind that check
+    instead of leading with it.
     """
     print(
-        f"cannot read the KB at {cfg.root}: {exc}. It is a readable SQLite "
-        f"database but not one this version of verinote can read. The file may "
-        f"already have been modified by the attempt — if it is a real KB, restore "
-        f"it from backup rather than trusting what is there now.",
+        f"cannot read the KB at {cfg.root}: {exc}. This is either a KB this "
+        f"version of verinote cannot read, or a bug in verinote — we cannot tell "
+        f"which from here. If this KB opens with another verinote version, it is "
+        f"ours: please report it, and do not restore anything. Otherwise the file "
+        f"may already have been modified by the attempt, and a backup is worth "
+        f"more than what is there now.",
         file=sys.stderr,
     )
     return 1

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -173,10 +173,13 @@ KB_PARTIAL_SCHEMA = "it has a `facts` table but is missing the rest of a KB"
 # What a `facts` table must have for the file to be a verinote KB at all. This is
 # deliberately *not* the current schema's column set: `_ensure_schema_migrations()`
 # adds columns (`job_id`) to KBs written before they existed, so requiring today's
-# full set would refuse the very KBs migration exists to repair. These four are the
-# fact itself — every verinote KB has always had them, and no migration adds them —
+# full set would refuse the very KBs migration exists to repair. These columns
+# are the fact identity and payload — every verinote KB has always had them, and
+# no migration adds them —
 # so the check stays put as the schema grows around it.
-_KB_FACTS_IDENTITY_COLUMNS = frozenset({"subject", "relation", "object", "status"})
+_KB_FACTS_IDENTITY_COLUMNS = frozenset(
+    {"id", "subject", "relation", "object", "status"}
+)
 
 # The tables that make the file a KB rather than a `facts` table someone left in a
 # database. Same principle as the columns above, one level up, and chosen the same

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -497,12 +497,45 @@ def _print_policy_state(store: Store) -> bool:
     return False
 
 
-def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
-    from verinote.engine import coverage
+def _unusable_kb(cfg: Config, exc: sqlite3.DatabaseError) -> int:
+    """Turn a SQLite error escaping a read-only command into a diagnosis.
 
+    `_require_existing_kb()` can only vouch for the `facts` table; the KB is made
+    of more tables than that, and checking every one of them against the current
+    schema is the drift trap that check is deliberately shaped to avoid. So a
+    file can still get past it and fail deeper in. Whatever it is, a command whose
+    whole job is to *report* on a KB must not answer with a traceback.
+
+    This closes the traceback, not the write: `_store()` has already run
+    `init_schema()` by the time most of these surface, so the file may have grown.
+    Issue #291 tracks the root of that — `_store()` writes unconditionally, so
+    even a healthy `status` writes — and until it lands, saying so is the honest
+    move. A user who is told the file is untouched, when it is not, cannot make
+    the one decision that matters here: whether to restore from backup.
+    """
+    print(
+        f"cannot read the KB at {cfg.root}: {exc}. It is a readable SQLite "
+        f"database but not one this version of verinote can read. The file may "
+        f"already have been modified by the attempt — if it is a real KB, restore "
+        f"it from backup rather than trusting what is there now.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
     refusal = _require_existing_kb(cfg)
     if refusal is not None:
         return refusal
+    try:
+        return _coverage(cfg, args)
+    except sqlite3.DatabaseError as exc:
+        return _unusable_kb(cfg, exc)
+
+
+def _coverage(cfg: Config, args: argparse.Namespace) -> int:
+    from verinote.engine import coverage
+
     store = _store(cfg)
     cov = coverage(store, root=cfg.root)
     halted = _print_policy_state(store)
@@ -536,6 +569,13 @@ def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
     refusal = _require_existing_kb(cfg)
     if refusal is not None:
         return refusal
+    try:
+        return _status(cfg)
+    except sqlite3.DatabaseError as exc:
+        return _unusable_kb(cfg, exc)
+
+
+def _status(cfg: Config) -> int:
     store = _store(cfg)
     counts = store.status_counts()
     print(f"KB: {cfg.root}")


### PR DESCRIPTION
읽기 전용 진단 명령 `status`/`coverage` 가 `_store()`→`init_schema()` 부작용으로 **없는 KB 를 만들어내고**, 그렇게 갓 만든 빈 KB 를 "0 facts, policy: default" 로 **정상인 것처럼 보고**하던 문제를 고친다.

Closes #247

## 무엇을 / 왜

`_store()`(cli.py)는 무조건 `init_schema()` 를 호출한다 — KB 를 만드는 유일한 지점이다. `cmd_status`/`cmd_coverage` 가 이걸 그대로 써서, 빈 디렉터리(또는 오타 경로)에서 실행하면 `./data/kb.sqlite` 를 새로 만든 뒤 rc=0 으로 "멀쩡한 빈 KB" 라고 거짓 보고했다. 읽기 전용 진단이 있지도 않은 KB 를 만들고 정상이라 말하는 건 사용자를 오도한다.

수정: cli.py 안에 공유 헬퍼 `_require_existing_kb(cfg)` 를 두고, `cmd_status`/`cmd_coverage` 가 `_store` 를 열기 **전에** 호출한다.
- KB 파일 부재 → `no KB at <root>`, rc=1
- 스키마 문제(0바이트/비-sqlite/스키마 없음) → `<db> is not a verinote KB (<사유>)`, rc=1, traceback 없음

`cmd_seed` 가 이미 세운 "명령이 store 를 열기 전에 자기 전제조건을 검사한다"는 idiom 을 그대로 따랐다. `store/db.py` 의 `Store`/`init_schema` 시그니처는 건드리지 않는다.

## 재현 & 검증

빈 디렉터리 / 0바이트 kb.sqlite / "not sqlite" kb.sqlite 4케이스에서 status·coverage 가 **파일을 만들지 않고** rc=1 로 거부함을 직접 재현. 유효 KB 와 **halted KB** 는 그대로 동작(halted 무회귀 테스트 14개 통과). 전체 1029 passed, ruff clean. 뮤테이션(fix 되돌리면 신규 4개 red) 확인.

## 범위 경계

- 변경은 `verinote/cli.py` + `tests/test_cli.py` 두 파일뿐. `store/db.py`·`web/app.py`(PR #263 점유) 무수정.
- **후속 분리**: write 명령 `query`/`repair` 도 인자 없이 빈 디렉터리에서 실행하면 같은 계열의 scaffold side-effect(`_store`→init_schema 로 KB 생성 후 rc=1)가 있다. 이 PR 범위 밖이며 별도 이슈로 분리한다.
- #185(어느 KB 를 여느냐 — CWD 폴백 선택 문제)와는 구분되는 이슈다.

## 커밋 (atomic)

1. `test(#247)`: 부재/못쓰는 KB 에서 status/coverage 가 scaffold 안 함을 잠금 (red)
2. `fix(#247)`: `_require_existing_kb` 게이트 추가 (green)
