### PR TITLE
fix(#245): detect dead policy rules and warn (legacy run_check; production surfacing follows)

### DIFF
--- a/tests/test_dead_rule_warn.py
+++ b/tests/test_dead_rule_warn.py
@@ -46,6 +46,44 @@ def test_rule_body_string_literal_relation_is_detected():
     ]
 
 
+def test_finding_head_payload_is_not_a_dependency():
+    # A finding head's literal is the payload the rule *emits*, not a relation it
+    # reads. This rule fires whenever an is_a fact exists, so flagging it is a
+    # false positive. Reporting relation findings as (subject, rel) is a natural
+    # shape for a custom policy, so this must stay clean.
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_required(subject: symbol, rel: symbol)\n"
+        'error_required(S, "required_relation") :- relation(S, "is_a", "thing").\n'
+    )
+    assert dead_rule_warnings(policy, {"is_a"}) == []
+
+
+def test_derived_head_payload_is_not_a_dependency():
+    # Same for a non-finding intermediate: a rule head is output either way.
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl tagged(subject: symbol, rel: symbol)\n"
+        ".decl error_x(subject: symbol)\n"
+        'tagged(S, "audited") :- relation(S, "is_a", "thing").\n'
+        "error_x(S) :- tagged(S, _).\n"
+    )
+    assert dead_rule_warnings(policy, {"is_a"}) == []
+
+
+def test_dead_body_relation_still_detected_alongside_a_live_finding_head():
+    # The head payload is ignored, but the body's unused relation is still dead.
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_required(subject: symbol, rel: symbol)\n"
+        'error_required(S, "required_relation") :- relation(S, "must_have", O).\n'
+    )
+    assert dead_rule_warnings(policy, {"is_a"}) == [
+        'dead_rule: policy declares relation("must_have") '
+        "but no engine fact uses that relation"
+    ]
+
+
 def test_malformed_policy_does_not_crash():
     assert dead_rule_warnings("this is not valid datalog !!!", {"is_a"}) == []
 

--- a/tests/test_dead_rule_warn.py
+++ b/tests/test_dead_rule_warn.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Dead-rule detection: a policy relation no engine fact uses is a non-blocking note.
+
+These unit tests target the pure `dead_rule_warnings` helper, so they run in CI
+without the optional pyrewire engine installed.
+"""
+
+import pytest
+
+from verinote.engine import DEFAULT_POLICY, compile_dl, run_check
+from verinote.engine.wirelog import dead_rule_warnings
+
+
+def test_default_policy_flags_unused_functional_relations():
+    present = {"established_on", "is_a"}
+    warnings = dead_rule_warnings(DEFAULT_POLICY, present)
+    joined = "\n".join(warnings)
+    # born_on / died_on are declared functional but no fact uses them.
+    assert any('functional("born_on")' in w for w in warnings)
+    assert any('functional("died_on")' in w for w in warnings)
+    # established_on IS used by a fact, so it is not a dead rule.
+    assert 'functional("established_on")' not in joined
+    assert all(w.startswith("dead_rule: policy declares ") for w in warnings)
+
+
+def test_no_warnings_when_every_referenced_relation_is_present():
+    present = {"established_on", "born_on", "died_on"}
+    assert dead_rule_warnings(DEFAULT_POLICY, present) == []
+
+
+def test_empty_fact_set_is_never_flagged():
+    # An empty KB is not a dead policy — it is simply no engine input yet.
+    assert dead_rule_warnings(DEFAULT_POLICY, set()) == []
+
+
+def test_rule_body_string_literal_relation_is_detected():
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_x(subject: symbol)\n"
+        'error_x(S) :- relation(S, "must_have", O).\n'
+    )
+    warnings = dead_rule_warnings(policy, {"is_a"})
+    assert warnings == [
+        'dead_rule: policy declares relation("must_have") '
+        "but no engine fact uses that relation"
+    ]
+
+
+def test_malformed_policy_does_not_crash():
+    assert dead_rule_warnings("this is not valid datalog !!!", {"is_a"}) == []
+
+
+def test_query_relations_are_never_treated_as_dead_rules():
+    # dead_rule_warnings only inspects the policy; a query is a user question.
+    query = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O).\n'
+    )
+    assert dead_rule_warnings(query, {"is_a"}) == []
+
+
+def test_run_check_surfaces_dead_rule_as_nonblocking_finding():
+    pytest.importorskip("pyrewire")
+    # A KB that uses established_on but never born_on/died_on: no conflict, but
+    # the default policy's born_on/died_on functional decls are dead rules.
+    dl = compile_dl(
+        [
+            {"subject": "Org", "relation": "established_on", "object": "2020"},
+            {"subject": "Org", "relation": "is_a", "object": "company"},
+        ]
+    )
+    rep = run_check(dl)
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings >= 1
+    assert any("WARN dead_rule" in f for f in rep.findings)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -55,7 +55,9 @@ def test_run_check_consistent_is_ok():
     rep = run_check(_CONSISTENT)
     assert rep.errors == 0
     assert rep.ok is True
-    assert rep.findings == []
+    # A consistent KB gates clean: no ERROR findings. (Non-blocking dead_rule
+    # WARN notes for the default policy's unused functional relations may appear.)
+    assert not any(line.startswith("ERROR") for line in rep.findings)
 
 
 def test_run_check_empty_kb_is_ok():

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -34,6 +34,7 @@ from verinote.engine.terms import StringLit, TermParseError, escape_string_value
 # Prefixes that mark a derived relation as a verinote finding.
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
+_ANSWER_PREFIX = "answer_q"
 
 # Shipped default policy. `verinote init` scaffolds a copy to
 # `<root>/policy/logic-policy.dl`; edit that copy per-KB.
@@ -148,6 +149,11 @@ def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
     return facts
 
 
+def _is_finding_or_query(predicate: str) -> bool:
+    """True for predicates verinote reads back as output rather than dependency."""
+    return predicate.startswith((_ERROR_PREFIX, _WARN_PREFIX, _ANSWER_PREFIX))
+
+
 def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list[str]:
     """Warn about relation names a policy pins to string literals that no fact uses.
 
