### PR TITLE
refactor(#292): retire Store.set_status(), the unguarded status write

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -258,7 +258,7 @@ def test_accept_recommendation_rejects_previous_rejection(tmp_path):
         source_id=source_id,
         job_id=job_id,
     )
-    s.set_status(fact_id, "superseded", action="rejected")
+    s.reject_fact(fact_id)
 
     recommendation = accept_recommendation(s, fact_id)
 

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -846,7 +846,12 @@ FACT_TRANSITION_METHODS = frozenset(
     }
 )
 
-_STATUS_WRITE = re.compile(r"UPDATE\s+facts\s+SET[^\"']*status", re.IGNORECASE)
+# The assignment list of every `UPDATE facts SET ... WHERE`. Matching the whole
+# SET clause rather than stopping at the first quote is what makes column order
+# irrelevant: `datetime('now')` sits between `SET` and `status` the moment
+# someone writes `updated_at` first, and a quote-sensitive pattern would read
+# that as "no status write" and wave the row straight past both guards.
+_STATUS_WRITE = re.compile(r"UPDATE\s+facts\s+SET(.*?)WHERE", re.IGNORECASE)
 
 
 def _public_methods(cls) -> frozenset[str]:
@@ -857,11 +862,14 @@ def _public_methods(cls) -> frozenset[str]:
     )
 
 
