### PR TITLE
fix(#222): style term-kind slots so structural terms and string literals differ

### DIFF
--- a/tests/test_term_css.py
+++ b/tests/test_term_css.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Regression lock on term-kind styling (#222).
+
+fact_row.html and provenance.html tag every triple span with `term-{{ kind }}`,
+where `kind` is whatever `term_input_kind` returns -- either `string` (a StringLit)
+or `term` (anything else). Issue #51 shipped those hooks but left app.css with no
+matching rules, so `.term-term` and `.term-string` rendered identically: the reader
+could not tell a structural Datalog term from a bare string literal.
+
+These tests pin three things, each written so reverting the CSS turns them red:
+
+1. **The two kinds are styled differently**, compared by parsed declaration set
+   rather than "does a rule exist" -- two rules with identical bodies would still be
+   the bug. Concretely `.term-term` must carry a `background` chip and `.term-string`
+   must not, which is the at-a-glance distinction the issue asked for.
+2. **The rules are unscoped.** Scoping them under `.facts` would silently drop the
+   provenance page's `<p class="triple">` (it lives under `.trust-block`, not
+   `.facts`), reintroducing the bug on exactly one of the two call sites.
+3. **The templates still emit the hooks**, and `term_input_kind`'s vocabulary is
+   exactly `{string, term}` -- so the two classes the CSS styles are the complete set
+   the markup can produce, not a coincidental pair.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var
+from verinote.store.fact_input import term_input_kind
+
+WEB = Path(__file__).resolve().parents[1] / "verinote" / "web"
+CSS_PATH = WEB / "static" / "app.css"
+TEMPLATES = WEB / "templates"
+
+# The templates that render triple spans with a term-kind class.
+HOOK_TEMPLATES = ("partials/fact_row.html", "provenance.html")
+
+
+def _read_css() -> str:
+    return CSS_PATH.read_text(encoding="utf-8")
+
+
+def _strip_comments(css: str) -> str:
+    return re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+
+
+def _declarations(selector: str, css: str) -> dict[str, str]:
+    """Parsed `property -> value` for the flat rule whose selector is exactly `selector`.
+
+    Returns `{}` when no such rule exists, so a *missing* `.term-string` rule reads as
+    the empty declaration set -- which is still legitimately different from `.term-term`
+    and correctly carries no `background`.
+    """
+    css = _strip_comments(css)
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", css):
+        if " ".join(match.group(1).split()) != selector:
+            continue
+        declarations: dict[str, str] = {}
+        for chunk in match.group(2).split(";"):
+            prop, sep, value = chunk.partition(":")
+            if sep:
+                declarations[" ".join(prop.split())] = " ".join(value.split())
+        return declarations
+    return {}
+
+
+def test_term_and_string_kinds_are_styled_differently() -> None:
+    """The whole point of #222: the two kinds must not render the same.
+
+    Compared by declaration set, so two rules with identical bodies (the pre-fix
+    state, where both were unstyled) fail rather than pass on "a rule exists".
+    """
+    css = _read_css()
+    term = _declarations(".term-term", css)
+    string = _declarations(".term-string", css)
+
+    assert term, "app.css defines no .term-term rule; structural terms render unstyled"
+    assert term != string, (
+        f".term-term and .term-string carry identical declarations ({term}); a "
+        "structural term and a string literal would look the same, which is bug #222."
+    )
+
+
+def test_only_the_term_kind_wears_a_chip() -> None:
+    """The at-a-glance distinction: a structural term is a chip, a string is plain.
+
+    `.term-term` must set a `background`; `.term-string` must not (a string literal
+    reads as plain prose). Reverting either half of the CSS flips one assertion.
+    """
+    css = _read_css()
+    term = _declarations(".term-term", css)
+    string = _declarations(".term-string", css)
+
+    assert "background" in term, ".term-term must carry a chip background"
+    assert "background" not in string, (
+        ".term-string must stay plain prose (no background), or it blurs into a term chip"
+    )
+
+
+def test_term_rules_are_unscoped() -> None:
+    """A `.facts`-scoped rule would miss provenance.html's `<p class="triple">`.
+
+    The provenance page renders the triple outside `.facts`, so the term-kind rules
+    must match the bare class. Guard against a descendant-scoped selector sneaking in.
+    """
+    css = _strip_comments(_read_css())
+    for selector in (".term-term", ".term-string"):
+        assert re.search(rf"(?m)^\s*{re.escape(selector)}\s*(::before)?\s*\{{", css), (
+            f"app.css has no unscoped `{selector}` rule; a scoped one would leave the "
+            "provenance page's <p class='triple'> spans untagged"
+        )
+        assert not re.search(rf"\.facts[^{{}}]*{re.escape(selector)}\b", css), (
+            f"`{selector}` is scoped under .facts; the provenance triple would go untagged"
+        )
+
+
+def test_templates_still_emit_the_term_kind_hooks() -> None:
+    """CSS is dead unless the markup keeps emitting `term-{{ kind }}` classes."""
+    for name in HOOK_TEMPLATES:
+        html = (TEMPLATES / name).read_text(encoding="utf-8")
+        assert re.search(r"term-\{\{\s*f\[['\"]\w+_kind['\"]\]\s*\}\}", html), (
+            f"{name} no longer emits a term-{{{{ ..._kind }}}} class; the .term-* rules "
+            "would have nothing to style"
+        )
+
+
+def test_term_input_kind_vocabulary_is_exactly_string_and_term() -> None:
+    """The CSS styles two classes; this proves those two are the complete vocabulary.
+
+    `term_input_kind` maps every Term variant to one of two words. If a third ever
+    appeared, `.term-<that>` would render unstyled and this test would catch it before
+    the CSS silently fell short.
+    """
+    samples = (
+        StringLit("plain text"),
+        Atom("subject_of"),
+        NumberLit(7),
+        Compound("addr", (Atom("home"),)),
+        Var("X"),
+    )
+    kinds = {term_input_kind(term) for term in samples}
+    assert kinds == {"string", "term"}, (
+        f"term_input_kind produced {sorted(kinds)}; app.css only styles "
+        ".term-string and .term-term, so any other value renders unstyled"
+    )
+    assert term_input_kind(StringLit("x")) == "string"
+    assert term_input_kind(Atom("x")) == "term"

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -7,6 +7,7 @@
   --ok-bg: rgba(63, 185, 80, .12);
   --warn-bg: rgba(210, 153, 34, .12);
   --danger-bg: rgba(240, 82, 109, .12);
+  --term-bg: rgba(139, 147, 165, .12);
   --btn-hover-filter: brightness(1.08);
   --btn-active-filter: brightness(.95);
 }