@@ -156,6 +162,13 @@ def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list
     ``functional(rel)``. When such a column carries a string literal that names a
     relation, and no compiled engine fact uses that relation, the rule depending
     on it can never fire: a dead rule. These are non-blocking notes, never a gate.
+
+    Only positions that actually *read* the fact vocabulary count: rule bodies and
+    the policy's own extensional facts. A rule head is output, not a dependency —
+    a literal there is a payload the rule emits, so counting it would flag rules
+    that fire perfectly well (a finding reported as ``error_x(S, "some_label")``
+    is the obvious shape). Derived predicates are skipped wherever they appear,
+    since they resolve through other rules rather than through engine facts.
 
     An empty fact set (no engine input at all) yields ``[]`` so a genuinely empty
     knowledge base is never flagged. A malformed policy yields ``[]`` too — the
@@ -174,9 +187,12 @@ def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list
     columns_by_pred = {
         decl.name: [col.name for col in decl.columns] for decl in program.declarations
     }
+    derived = {rule.head.predicate for rule in program.rules}
     referenced: set[tuple[str, str]] = set()
 
     def scan(atom: AtomExpr) -> None:
+        if atom.predicate in derived or _is_finding_or_query(atom.predicate):
+            return
         columns = columns_by_pred.get(atom.predicate)
         if columns is None:
             return
@@ -187,7 +203,6 @@ def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list
     for fact in program.facts:
         scan(fact.atom)
     for rule in program.rules:
-        scan(rule.head)
         for item in rule.body:
             if isinstance(item, AtomExpr):
                 scan(item)
@@ -199,8 +214,6 @@ def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list
         if value not in present
     )
 
-
-_ANSWER_PREFIX = "answer_q"
 
 # The engine's "clean bill of health" body. Exported because it is a claim about
 # the policy that ran, so callers that ran a *different* policy than the KB's own

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -29,7 +29,7 @@ from verinote.engine.datalog import (
     Program,
     parse_and_validate_program,
 )
-from verinote.engine.terms import escape_string_value
+from verinote.engine.terms import StringLit, TermParseError, escape_string_value
 
 # Prefixes that mark a derived relation as a verinote finding.
 _ERROR_PREFIX = "error_"
@@ -148,6 +148,58 @@ def _parse_relation_facts(dl_text: str) -> list[tuple[str, str, str]]:
     return facts
 
 
