### PR TITLE
docs(#279): document how to update and re-pin the vendored htmx

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ exact failure modes are in [docs/operations.md](docs/operations.md).
   document, or source data in an issue, a PR, or the docs. If showing the bug
   needs real input, reduce it to a synthetic minimal reproduction first. See
   [Data Privacy](AGENTS.md#data-privacy).
+- **Updating the vendored htmx.** verinote self-hosts htmx, so no bot watches it
+  for security releases. The manual update procedure and the cadence for checking
+  are in [docs/vendored-assets.md](docs/vendored-assets.md).
 
 ## License
 

--- a/docs/vendored-assets.md
+++ b/docs/vendored-assets.md
@@ -112,9 +112,11 @@ pytest -q
 ruff check .
 ```
 
-If the hash test fails, it prints the digest it actually found — compare it with
-the one you verified in step 2. A mismatch means the pin and the bytes came from
-different fetches, so redo step 1 rather than pasting the reported digest in.
+If the hash test fails, it prints the digest of the file on disk — compare that
+with the one you verified in step 2. **If they match**, the vendored file is fine
+and the constant you pasted in step 3 is wrong; fix the constant. **If they
+differ**, the pin and the bytes came from different fetches, so redo step 1
+rather than pasting the reported digest in.
 
 **5. Check it by hand.** The tests prove the bytes are pinned and the file is
 served; they do not prove htmx still works. Cut off network access, clear the

--- a/docs/vendored-assets.md
+++ b/docs/vendored-assets.md
@@ -1,0 +1,108 @@
+# Updating vendored assets
+
+verinote ships one third-party asset in its own tree: `verinote/web/static/htmx.min.js`.
+Nothing updates it for you. Dependabot and renovate read manifests, and a vendored
+blob is not in any manifest — so no bot will ever tell you that htmx shipped a
+security fix. This page is the manual procedure that replaces them, and the
+cadence that decides when to run it.
+
+## What is vendored, and why
+
+htmx used to load from a CDN `<script>` tag. The review UI renders your document
+text into the DOM, so unverified third-party code was executing in the same page
+as your source material —
+[#219](https://github.com/semantic-reasoning/verinote/issues/219). The fix was to
+self-host: `verinote/web/templates/base.html` loads `/static/htmx.min.js`, and
+[tests/test_base_template_assets.py](../tests/test_base_template_assets.py)
+forbids any absolute-origin `src`/`href` in that template at all.
+
+htmx is 0BSD-licensed, so vendoring the minified file carries no attribution
+obligation beyond the source comment described below.
+
+## Where the version and the hash live
+
+**There is no manifest, no checksum file, and no SRI attribute.** Both facts live
+in two adjacent lines at the top of `tests/test_base_template_assets.py`:
+
+```python
+# Source: htmx 2.0.3, https://unpkg.com/htmx.org@2.0.3/dist/htmx.min.js (0BSD).
+HTMX_SHA256 = "491955cd1810747d7d7b9ccb936400afb760e06d25d53e4572b64b6563b2784e"
+```
+
+The comment is the only record of *which* htmx version is vendored — grep the
+repository for a version number and you will find nothing else. The constant is
+enforced by `test_vendored_htmx_bytes_match_the_pinned_hash`, which fails on any
+byte change to the vendored file.
+
+**Update both lines together.** Bumping the hash without the comment leaves the
+repository with no record of what it is running.
+
+## Updating
+
+Replace `<VER>` with the target version throughout (for example `2.0.9`). Run
+these from the repository root.
+
+**1. Fetch the release artefact.** Prefer the official GitHub release asset over
+a CDN mirror:
+
+```sh
+curl -sSL -o verinote/web/static/htmx.min.js \
+  https://github.com/bigskysoftware/htmx/releases/download/v<VER>/htmx.min.js
+```
+
+**2. Cross-check against an independent mirror.** Two publishers agreeing on the
+bytes is worth more than one publisher you trust. These two digests must match:
+
+```sh
+shasum -a 256 verinote/web/static/htmx.min.js
+curl -sSL https://unpkg.com/htmx.org@<VER>/dist/htmx.min.js | shasum -a 256
+```
+
+If they disagree, **stop and investigate** — do not pick one. (For 2.0.3 the
+GitHub release asset, unpkg, and jsDelivr are byte-identical.)
+
+**3. Update the pin.** Edit `tests/test_base_template_assets.py`: set
+`HTMX_SHA256` to the digest you just verified, and update the version and URL in
+the `# Source:` comment above it.
+
+**4. Verify.**
+
+```sh
+pytest -q tests/test_base_template_assets.py
+pytest -q
+ruff check .
+```
+
+**5. Check it by hand.** The tests prove the bytes are pinned and the file is
+served; they do not prove htmx still works. Cut off network access, clear the
+browser cache, run `verinote ui`, and accept something in the review queue. A
+major-version jump can break htmx attributes that no test covers.
+
+**6. Commit the bytes and the pin as one commit.** Splitting them leaves a commit
+where the vendored file and `HTMX_SHA256` disagree, so the tree is red at that
+revision and `git bisect` gets a false failure.
+
+## When to check
+
+- **Watch releases.** On
+  [bigskysoftware/htmx](https://github.com/bigskysoftware/htmx), use Watch →
+  Custom → Releases.
+- **Watch for advisories.** The GitHub Advisory Database and `npm audit` against
+  the `htmx.org` package are the two channels that would carry an htmx CVE. A
+  security fix is the one reason to update out of band.
+- **Check manually once a quarter.** Notifications get muted and filtered; the
+  quarterly pass is what catches a release you never saw.
+
+### Do not trust `/releases/latest`
+
+htmx marks its prereleases with `prerelease: false`, so GitHub treats them as
+stable. As of 2026-07-20 the API returns:
+
+```sh
+$ curl -sSL https://api.github.com/repos/bigskysoftware/htmx/releases/latest \
+    | grep tag_name
+  "tag_name": "v4.0.0-beta5",
+```
+
+**Read the tag names yourself and pick the newest 2.x stable release** — do not
+let `/releases/latest`, or any tool built on it, choose the version.

--- a/docs/vendored-assets.md
+++ b/docs/vendored-assets.md
@@ -61,8 +61,8 @@ $ curl -sSL https://api.github.com/repos/bigskysoftware/htmx/releases/latest \
   "tag_name": "v4.0.0-beta5",
 ```
 
-List the tags and choose the newest stable release on the line verinote is on
-(2.x today):
+List the tags and choose the newest stable release on the major line verinote is
+already on — read that line off the `# Source:` comment quoted above:
 
 ```sh
 curl -sSL "https://api.github.com/repos/bigskysoftware/htmx/releases?per_page=30" \
@@ -97,8 +97,14 @@ curl -sSL https://unpkg.com/htmx.org@<VER>/dist/htmx.min.js | shasum -a 256
 On Linux use `sha256sum` in place of `shasum -a 256` — same digest, different
 tool name.
 
-If they disagree, **stop and investigate** — do not pick one. (For 2.0.3 the
-GitHub release asset, unpkg, and jsDelivr are byte-identical.)
+If they disagree, **stop and investigate** — do not pick one. Step 1 has already
+overwritten the real file, so put the tree back before you walk away:
+
+```sh
+git checkout -- verinote/web/static/htmx.min.js
+```
+
+(For 2.0.3 the GitHub release asset, unpkg, and jsDelivr are byte-identical.)
 
 **3. Update the pin.** Edit `tests/test_base_template_assets.py`: set
 `HTMX_SHA256` to the digest you just verified, and update the version and URL in
@@ -120,8 +126,14 @@ rather than pasting the reported digest in.
 
 **5. Check it by hand.** The tests prove the bytes are pinned and the file is
 served; they do not prove htmx still works. Cut off network access, clear the
-browser cache, run `verinote ui`, and accept something in the review queue. A
-major-version jump can break htmx attributes that no test covers.
+browser cache, run `verinote ui`, and accept something in the review queue. If it
+misbehaves, revert both halves of the change — `git checkout -- verinote/web/static/htmx.min.js`
+and the pin you edited in step 3 — rather than leaving a half-updated tree.
+
+A major-version jump can break htmx attributes that no test covers. Crossing one
+is not the asset swap this page describes: read the upstream migration guide and
+treat it as a code change reaching every template that carries `hx-` attributes,
+with its own issue and review.
 
 **6. Commit the bytes and the pin as one commit.** Splitting them leaves a commit
 where the vendored file and `HTMX_SHA256` disagree, so the tree is red at that

--- a/docs/vendored-assets.md
+++ b/docs/vendored-assets.md
@@ -29,18 +29,54 @@ in two adjacent lines at the top of `tests/test_base_template_assets.py`:
 HTMX_SHA256 = "491955cd1810747d7d7b9ccb936400afb760e06d25d53e4572b64b6563b2784e"
 ```
 
-The comment is the only record of *which* htmx version is vendored — grep the
-repository for a version number and you will find nothing else. The constant is
-enforced by `test_vendored_htmx_bytes_match_the_pinned_hash`, which fails on any
-byte change to the vendored file.
+That comment is the only record of *which* htmx version is currently vendored,
+and the constant is enforced by `test_vendored_htmx_bytes_match_the_pinned_hash`,
+which fails on any byte change to the vendored file.
 
 **Update both lines together.** Bumping the hash without the comment leaves the
 repository with no record of what it is running.
 
+**Those two lines are the whole edit.** The same file mentions `2.0.3` once more,
+in its module docstring:
+
+```python
+base.html used to pull htmx from `https://unpkg.com/htmx.org@2.0.3` with no
+integrity attribute: ...
+```
+
+That is a historical record of what #219 fixed, not a pin. **Leave it alone.**
+Rewriting it to a newer version would assert that base.html once loaded a version
+it never loaded, which destroys the explanation of why these guards exist.
+
+## Choosing the version — do not trust `/releases/latest`
+
+Pick the version before you fetch anything, and pick it by reading tag names.
+
+htmx marks its prereleases with `prerelease: false`, so GitHub treats them as
+stable. As of 2026-07-20 the "latest release" API returns a 4.x beta:
+
+```sh
+$ curl -sSL https://api.github.com/repos/bigskysoftware/htmx/releases/latest \
+    | grep tag_name
+  "tag_name": "v4.0.0-beta5",
+```
+
+List the tags and choose the newest stable release on the line verinote is on
+(2.x today):
+
+```sh
+curl -sSL "https://api.github.com/repos/bigskysoftware/htmx/releases?per_page=30" \
+  | grep tag_name
+```
+
+**Never let `/releases/latest`, or any tool built on it, choose the version for
+you** — it will hand you a prerelease, and the steps below will vendor it without
+complaint.
+
 ## Updating
 
-Replace `<VER>` with the target version throughout (for example `2.0.9`). Run
-these from the repository root.
+Replace `<VER>` with the version you chose above (for example `2.0.9`). Run these
+from the repository root.
 
 **1. Fetch the release artefact.** Prefer the official GitHub release asset over
 a CDN mirror:
@@ -58,6 +94,9 @@ shasum -a 256 verinote/web/static/htmx.min.js
 curl -sSL https://unpkg.com/htmx.org@<VER>/dist/htmx.min.js | shasum -a 256
 ```
 
+On Linux use `sha256sum` in place of `shasum -a 256` — same digest, different
+tool name.
+
 If they disagree, **stop and investigate** — do not pick one. (For 2.0.3 the
 GitHub release asset, unpkg, and jsDelivr are byte-identical.)
 
@@ -72,6 +111,10 @@ pytest -q tests/test_base_template_assets.py
 pytest -q
 ruff check .
 ```
+
+If the hash test fails, it prints the digest it actually found — compare it with
+the one you verified in step 2. A mismatch means the pin and the bytes came from
+different fetches, so redo step 1 rather than pasting the reported digest in.
 
 **5. Check it by hand.** The tests prove the bytes are pinned and the file is
 served; they do not prove htmx still works. Cut off network access, clear the
@@ -92,17 +135,3 @@ revision and `git bisect` gets a false failure.
   security fix is the one reason to update out of band.
 - **Check manually once a quarter.** Notifications get muted and filtered; the
   quarterly pass is what catches a release you never saw.
-
-### Do not trust `/releases/latest`
-
-htmx marks its prereleases with `prerelease: false`, so GitHub treats them as
-stable. As of 2026-07-20 the API returns:
-
-```sh
-$ curl -sSL https://api.github.com/repos/bigskysoftware/htmx/releases/latest \
-    | grep tag_name
-  "tag_name": "v4.0.0-beta5",
-```
-
-**Read the tag names yourself and pick the newest 2.x stable release** — do not
-let `/releases/latest`, or any tool built on it, choose the version.


### PR DESCRIPTION
Closes #279

## What

Documents how to update the vendored htmx and re-pin its integrity hash, in a new
`docs/vendored-assets.md`, plus a one-line link from README's Contributing section.

**Documentation only — no changes under `verinote/**` or `tests/**`.** Actually
bumping htmx is deliberately out of scope (see Follow-ups).

## Why the document centres on two lines

The integrity check is not an SRI attribute, a checksum file, or a manifest. It is
a single test constant, `HTMX_SHA256` in `tests/test_base_template_assets.py`, and
the only record of *which* version is vendored is the `# Source:` comment directly
above it. So an update has to change **both of those lines together**, and that is
what the procedure is built around.

**The trap in the same file:** its module docstring also mentions `2.0.3`, but that
is the #219 regression narrative recording what base.html loaded *before* vendoring.
It must not be updated — rewriting it would assert that base.html once loaded a
version it never loaded, destroying the explanation of why the guards exist. The
document quotes it verbatim and says to leave it alone.

**The `/releases/latest` trap:** htmx marks its prereleases with `prerelease: false`,
so the API returns `v4.0.0-beta5` as "latest" (measured against the API on
2026-07-20). Version selection therefore comes *before* the fetch step, so a
maintainer reading top-to-bottom meets the warning before overwriting anything.

The procedure covers: choosing the version, fetching the release artefact,
cross-checking the bytes against an independent mirror, updating the pin, verifying,
manual UI check, and committing bytes and pin as one commit. Rollback instructions
are included at both points where the procedure can abort with an unverified blob
already on disk. Cadence and the signals to watch (releases, GitHub Advisory,
`htmx.org` npm advisory, plus a quarterly manual pass) are covered.

## Verification

Every command in the document was executed, not just written:

- GitHub release asset, unpkg, and jsDelivr are byte-identical for 2.0.3, all
  reproducing the pinned `491955cd…784e`.
- The procedure generalises to v2.0.9 (the newest stable 2.x).
- The rollback command actually restores: the vendored file was dirtied, then
  `git checkout --` returned it to the pinned digest and a clean status.
- `1229 passed`, `ruff check .` clean.

## Review history

Eight findings from two review rounds plus an architect critique are folded in.
The most significant: the first draft asserted that grepping the repository for a
version number "will find nothing else", which was **false** — there is a second
`2.0.3` in the same test file's docstring. Left in, it would have led a reader to
update the regression narrative that the document elsewhere depends on.

## Follow-ups (not filed here)

- The vendored htmx is 2.0.3 while the newest stable 2.x is 2.0.9, so an update is
  due.
- Moving the integrity pin out of the test file into a data file is a separate
  question.

Both are code changes and fall outside this documentation lane.