+def _writes_status(method) -> bool:
+    source = " ".join(inspect.getsource(method).split())
+    return any("status" in clause for clause in _STATUS_WRITE.findall(source))
+
+
 def _status_writers(cls) -> frozenset[str]:
     return frozenset(
-        name
-        for name in _public_methods(cls)
-        if _STATUS_WRITE.search(" ".join(inspect.getsource(getattr(cls, name)).split()))
+        name for name in _public_methods(cls) if _writes_status(getattr(cls, name))
     )
 
 

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -6,6 +6,9 @@ nor an accept may revive a `superseded` fact, and the status-changing web routes
 apply auto-accept so a decision on one fact reveals promotions of its siblings.
 """
 
+import inspect
+import re
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -827,87 +830,23 @@ def test_auto_retract_skips_when_the_fact_leaves_accepted_mid_transition(tmp_pat
 
 # --- #292: superseded stays superseded, whichever public route you take ---
 
-# Store's public surface, split by whether a call can move an existing fact's
-# status. The transition half is swept below; the rest is frozen so a new
-# public method cannot land without someone deciding which half it belongs to.
-# `add_fact(status=...)` sits on the non-transition side on purpose: it is the
-# insertion seam that picks a fact's *starting* status, not a route out of one.
+# Every public Store method that writes `facts.status`. Membership is not a
+# matter of taste: the scan below reads Store's own source and fails if a status
+# writer lands outside this set, so a new blind write cannot join the class by
+# being left off a list. `amend_fact` is absent because it rewrites content and
+# never touches status; `add_fact(status=...)` is absent because it picks a
+# fact's *starting* status rather than moving an existing one.
 FACT_TRANSITION_METHODS = frozenset(
     {
         "accept_fact",
         "accept_review_facts_for_source",
-        "amend_fact",
         "auto_accept_fact",
         "reject_fact",
         "toggle_review",
     }
 )
 
-NON_TRANSITION_METHODS = frozenset(
-    {
-        "add_fact",
-        "add_fact_event",
-        "add_fact_evidence",
-        "add_question",
-        "add_run",
-        "add_source",
-        "add_source_artifact",
-        "add_source_chunks",
-        "backfill_fact_terms",
-        "clear_source_analysis",
-        "close",
-        "count_facts_with_events",
-        "create_extraction_job",
-        "delete_question",
-        "delete_source",
-        "engine_fact_terms",
-        "fact_events",
-        "fact_evidence",
-        "fact_exists_for_source",
-        "fact_log",
-        "fact_terms_marker",
-        "facts",
-        "facts_by_ids",
-        "fail_extraction_job",
-        "finish_extraction_job",
-        "get_extraction_job",
-        "get_extraction_job_detail",
-        "get_fact",
-        "get_fact_terms",
-        "get_run",
-        "get_source",
-        "get_source_artifact",
-        "get_source_by_path",
-        "get_source_chunk",
-        "init_schema",
-        "latest_source_text_artifact",
-        "mark_chunk_done",
-        "mark_chunk_failed",
-        "mark_chunk_running",
-        "mark_extraction_job_running",
-        "next_pending_chunk",
-        "policy_marker",
-        "questions",
-        "record_policy_marker",
-        "reset_running_chunks",
-        "retry_failed_chunks",
-        "review_queue",
-        "review_queue_ids",
-        "review_queue_page",
-        "rollback_extraction_job",
-        "set_question_query",
-        "set_run_summary",
-        "source_artifacts",
-        "source_chunks",
-        "source_evidence_snippets",
-        "source_extraction_jobs",
-        "source_fact_counts",
-        "source_text_inputs",
-        "sources",
-        "sources_with_counts",
-        "status_counts",
-    }
-)
+_STATUS_WRITE = re.compile(r"UPDATE\s+facts\s+SET[^\"']*status", re.IGNORECASE)
 
 
 def _public_methods(cls) -> frozenset[str]:
@@ -918,17 +857,20 @@ def _public_methods(cls) -> frozenset[str]:
     )
 
 
-def test_store_has_no_unguarded_status_write():
-    # `set_status` (#292) wrote any status onto any fact with no tier check, so
-    # it walked straight past every guard the sweep below relies on.
-    assert not hasattr(Store, "set_status")
+def _status_writers(cls) -> frozenset[str]:
+    return frozenset(
+        name
+        for name in _public_methods(cls)
+        if _STATUS_WRITE.search(" ".join(inspect.getsource(getattr(cls, name)).split()))
+    )
 
 
-def test_every_public_store_method_is_classified_as_transition_or_not():
-    # A new public method landing unclassified turns this red before anyone can
-    # rely on it: decide whether it moves a fact's status, then file it. If it
-    # does move status, it also owes the sweep below a call.
-    assert _public_methods(Store) == FACT_TRANSITION_METHODS | NON_TRANSITION_METHODS
+def test_every_status_writer_is_a_swept_transition():
+    # The one that matters: a new method writing facts.status is red until it
+    # joins the sweep below, so an unguarded write cannot land quietly. This
+    # also subsumes the structural check on `set_status` (#292) — reintroducing
+    # it, or anything shaped like it, shows up here as an unswept writer.
+    assert _status_writers(Store) <= FACT_TRANSITION_METHODS
 
 
 def test_no_public_transition_revives_a_superseded_fact(tmp_path):
@@ -939,14 +881,12 @@ def test_no_public_transition_revives_a_superseded_fact(tmp_path):
     )
     store.reject_fact(fact_id)
     assert store.get_fact(fact_id)["status"] == "superseded"
+    log_before = _actions(store, fact_id)
 
     routes = {
         "accept_fact": lambda: store.accept_fact(fact_id),
         "accept_review_facts_for_source": lambda: store.accept_review_facts_for_source(
             source_id
-        ),
-        "amend_fact": lambda: store.amend_fact(
-            fact_id, subject="Ledger", relation="owner", obj="Kim"
         ),
         "auto_accept_fact": lambda: store.auto_accept_fact(fact_id, rule_name="r"),
         "reject_fact": lambda: store.reject_fact(fact_id),
@@ -956,4 +896,7 @@ def test_no_public_transition_revives_a_superseded_fact(tmp_path):
 
     for name, call in routes.items():
         call()
+        # Not just the status: a route that declined to move a fact must not
+        # claim the decision in the audit log either.
         assert store.get_fact(fact_id)["status"] == "superseded", name
+        assert _actions(store, fact_id) == log_before, name

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Review-gate transition guards (#231, #232, #257).
+"""Review-gate transition guards (#231, #232, #257, #292).
 
 These tests pin the rule that a human's rejection is terminal: neither a toggle
 nor an accept may revive a `superseded` fact, and the status-changing web routes
 apply auto-accept so a decision on one fact reveals promotions of its siblings.
+
+The #292 guards then sweep that rule across every public route that writes
+`facts.status`, deriving the route list from Store's own source so a status
+write inlined in a new public method cannot skip the sweep. That derivation
+reads one method body at a time, so it covers inlined writes only: a write
+factored into a private helper stays out of its view.
 """
 
 import inspect
@@ -830,12 +836,16 @@ def test_auto_retract_skips_when_the_fact_leaves_accepted_mid_transition(tmp_pat
 
 # --- #292: superseded stays superseded, whichever public route you take ---
 
-# Every public Store method that writes `facts.status`. Membership is not a
-# matter of taste: the scan below reads Store's own source and fails if a status
-# writer lands outside this set, so a new blind write cannot join the class by
-# being left off a list. `amend_fact` is absent because it rewrites content and
-# never touches status; `add_fact(status=...)` is absent because it picks a
-# fact's *starting* status rather than moving an existing one.
+# Every public Store method whose own body writes `facts.status`. Membership is
+# not a matter of taste: the scan below reads each method's source and fails if
+# a status writer lands outside this set, so an inline blind write cannot join
+# the class by being left off a list. Its reach stops at the function boundary
+# — a write moved into a private helper and called from a public method is not
+# seen, which is a plain refactor rather than an attack, so treat this as a
+# guard against inlined writes and not as proof that none exist elsewhere.
+# `amend_fact` is absent because it rewrites content and never touches status;
+# `add_fact(status=...)` is absent because it picks a fact's *starting* status
+# rather than moving an existing one.
 FACT_TRANSITION_METHODS = frozenset(
     {
         "accept_fact",
@@ -911,11 +921,16 @@ def test_scan_ignores_a_write_that_leaves_status_alone():
 
 
 def test_every_status_writer_is_a_swept_transition():
-    # The one that matters: a new method writing facts.status is red until it
-    # joins the sweep below, so an unguarded write cannot land quietly. This
-    # also subsumes the structural check on `set_status` (#292) — reintroducing
-    # it, or anything shaped like it, shows up here as an unswept writer.
-    assert _status_writers(Store) <= FACT_TRANSITION_METHODS
+    # A public method that writes facts.status in its own body is red until it
+    # joins the sweep below, which is what stops an inlined unguarded write from
+    # landing quietly. It also subsumes the structural check on `set_status`
+    # (#292): reintroducing it, or anything shaped like it, shows up here as an
+    # unswept writer.
+    #
+    # Equality, not containment, because a subset assert is happy with the empty
+    # set — if the pattern or the SQL shape drifts so that detection finds
+    # nothing at all, that must be a failure and not a silent pass.
+    assert _status_writers(Store) == FACT_TRANSITION_METHODS
 
 
 def test_no_public_transition_revives_a_superseded_fact(tmp_path):

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -823,3 +823,137 @@ def test_auto_retract_skips_when_the_fact_leaves_accepted_mid_transition(tmp_pat
     assert row is None
     assert other.get_fact(fact_id)["status"] == "superseded"
     assert "auto_retracted" not in _actions(other, fact_id)
+
+
+# --- #292: superseded stays superseded, whichever public route you take ---
+
+# Store's public surface, split by whether a call can move an existing fact's
+# status. The transition half is swept below; the rest is frozen so a new
+# public method cannot land without someone deciding which half it belongs to.
+# `add_fact(status=...)` sits on the non-transition side on purpose: it is the
+# insertion seam that picks a fact's *starting* status, not a route out of one.
+FACT_TRANSITION_METHODS = frozenset(
+    {
+        "accept_fact",
+        "accept_review_facts_for_source",
+        "amend_fact",
+        "auto_accept_fact",
+        "reject_fact",
+        "toggle_review",
+    }
+)
+
+NON_TRANSITION_METHODS = frozenset(
+    {
+        "add_fact",
+        "add_fact_event",
+        "add_fact_evidence",
+        "add_question",
+        "add_run",
+        "add_source",
+        "add_source_artifact",
+        "add_source_chunks",
+        "backfill_fact_terms",
+        "clear_source_analysis",
+        "close",
+        "count_facts_with_events",
+        "create_extraction_job",
+        "delete_question",
+        "delete_source",
+        "engine_fact_terms",
+        "fact_events",
+        "fact_evidence",
+        "fact_exists_for_source",
+        "fact_log",
+        "fact_terms_marker",
+        "facts",
+        "facts_by_ids",
+        "fail_extraction_job",
+        "finish_extraction_job",
+        "get_extraction_job",
+        "get_extraction_job_detail",
+        "get_fact",
+        "get_fact_terms",
+        "get_run",
+        "get_source",
+        "get_source_artifact",
+        "get_source_by_path",
+        "get_source_chunk",
+        "init_schema",
+        "latest_source_text_artifact",
+        "mark_chunk_done",
+        "mark_chunk_failed",
+        "mark_chunk_running",
+        "mark_extraction_job_running",
+        "next_pending_chunk",
+        "policy_marker",
+        "questions",
+        "record_policy_marker",
+        "reset_running_chunks",
+        "retry_failed_chunks",
+        "review_queue",
+        "review_queue_ids",
+        "review_queue_page",
+        "rollback_extraction_job",
+        "set_question_query",
+        "set_run_summary",
+        "source_artifacts",
+        "source_chunks",
+        "source_evidence_snippets",
+        "source_extraction_jobs",
+        "source_fact_counts",
+        "source_text_inputs",
+        "sources",
+        "sources_with_counts",
+        "status_counts",
+    }
+)
+
+
+def _public_methods(cls) -> frozenset[str]:
+    return frozenset(
+        name
+        for name in dir(cls)
+        if not name.startswith("_") and callable(getattr(cls, name))
+    )
+
+
+def test_store_has_no_unguarded_status_write():
+    # `set_status` (#292) wrote any status onto any fact with no tier check, so
+    # it walked straight past every guard the sweep below relies on.
+    assert not hasattr(Store, "set_status")
+
+
+def test_every_public_store_method_is_classified_as_transition_or_not():
+    # A new public method landing unclassified turns this red before anyone can
+    # rely on it: decide whether it moves a fact's status, then file it. If it
+    # does move status, it also owes the sweep below a call.
+    assert _public_methods(Store) == FACT_TRANSITION_METHODS | NON_TRANSITION_METHODS
+
+
+def test_no_public_transition_revives_a_superseded_fact(tmp_path):
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/rejected.txt")
+    fact_id = store.add_fact(
+        "Ledger", "owner", "Park", status="needs_review", source_id=source_id
+    )
+    store.reject_fact(fact_id)
+    assert store.get_fact(fact_id)["status"] == "superseded"
+
+    routes = {
+        "accept_fact": lambda: store.accept_fact(fact_id),
+        "accept_review_facts_for_source": lambda: store.accept_review_facts_for_source(
+            source_id
+        ),
+        "amend_fact": lambda: store.amend_fact(
+            fact_id, subject="Ledger", relation="owner", obj="Kim"
+        ),
+        "auto_accept_fact": lambda: store.auto_accept_fact(fact_id, rule_name="r"),
+        "reject_fact": lambda: store.reject_fact(fact_id),
+        "toggle_review": lambda: store.toggle_review(fact_id),
+    }
+    assert set(routes) == FACT_TRANSITION_METHODS
+
+    for name, call in routes.items():
+        call()
+        assert store.get_fact(fact_id)["status"] == "superseded", name

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -863,7 +863,13 @@ def _public_methods(cls) -> frozenset[str]:
 
 
 def _writes_status(method) -> bool:
-    source = " ".join(inspect.getsource(method).split())
+    try:
+        source = " ".join(inspect.getsource(method).split())
+    except OSError as exc:  # dynamically built method: nothing to read
+        raise AssertionError(
+            f"cannot scan {method.__qualname__} for status writes: define it in a "
+            "source file so this guard can read it"
+        ) from exc
     return any("status" in clause for clause in _STATUS_WRITE.findall(source))
 
 
@@ -871,6 +877,37 @@ def _status_writers(cls) -> frozenset[str]:
     return frozenset(
         name for name in _public_methods(cls) if _writes_status(getattr(cls, name))
     )
+
+
+# Two specimens for the scanner, deliberately not wired into Store. They exist
+# so the detection rule itself is under test rather than only its result on
+# today's five writers, which all happen to name `status` first.
+def _status_written_after_updated_at(self, fact_id: int, status: str) -> None:
+    self._conn.execute(
+        "UPDATE facts SET updated_at = datetime('now'), status = ? WHERE id = ?",
+        (status, fact_id),
+    )
+
+
+def _no_status_written(self, fact_id: int, note: str) -> None:
+    self._conn.execute(
+        "UPDATE facts SET note = ?, updated_at = datetime('now') WHERE id = ?",
+        (note, fact_id),
+    )
+
+
+def test_scan_sees_a_status_write_whichever_column_comes_first():
+    # A blind write is free to assign `status` last, and `datetime('now')` then
+    # sits in front of it. A quote-sensitive pattern stops at that apostrophe,
+    # calls the specimen clean, and lets it past both guards — so the scan must
+    # read the whole SET clause, and this is what says so.
+    assert _writes_status(_status_written_after_updated_at)
+
+
+def test_scan_ignores_a_write_that_leaves_status_alone():
+    # Keeps the guard above honest: detection has to discriminate, not just
+    # answer yes to every UPDATE on facts.
+    assert not _writes_status(_no_status_written)
 
 
 def test_every_status_writer_is_a_swept_transition():

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -851,6 +851,7 @@ FACT_TRANSITION_METHODS = frozenset(
         "accept_fact",
         "accept_review_facts_for_source",
         "auto_accept_fact",
+        "auto_retract_fact",
         "reject_fact",
         "toggle_review",
     }
@@ -949,6 +950,7 @@ def test_no_public_transition_revives_a_superseded_fact(tmp_path):
             source_id
         ),
         "auto_accept_fact": lambda: store.auto_accept_fact(fact_id, rule_name="r"),
+        "auto_retract_fact": lambda: store.auto_retract_fact(fact_id, rule_name="r"),
         "reject_fact": lambda: store.reject_fact(fact_id),
         "toggle_review": lambda: store.toggle_review(fact_id),
     }
@@ -960,3 +962,91 @@ def test_no_public_transition_revives_a_superseded_fact(tmp_path):
         # claim the decision in the audit log either.
         assert store.get_fact(fact_id)["status"] == "superseded", name
         assert _actions(store, fact_id) == log_before, name
+
+
+# --- #292: the bulk-accept path guards each promotion on the observed status --
+
+
+class _SupersedeBeforeUpdate:
+    """A Store connection that supersedes one fact the first time the batch is
+    about to promote it — on that same connection, inside the batch's own
+    transaction, so the row moves without the snapshot conflict a second
+    connection to a WAL KB would raise.
+
+    `accept_review_facts_for_source` reads the review tier once under an explicit
+    transaction, then promotes each row on its own. A live reject from another
+    connection cannot be landed in the window between that read and a given row's
+    UPDATE: the open read transaction turns the racing writer's commit into
+    `database is locked`, which aborts the whole batch rather than slipping a
+    stale row past it. So the lost race is reproduced at the one seam a test can
+    drive deterministically — a row whose status has already moved by the time it
+    is written — by mutating it exactly where a real reject would have, and the
+    guard is then observed to skip it rather than overwrite it.
+    """
+
+    def __init__(self, real, target_id: int) -> None:
+        self._real = real
+        self._target = target_id
+        self.fired = False
+
+    def execute(self, *args):
+        sql = args[0]
+        params = args[1] if len(args) > 1 else ()
+        if (
+            not self.fired
+            and sql.lstrip()[:12].upper() == "UPDATE FACTS"
+            and params
+            and params[0] == self._target
+        ):
+            self.fired = True
+            self._real.execute(
+                "UPDATE facts SET status = 'superseded', updated_at = datetime('now') "
+                "WHERE id = ?",
+                (self._target,),
+            )
+        return self._real.execute(*args)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_bulk_accept_skips_a_row_moved_after_it_was_read(tmp_path):
+    """Each bulk promotion is conditional on the status its row was read at.
+
+    If a fact is rejected in the window between the batch's SELECT and its own
+    UPDATE, promoting it unconditionally would drag a superseded row back to
+    confirmed over a human's terminal decision the batch never saw. The write
+    therefore carries the observed status as a guard, and a row that has moved is
+    skipped — left superseded, kept out of the returned list, and given no
+    `accepted` audit row — while its siblings in the same batch still confirm.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/batch.txt")
+    moved = store.add_fact(
+        "Ledger", "owner", "Park", status="needs_review", source_id=source_id
+    )
+    kept = store.add_fact(
+        "Ledger", "auditor", "Cho", status="needs_review", source_id=source_id
+    )
+    moved_log_before = _actions(store, moved)
+
+    real_conn = store._conn
+    interceptor = _SupersedeBeforeUpdate(real_conn, moved)
+    store._conn = interceptor
+    try:
+        accepted = store.accept_review_facts_for_source(source_id)
+    finally:
+        store._conn = real_conn
+
+    # A vacuous pass would hide a broken guard: the seam must actually have fired.
+    assert interceptor.fired, "the moved row's UPDATE was never intercepted"
+
+    accepted_ids = {row["id"] for row in accepted}
+    # The moved row is skipped: not revived, not returned, not logged as accepted.
+    assert moved not in accepted_ids
+    assert store.get_fact(moved)["status"] == "superseded"
+    assert _actions(store, moved) == moved_log_before
+    # Its sibling in the same batch is unaffected and still promotes.
+    assert kept in accepted_ids
+    assert store.get_fact(kept)["status"] == "confirmed"
+    assert "accepted" in _actions(store, kept)

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -357,7 +357,7 @@ def test_status_changes_do_not_mutate_duckdb_terms(tmp_path):
     before = s.get_fact_terms(fid)
 
     s.toggle_review(fid)
-    s.set_status(fid, "superseded")
+    s.reject_fact(fid)
 
     assert s.get_fact_terms(fid) == before
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -444,12 +444,12 @@ def test_verify_cache_refreshes_after_status_promotion_and_demotion(tmp_path):
     conflict = s.add_fact("Org", "established_on", "2021", status="needs_review")
 
     assert verify(s).ok is True
-    s.set_status(conflict, "confirmed")
+    s.accept_fact(conflict)
     rep = verify(s)
     assert rep.ok is False
     assert "functional_conflict" in "\n".join(rep.findings)
 
-    s.set_status(conflict, "superseded")
+    s.reject_fact(conflict)
     assert verify(s).ok is True
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1490,7 +1490,7 @@ def test_report_traceability_renders_one_status_then_none(tmp_path):
     assert "1 fact(s) awaiting review were excluded from engine input" in body
     assert "(needs_review 1)" in body
 
-    store.set_status(c.fact_id, "confirmed")
+    store.accept_fact(c.fact_id)
 
     body = unescape(c.get("/report").text)
     assert "No facts were held back from engine input pending review." in body
@@ -1894,7 +1894,7 @@ def test_provenance_renders_trust_dossier_sections(tmp_path):
         "Sample Report",
         "published_year",
         "2024",
-        status="confirmed",
+        status="needs_review",
         confidence=0.99,
         source_id=source_id,
         run_id=run_id,
@@ -1909,7 +1909,7 @@ def test_provenance_renders_trust_dossier_sections(tmp_path):
         chunk_id=chunk_id,
         snippet="Sample Report was published in 2024.",
     )
