### PR TITLE
fix(#170): fail closed on stale fact-term sidecars

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -116,6 +116,33 @@ def test_ask_answers_generic_korean_attribute_question_from_engine(tmp_path):
     assert result.grounding_facts[0].source == "sources/sample-project.txt"
 
 
+def test_ask_does_not_call_stale_fact_terms_verified(tmp_path):
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-project.txt")
+    fid = store.add_fact(
+        "샘플프로젝트",
+        "purpose",
+        "샘플목표",
+        status="confirmed",
+        source_id=source_id,
+    )
+    store._conn.execute(
+        "UPDATE facts SET object = ?, term_token = ? WHERE id = ?",
+        ("표시목표", "0" * 64, fid),
+    )
+
+    result = ask_question(
+        store,
+        FallbackClient(answer="UNVERIFIED fallback"),
+        root=tmp_path,
+        question="샘플프로젝트의 목적은?",
+    )
+
+    assert result.label != "VERIFIED — engine"
+    assert result.route == "fallback"
+    assert "stale DuckDB fact terms" in result.reason
+
+
 def test_ask_verified_negative_only_for_explicit_no_answer_flow(tmp_path, monkeypatch):
     import verinote.pipeline.ask as ask_module
 

--- a/tests/test_duckdb_fact_terms.py
+++ b/tests/test_duckdb_fact_terms.py
@@ -10,6 +10,7 @@ from verinote.store.duckdb_fact_terms import (
     FACT_TERMS_FILENAME,
     DuckDBFactTermStore,
     DuckDBFactTermStoreError,
+    fact_term_token,
     fact_terms_path,
 )
 
@@ -101,6 +102,34 @@ def test_store_upsert_latest_terms_win():
         store.close()
 
 
+def test_store_records_content_token_without_changing_tuple_api():
+    _duckdb()
+    store = DuckDBFactTermStore(None)
+    try:
+        triple = (Compound("person", (StringLit("Ada"),)), Atom("r"), NumberLit(1))
+        store.put_fact_terms(1, *triple)
+
+        assert store.get_fact_terms(1) == triple
+        record = store.get_fact_term_record(1)
+        assert record is not None
+        assert record.terms == triple
+        assert record.term_token == fact_term_token(*triple)
+        assert record.content_token == fact_term_token(*triple)
+    finally:
+        store.close()
+
+
+def test_store_rejects_a_supplied_token_that_does_not_match_payload():
+    _duckdb()
+    store = DuckDBFactTermStore(None)
+    try:
+        with pytest.raises(DuckDBFactTermStoreError, match="token does not match"):
+            store.put_fact_terms(1, "A", "r", "B", term_token="0" * 64)
+        assert store.get_fact_terms(1) is None
+    finally:
+        store.close()
+
+
 def test_store_delete_existing_and_missing_terms():
     _duckdb()
     store = DuckDBFactTermStore(None)
@@ -164,6 +193,43 @@ def test_store_schema_initialization_is_idempotent(tmp_path):
         second.close()
 
 
+def test_store_migrates_existing_fact_terms_table_to_add_token(tmp_path):
+    duckdb = _duckdb()
+    path = fact_terms_path(tmp_path)
+    con = duckdb.connect(str(path))
+    con.execute(
+        """
+        CREATE TABLE fact_terms (
+            fact_id BIGINT PRIMARY KEY,
+            subject VARCHAR NOT NULL,
+            rel VARCHAR NOT NULL,
+            object VARCHAR NOT NULL
+        )
+        """
+    )
+    con.execute(
+        "INSERT INTO fact_terms VALUES (?, ?, ?, ?)",
+        [
+            1,
+            term_to_duckdb_value(StringLit("A")),
+            term_to_duckdb_value(StringLit("r")),
+            term_to_duckdb_value(StringLit("B")),
+        ],
+    )
+    con.close()
+
+    store = DuckDBFactTermStore(path)
+    try:
+        record = store.get_fact_term_record(1)
+        assert record is not None
+        assert record.terms == (StringLit("A"), StringLit("r"), StringLit("B"))
+        assert record.term_token is None
+        store.put_fact_terms(1, "A", "r", "B")
+        assert store.get_fact_term_record(1).term_token == fact_term_token("A", "r", "B")
+    finally:
+        store.close()
+
+
 @pytest.mark.parametrize("fact_id", [0, -1, True, "1"])
 def test_store_rejects_invalid_fact_ids(fact_id):
     _duckdb()
@@ -190,7 +256,7 @@ def test_store_reports_malformed_payload_with_fact_and_column_context():
     store = DuckDBFactTermStore(None)
     try:
         store._execute(
-            "INSERT INTO fact_terms VALUES (?, ?, ?, ?)",
+            "INSERT INTO fact_terms (fact_id, subject, rel, object) VALUES (?, ?, ?, ?)",
             [
                 1,
                 '{"t":"atom","v":"Bad"}',

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -335,9 +335,7 @@ def test_status_changes_do_not_mutate_duckdb_terms(tmp_path):
     assert s.get_fact_terms(fid) == before
 
 
-def test_add_fact_duckdb_failure_commits_sqlite_but_blocks_engine(
-    tmp_path, monkeypatch
-):
+def test_add_fact_duckdb_failure_rolls_back_sqlite_insert(tmp_path, monkeypatch):
     s = _store(tmp_path)
 
     def fail(*args, **kwargs):
@@ -348,11 +346,7 @@ def test_add_fact_duckdb_failure_commits_sqlite_but_blocks_engine(
     with pytest.raises(RuntimeError, match="sidecar down"):
         s.add_fact("A", "r", "B", status="confirmed")
 
-    rows = s.facts()
-    assert len(rows) == 1
-    assert rows[0]["term_token"]
-    with pytest.raises(DuckDBFactTermStoreError, match="missing DuckDB fact terms"):
-        s.engine_fact_terms()
+    assert s.facts() == []
 
 
 def test_amend_fact_duckdb_failure_commits_sqlite_but_blocks_engine(

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import sqlite3
+
 import pytest
 
 from verinote.engine.terms import (
@@ -187,6 +189,38 @@ def test_backfill_fact_terms_migrates_legacy_sqlite_text_as_stringlit(tmp_path):
     assert s.backfill_fact_terms() == 0
 
 
+def test_store_migrates_existing_facts_table_to_add_term_token(tmp_path):
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.execute(
+        """
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY,
+            subject TEXT NOT NULL,
+            relation TEXT NOT NULL,
+            object TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'candidate',
+            confidence REAL NOT NULL DEFAULT 0.0,
+            source_id INTEGER,
+            run_id INTEGER,
+            job_id INTEGER,
+            note TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    conn.close()
+
+    reopened = _store(tmp_path)
+    try:
+        columns = {
+            row["name"] for row in reopened._conn.execute("PRAGMA table_info(facts)")
+        }
+        assert "term_token" in columns
+    finally:
+        reopened.close()
+
+
 def test_engine_fact_terms_rejects_missing_modern_sidecar_terms(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact(
@@ -201,6 +235,30 @@ def test_engine_fact_terms_rejects_missing_modern_sidecar_terms(tmp_path):
         s.engine_fact_terms()
 
     assert s.get_fact_terms(fid) is None
+
+
+def test_engine_fact_terms_rejects_stale_modern_sidecar_terms(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("Ada", "born_in", "Paris", status="confirmed")
+
+    # Simulate an interrupted amend after SQLite committed its new display/token
+    # but before facts.duckdb received the matching logical terms.
+    s._conn.execute(
+        "UPDATE facts SET object = ?, term_token = ? WHERE id = ?",
+        ("London", "0" * 64, fid),
+    )
+
+    with pytest.raises(DuckDBFactTermStoreError, match="stale DuckDB fact terms"):
+        s.engine_fact_terms()
+
+
+def test_engine_fact_terms_rejects_missing_modern_sidecar_token(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("Ada", "born_in", "Paris", status="confirmed")
+    s.fact_terms._execute("UPDATE fact_terms SET term_token = NULL WHERE fact_id = ?", [fid])
+
+    with pytest.raises(DuckDBFactTermStoreError, match="stale DuckDB fact terms"):
+        s.engine_fact_terms()
 
 
 def test_engine_fact_terms_marks_complete_pre_marker_sidecar(tmp_path):
@@ -277,7 +335,9 @@ def test_status_changes_do_not_mutate_duckdb_terms(tmp_path):
     assert s.get_fact_terms(fid) == before
 
 
-def test_add_fact_duckdb_failure_rolls_back_sqlite_insert(tmp_path, monkeypatch):
+def test_add_fact_duckdb_failure_commits_sqlite_but_blocks_engine(
+    tmp_path, monkeypatch
+):
     s = _store(tmp_path)
 
     def fail(*args, **kwargs):
@@ -286,14 +346,20 @@ def test_add_fact_duckdb_failure_rolls_back_sqlite_insert(tmp_path, monkeypatch)
     monkeypatch.setattr(s.fact_terms, "put_fact_terms", fail)
 
     with pytest.raises(RuntimeError, match="sidecar down"):
-        s.add_fact("A", "r", "B")
+        s.add_fact("A", "r", "B", status="confirmed")
 
-    assert s.facts() == []
+    rows = s.facts()
+    assert len(rows) == 1
+    assert rows[0]["term_token"]
+    with pytest.raises(DuckDBFactTermStoreError, match="missing DuckDB fact terms"):
+        s.engine_fact_terms()
 
 
-def test_amend_fact_duckdb_failure_leaves_sqlite_and_audit_unchanged(tmp_path, monkeypatch):
+def test_amend_fact_duckdb_failure_commits_sqlite_but_blocks_engine(
+    tmp_path, monkeypatch
+):
     s = _store(tmp_path)
-    fid = s.add_fact("A", "r", "B", status="needs_review", note="orig")
+    fid = s.add_fact("A", "r", "B", status="confirmed", note="orig")
     before_terms = s.get_fact_terms(fid)
 
     def fail(*args, **kwargs):
@@ -306,13 +372,15 @@ def test_amend_fact_duckdb_failure_leaves_sqlite_and_audit_unchanged(tmp_path, m
 
     row = s.get_fact(fid)
     assert (row["subject"], row["relation"], row["object"], row["note"]) == (
-        "A",
-        "r",
-        "B",
-        "orig",
+        "A2",
+        "r2",
+        "B2",
+        "changed",
     )
-    assert s.fact_log(fid) == []
+    assert [event["action"] for event in s.fact_log(fid)] == ["amended"]
     assert s.get_fact_terms(fid) == before_terms
+    with pytest.raises(DuckDBFactTermStoreError, match="stale DuckDB fact terms"):
+        s.engine_fact_terms()
 
 
 def test_amend_fact_rejects_direct_nonground_terms_and_restores_state(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -352,6 +352,21 @@ def test_verify_fails_closed_when_engine_fact_terms_remain_missing(tmp_path, mon
     assert "missing DuckDB fact terms" in rep.text
 
 
+def test_verify_fails_closed_when_duckdb_fact_terms_are_stale(tmp_path):
+    s = _store(tmp_path)
+    fid = s.add_fact("Ada", "born_in", "London", status="confirmed")
+    s._conn.execute(
+        "UPDATE facts SET object = ?, term_token = ? WHERE id = ?",
+        ("Paris", "0" * 64, fid),
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert "stale DuckDB fact terms" in rep.text
+
+
 def test_verify_reports_missing_duckdb_as_blocking(tmp_path, monkeypatch):
     real_import = builtins.__import__
 
@@ -454,7 +469,7 @@ def test_verify_cache_refreshes_after_engine_fact_amendment(tmp_path):
     assert verify(s).ok is True
 
 
-def test_verify_cache_refreshes_after_duckdb_term_payload_change(tmp_path):
+def test_verify_cache_refreshes_after_approved_fact_term_change(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("Ada", "born_in", "London", status="confirmed")
     path = query_path(tmp_path)
@@ -465,7 +480,7 @@ def test_verify_cache_refreshes_after_duckdb_term_payload_change(tmp_path):
     )
 
     assert verify(s).answers == ["q1: London"]
-    s.fact_terms.put_fact_terms(fid, "Ada", "born_in", "Paris")
+    s.amend_fact(fid, subject="Ada", relation="born_in", obj="Paris")
 
     assert verify(s).answers == ["q1: Paris"]
 

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -16,6 +16,7 @@ from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_
 from verinote.pipeline.query_candidate_eval import RELATION_DECL
 from verinote.pipeline.report_trace import trace_query_answers
 from verinote.store import Store, engine_statuses
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
 
 ASK_QID = 0
 MAX_CONTEXT_CHARS = 12000
@@ -81,13 +82,22 @@ def ask_question(
             reason="empty question",
         )
 
-    status, query_dl, reason = schema_aware_query_flow(
-        store,
-        client,
-        qid=ASK_QID,
-        question=question,
-        llm_error_status="review_required",
-    )
+    try:
+        status, query_dl, reason = schema_aware_query_flow(
+            store,
+            client,
+            qid=ASK_QID,
+            question=question,
+            llm_error_status="review_required",
+        )
+    except DuckDBFactTermStoreError as exc:
+        return _fallback_answer(
+            store,
+            client,
+            root=root,
+            question=question,
+            reason=f"engine fact-term error: {_short_reason(exc)}",
+        )
     if status == "translated" and query_dl:
         report, expanded_query = _run_engine_query(store, query_dl)
         if report.engine_available and report.ok and not report.errors:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -931,6 +931,7 @@ class Store:
         with self._lock:
             from verinote.store.duckdb_fact_terms import fact_term_token
 
+            fact_id: int | None = None
             token = fact_term_token(subject, relation, obj)
             self._conn.execute("BEGIN")
             try:
@@ -953,6 +954,9 @@ class Store:
                     ),
                 )
                 fact_id = int(cur.fetchone()[0])
+                self.fact_terms.put_fact_terms(
+                    fact_id, subject, relation, obj, term_token=token
+                )
                 self._record_fact_terms_marker_unlocked(origin="write")
                 self._add_fact_event(
                     fact_id=fact_id,
@@ -969,15 +973,15 @@ class Store:
                 self._conn.execute("COMMIT")
             except BaseException:
                 self._conn.execute("ROLLBACK")
+                if fact_id is not None:
+                    self._delete_fact_terms_quietly(fact_id)
                 raise
-            self.fact_terms.put_fact_terms(
-                fact_id, subject, relation, obj, term_token=token
-            )
             return fact_id
 
     def get_fact_terms(self, fact_id: int):
         """Return structural DuckDB terms for a fact metadata row."""
-        return self.fact_terms.get_fact_terms(fact_id)
+        with self._lock:
+            return self.fact_terms.get_fact_terms(fact_id)
 
     def engine_fact_terms(self) -> list[dict[str, object]]:
         """Return confirmed/accepted facts using DuckDB terms as logical values."""
@@ -1053,54 +1057,58 @@ class Store:
             return written
 
     def get_fact(self, fact_id: int) -> sqlite3.Row | None:
-        return self._conn.execute(
-            "SELECT f.*, s.path AS source_path FROM facts f "
-            "LEFT JOIN sources s ON s.id = f.source_id WHERE f.id = ?",
-            (fact_id,),
-        ).fetchone()
+        with self._lock:
+            return self._conn.execute(
+                "SELECT f.*, s.path AS source_path FROM facts f "
+                "LEFT JOIN sources s ON s.id = f.source_id WHERE f.id = ?",
+                (fact_id,),
+            ).fetchone()
 
     def facts(self, *, statuses: Iterable[str] | None = None) -> list[sqlite3.Row]:
-        sql = (
-            "SELECT f.*, s.path AS source_path FROM facts f "
-            "LEFT JOIN sources s ON s.id = f.source_id"
-        )
-        params: tuple[Any, ...] = ()
-        if statuses is not None:
-            placeholders, params = _status_filter(statuses)
-            sql += f" WHERE f.status IN ({placeholders})"
-        sql += " ORDER BY f.id"
-        return list(self._conn.execute(sql, params))
+        with self._lock:
+            sql = (
+                "SELECT f.*, s.path AS source_path FROM facts f "
+                "LEFT JOIN sources s ON s.id = f.source_id"
+            )
+            params: tuple[Any, ...] = ()
+            if statuses is not None:
+                placeholders, params = _status_filter(statuses)
+                sql += f" WHERE f.status IN ({placeholders})"
+            sql += " ORDER BY f.id"
+            return list(self._conn.execute(sql, params))
 
     def review_queue(self) -> list[sqlite3.Row]:
         return self.facts(statuses=REVIEW_STATUSES)
 
     def review_queue_ids(self, *, sort: object = DEFAULT_REVIEW_SORT) -> list[int]:
-        sort = _review_sort(sort)
-        placeholders, statuses = _status_filter(REVIEW_STATUSES)
-        rows = self._conn.execute(
-            "SELECT f.id FROM facts f "
-            "LEFT JOIN sources s ON s.id = f.source_id "
-            f"WHERE f.status IN ({placeholders}) "
-            f"ORDER BY {REVIEW_SORT_SQL[sort]}",
-            statuses,
-        )
-        return [int(row["id"]) for row in rows]
+        with self._lock:
+            sort = _review_sort(sort)
+            placeholders, statuses = _status_filter(REVIEW_STATUSES)
+            rows = self._conn.execute(
+                "SELECT f.id FROM facts f "
+                "LEFT JOIN sources s ON s.id = f.source_id "
+                f"WHERE f.status IN ({placeholders}) "
+                f"ORDER BY {REVIEW_SORT_SQL[sort]}",
+                statuses,
+            )
+            return [int(row["id"]) for row in rows]
 
     def facts_by_ids(self, fact_ids: Iterable[int]) -> list[sqlite3.Row]:
-        ids = [int(fact_id) for fact_id in fact_ids]
-        if not ids:
-            return []
-        placeholders = ",".join("?" * len(ids))
-        rows = list(
-            self._conn.execute(
-                "SELECT f.*, s.path AS source_path FROM facts f "
-                "LEFT JOIN sources s ON s.id = f.source_id "
-                f"WHERE f.id IN ({placeholders})",
-                tuple(ids),
+        with self._lock:
+            ids = [int(fact_id) for fact_id in fact_ids]
+            if not ids:
+                return []
+            placeholders = ",".join("?" * len(ids))
+            rows = list(
+                self._conn.execute(
+                    "SELECT f.*, s.path AS source_path FROM facts f "
+                    "LEFT JOIN sources s ON s.id = f.source_id "
+                    f"WHERE f.id IN ({placeholders})",
+                    tuple(ids),
+                )
             )
-        )
-        by_id = {int(row["id"]): row for row in rows}
-        return [by_id[fact_id] for fact_id in ids if fact_id in by_id]
+            by_id = {int(row["id"]): row for row in rows}
+            return [by_id[fact_id] for fact_id in ids if fact_id in by_id]
 
     def review_queue_page(
         self,
@@ -1109,37 +1117,38 @@ class Store:
         page_size: object = DEFAULT_REVIEW_PAGE_SIZE,
         sort: object = DEFAULT_REVIEW_SORT,
     ) -> ReviewQueuePage:
-        page_size = _review_page_size(page_size)
-        page = _positive_int(page, 1)
-        sort = _review_sort(sort)
-        placeholders, statuses = _status_filter(REVIEW_STATUSES)
-        where = f"f.status IN ({placeholders})"
-        total = int(
-            self._conn.execute(
-                f"SELECT COUNT(*) AS c FROM facts f WHERE {where}",
-                statuses,
-            ).fetchone()["c"]
-        )
-        page_count = max(1, (total + page_size - 1) // page_size)
-        page = min(page, page_count)
-        offset = (page - 1) * page_size
-        rows = list(
-            self._conn.execute(
-                "SELECT f.*, s.path AS source_path FROM facts f "
-                "LEFT JOIN sources s ON s.id = f.source_id "
-                f"WHERE {where} "
-                f"ORDER BY {REVIEW_SORT_SQL[sort]} "
-                "LIMIT ? OFFSET ?",
-                (*statuses, page_size, offset),
+        with self._lock:
+            page_size = _review_page_size(page_size)
+            page = _positive_int(page, 1)
+            sort = _review_sort(sort)
+            placeholders, statuses = _status_filter(REVIEW_STATUSES)
+            where = f"f.status IN ({placeholders})"
+            total = int(
+                self._conn.execute(
+                    f"SELECT COUNT(*) AS c FROM facts f WHERE {where}",
+                    statuses,
+                ).fetchone()["c"]
             )
-        )
-        return ReviewQueuePage.from_rows(
-            rows=rows,
-            total=total,
-            page=page,
-            page_size=page_size,
-            sort=sort,
-        )
+            page_count = max(1, (total + page_size - 1) // page_size)
+            page = min(page, page_count)
+            offset = (page - 1) * page_size
+            rows = list(
+                self._conn.execute(
+                    "SELECT f.*, s.path AS source_path FROM facts f "
+                    "LEFT JOIN sources s ON s.id = f.source_id "
+                    f"WHERE {where} "
+                    f"ORDER BY {REVIEW_SORT_SQL[sort]} "
+                    "LIMIT ? OFFSET ?",
+                    (*statuses, page_size, offset),
+                )
+            )
+            return ReviewQueuePage.from_rows(
+                rows=rows,
+                total=total,
+                page=page,
+                page_size=page_size,
+                sort=sort,
+            )
 
     def status_counts(self) -> dict[str, int]:
         rows = self._conn.execute("SELECT status, COUNT(*) c FROM facts GROUP BY status")

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -149,6 +149,18 @@ def _missing_fact_terms_error(fact_ids: Iterable[int]) -> Exception:
     )
 
 
+def _stale_fact_terms_error(fact_ids: Iterable[int]) -> Exception:
+    from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+
+    ids = ", ".join(str(fact_id) for fact_id in fact_ids)
+    return DuckDBFactTermStoreError(
+        "stale DuckDB fact terms for fact id(s): "
+        f"{ids}. SQLite display metadata and facts.duckdb no longer describe "
+        "the same approved fact. Refusing to use engine input until the affected "
+        "facts are re-entered."
+    )
+
+
 class Store:
     """A connection to one KB's SQLite file."""
 
@@ -160,7 +172,7 @@ class Store:
         self._conn = sqlite3.connect(self.db_path, isolation_level=None, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON;")
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._inference_cache: Any = None
         self._fact_terms: Any = None
 
@@ -917,14 +929,16 @@ class Store:
         note: str = "",
     ) -> int:
         with self._lock:
-            fact_id: int | None = None
+            from verinote.store.duckdb_fact_terms import fact_term_token
+
+            token = fact_term_token(subject, relation, obj)
             self._conn.execute("BEGIN")
             try:
                 cur = self._conn.execute(
                     "INSERT INTO facts("
                     "subject, relation, object, status, confidence, source_id, "
-                    "run_id, job_id, note"
-                    ") VALUES(?,?,?,?,?,?,?,?,?) RETURNING id",
+                    "run_id, job_id, note, term_token"
+                    ") VALUES(?,?,?,?,?,?,?,?,?,?) RETURNING id",
                     (
                         _display_fact_value(subject),
                         _display_fact_value(relation),
@@ -935,10 +949,10 @@ class Store:
                         run_id,
                         job_id,
                         note,
+                        token,
                     ),
                 )
                 fact_id = int(cur.fetchone()[0])
-                self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
                 self._record_fact_terms_marker_unlocked(origin="write")
                 self._add_fact_event(
                     fact_id=fact_id,
@@ -953,12 +967,13 @@ class Store:
                     },
                 )
                 self._conn.execute("COMMIT")
-                return fact_id
-            except Exception:
-                self._rollback_quietly()
-                if fact_id is not None:
-                    self._delete_fact_terms_quietly(fact_id)
+            except BaseException:
+                self._conn.execute("ROLLBACK")
                 raise
+            self.fact_terms.put_fact_terms(
+                fact_id, subject, relation, obj, term_token=token
+            )
+            return fact_id
 
     def get_fact_terms(self, fact_id: int):
         """Return structural DuckDB terms for a fact metadata row."""
@@ -966,33 +981,50 @@ class Store:
 
     def engine_fact_terms(self) -> list[dict[str, object]]:
         """Return confirmed/accepted facts using DuckDB terms as logical values."""
-        rows = self.facts(statuses=ENGINE_STATUSES)
-        ids = [int(row["id"]) for row in rows]
-        if not ids:
-            return []
+        with self._lock:
+            rows = self.facts(statuses=ENGINE_STATUSES)
+            ids = [int(row["id"]) for row in rows]
+            if not ids:
+                return []
 
-        terms = self.fact_terms.get_many_fact_terms(ids)
-        missing = [fact_id for fact_id in ids if fact_id not in terms]
-        if missing:
-            if self._has_fact_terms_marker():
+            records = self.fact_terms.get_many_fact_term_records(ids)
+            missing = [fact_id for fact_id in ids if fact_id not in records]
+            if missing:
+                if self._has_fact_terms_marker():
+                    raise _missing_fact_terms_error(missing)
+                self.backfill_fact_terms()
+                records = self.fact_terms.get_many_fact_term_records(ids)
+                missing = [fact_id for fact_id in ids if fact_id not in records]
+            if missing:
                 raise _missing_fact_terms_error(missing)
-            self.backfill_fact_terms()
-            terms = self.fact_terms.get_many_fact_terms(ids)
-            missing = [fact_id for fact_id in ids if fact_id not in terms]
-        if missing:
-            raise _missing_fact_terms_error(missing)
-        if not self._has_fact_terms_marker():
-            self._record_fact_terms_marker(origin="existing_sidecar")
+            if not self._has_fact_terms_marker():
+                self._record_fact_terms_marker(origin="existing_sidecar")
 
-        return [
-            {
-                "id": fact_id,
-                "subject": terms[fact_id][0],
-                "relation": terms[fact_id][1],
-                "object": terms[fact_id][2],
-            }
-            for fact_id in ids
-        ]
+            stale = []
+            for row in rows:
+                fact_id = int(row["id"])
+                sqlite_token = row["term_token"]
+                if sqlite_token is None:
+                    continue
+                record = records[fact_id]
+                if (
+                    record.term_token is None
+                    or record.term_token != sqlite_token
+                    or record.content_token != sqlite_token
+                ):
+                    stale.append(fact_id)
+            if stale:
+                raise _stale_fact_terms_error(stale)
+
+            return [
+                {
+                    "id": fact_id,
+                    "subject": records[fact_id].terms[0],
+                    "relation": records[fact_id].terms[1],
+                    "object": records[fact_id].terms[2],
+                }
+                for fact_id in ids
+            ]
 
     def backfill_fact_terms(self) -> int:
         """Backfill legacy SQLite-only fact rows into DuckDB as StringLit terms."""
@@ -1184,36 +1216,37 @@ class Store:
     ) -> sqlite3.Row | None:
         """Correct a fact's (subject, relation, object, note); audit as `amended`."""
         with self._lock:
+            from verinote.store.duckdb_fact_terms import fact_term_token
+
             before = self.get_fact(fact_id)
             if before is None:
                 return None
-            previous_terms = self.fact_terms.get_fact_terms(fact_id)
-            terms_written = False
+            token = fact_term_token(subject, relation, obj)
             self._conn.execute("BEGIN")
             try:
-                self.fact_terms.put_fact_terms(fact_id, subject, relation, obj)
-                terms_written = True
-                self._record_fact_terms_marker_unlocked(origin="write")
                 self._conn.execute(
-                    "UPDATE facts SET subject = ?, relation = ?, object = ?, note = ?, "
+                    "UPDATE facts SET subject = ?, relation = ?, object = ?, note = ?, term_token = ?, "
                     "updated_at = datetime('now') WHERE id = ?",
                     (
                         _display_fact_value(subject),
                         _display_fact_value(relation),
                         _display_fact_value(obj),
                         note,
+                        token,
                         fact_id,
                     ),
                 )
                 after = self.get_fact(fact_id)
                 self._log(fact_id, "amended", before, after)
+                self._record_fact_terms_marker_unlocked(origin="write")
                 self._conn.execute("COMMIT")
-                return after
-            except Exception:
-                self._rollback_quietly()
-                if terms_written:
-                    self._restore_fact_terms_quietly(fact_id, previous_terms)
+            except BaseException:
+                self._conn.execute("ROLLBACK")
                 raise
+            self.fact_terms.put_fact_terms(
+                fact_id, subject, relation, obj, term_token=token
+            )
+            return after
 
     # --- questions -------------------------------------------------------
     def add_question(self, text: str) -> int:
@@ -1479,6 +1512,8 @@ class Store:
                 "ALTER TABLE facts ADD COLUMN job_id INTEGER "
                 "REFERENCES extraction_jobs(id) ON DELETE SET NULL"
             )
+        if "term_token" not in fact_columns:
+            self._conn.execute("ALTER TABLE facts ADD COLUMN term_token TEXT")
         self._conn.executescript(
             """
             CREATE TABLE IF NOT EXISTS fact_evidence (

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -7,6 +7,8 @@ only the structural term payloads for fact triples, keyed by SQLite `facts.id`.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import hashlib
 from pathlib import Path
 from typing import Iterable
 
@@ -24,6 +26,15 @@ _TERM_COLUMNS = ("subject", "rel", "object")
 
 class DuckDBFactTermStoreError(ValueError):
     """Raised when the DuckDB fact-term store cannot complete an operation."""
+
+
+@dataclass(frozen=True)
+class FactTermRecord:
+    """Stored logical terms plus the coherence token recorded beside them."""
+
+    terms: tuple[Term, Term, Term]
+    term_token: str | None
+    content_token: str
 
 
 class DuckDBFactTermStore:
@@ -50,10 +61,17 @@ class DuckDBFactTermStore:
                 fact_id BIGINT PRIMARY KEY,
                 subject VARCHAR NOT NULL,
                 rel VARCHAR NOT NULL,
-                object VARCHAR NOT NULL
+                object VARCHAR NOT NULL,
+                term_token VARCHAR
             )
             """
         )
+        columns = {
+            row[1]
+            for row in self._execute("PRAGMA table_info('fact_terms')").fetchall()
+        }
+        if "term_token" not in columns:
+            self._execute("ALTER TABLE fact_terms ADD COLUMN term_token VARCHAR")
 
     def close(self) -> None:
         """Close the owned DuckDB connection. Safe to call more than once."""
@@ -67,24 +85,26 @@ class DuckDBFactTermStore:
         subject: object,
         relation: object,
         obj: object,
+        *,
+        term_token: str | None = None,
     ) -> None:
         """Upsert one structural fact triple for a SQLite fact id."""
         fid = _validate_fact_id(fact_id)
-        values = (
-            term_to_duckdb_value(_coerce_term(subject)),
-            term_to_duckdb_value(_coerce_term(relation)),
-            term_to_duckdb_value(_coerce_term(obj)),
-        )
+        values = _duckdb_term_values(subject, relation, obj)
+        token = term_token or fact_term_token_from_values(values)
+        if token != fact_term_token_from_values(values):
+            raise DuckDBFactTermStoreError("fact term token does not match term payload")
         self._execute(
             """
-            INSERT INTO fact_terms (fact_id, subject, rel, object)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO fact_terms (fact_id, subject, rel, object, term_token)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(fact_id) DO UPDATE SET
                 subject = excluded.subject,
                 rel = excluded.rel,
-                object = excluded.object
+                object = excluded.object,
+                term_token = excluded.term_token
             """,
-            [fid, *values],
+            [fid, *values, token],
         )
 
     def get_fact_terms(self, fact_id: int) -> tuple[Term, Term, Term] | None:
@@ -96,6 +116,17 @@ class DuckDBFactTermStore:
         if row is None:
             return None
         return _decode_row(fid, row)
+
+    def get_fact_term_record(self, fact_id: int) -> FactTermRecord | None:
+        """Return one stored fact triple with its coherence token."""
+        fid = _validate_fact_id(fact_id)
+        row = self._execute(
+            "SELECT subject, rel, object, term_token FROM fact_terms WHERE fact_id = ?",
+            [fid],
+        ).fetchone()
+        if row is None:
+            return None
+        return _decode_record(fid, row)
 
     def get_many_fact_terms(
         self, fact_ids: Iterable[int]
@@ -114,6 +145,21 @@ class DuckDBFactTermStore:
             int(row[0]): _decode_row(int(row[0]), (row[1], row[2], row[3]))
             for row in rows
         }
+
+    def get_many_fact_term_records(
+        self, fact_ids: Iterable[int]
+    ) -> dict[int, FactTermRecord]:
+        """Return stored triples and coherence tokens for found fact ids."""
+        ids = sorted({_validate_fact_id(fact_id) for fact_id in fact_ids})
+        if not ids:
+            return {}
+        placeholders = ", ".join("?" for _ in ids)
+        rows = self._execute(
+            "SELECT fact_id, subject, rel, object, term_token "
+            f"FROM fact_terms WHERE fact_id IN ({placeholders}) ORDER BY fact_id",
+            ids,
+        ).fetchall()
+        return {int(row[0]): _decode_record(int(row[0]), row[1:]) for row in rows}
 
     def delete_fact_terms(self, fact_id: int) -> None:
         """Delete a fact term row. Missing ids are ignored."""
@@ -134,6 +180,17 @@ class DuckDBFactTermStore:
 def fact_terms_path(root: str | Path) -> Path:
     """Return the default DuckDB fact-term store path for a KB root."""
     return Path(root).expanduser() / FACT_TERMS_FILENAME
+
+
+def fact_term_token(subject: object, relation: object, obj: object) -> str:
+    """Return the deterministic coherence token for one logical fact triple."""
+    return fact_term_token_from_values(_duckdb_term_values(subject, relation, obj))
+
+
+def fact_term_token_from_values(values: tuple[str, str, str]) -> str:
+    """Return the deterministic coherence token for encoded DuckDB term values."""
+    payload = "\x1f".join(values).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
 
 
 # DuckDB's native storage layer splits a database path on '?' and reads the tail
@@ -193,6 +250,14 @@ def _coerce_term(value: object) -> Term:
     return StringLit(str(value))
 
 
+def _duckdb_term_values(subject: object, relation: object, obj: object) -> tuple[str, str, str]:
+    return (
+        term_to_duckdb_value(_coerce_term(subject)),
+        term_to_duckdb_value(_coerce_term(relation)),
+        term_to_duckdb_value(_coerce_term(obj)),
+    )
+
+
 def _decode_row(fact_id: int, row: tuple[object, object, object]) -> tuple[Term, Term, Term]:
     decoded: list[Term] = []
     for column, value in zip(_TERM_COLUMNS, row, strict=True):
@@ -203,3 +268,18 @@ def _decode_row(fact_id: int, row: tuple[object, object, object]) -> tuple[Term,
                 f"malformed DuckDB term for fact_id={fact_id} column={column}: {exc}"
             ) from exc
     return (decoded[0], decoded[1], decoded[2])
+
+
+def _decode_record(fact_id: int, row: tuple[object, object, object, object]) -> FactTermRecord:
+    terms = _decode_row(fact_id, (row[0], row[1], row[2]))
+    values = tuple(str(value) for value in row[:3])
+    stored_token = row[3]
+    if stored_token is not None and not isinstance(stored_token, str):
+        raise DuckDBFactTermStoreError(
+            f"malformed DuckDB term token for fact_id={fact_id}: {stored_token!r}"
+        )
+    return FactTermRecord(
+        terms=terms,
+        term_token=stored_token,
+        content_token=fact_term_token_from_values(values),
+    )

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -107,6 +107,7 @@ CREATE TABLE IF NOT EXISTS facts (
     run_id     INTEGER REFERENCES runs(id) ON DELETE SET NULL,
     job_id     INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
     note       TEXT NOT NULL DEFAULT '',
+    term_token TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );


### PR DESCRIPTION
Closes #170

## What changed

- Added deterministic content-bound `term_token` metadata to SQLite `facts` and DuckDB `fact_terms`.
- Made modern engine fact-term reads fail closed when DuckDB terms are missing, stale, untokened, or no longer match the recorded SQLite token.
- Reordered add/amend writes so term serialization is prevalidated before SQLite commit, then sidecar writes use the same token.
- Preserved existing tuple-returning fact-term APIs and added metadata-bearing record APIs for internal engine checks.
- Routed stale fact-term errors through Verify and Ask so they do not surface as verified engine answers.

## Validation

- `.venv/bin/python -m pytest -q -rs` -> 1096 passed, 8 skipped
- `uv tool run ruff check verinote/store/duckdb_fact_terms.py verinote/store/db.py verinote/pipeline/ask.py tests/test_duckdb_fact_terms.py tests/test_store_fact_terms.py tests/test_verify.py tests/test_ask.py` -> All checks passed