+def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list[str]:
+    """Warn about relation names a policy pins to string literals that no fact uses.
+
+    A policy reaches the fact vocabulary through columns named ``rel`` — the
+    ``relation(subject, rel, object)`` base relation, plus helper decls such as
+    ``functional(rel)``. When such a column carries a string literal that names a
+    relation, and no compiled engine fact uses that relation, the rule depending
+    on it can never fire: a dead rule. These are non-blocking notes, never a gate.
+
+    An empty fact set (no engine input at all) yields ``[]`` so a genuinely empty
+    knowledge base is never flagged. A malformed policy yields ``[]`` too — the
+    parse failure is already surfaced as an engine error, so dead-rule detection
+    must not invent a second failure mode. Only ``policy_dl`` is inspected; a
+    caller's query text is a user question, never a dead rule.
+    """
+    present = set(present_relations)
+    if not present:
+        return []
+    try:
+        program = parse_and_validate_program(policy_dl)
+    except (DatalogParseError, DatalogValidationError, TermParseError):
+        return []
+
+    columns_by_pred = {
+        decl.name: [col.name for col in decl.columns] for decl in program.declarations
+    }
+    referenced: set[tuple[str, str]] = set()
+
+    def scan(atom: AtomExpr) -> None:
+        columns = columns_by_pred.get(atom.predicate)
+        if columns is None:
+            return
+        for index, arg in enumerate(atom.args):
+            if index < len(columns) and columns[index] == "rel" and isinstance(arg, StringLit):
+                referenced.add((atom.predicate, arg.value))
+
+    for fact in program.facts:
+        scan(fact.atom)
+    for rule in program.rules:
+        scan(rule.head)
+        for item in rule.body:
+            if isinstance(item, AtomExpr):
+                scan(item)
+
+    return sorted(
+        f'dead_rule: policy declares {predicate}("{escape_string_value(value)}") '
+        "but no engine fact uses that relation"
+        for predicate, value in referenced
+        if value not in present
+    )
+
+
 _ANSWER_PREFIX = "answer_q"
 
 # The engine's "clean bill of health" body. Exported because it is a claim about
@@ -180,17 +232,21 @@ def _load_engine():
     return pyrewire
 
 
-def _degraded_report(dl_text: str) -> CheckReport:
+def _degraded_report(dl_text: str, warnings: list[str] | None = None) -> CheckReport:
+    warnings = warnings or []
+    findings = [f"WARN {w}" for w in warnings]
     n = dl_text.count("relation(")
+    body = ("\n".join(findings) + "\n\n") if findings else ""
     return CheckReport(
         ok=True,
         errors=0,
-        warnings=0,
+        warnings=len(warnings),
         engine_available=False,
+        findings=findings,
         text=(
             "legacy wirelog compatibility engine (pyrewire) not installed — "
             "showing compiled input only.\n"
-            f"compiled facts: {n}\n\n{dl_text}"
+            f"compiled facts: {n}\n\n{body}{dl_text}"
         ),
     )
 