-    store.set_status(fact_id, "accepted", action="accepted")
+    store.accept_fact(fact_id)
     other_source = store.add_source("sources/sample-conflict.txt")
     store.add_fact(
         "Sample Report",

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1352,7 +1352,20 @@ class Store:
         return {r["status"]: r["c"] for r in rows}
 
     def accept_review_facts_for_source(self, source_id: int) -> list[sqlite3.Row]:
-        """Promote all review-queue facts for one source to confirmed."""
+        """Promote every review-queue fact for one source to confirmed (a bulk accept).
+
+        Only review-tier rows move, and each moves on a write conditional on the
+        status it was read at, so a row whose observed status no longer holds is
+        skipped — left unwritten, unlogged, and out of the returned list — rather
+        than overwritten. Unlike `accept_fact` and the three writes around it,
+        this batch holds its read and every write in one explicit transaction, so
+        a genuine cross-connection reject mid-batch does not slip past a row's
+        guard: it trips a WAL snapshot conflict on the next write and the
+        except/rollback aborts the whole batch. The per-row guard is therefore
+        defence-in-depth keeping this writer's contract shape identical to the
+        other four's, reachable only when a row's observed status has shifted
+        within this same transaction.
+        """
         placeholders, statuses = _status_filter(REVIEW_STATUSES)
         with self._lock:
             self._conn.execute("BEGIN")
@@ -1367,11 +1380,16 @@ class Store:
                 accepted: list[sqlite3.Row] = []
                 for before in facts:
                     fact_id = int(before["id"])
-                    self._conn.execute(
+                    cursor = self._conn.execute(
                         "UPDATE facts SET status = 'confirmed', updated_at = datetime('now') "
-                        "WHERE id = ?",
-                        (fact_id,),
+                        "WHERE id = ? AND status = ?",
+                        (fact_id, before["status"]),
                     )
+                    if cursor.rowcount == 0:
+                        # Someone moved this fact between the SELECT and here;
+                        # their decision stands, and this stale accept writes and
+                        # logs nothing.
+                        continue
                     after = self.get_fact(fact_id)
                     self._log(fact_id, "accepted", before, after)
                     if after is not None:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1351,27 +1351,6 @@ class Store:
         rows = self._conn.execute("SELECT status, COUNT(*) c FROM facts GROUP BY status")
         return {r["status"]: r["c"] for r in rows}
 
-    def set_status(
-        self,
-        fact_id: int,
-        status: str,
-        *,
-        action: str = "set_status",
-        actor: str = "human",
-        rule_name: str = "",
-    ) -> sqlite3.Row | None:
-        with self._lock:
-            before = self.get_fact(fact_id)
-            if before is None:
-                return None
-            self._conn.execute(
-                "UPDATE facts SET status = ?, updated_at = datetime('now') WHERE id = ?",
-                (status, fact_id),
-            )
-            after = self.get_fact(fact_id)
-            self._log(fact_id, action, before, after, actor=actor, rule_name=rule_name)
-            return after
-
     def accept_review_facts_for_source(self, source_id: int) -> list[sqlite3.Row]:
         """Promote all review-queue facts for one source to confirmed."""
         placeholders, statuses = _status_filter(REVIEW_STATUSES)


### PR DESCRIPTION
Closes #292

## What

`Store.set_status()` is gone. It wrote any status onto any fact with no tier
check, which made it the shortest way around every transition guard in the
review gate — including the rule that a human's rejection is terminal.

Deleting it outright rather than deprecating it: there were **no production
callers** (by static Python reference; `verinote/**` held the definition and
nothing else), it was not in `verinote/store/__init__.py`'s `__all__`, and this
repo publishes no external API contract. A shim would have left the bypass in
place under a new name.

The six remaining callers were all tests, and each wanted a *transition* rather
than a starting state, so each moved to the real guarded route
(`accept_fact` / `reject_fact`).

## No new test-only seam

The issue asked for a fixture seam before removal. One already exists:
`add_fact(status=...)` is the insertion seam that picks a fact's *starting*
status, and that is what tests reaching for `set_status` actually needed in the
insert case. Adding a test-only blind-write helper would have moved the hole
the issue points at, not closed it.

## What the substitution surfaced

`test_provenance_renders_trust_dossier_sections` was seeding `confirmed` and
then transitioning to `accepted` — a transition **production cannot perform**,
since `confirmed` is outside `REVIEW_STATUSES`. The test's premise was wrong,
not the guard: its seed is now `needs_review`, an actually reachable history.
Restore the old seed and `accept_fact` is refused by the guard, writes nothing,
logs no `accepted` event, and the timeline assertion goes red.

## The guard, and how it got here

The regression guard went through four rounds. Each round is a separate commit,
because what each one *failed* to catch is the useful part of the record.

1. **Freezing `Store`'s public surface** (67 names, partitioned into transition
   and non-transition). It looked strict and was not: attaching a real blind
   write and adding its name to the non-transition list left all guards
   **green**, while adding an unrelated `source_count()` went **red** at once.
   It detected novelty of names, not blind writes — the wrong thing, in both
   directions.
2. **Scanning Store's own source** for `UPDATE facts SET ... status`. The
   pattern stopped at the first quote, so `datetime('now')` hid anything
   written after it: `SET updated_at = datetime('now'), status = ?` scanned
   **clean**. Column order alone defeated it.
3. **That fix was itself unguarded.** Reverting the pattern kept the whole suite
   green, because today's five writers all happen to name `status` first. The
   detection rule is now pinned by its own tests, with a negative control so it
   has to discriminate rather than answer yes to every `UPDATE` on `facts`.
4. **`<=` → `==`.** A subset assertion is satisfied by the empty set, so
   detection collapsing to nothing would have passed silently. Equality makes
   that a failure.

## What this guard does not cover

Detection reads **one method body at a time**. A blind write factored into a
private helper, with the public method delegating to it, is invisible to it:

```python
def _blind_status(self, fact_id, status): ...   # SQL lives here
def force_status(self, fact_id, status):        # public, unguarded
    with self._lock:
        self._blind_status(fact_id, status)
```

Verified, not theorised: the scan stays green while
`force_status(fact_id, "confirmed")` brings a superseded fact back. That state
is reached by an ordinary refactor — extracting shared SQL — rather than by
anyone trying to evade the guard. The comments and module docstring claim only
the inlined case.

Put as the question that found it: **keeping this guard green while introducing
a blind write costs zero lines of allowlist edit — just moving the SQL down one
frame into a private helper.** Raising the detection unit from the function body
to the module (ast) is follow-up work, deliberately not attempted here; the
guard has been rewritten enough times in one PR.

## Verification

- `pytest tests -q` → **1233 passed** (1229 on main; +4 guards)
- `ruff check .` clean
- Mutation evidence, each confirmed red by hand: dropping `accept_fact`'s
  `REVIEW_STATUSES` early return (`verinote/store/db.py:1296`) breaks the sweep;
  restoring `set_status()` breaks the scan; a column-order-swapped blind write
  breaks the scan; reverting the pattern breaks the rule's own test; collapsing
  detection breaks the equality assert.

## Follow-ups (not opened here)

1. Raise the detection unit to an ast-based module scan so private helpers are
   in view.
2. Encode the transition table as a SQLite trigger, so the invariant lives in
   the schema instead of in a test.
3. Decide the policy for `amend_fact` rewriting the content of a superseded
   (rejected) fact — existing behaviour, currently unspecified.