@@ -20,6 +21,7 @@
     --ok-bg: rgba(26, 127, 55, .10);
     --warn-bg: rgba(154, 103, 0, .10);
     --danger-bg: rgba(207, 34, 46, .08);
+    --term-bg: rgba(89, 99, 110, .10);
     --btn-hover-filter: brightness(.95);
     /* Must differ from the light hover filter, or clicking a hovered button would
        show no brightness feedback at all -- only the translateY nudge. */
@@ -53,6 +55,21 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .facts .triple .rel { color: var(--accent); margin: 0 .35rem; }
 .conf { font-variant-numeric: tabular-nums; color: var(--muted); }
 .src { color: var(--muted); font-size: .85rem; }
+
+/* Term-kind tagging on the triple spans (#222). fact_row.html and provenance.html
+   emit `.term-term` for a structural Datalog term and `.term-string` for a string
+   literal (the only two values term_input_kind returns). Unscoped on purpose: the
+   provenance page's <p class="triple"> lives outside .facts, so a `.facts`-scoped
+   rule would leave those spans untagged. A structural term reads as a monospace chip
+   with a faint `t` label; a string literal stays plain prose so the two never blur. */
+.term-term { font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: var(--term-bg); border-radius: 5px; padding: .02rem .32rem; }
+/* `/ ""` is the pseudo-element alt-text: the "t" is a decorative kind marker, so it
+   is given an empty accessible name and stays out of the VoiceOver/NVDA reading of
+   the term value (this issue is about not hiding a verdict, not adding stray letters). */
+.term-term::before { content: "t" / ""; color: var(--muted); font-size: .72em;
+  margin-right: .28rem; vertical-align: .08em; }
+.term-string { font-style: italic; color: var(--fg); }
 
 .badge { padding: .1rem .5rem; border-radius: 999px; font-size: .78rem; border: 1px solid var(--line); }
 .badge-candidate { color: var(--muted); }


### PR DESCRIPTION
구조 term 과 문자열 리터럴이 리뷰 큐·provenance 에서 **똑같이 렌더되던** 문제를 CSS 로 고친다. 엔진 동작을 가르는 구분(규칙이 매칭되느냐)이 hover 툴팁 뒤에만 있었다.

Closes #222

## 무엇을 / 왜

`partials/fact_row.html` 과 `provenance.html` 은 이미 슬롯마다 `term-{{ f['..._kind'] }}` 클래스를 뱉는데, `app.css` 에 `.term-term`/`.term-string` 규칙이 **하나도 없었다**. #51 이 훅과 title 툴팁까지 만들어 두고 스타일을 붙이지 않은 채 닫혔다 — #51 이 스스로 지적한 "`person(\"Ada\")` 문자열과 컴파운드 term 이 시각적으로 모호하다"가 그대로 남아 있었다.

수정 (CSS-only, 훅이 이미 있으므로 템플릿 무변경):
- `.term-term`: 모노스페이스 + 칩 배경 + `::before` 미세 라벨 `t`
- `.term-string`: 평문(배경 없음) + italic

색은 전부 `var()` 토큰만 사용하고, 새 `--term-bg` 토큰을 dark/light **양 팔레트**에 추가했다(머지된 test_theme.py 가 raw 색 리터럴 금지 + 팔레트 대칭을 강제하므로). 규칙은 **unscoped** — provenance triple 이 `.facts` 밖 `.trust-block > p.triple` 이라 스코프하면 안 고쳐진다.

## 접근성 노트

- `.term-term::before` 는 `content: "t" / ""` — 장식 라벨이므로 스크린리더는 빈 accessible name 으로 스킵(term 값 앞에 "t" 를 낭독하지 않음).
- 그 결과 kind 를 보조기술에 노출하는 채널은 기존 `title` 속성만 남는다. **title 을 정식 accessible name(aria-label/visually-hidden)으로 교체하는 작업은 템플릿 변경이 필요해 후속 이슈로 분리**한다(단순 삭제하면 접근성 후퇴).

## 의도된 선택

`.term-string` 에 `font-style: italic` 을 더한 것은 이슈의 "현행 평문 유지"보다 나아간 것으로, term/string 을 색뿐 아니라 형태로도 구별하려는 두 번째 신호다(색맹·툴팁 없이 판별 가능하게).

## 검증

`pytest tests -q` 1030 passed, `test_theme.py` 무회귀(30 passed), ruff clean. 뮤테이션: `.term-term` 칩 규칙 제거 시 신규 테스트 red. 변경은 `app.css` + 신규 `tests/test_term_css.py` 두 파일뿐 — 템플릿/app.py/terms.py 무변경(병렬 레인 #219·#263 과 무충돌).

## 커밋 (atomic)

1. `feat(#222)`: term-kind 칩 스타일 (app.css)
2. `test(#222)`: term/string CSS 구별 + term_input_kind 어휘 잠금
