### PR TITLE
test(#280): poll the resume test to job done, not to fact visibility

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1208,10 +1208,10 @@ def test_launching_the_ui_on_a_healthy_kb_still_resumes(tmp_path, monkeypatch, f
 
     def resumed():
         assert "is_a" in c.get("/review").text
+        assert _job_row(cfg, job_id)["status"] == "done"
 
     _wait_for(resumed)
     assert clients != []  # the worker really was started
-    assert _job_row(cfg, job_id)["status"] == "done"
 
 
 def test_worker_halt_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1214,6 +1214,37 @@ def test_launching_the_ui_on_a_healthy_kb_still_resumes(tmp_path, monkeypatch, f
     assert clients != []  # the worker really was started
 
 
+def test_resume_polls_to_done_not_just_to_fact_visibility(tmp_path, monkeypatch, fake_client):
+    """Widen the fact-visible -> job-done gap; the resume guard must still reach `done`.
+
+    Facts land in /review inside `_extract_chunk`; the job flips to `done` a step
+    later in `mark_chunk_done`. Delay that flip and a guard that stopped at fact
+    visibility would read `running`. This pins the guard to the real finish signal.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    real_mark = Store.mark_chunk_done
+
+    def slow_mark(self, chunk_id, *, candidates=0):
+        time.sleep(0.3)
+        return real_mark(self, chunk_id, candidates=candidates)
+
+    monkeypatch.setattr(Store, "mark_chunk_done", slow_mark)
+
+    c = TestClient(create_app(cfg))
+
+    def resumed():
+        assert "is_a" in c.get("/review").text
+        assert _job_row(cfg, job_id)["status"] == "done"
+
+    _wait_for(resumed, timeout=3.0)  # > the injected 0.3s delay
+    assert _job_row(cfg, job_id)["status"] == "done"
+
+
 def test_worker_halt_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):
     """`except PolicyMissingError` must stay ABOVE `except Exception` in the worker.
 


### PR DESCRIPTION
CI 의 `pytest (py3.11)` 레그를 간헐적으로 붉게 만들던 `test_launching_the_ui_on_a_healthy_kb_still_resumes` 의 레이스를 고친다. 테스트 전용 하드닝 — 프로덕션 무수정.

Closes #280

## 근본 원인

테스트가 **중간 신호(사실 가시성)를 완료 신호로 오인**했다. `resumed()` predicate 는 `/review` 에 추출 사실("is_a")이 보이는지만 단언하고, 잡 상태 `== "done"` 단언은 `_wait_for` 루프 **밖**에 있었다.

워커는 두 개의 별개 쓰기를 한다:
1. 사실 삽입 (`_extract_chunk`, extract.py:214) → 이 순간 `/review` 에 사실이 보이지만 잡은 아직 `running`
2. 상태 `done` 플립 (`mark_chunk_done`, extract.py:231 → db.py:655; 단일 청크라 done==total, 메시지 `Analysis complete: 1/1 chunk(s)` 와 원자적)

(1)이 보이면 `_wait_for` 가 즉시 반환하고, 루프 밖 `status == "done"` 단언이 (2)를 앞질러 `running` 을 잡는다. 느린 CI(py3.11)에서 (1)~(2) 창이 벌어질 때 간헐 실패(`assert 'running' == 'done'`). 로컬은 대개 통과.

## 수정

상태 단언을 `resumed()` predicate **안으로** 이동해 워커의 진짜 완료 신호까지 폴링한다. 저장소에 이미 있는 정답 형제 `test_create_app_resumes_pending_source_jobs`(test_web.py:1119-1123)와 동형이다.

루프 밖 `assert clients != []` 는 그대로 둔다 — 레이스가 아니다(`clients` 는 get_client 람다에서 process 전에 append).

## 스코프: 테스트 전용, 프로덕션 무수정

사실-노출과 상태-갱신 사이의 창은 **의도된 progressive-visibility** 다 — 사실은 청크별로 추출 즉시 리뷰에 뜨고, `running` 은 잡이 실제로 도는 중이라는 참이다(#194 가 고친 "도는 게 없는데 running" 결함의 정반대). 사실-존재를 완료 대용으로 읽는 프로덕션 소비자는 없다(auto-accept 는 status done **이후** 실행, /sources 라벨은 status/message 파생). 오직 테스트만 혼동했으므로 수정은 테스트 안에서 끝난다.

## 결정론적 회귀 가드

두 번째 커밋은 `Store.mark_chunk_done` 앞에 고정 0.3s 지연을 주입해 사실→done 창을 결정론적으로 벌린다. 누가 나중에 상태 단언을 루프 밖으로 되돌리면 **플래키가 아니라 매번 red** 로 잡힌다. 클래스 메서드 몽키패치라 워커 데몬 스레드에도 적용된다.

- non-vacuity: 수정을 되돌리면 회귀 테스트 5/5 red(`running`!=`done`), 적용 후 green.
- 새 플래키 아님: call 0.42s vs timeout 3.0s = 7배 마진(지연이 고정값이라 경합에 잠식되지 않음).

## 검증

- 전체 스위트 1026 passed, ruff clean.
- 두 resume 테스트 셸 25회 반복 → 25/25 green.
- 형제 스윕: 전체 `_wait_for` 콜사이트 전수 점검 — "중간 신호 대기 + 완료 단언 루프 밖" 오프렌더는 이 하나뿐.
- 변경은 `tests/test_web.py` 한 파일(+31). 열린 PR 어디도 test_web.py 를 안 건드려 무충돌.

## CI 위생

이 플래키는 main 유래(#194 halt 작업에서 test_web.py:1197 로 유입)라 #274 뿐 아니라 **모든 PR 의 CI 를 간헐 오염**시켰다. 닫으면 전체 PR CI 가 디노이즈된다.

## 커밋 (atomic)

1. `test(#280)`: 상태 단언을 _wait_for 안으로 (fact visibility 아닌 job done 까지 폴링)
2. `test(#280)`: 결정론적 fact→done 지연 주입으로 가드 고정
