### PR TITLE
fix(#291): make CLI diagnostics read-only

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1026,22 +1026,13 @@ def _alien_sources_db(root: Path) -> Path:
 def test_read_only_commands_diagnose_an_alien_table_past_the_facts_probe(
     command, tmp_path, monkeypatch, capsys
 ):
-    """The probe checks `facts`; the KB is made of more tables than that.
+    """The probe now rejects alien core-table columns before opening read-write.
 
-    A file whose `facts` table is verinote's but whose `sources` table is
-    somebody else's gets past the probe and blows up deeper in
-    (`no such column: path`). Tightening the probe to every table's columns
-    would be the schema-drift trap the probe is shaped to avoid, so instead the
-    read-only commands own their contract at the boundary: a diagnosis reports,
-    it does not traceback.
-
-    LIMITATION, on purpose: this closes the traceback, *not* the write. By the
-    time the error surfaces, `_store()` has already run `init_schema()` and the
-    file has grown. Only refusing to open the KB read-write would fix that, and
-    that is issue #291 — `_store()` writes unconditionally, so today even a
-    healthy `status` writes. This test deliberately asserts nothing about the
-    file's bytes: pinning today's damage would be a test of the bug, and it must
-    not go red when #291 stops the write.
+    PR #274 originally let this file reach `_store().init_schema()`, then wrapped
+    the later SQL error. Issue #291 moves the boundary earlier: `sources` is one
+    of the oldest KB tables, and its `id`/`path` columns are part of the
+    historical read contract, so a table without them is refused without touching
+    the file.
     """
     _isolated(monkeypatch, tmp_path)
     root = tmp_path / "alien-sources"
@@ -1052,15 +1043,182 @@ def test_read_only_commands_diagnose_an_alien_table_past_the_facts_probe(
 
     out = capsys.readouterr()
     assert "Traceback" not in out.err
+    assert "is not a verinote KB" in out.err
+
+
+def _table_names(db: Path) -> set[str]:
+    conn = sqlite3.connect(db)
+    try:
+        return {
+            r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    finally:
+        conn.close()
+
+
+def _root_file_names(root: Path) -> list[str]:
+    return sorted(p.name for p in root.iterdir())
+
+
+@pytest.mark.parametrize("command", ["status", "coverage"])
+def test_read_only_diagnostics_leave_a_current_kb_untouched(
+    command, tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "healthy"
+    root.mkdir()
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("A", "r", "B", status="confirmed", source_id=source_id)
+    store.close()
+    db = root / "kb.sqlite"
+    before = db.read_bytes()
+    before_mtime = db.stat().st_mtime_ns
+    before_files = _root_file_names(root)
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main([command]) == 0
+
+    assert "policy:" in capsys.readouterr().out
+    assert db.read_bytes() == before
+    assert db.stat().st_mtime_ns == before_mtime
+    assert _root_file_names(root) == before_files
+
+
+def test_status_reads_a_live_wal_kb_without_false_schema_refusal(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "live-wal"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        PRAGMA journal_mode = WAL;
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY, subject TEXT, relation TEXT,
+            object TEXT, status TEXT
+        );
+        CREATE TABLE sources (id INTEGER PRIMARY KEY, path TEXT NOT NULL UNIQUE);
+        CREATE TABLE runs (id INTEGER PRIMARY KEY);
+        CREATE TABLE review_log (id INTEGER PRIMARY KEY);
+        INSERT INTO sources(id, path) VALUES (1, 'sources/sample.txt');
+        INSERT INTO facts(id, subject, relation, object, status)
+            VALUES (1, 'A', 'r', 'B', 'confirmed');
+        """
+    )
+    conn.commit()
+    assert (root / "kb.sqlite-wal").exists()
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    try:
+        assert cli.main(["status"]) == 0
+    finally:
+        conn.close()
+
+    out = capsys.readouterr()
+    assert "facts:   1" in out.out
+    assert "is not a verinote KB" not in out.err
+
+
+def test_status_does_not_adopt_a_pre_marker_policy_file_read_only(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "pre-marker-policy"
+    root.mkdir()
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    store.close()
+    policy = root / "policy" / "logic-policy.dl"
+    policy.parent.mkdir()
+    policy.write_text("// synthetic policy\n", encoding="utf-8")
+    db = root / "kb.sqlite"
+    before = db.read_bytes()
+    before_mtime = db.stat().st_mtime_ns
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main(["status"]) == 0
+
+    assert "policy: ok" in capsys.readouterr().out
+    assert db.read_bytes() == before
+    assert db.stat().st_mtime_ns == before_mtime
+    conn = sqlite3.connect(db)
+    marker = conn.execute(
+        "SELECT value FROM kb_meta WHERE key = 'policy.logic'"
+    ).fetchone()
+    conn.close()
+    assert marker is None
+
+
+@pytest.mark.parametrize("command", ["status", "coverage"])
+def test_read_only_commands_do_not_modify_an_alien_sources_table(
+    command, tmp_path, monkeypatch, capsys
+):
+    """Even deeper malformed tables must not be half-migrated by diagnostics."""
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "alien-sources-readonly"
+    db = _alien_sources_db(root)
+    before = db.read_bytes()
+    before_mtime = db.stat().st_mtime_ns
+    before_tables = _table_names(db)
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main([command]) == 1
+
+    out = capsys.readouterr()
+    assert "Traceback" not in out.err
+    assert "is not a verinote KB" in out.err
+    assert db.read_bytes() == before
+    assert db.stat().st_mtime_ns == before_mtime
+    assert _table_names(db) == before_tables
+    assert sorted(p.name for p in root.iterdir()) == ["kb.sqlite"]
+
+
+def _sources_with_null_path_db(root: Path) -> Path:
+    """A malformed DB that passes shape checks but has invalid source data."""
+    root.mkdir(parents=True, exist_ok=True)
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY, subject TEXT, relation TEXT,
+            object TEXT, status TEXT, source_id INTEGER
+        );
+        CREATE TABLE sources (id INTEGER PRIMARY KEY, path TEXT, kind TEXT);
+        CREATE TABLE runs (id INTEGER PRIMARY KEY);
+        CREATE TABLE review_log (id INTEGER PRIMARY KEY);
+        INSERT INTO sources(id, path, kind) VALUES (1, NULL, 'text');
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_coverage_refuses_null_source_path_without_traceback_or_write(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "null-source-path"
+    db = _sources_with_null_path_db(root)
+    before = db.read_bytes()
+    before_mtime = db.stat().st_mtime_ns
+    before_tables = _table_names(db)
+    monkeypatch.setenv("VERINOTE_ROOT", str(root))
+
+    assert cli.main(["coverage"]) == 1
+
+    out = capsys.readouterr()
+    assert "Traceback" not in out.err
     assert "cannot read the KB" in out.err
-    # The message may not pin the blame on the KB: a `DatabaseError` here is just
-    # as likely to be verinote's own SQL bug, and telling *that* user to restore a
-    # healthy KB from backup is worse advice than the traceback this replaced.
-    assert "or a bug in verinote" in out.err
-    # So the one check the code cannot make is handed to the user, and the restore
-    # advice waits behind it rather than being an unconditional imperative.
-    assert "opens with another verinote version" in out.err
-    assert "do not restore anything" in out.err
+    assert "unsupported operand" not in out.err
+    assert db.read_bytes() == before
+    assert db.stat().st_mtime_ns == before_mtime
+    assert _table_names(db) == before_tables
 
 
 def test_the_two_refusal_paths_do_not_borrow_each_others_diagnosis(
@@ -1089,10 +1247,10 @@ def test_the_two_refusal_paths_do_not_borrow_each_others_diagnosis(
     assert "bug in verinote" not in probe_err
 
     wrap_root = tmp_path / "wrap"
-    _alien_sources_db(wrap_root)
+    _sources_with_null_path_db(wrap_root)
     monkeypatch.setenv("VERINOTE_ROOT", str(wrap_root))
 
-    assert cli.main(["status"]) == 1
+    assert cli.main(["coverage"]) == 1
 
     wrap_err = capsys.readouterr().err
     assert "cannot read the KB" in wrap_err

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -165,10 +165,10 @@ def test_init_records_a_scaffold_marker(tmp_path, monkeypatch):
     store.close()
 
 
-# --- 4. backwards compatibility: a pre-marker KB adopts its policy on open ---
+# --- 4. backwards compatibility: a pre-marker KB adopts its policy on write open ---
 
 
-def test_existing_policy_file_is_adopted_on_open(tmp_path, monkeypatch):
+def test_existing_policy_file_is_adopted_on_write_open(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     path = _write_policy(tmp_path)
     store = Store(tmp_path / "kb.sqlite")
@@ -176,7 +176,8 @@ def test_existing_policy_file_is_adopted_on_open(tmp_path, monkeypatch):
     assert store.policy_marker() is None  # pre-#155 KB
     store.close()
 
-    assert cli.main(["status"]) == 0
+    assert cli.main(["seed"]) == 0
+    capsys.readouterr()
 
     store = Store(tmp_path / "kb.sqlite")
     store.init_schema()

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sqlite3
 from dataclasses import dataclass
 import sys
@@ -12,7 +13,7 @@ from pathlib import Path
 from verinote import __version__
 from verinote.config import Config, local_root
 from verinote.pipeline.question_outcome import format_question_outcome
-from verinote.store import Store
+from verinote.store import Store, engine_statuses
 
 # Local commands own their KB location: they never inherit the KB the web UI
 # last selected, so `verinote init` cannot scribble into somebody else's data.
@@ -194,6 +195,20 @@ _KB_FACTS_IDENTITY_COLUMNS = frozenset(
 # exists to repair. The intersection over the schema's history is the part that has
 # never been a migration's job, and only that part can be demanded up front.
 _KB_CORE_TABLES = frozenset({"facts", "review_log", "runs", "sources"})
+_KB_CORE_TABLE_COLUMNS = {
+    "sources": frozenset({"id", "path"}),
+    "runs": frozenset({"id"}),
+    "review_log": frozenset({"id"}),
+}
+
+
+def _sqlite_read_only_uri(db_path: Path) -> str:
+    base = db_path.resolve().as_uri()
+    if db_path.with_name(db_path.name + "-wal").exists() or db_path.with_name(
+        db_path.name + "-shm"
+    ).exists():
+        return f"{base}?mode=ro"
+    return f"{base}?mode=ro&immutable=1"
 
 
 def _kb_schema_problem(db_path: Path) -> str | None:
@@ -221,7 +236,7 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     drops `mode=ro`, so SQLite would create a stray file at the truncated path.
     """
     try:
-        uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        uri = _sqlite_read_only_uri(db_path)
         conn = sqlite3.connect(uri, uri=True)
         conn.row_factory = sqlite3.Row
         try:
@@ -232,6 +247,13 @@ def _kb_schema_problem(db_path: Path) -> str | None:
             if "facts" not in tables:
                 return KB_NO_SCHEMA
             columns = {c["name"] for c in conn.execute("PRAGMA table_info(facts)")}
+            table_columns = {
+                table: {
+                    c["name"] for c in conn.execute(f"PRAGMA table_info({table})")
+                }
+                for table in _KB_CORE_TABLE_COLUMNS
+                if table in tables
+            }
         finally:
             conn.close()
     except sqlite3.DatabaseError:
@@ -244,6 +266,9 @@ def _kb_schema_problem(db_path: Path) -> str | None:
     missing = _KB_CORE_TABLES - tables
     if missing:
         return f"{KB_PARTIAL_SCHEMA} (no {', '.join('`' + t + '`' for t in sorted(missing))})"
+    for table, required in _KB_CORE_TABLE_COLUMNS.items():
+        if not required <= table_columns[table]:
+            return f"{KB_PARTIAL_SCHEMA} (`{table}` is not verinote's)"
     return None
 
 
@@ -261,6 +286,92 @@ def _require_existing_kb(cfg: Config) -> int | None:
         print(f"{cfg.db_path} is not a verinote KB ({problem})", file=sys.stderr)
         return 1
     return None
+
+
+def _read_only_conn(cfg: Config) -> sqlite3.Connection:
+    uri = _sqlite_read_only_uri(cfg.db_path)
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _read_only_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _status_counts_ro(conn: sqlite3.Connection) -> dict[str, int]:
+    rows = conn.execute("SELECT status, COUNT(*) c FROM facts GROUP BY status")
+    return {row["status"]: row["c"] for row in rows}
+
+
+def _sources_count_ro(conn: sqlite3.Connection) -> int:
+    return int(conn.execute("SELECT COUNT(*) c FROM sources").fetchone()["c"])
+
+
+def _source_fact_counts_ro(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    facts_columns = _read_only_columns(conn, "facts")
+    sources_columns = _read_only_columns(conn, "sources")
+    kind_expr = "s.kind" if "kind" in sources_columns else "'text'"
+    if "source_id" not in facts_columns:
+        return list(
+            conn.execute(
+                "SELECT s.id, s.path, "
+                f"{kind_expr} AS kind, "
+                "0 AS total, 0 AS engine "
+                "FROM sources s ORDER BY s.path"
+            )
+        )
+    placeholders = ",".join("?" for _ in engine_statuses())
+    return list(
+        conn.execute(
+            "SELECT s.id, s.path, "
+            f"{kind_expr} AS kind, "
+            "COUNT(f.id) AS total, "
+            f"COALESCE(SUM(CASE WHEN f.status IN ({placeholders}) "
+            "THEN 1 ELSE 0 END), 0) AS engine "
+            "FROM sources s LEFT JOIN facts f ON f.source_id = s.id "
+            "GROUP BY s.id ORDER BY s.path",
+            tuple(engine_statuses()),
+        )
+    )
+
+
+def _policy_marker_ro(conn: sqlite3.Connection) -> dict[str, object] | None:
+    tables = {
+        row["name"]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    if "kb_meta" not in tables:
+        return None
+    raw = conn.execute(
+        "SELECT value FROM kb_meta WHERE key = 'policy.logic'"
+    ).fetchone()
+    if raw is None:
+        return None
+    try:
+        marker = json.loads(raw["value"])
+    except json.JSONDecodeError:
+        return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+    if not isinstance(marker, dict):
+        return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+    return marker
+
+
+def _policy_state_ro(conn: sqlite3.Connection, cfg: Config):
+    from verinote.pipeline.policy_state import POLICY_RELPATH, PolicyState, PolicyStatus
+
+    path = cfg.root / POLICY_RELPATH
+    marker = _policy_marker_ro(conn)
+    if path.is_file():
+        return PolicyState(
+            status=PolicyStatus.PRESENT,
+            path=path,
+            text=path.read_text(encoding="utf-8"),
+            marker=marker,
+        )
+    if marker is not None:
+        return PolicyState(status=PolicyStatus.MISSING_RECORDED, path=path, marker=marker)
+    return PolicyState(status=PolicyStatus.UNRECORDED_DEFAULT, path=path)
 
 
 def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
@@ -528,7 +639,22 @@ def _print_policy_state(store: Store) -> bool:
     return False
 
 
-def _unusable_kb(cfg: Config, exc: sqlite3.DatabaseError) -> int:
+def _print_policy_state_ro(conn: sqlite3.Connection, cfg: Config) -> bool:
+    from verinote.pipeline.policy_state import (
+        PolicyStatus,
+        policy_cli_line,
+        policy_missing_message,
+    )
+
+    state = _policy_state_ro(conn, cfg)
+    print(policy_cli_line(state))
+    if state.status is PolicyStatus.MISSING_RECORDED:
+        print(f"error: {policy_missing_message(state)}", file=sys.stderr)
+        return True
+    return False
+
+
+def _unusable_kb(cfg: Config, exc: Exception) -> int:
     """Turn a SQLite error escaping a read-only command into a diagnosis.
 
     `_require_existing_kb()` can only vouch for the `facts` table; the KB is made
@@ -536,13 +662,6 @@ def _unusable_kb(cfg: Config, exc: sqlite3.DatabaseError) -> int:
     schema is the drift trap that check is deliberately shaped to avoid. So a
     file can still get past it and fail deeper in. Whatever it is, a command whose
     whole job is to *report* on a KB must not answer with a traceback.
-
-    This closes the traceback, not the write: `_store()` has already run
-    `init_schema()` by the time most of these surface, so the file may have grown.
-    Issue #291 tracks the root of that — `_store()` writes unconditionally, so
-    even a healthy `status` writes — and until it lands, saying so is the honest
-    move. A user who is told the file is untouched, when it is not, cannot make
-    the one decision that matters here: whether to restore from backup.
 
     The message must not blame the KB, though, because we cannot see from here
     whether it earned the blame: a `DatabaseError` this deep is just as easily
@@ -556,9 +675,8 @@ def _unusable_kb(cfg: Config, exc: sqlite3.DatabaseError) -> int:
         f"cannot read the KB at {cfg.root}: {exc}. This is either a KB this "
         f"version of verinote cannot read, or a bug in verinote — we cannot tell "
         f"which from here. If this KB opens with another verinote version, it is "
-        f"ours: please report it, and do not restore anything. Otherwise the file "
-        f"may already have been modified by the attempt, and a backup is worth "
-        f"more than what is there now.",
+        f"ours: please report it. Otherwise, inspect the KB with a known-good "
+        f"version before trusting this one.",
         file=sys.stderr,
     )
     return 1
@@ -570,17 +688,35 @@ def cmd_coverage(cfg: Config, args: argparse.Namespace) -> int:
         return refusal
     try:
         return _coverage(cfg, args)
-    except sqlite3.DatabaseError as exc:
+    except (sqlite3.DatabaseError, TypeError, ValueError) as exc:
         return _unusable_kb(cfg, exc)
 
 
 def _coverage(cfg: Config, args: argparse.Namespace) -> int:
-    from verinote.engine import coverage
+    from verinote.engine.coverage import Coverage, SourceCoverage
 
-    store = _store(cfg)
-    cov = coverage(store, root=cfg.root)
-    halted = _print_policy_state(store)
-    store.close()
+    conn = _read_only_conn(cfg)
+    try:
+        sources = []
+        for row in _source_fact_counts_ro(conn):
+            path = row["path"]
+            if not isinstance(path, str) or not path:
+                raise ValueError("invalid source path in KB")
+            engine = int(row["engine"])
+            sources.append(
+                SourceCoverage(
+                    path=path,
+                    kind=str(row["kind"]),
+                    engine_facts=engine,
+                    total_facts=int(row["total"]),
+                    is_gap=engine == 0,
+                    is_orphan=not (cfg.root / path).exists(),
+                )
+            )
+        cov = Coverage(sources=sources)
+        halted = _print_policy_state_ro(conn, cfg)
+    finally:
+        conn.close()
     for s in cov.sources:
         flags = []
         if s.is_gap:
@@ -612,23 +748,26 @@ def cmd_status(cfg: Config, args: argparse.Namespace) -> int:
         return refusal
     try:
         return _status(cfg)
-    except sqlite3.DatabaseError as exc:
+    except (sqlite3.DatabaseError, TypeError, ValueError) as exc:
         return _unusable_kb(cfg, exc)
 
 
 def _status(cfg: Config) -> int:
-    store = _store(cfg)
-    counts = store.status_counts()
-    print(f"KB: {cfg.root}")
-    print(f"sources: {len(store.sources())}")
-    print(f"facts:   {sum(counts.values())}")
-    for s in ("candidate", "needs_review", "confirmed", "accepted", "superseded"):
-        print(f"  {s:<13} {counts.get(s, 0)}")
-    # `status` stays rc=0 even when halted: it is one of the paths that must keep
-    # working *on* a halted KB, and a diagnosis command that fails is not a
-    # diagnosis. The stdout marker is what makes the halt impossible to miss.
-    _print_policy_state(store)
-    store.close()
+    conn = _read_only_conn(cfg)
+    try:
+        counts = _status_counts_ro(conn)
+        sources_count = _sources_count_ro(conn)
+        print(f"KB: {cfg.root}")
+        print(f"sources: {sources_count}")
+        print(f"facts:   {sum(counts.values())}")
+        for s in ("candidate", "needs_review", "confirmed", "accepted", "superseded"):
+            print(f"  {s:<13} {counts.get(s, 0)}")
+        # `status` stays rc=0 even when halted: it is one of the paths that must keep
+        # working *on* a halted KB, and a diagnosis command that fails is not a
+        # diagnosis. The stdout marker is what makes the halt impossible to miss.
+        _print_policy_state_ro(conn, cfg)
+    finally:
+        conn.close()
     return 0
 
 


### PR DESCRIPTION
Closes #291

## What changed

- Route `verinote status` and `verinote coverage` through CLI-only read-only SQLite queries instead of `_store()`.
- Keep write commands on the existing `_store()` path, so schema migration and policy-marker adoption still happen only on write/open paths.
- Extend the KB preflight to reject malformed historical core tables before any read-write open.
- Preserve live WAL correctness by using plain `mode=ro` when WAL/SHM sidecars already exist, and `immutable=1` only for closed DBs without sidecars.
- Convert malformed coverage source paths into a clean diagnostic instead of a raw `TypeError`.
- Remove the old diagnostic language that implied the read-only attempt may already have modified the DB.

## Validation

- `.venv/bin/python -m pytest -q -rs` -> 1118 passed, 8 skipped
- `uv tool run ruff check verinote/cli.py tests/test_cli.py tests/test_policy_state.py` -> All checks passed
- Implementation-skill Reviewer, Architect, and Critic validation passed