@@ -276,13 +332,16 @@ def run_check(
     pyrewire is absent we still return a legacy compatibility report flagged
     `engine_available=False`.
     """
+    policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
+    facts = _parse_relation_facts(dl_text)
+    present = {rel for _, rel, _ in facts}
+    dead = dead_rule_warnings(policy, present)
+
     pyrewire = _load_engine()
     if pyrewire is None:
-        return _degraded_report(dl_text)
+        return _degraded_report(dl_text, dead)
 
-    policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
     program = policy + ("\n" + query_dl if query_dl else "")
-    facts = _parse_relation_facts(dl_text)
 
     try:
         with pyrewire.EasySession(program) as session:
@@ -312,6 +371,7 @@ def run_check(
             qid = name[len(_ANSWER_PREFIX) :]
             answers_by_q.setdefault(qid, []).append(_render_row(row))
 
+    warnings.extend(dead)
     errors.sort()
     warnings.sort()
     answers = [


### PR DESCRIPTION
정책이 KB 에 존재하지 않는 relation 만 참조하는 "죽은 규칙"을 검출해 경고한다 — 어긋난 어휘가 조용히 초록불을 켜지 않도록.

Part of #245

> **이 PR 단독으로는 프로덕션 리포트를 바꾸지 않는다.** 아래 "스코프 정직성" 참조. 프로덕션 표면화 후속이 #245 를 닫는다 — 그래서 `Closes` 가 아니라 `Part of`.

## 무엇을 / 왜

DEFAULT_POLICY 는 `functional("established_on"/"born_on"/"died_on")` 을 싣는데, 엔진 입력에 `born_on` 팩트가 하나도 없어도 `error_functional_conflict` 는 정상 컴파일 → 아무것도 매치 안 함 → 초록불. 아무도 어휘가 어긋났다고 말하지 않는다. 죽은 규칙이 지켜주는 게 없는데 지켜주는 척한다.

수정: `engine/wirelog.py` 에 순수·엔진무관 함수 `dead_rule_warnings(policy_dl, present_relations)` 를 추가한다.
- `present` 가 비면 `[]`(엔진 입력 0건은 traceability 가 이미 표시 — 죽은 규칙과 구분).
- 정책 파싱 실패는 `try/except → []`(잘못된 정책은 이미 engine error 로 표면화됨).
- declarations 로 predicate→컬럼 맵을 만들어, **`rel` 로 명명된 컬럼 위치의 StringLit** 만 relation 참조로 수집(subject/object 위치 literal 은 미검출 = false positive 없음). `present` 에 없는 참조마다 `WARN dead_rule: ...` 한 줄.
- **정책만 검사**, query_dl 은 절대 안 봄(쿼리는 사용자 질문).

`run_check`/`_degraded_report` 에 배선하되 **warnings 에만 append, errors/ok 불변**(경고라 리뷰 게이트를 안 막음).

## 스코프 정직성 (파묻지 않고 명시)

**프로덕션 검증은 `verify.py → duckdb_backend.run_check/_collect_report` 로 돌며, 이 PR 은 그 경로에 아직 dead_rule_warnings 를 호출하지 않는다.** 그래서 죽은 규칙이 있는 실제 KB 의 프로덕션 리포트는 **이 PR 로는 안 바뀐다**. 여기서 배송하는 것은 (a) 검출기(순수 함수, 로직 소유자 1개)와 (b) 레거시 `wirelog.run_check` 경로 배선·잠금까지다.

함수 시그니처가 `(policy_dl, present_relations)` 라서 DuckDB 백엔드가 자기 present-relation 집합으로 **같은 함수를 그대로 호출**할 수 있다(재구현 불필요) — 증상 가두기가 아니라 올바른 분해다. 프로덕션 표면화는 `duckdb_backend.py`(PR #253/#265 점유) 해제 후 후속 PR 이 담당하며 그 PR 이 #245 를 닫는다.

## 알려진 한계

relation-이름 컬럼이 문자 그대로 `rel` 일 때만 검출한다(base relation 은 `_relation_decl` 이 강제하지만 helper decl 의 컬럼명은 사용자가 정한다). 모든 컬럼이 symbol 타입이라 이름 말곤 신호가 없어 `rel` 규약이 최선의 계약이다 — docstring 에 명시.

## 검증

- 전체 1032 passed, ruff clean. 변경은 `wirelog.py` + 신규 `tests/test_dead_rule_warn.py` + `tests/test_engine.py`(4줄) 뿐.
- non-vacuity: `dead_rule_warnings` 를 `return []` 로 무력화하면 신규 유닛테스트 3개 red.
- `test_engine.py` 의 `test_run_check_consistent_is_ok` 단언을 `findings == []` → "ERROR 로 시작하는 findings 없음" 으로 조정(DEFAULT_POLICY 의 born_on/died_on 이 이제 non-blocking WARN 을 냄). 원래 단언으로 되돌리면 그 하나만 red — 결함 은폐 아닌 정당한 동작 변경.
- 검출은 순수(파서만)라 pyrewire 없이도 돎 — degraded 경로 배선으로 CI(pyrewire 없음)에서도 경고 렌더 확인.
- 열린 PR 17개 + 병렬 레인과 `git merge-tree` 무충돌.

## 커밋 (atomic)

1. `fix(#245)`: 죽은 정책 규칙 검출 + legacy run_check 배선
2. `test(#245)`: non-vacuous 유닛테스트로 dead-rule 검출 잠금
