### PR TITLE
test(#297): guard the wirelog finding shape the annotator reads

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,6 +5,11 @@ import pytest
 
 import verinote.engine.wirelog as wl
 from verinote.engine import DEFAULT_POLICY, compile_dl, run_check, validate_query
+from verinote.engine.policy_vocabulary import (
+    FUNCTIONAL_CONFLICT_COLUMNS,
+    FUNCTIONAL_CONFLICT_RULE,
+    functional_conflict_target,
+)
 from verinote.engine.terms import (
     StringLit,
     TermParseError,
@@ -501,3 +506,32 @@ def test_run_check_annotator_row_survives_a_dead_rule_warning():
     # The real conflict still carries its row for the annotator to read.
     assert rep.errors == 1
     assert [row.values for row in rep.finding_rows] == [("Org", "established_on")]
+
+
+def test_wirelog_finding_row_carries_a_shape_the_annotator_can_read():
+    """Values alone are anonymous: the row must say which rule and columns they are.
+
+    `functional_conflict_target` refuses to read a row positionally unless the
+    row names verinote's own rule *and* the columns verinote declared — that
+    refusal is what stops a note being attached to a user rule whose second
+    column is not a relation. So `rule` and `columns` are not decoration on the
+    way to `values`; drop either and the annotator correctly goes silent, and
+    every finding loses its provenance while the report still looks right.
+
+    The reader here is the real consumer, not a literal: if the declared shape
+    ever changes, the policy, `policy_vocabulary` and this test move together.
+    """
+    _require_pyrewire()
+    rep = run_check(_CONFLICT)
+
+    errors = [row for row in rep.finding_rows if row.text.startswith("ERROR ")]
+    assert len(errors) == 1
+    row = errors[0]
+    # The load-bearing assertion: the consumer can name the subject and relation.
+    assert functional_conflict_target(row.rule, row.columns, row.values) == (
+        "Org",
+        "established_on",
+    )
+    # Reported per axis too, so a break says which of the two went missing.
+    assert row.rule == FUNCTIONAL_CONFLICT_RULE
+    assert row.columns == FUNCTIONAL_CONFLICT_COLUMNS

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -514,16 +514,22 @@ def test_wirelog_finding_row_carries_a_shape_the_annotator_can_read():
     `functional_conflict_target` refuses to read a row positionally unless the
     row names verinote's own rule *and* the columns verinote declared — that
     refusal is what stops a note being attached to a user rule whose second
-    column is not a relation. So `rule` and `columns` are not decoration on the
-    way to `values`; drop either and the annotator correctly goes silent, and
-    every finding loses its provenance while the report still looks right.
+    column is not a relation. So this asserts that the row the wirelog engine
+    produced carries both, by handing them to that reader and requiring it to
+    name the subject and relation rather than decline.
 
     The reader here is the real consumer, not a literal: if the declared shape
     ever changes, the policy, `policy_vocabulary` and this test move together.
+    What the caller *does* with a declined row — go silent and leave a finding
+    without provenance — is a separate contract, pinned end to end in
+    `test_wirelog_finding_shape.py`.
     """
     _require_pyrewire()
     rep = run_check(_CONFLICT)
 
+    # The level prefix picks the error rows; the count pins this to the one
+    # conflict. The dead-rule WARN notes this policy also emits are not what the
+    # prefix removes -- they derive no tuple, so they never reach `finding_rows`.
     errors = [row for row in rep.finding_rows if row.text.startswith("ERROR ")]
     assert len(errors) == 1
     row = errors[0]

--- a/tests/test_wirelog_finding_shape.py
+++ b/tests/test_wirelog_finding_shape.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The wirelog engine must produce findings the source-label annotator can use.
+
+`annotate_source_labels` names the facts behind a finding by reading the
+finding's row positionally, and it is only allowed to do that when the row says
+which rule it came from and how that rule declared its columns. Both halves are
+filled in by the engine backend, so a backend that carries values but forgets
+the shape produces a report that still reads fine and silently names no facts.
+
+The DuckDB half of that contract is pinned in `test_engine_input.py`; this is
+its wirelog twin. It goes end to end on purpose: not "is the field set" (that is
+`test_engine.py`) but "does the line the user reads actually get its note".
+"""
+
+from pathlib import Path
+
+import pytest
+
+from verinote.engine import DEFAULT_POLICY, compile_dl, run_check
+from verinote.engine.terms import StringLit
+from verinote.pipeline.engine_input import annotate_source_labels, engine_relation_rows
+from verinote.store import Store
+
+
+def _store(tmp_path) -> Store:
+    s = Store(Path(tmp_path) / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _text(term: object) -> str:
+    assert isinstance(term, StringLit)
+    return term.value
+
+
+def test_wirelog_findings_name_the_conflicting_facts_in_the_source_s_own_words(tmp_path):
+    """A report about `established_on` is unreadable to a KB that only said `설립`.
+
+    The default alias table already maps `설립 -> established_on`, so the engine
+    gates on a relation label this KB never used. The note is the only thing
+    that ties the finding back to the facts the user wrote.
+
+    The wirelog engine only runs when pyrewire is installed; without it
+    `run_check` returns an `engine_available=False` compatibility report and the
+    assertion would be vacuous, so this skips rather than passes (see #234).
+    """
+    pytest.importorskip("pyrewire")
+    s = _store(tmp_path)
+    first = s.add_fact("회사", "설립", "2020", status="accepted")
+    second = s.add_fact("회사", "설립", "2021", status="accepted")
+
+    rows = engine_relation_rows(s)
+    rep = run_check(
+        compile_dl(
+            [
+                {key: _text(row[key]) for key in ("subject", "relation", "object")}
+                for row in rows
+            ]
+        ),
+        policy_dl=DEFAULT_POLICY,
+    )
+    annotated = annotate_source_labels(rep, rows)
+
+    errors = [f for f in annotated.findings if f.startswith("ERROR ")]
+    assert errors == [
+        f"ERROR functional_conflict: 회사 established_on "
+        f"(설립 #{first}=2020, 설립 #{second}=2021)"
+    ]
+    assert errors[0] in annotated.text


### PR DESCRIPTION
Closes #297

## 무엇을

wirelog 의 finding shape 전달에 회귀 가드 2개를 추가한다. **`verinote/**` 무수정 — 테스트 전용 PR 이다.** 계약은 이미 코드에 있었고 그것을 지키는 가드만 없었다.

## 구멍이 하나가 아니라 둘이었다

이슈는 columns 축만 지목했는데, **rule 이름 축도 무가드**였다. `functional_conflict_target()` 은 rule 과 columns 를 **둘 다** 요구하므로 어느 한 축이 죽어도 결과는 같다 — 리더가 declined 를 반환하고, 주석이 **조용히** 사라진 채 리포트는 멀쩡해 보인다.

`main` 에서 두 뮤턴트 모두 전체 스위트를 통과하며 생존했다 (baseline **1229 passed**):

| | 뮤테이션 | main 에서 |
|---|---|---|
| **M1** | `wirelog.py:495` `columns_by_rule = _declared_columns(...) if ... else {}` → `columns_by_rule = {}` | 1229 passed **생존** |
| **M2** | `wirelog.py:507`/`:516` `_Derived(...)` 3번째 인자 `name` → `""` | 1229 passed **생존** |

## 비중복성 실증

두 뮤턴트 각각에서 **신규 가드 2개는 red 이고 나머지 1229개는 전원 생존**한다. 기존 가드가 이 계약을 덮지 않는다는 직접 증거다 — 새 테스트가 잡는 것을 기존 테스트는 하나도 잡지 못한다.

`_declared_columns → return {}` (M3) 는 **완료 판정에 쓰지 않았다.** 기존 5개 테스트(#245 의 dead-rule 가드 등)가 먼저 울기 때문에 그 뮤턴트로는 아무것도 증명되지 않는다.

## 배치

- **`tests/test_engine.py`** — finding row 가 소비자가 읽을 수 있는 shape 를 싣는지. engine 안에서 전부 해결되므로 기존 `_CONFLICT` 픽스처와 `_require_pyrewire()` 를 재사용한다.
- **`tests/test_wirelog_finding_shape.py` (신규)** — 그 결과로 사용자가 보는 줄이 실제로 원본 라벨 주석을 얻는지, end-to-end. `Store` 와 `pipeline.engine_input` 이 필요한데 `test_engine.py` 는 `verinote.engine.*` 만 import 하는 파일이라 그 경계를 깨지 않으려고 파일을 분리했다. DuckDB 쪽에만 있던 종단 계약의 wirelog 쌍둥이다.

두 테스트 모두 필드를 문자열 리터럴로 비교하지 않고 **실제 소비자** (`functional_conflict_target()`, `annotate_source_labels()`) 로 읽는다. 오늘의 값에 우연히 맞아 통과하는 형태를 피하는 것이 이 이슈의 핵심이다.

## skip 이 초록불이 아니다

`-rs` 로 **스킵 0건**을 확인했다 (pyrewire 1.0.3 로 실제 실행). CI 는 #248 이후 pyrewire 를 설치한다. 게이트에서 빠져나갔다면 애초에 위 뮤테이션 red 가 나올 수 없다.

## 검증

- `pytest tests -q` → **1231 passed** (baseline 1229 + 신규 2)
- `ruff check .` → clean

## 이슈 본문의 완료 판정이 낡았다

이슈는 `wirelog.py:473` 을 지목하지만 현재 `:473` 은 `if pyrewire is None:` 이고 실제 지점은 `:495` 다 (같은 표현식이 드리프트했다). 또한 M2 축은 이슈 본문에 없지만 PR #250 이 세운 "이름 **과** 컬럼" 계약의 나머지 절반이므로 범위 이탈이 아니다.

## 후속 (조건부 부채, 열린 구멍 아님)

`wirelog.py:514-519` 의 WARN 분기도 shape 를 전달하지만 가드가 없다. 다만 **오늘 도달 불가능하다**: `policy_vocabulary` 가 아는 shape 는 `error_functional_conflict` 하나뿐이고 그 이름이 `error_` 로 시작하므로 어떤 `warn_*` rule 도 `functional_conflict_target()` 을 통과할 수 없다. 누군가 `warn_*` shape 를 선언하는 순간 가드가 필요해진다.
