### PR TITLE
fix(#298): derive the query intent field lists from the schema

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
+import copy
+import dataclasses
+
 import pytest
 
 from verinote.llm import LLMError
@@ -12,9 +15,27 @@ from verinote.pipeline.query_intent import (
     QUERY_INTENT_BLANK_NULLABLE_FIELDS,
     QUERY_INTENT_COMPARISON_DOMAINS,
     IntentTarget,
+    QueryIntent,
     QueryIntentKind,
+    _blank_nullable_fields,
+    _comparison_domains,
+    _nullable_string_fields,
     parse_query_intent,
 )
+
+
+def _synthetic_intent_schema():
+    """QUERY_INTENT_SCHEMA plus two nullable string properties it has never had.
+
+    A hand-written name list and a schema derivation agree on today's contract, so
+    only a schema the module has never seen tells them apart: the derivation
+    answers with `unit` and `note`, the list cannot.
+    """
+    schema = copy.deepcopy(QUERY_INTENT_SCHEMA)
+    schema["properties"]["unit"] = {"type": ["string", "null"], "enum": ["kg", "m", None]}
+    schema["properties"]["note"] = {"type": ["string", "null"], "minLength": 1}
+    schema["required"] = list(schema["properties"])
+    return schema
 
 
 def _intent_payload(**overrides):
@@ -316,10 +337,79 @@ def test_query_intent_blank_nullable_fields_are_the_schema_fields_without_an_enu
     """
     assert QUERY_INTENT_BLANK_NULLABLE_FIELDS == frozenset(
         name
-        for name in ("operator", "value_type", "value", "reason")
+        for name in _nullable_string_fields(QUERY_INTENT_SCHEMA)
         if "enum" not in QUERY_INTENT_SCHEMA["properties"][name]
     )
     assert QUERY_INTENT_BLANK_NULLABLE_FIELDS == frozenset({"value", "reason"})
+
+
+def test_nullable_string_fields_follow_a_schema_it_has_never_seen():
+    """A property added to the schema alone must show up without a code change.
+
+    That is the whole of issue #298: the module used to carry
+    `("operator", "value_type", "value", "reason")` by hand, so a nullable string
+    property added to QUERY_INTENT_SCHEMA was silently exempt from trimming,
+    blank-to-null normalisation, and enum checking until somebody remembered to
+    retype its name here.
+    """
+    synthetic = _synthetic_intent_schema()
+
+    derived = _nullable_string_fields(synthetic)
+
+    assert "unit" in derived
+    assert "note" in derived
+
+
+def test_nullable_string_fields_exclude_the_other_nullable_types():
+    """Nullable is not enough -- the value has to be a string.
+
+    `relation_candidates` is `["array", "null"]` and the target properties are
+    `["object", "null"]`; a predicate written as `"null" in type` would pull all
+    four in and hand them to `_clean_optional_string`, which trims strings. `kind`
+    is a bare `"string"` and is not nullable at all.
+    """
+    derived = _nullable_string_fields(_synthetic_intent_schema())
+
+    assert "relation_candidates" not in derived
+    assert "subject" not in derived
+    assert "relation" not in derived
+    assert "object" not in derived
+    assert "kind" not in derived
+
+
+def test_comparison_domains_follow_a_schema_it_has_never_seen():
+    """A new enum-constrained property is validated against its enum, not ignored."""
+    domains = _comparison_domains(_synthetic_intent_schema())
+
+    assert domains["unit"] == frozenset({"kg", "m"})
+
+
+def test_blank_nullable_fields_split_a_new_property_by_its_enum():
+    """The blank-is-null special case follows the enum, on properties and all.
+
+    An enum-constrained property has no spelling of null other than null, so "" on
+    it is an off-schema value for `_validate_schema_domains` to reject. A nullable
+    string the schema leaves open keeps the #237 tolerance.
+    """
+    blank_nullable = _blank_nullable_fields(_synthetic_intent_schema())
+
+    assert "unit" not in blank_nullable
+    assert "note" in blank_nullable
+
+
+def test_derived_nullable_string_fields_all_exist_on_the_query_intent_dataclass():
+    """`__post_init__` getattr's every derived name, so a stray one is AttributeError.
+
+    Deliberately a red test rather than a `hasattr` skip in the loop: skipping the
+    names the dataclass lacks would let a nullable string property added to
+    QUERY_INTENT_SCHEMA through parsing unnormalised and unvalidated, which is the
+    exact hole #298 closes -- it would just move from "the hand list forgot it" to
+    "the loop stepped over it". Adding a property to the schema is meant to force
+    adding the field here; failing loudly is how that gets said.
+    """
+    dataclass_field_names = {f.name for f in dataclasses.fields(QueryIntent)}
+
+    assert set(_nullable_string_fields(QUERY_INTENT_SCHEMA)) <= dataclass_field_names
 
 
 @pytest.mark.parametrize("blank", ["", "   "])

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -19,6 +19,7 @@ from verinote.pipeline.query_intent import (
     QueryIntentKind,
     _blank_nullable_fields,
     _comparison_domains,
+    _intent_field_names,
     _nullable_string_fields,
     parse_query_intent,
 )
@@ -395,6 +396,22 @@ def test_blank_nullable_fields_split_a_new_property_by_its_enum():
 
     assert "unit" not in blank_nullable
     assert "note" in blank_nullable
+
+
+def test_parser_allow_list_follows_a_schema_it_has_never_seen():
+    """The accepted keys track the schema's properties, name list or no name list.
+
+    Without this, deriving the nullable string fields is not enough to make
+    "add an enum-constrained nullable property and it becomes blank-rejecting"
+    true: `_parse_query_intent_object` would refuse the new key as an unexpected
+    field before any of that ran. Asserting the constant equals
+    `tuple(QUERY_INTENT_SCHEMA["properties"])` would prove nothing -- today's hand
+    list satisfies that too.
+    """
+    allowed = _intent_field_names(_synthetic_intent_schema())
+
+    assert "unit" in allowed
+    assert "note" in allowed
 
 
 def test_derived_nullable_string_fields_all_exist_on_the_query_intent_dataclass():

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 import copy
 import dataclasses
+import importlib.util
+import sys
 
 import pytest
 
 from verinote.llm import LLMError
+from verinote.llm import schema as llm_schema
 from verinote.llm.schema import (
     EXTRACTION_SYSTEM,
     FACT_OBJECT_SCHEMA,
@@ -20,7 +23,6 @@ from verinote.pipeline.query_intent import (
     QueryIntentKind,
     _blank_nullable_fields,
     _comparison_domains,
-    _intent_field_names,
     _nullable_string_fields,
     parse_query_intent,
 )
@@ -399,38 +401,64 @@ def test_blank_nullable_fields_split_a_new_property_by_its_enum():
     assert "note" in blank_nullable
 
 
-@pytest.mark.parametrize("unit", ["", "   ", "lb", "kg"])
-def test_a_schema_property_the_parser_never_reads_is_not_silently_dropped(monkeypatch, unit):
+def _build_query_intent_module(monkeypatch, schema):
+    """Run a fresh, isolated copy of query_intent.py against `schema`.
+
+    A separate module object rather than `importlib.reload`: a reload that raises
+    part-way leaves the real module half-rebuilt, and even a successful one swaps
+    the identity of `QueryIntent`/`IntentTarget` out from under every test that
+    imported them, so dataclass equality starts failing elsewhere in the session.
+    """
+    monkeypatch.setattr(llm_schema, "QUERY_INTENT_SCHEMA", schema)
+    name = "query_intent_under_test"
+    spec = importlib.util.spec_from_file_location(name, query_intent.__file__)
+    module = importlib.util.module_from_spec(spec)
+    # `dataclasses` resolves a field's annotations through
+    # `sys.modules[cls.__module__]`, so the copy has to be registered while it
+    # executes or building QueryIntent dies on an unrelated AttributeError.
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_schema_property_the_parser_never_reads_is_refused_at_import(monkeypatch):
     """Widening the allow-list without wiring the parser must fail, not discard.
 
-    Deriving the allow-list alone moved the failure rather than fixing it: the new
-    key stopped being refused as unexpected and started being accepted and thrown
-    away, because the QueryIntent construction names its kwargs by hand. Blank and
-    off-enum values then came back as None instead of being rejected -- the intent
-    was quietly wrong rather than loudly refused, which is worse than the
-    "unexpected fields" error it replaced.
+    Deriving the allow-list alone moved the failure rather than closing it: the
+    new key stopped being refused as an unexpected field and started being
+    accepted and thrown away, because the QueryIntent construction names its
+    kwargs by hand. A blank or off-enum value then came back as None instead of
+    being rejected -- quietly wrong rather than loudly refused, which is worse
+    than the error it replaced.
 
-    Asserting `"unit" in _intent_field_names(synthetic)` does not project any of
-    this: it restates the derivation instead of exercising what the derivation was
-    for. This drives the real parser, so it goes red both if the allow-list stops
-    following the schema and if the parser stops checking that it reads what it
-    admits.
+    Asserting `"unit" in _intent_field_names(synthetic)` did not project any of
+    that; it restated the derivation instead of exercising what the derivation was
+    for, which is how the drop stayed green. This builds the module against a
+    schema it has never seen and so fails both if the allow-list stops following
+    the schema and if the check that the parser reads what it admits goes away.
     """
-    synthetic = _synthetic_intent_schema()
-    monkeypatch.setattr(
-        query_intent, "QUERY_INTENT_FIELDS", _intent_field_names(synthetic)
-    )
-    payload = _intent_payload()
-    payload["unit"] = unit
-
     with pytest.raises(RuntimeError) as excinfo:
-        parse_query_intent(payload)
+        _build_query_intent_module(monkeypatch, _synthetic_intent_schema())
 
-    assert "unit" in str(excinfo.value)
-    # Not laundered into LLMError: no provider output can trigger this, so
-    # reporting it as a schema mismatch would blame the provider for a local
-    # wiring bug. `parse_query_intent` converts KeyError/TypeError/ValueError.
+    message = str(excinfo.value)
+    assert "unit" in message
+    assert "note" in message
+    # Not laundered into LLMError: no provider output can reach this, so calling
+    # it a schema mismatch would blame the provider for a local wiring bug.
+    # `parse_query_intent` converts KeyError/TypeError/ValueError; this is raised
+    # at import, outside that path entirely.
     assert not isinstance(excinfo.value, LLMError)
+
+
+def test_the_import_check_passes_on_the_schema_the_parser_does_read(monkeypatch):
+    """The guard has to be satisfiable, or its red is worth nothing.
+
+    Without this, a check hard-wired to raise would pass the test above while
+    making the package unimportable.
+    """
+    module = _build_query_intent_module(monkeypatch, copy.deepcopy(QUERY_INTENT_SCHEMA))
+
+    assert module.QUERY_INTENT_FIELDS == tuple(QUERY_INTENT_SCHEMA["properties"])
 
 
 def test_derived_nullable_string_fields_all_exist_on_the_query_intent_dataclass():

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -11,6 +11,7 @@ from verinote.llm.schema import (
     QUERY_INTENT_SCHEMA,
     parse_facts,
 )
+from verinote.pipeline import query_intent
 from verinote.pipeline.query_intent import (
     QUERY_INTENT_BLANK_NULLABLE_FIELDS,
     QUERY_INTENT_COMPARISON_DOMAINS,
@@ -398,20 +399,38 @@ def test_blank_nullable_fields_split_a_new_property_by_its_enum():
     assert "note" in blank_nullable
 
 
-def test_parser_allow_list_follows_a_schema_it_has_never_seen():
-    """The accepted keys track the schema's properties, name list or no name list.
+@pytest.mark.parametrize("unit", ["", "   ", "lb", "kg"])
+def test_a_schema_property_the_parser_never_reads_is_not_silently_dropped(monkeypatch, unit):
+    """Widening the allow-list without wiring the parser must fail, not discard.
 
-    Without this, deriving the nullable string fields is not enough to make
-    "add an enum-constrained nullable property and it becomes blank-rejecting"
-    true: `_parse_query_intent_object` would refuse the new key as an unexpected
-    field before any of that ran. Asserting the constant equals
-    `tuple(QUERY_INTENT_SCHEMA["properties"])` would prove nothing -- today's hand
-    list satisfies that too.
+    Deriving the allow-list alone moved the failure rather than fixing it: the new
+    key stopped being refused as unexpected and started being accepted and thrown
+    away, because the QueryIntent construction names its kwargs by hand. Blank and
+    off-enum values then came back as None instead of being rejected -- the intent
+    was quietly wrong rather than loudly refused, which is worse than the
+    "unexpected fields" error it replaced.
+
+    Asserting `"unit" in _intent_field_names(synthetic)` does not project any of
+    this: it restates the derivation instead of exercising what the derivation was
+    for. This drives the real parser, so it goes red both if the allow-list stops
+    following the schema and if the parser stops checking that it reads what it
+    admits.
     """
-    allowed = _intent_field_names(_synthetic_intent_schema())
+    synthetic = _synthetic_intent_schema()
+    monkeypatch.setattr(
+        query_intent, "QUERY_INTENT_FIELDS", _intent_field_names(synthetic)
+    )
+    payload = _intent_payload()
+    payload["unit"] = unit
 
-    assert "unit" in allowed
-    assert "note" in allowed
+    with pytest.raises(RuntimeError) as excinfo:
+        parse_query_intent(payload)
+
+    assert "unit" in str(excinfo.value)
+    # Not laundered into LLMError: no provider output can trigger this, so
+    # reporting it as a schema mismatch would blame the provider for a local
+    # wiring bug. `parse_query_intent` converts KeyError/TypeError/ValueError.
+    assert not isinstance(excinfo.value, LLMError)
 
 
 def test_derived_nullable_string_fields_all_exist_on_the_query_intent_dataclass():

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -13,44 +13,82 @@ from verinote.llm.base import LLMError
 from verinote.llm.schema import QUERY_INTENT_SCHEMA
 
 
-def _schema_domain(field_name: str) -> frozenset[str] | None:
-    """The non-null values QUERY_INTENT_SCHEMA's enum admits for one field.
+# Every derivation below takes its schema as an argument rather than reading
+# QUERY_INTENT_SCHEMA directly. That is what makes the derivation testable: fed a
+# synthetic schema carrying a property the module has never heard of, a real
+# derivation answers with that property and a hand-written name list cannot. The
+# module constants are these functions applied to the real contract.
+def _nullable_string_fields(schema: dict[str, Any]) -> tuple[str, ...]:
+    """The schema's nullable string properties, in schema order.
+
+    A property qualifies when its declared type is exactly `["string", "null"]`.
+    Testing `"null" in type` instead would sweep in `relation_candidates`
+    (`["array", "null"]`) and the target properties (`["object", "null"]`), whose
+    values are not strings and must not be trimmed or blank-normalised as if they
+    were. Each qualifying property is also listed in `required` (OpenAI strict
+    mode), so any of them can legitimately arrive as null.
+    """
+    return tuple(
+        field_name
+        for field_name, spec in schema["properties"].items()
+        if isinstance(spec.get("type"), list) and set(spec["type"]) == {"string", "null"}
+    )
+
+
+def _schema_domain(schema: dict[str, Any], field_name: str) -> frozenset[str] | None:
+    """The non-null values the schema's enum admits for one field.
 
     None when the schema pins no domain: `value` and `reason` carry `minLength: 1`
     and no enum, so every non-blank string is on-schema for them.
     """
-    enum = QUERY_INTENT_SCHEMA["properties"][field_name].get("enum")
+    enum = schema["properties"][field_name].get("enum")
     if enum is None:
         return None
     return frozenset(value for value in enum if value is not None)
 
 
-# The schema's nullable string properties. Each is typed `["string", "null"]` and
-# each is still listed in `required` (OpenAI strict mode), so any of them can
-# legitimately arrive as null.
-_NULLABLE_STRING_FIELDS = ("operator", "value_type", "value", "reason")
+def _comparison_domains(schema: dict[str, Any]) -> dict[str, frozenset[str]]:
+    """Every nullable string property the schema constrains to an enum.
 
-# Read off the schema rather than restated here: the schema is the contract every
-# adapter hands the provider, so a second hand-maintained copy of these enums can
-# only drift out of it -- and either half of that drift is a bug (rejecting
-# on-schema output, or accepting output no strict-mode provider could send).
-QUERY_INTENT_COMPARISON_DOMAINS: dict[str, frozenset[str]] = {
-    field_name: domain
-    for field_name in _NULLABLE_STRING_FIELDS
-    if (domain := _schema_domain(field_name)) is not None
-}
+    Read off the schema rather than restated here: the schema is the contract
+    every adapter hands the provider, so a second hand-maintained copy of these
+    enums can only drift out of it -- and either half of that drift is a bug
+    (rejecting on-schema output, or accepting output no strict-mode provider
+    could send).
+    """
+    return {
+        field_name: domain
+        for field_name in _nullable_string_fields(schema)
+        if (domain := _schema_domain(schema, field_name)) is not None
+    }
 
-# Blank means null only where the schema pins no domain. A prompt-only provider
-# spells the null it is forced to emit as "", so `reason: ""` has to read as
-# absent (issue #237) -- but "" is in no enum, so on an enum-constrained field it
-# is an off-schema *value*, not an absent one, and `_validate_schema_domains`
-# must get to see it. Derived from the schema so the rule cannot drift out of the
-# contract: give `value` an enum tomorrow and it stops taking blank as null here,
-# with no name list to remember to update.
-QUERY_INTENT_BLANK_NULLABLE_FIELDS: frozenset[str] = frozenset(
-    field_name
-    for field_name in _NULLABLE_STRING_FIELDS
-    if _schema_domain(field_name) is None
+
+def _blank_nullable_fields(schema: dict[str, Any]) -> frozenset[str]:
+    """The nullable string properties on which blank reads as null.
+
+    Blank means null only where the schema pins no domain. A prompt-only provider
+    spells the null it is forced to emit as "", so `reason: ""` has to read as
+    absent (issue #237) -- but "" is in no enum, so on an enum-constrained field
+    it is an off-schema *value*, not an absent one, and `_validate_schema_domains`
+    must get to see it. Add an enum to `value` tomorrow and it stops taking blank
+    as null here; add a whole new nullable string property and it starts,
+    with no name list to remember to update either way.
+    """
+    return frozenset(
+        field_name
+        for field_name in _nullable_string_fields(schema)
+        if _schema_domain(schema, field_name) is None
+    )
+
+
+_NULLABLE_STRING_FIELDS = _nullable_string_fields(QUERY_INTENT_SCHEMA)
+
+QUERY_INTENT_COMPARISON_DOMAINS: dict[str, frozenset[str]] = _comparison_domains(
+    QUERY_INTENT_SCHEMA
+)
+
+QUERY_INTENT_BLANK_NULLABLE_FIELDS: frozenset[str] = _blank_nullable_fields(
+    QUERY_INTENT_SCHEMA
 )
 
 
@@ -125,14 +163,16 @@ class QueryIntent:
             tuple(_clean_required_string(item, "relation candidate") for item in self.relation_candidates),
         )
         # A blank nullable string is an absent one -- but only where the schema
-        # pins no domain for the field. All four are nullable yet still listed in
-        # `required` (OpenAI strict mode), and prompt-only providers do not
-        # enforce `minLength: 1`, so a model told to "leave reason null" routinely
-        # emits "" instead; treating that as a hard error would kill a correctly
-        # classified intent, the same failure as #237. On `operator`/`value_type`
-        # the schema's enum settles it the other way: "" is not in the enum, so it
-        # is an off-schema value that `_validate_schema_domains` must reject
-        # rather than an absent one to normalise away.
+        # pins no domain for the field. Every schema property typed
+        # `["string", "null"]` is normalised here, and each is still listed in
+        # `required` (OpenAI strict mode); prompt-only providers do not enforce
+        # `minLength: 1`, so a model told to "leave reason null" routinely emits
+        # "" instead, and treating that as a hard error would kill a correctly
+        # classified intent, the same failure as #237. On the enum-constrained
+        # ones (`operator`/`value_type` today) the schema settles it the other
+        # way: "" is in no enum, so it is an off-schema value that
+        # `_validate_schema_domains` must reject rather than an absent one to
+        # normalise away.
         for field_name in _NULLABLE_STRING_FIELDS:
             current = getattr(self, field_name)
             if current is not None:
@@ -536,12 +576,14 @@ def _clean_optional_string(value: str, field_name: str) -> str | None:
     """Trim a nullable string field, mapping blank to None off the enum fields.
 
     Blank is how a prompt-only provider spells null in a key the schema forces it
-    to emit, so on a field the schema leaves open (`value`, `reason`) it means
-    "absent" rather than "invalid". Where the schema pins an enum it means neither:
-    "" is not one of the admitted values, so it is returned as-is for
+    to emit, so on a field the schema leaves open (`value` and `reason` today) it
+    means "absent" rather than "invalid". Where the schema pins an enum it means
+    neither: "" is not one of the admitted values, so it is returned as-is for
     `_validate_schema_domains` to reject, the same as `operator="contains"`. A
     wrong *value* was always a violation; the enum fields simply have no spelling
-    of null other than null.
+    of null other than null. Which side a field falls on comes from
+    `_blank_nullable_fields`, so the split follows the schema rather than a list
+    kept here.
     """
     if not isinstance(value, str):
         raise ValueError(f"{field_name} must be a string")

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -476,19 +476,45 @@ def _attribute_relation_candidates(label: str) -> tuple[str, ...]:
 
 
 def _intent_field_names(schema: dict[str, Any]) -> tuple[str, ...]:
-    """The property names the parser will accept, in schema order.
+    """The property names the parser will accept as keys, in schema order.
 
     `_parse_query_intent_object` rejects any key outside this allow-list, so a
     hand-written copy of it turns a property added to the schema into an
     "unexpected fields" error -- the provider is told to emit the key and then
-    refused for emitting it. Deriving it means a new property reaches the
-    normalisation and enum checks that `_nullable_string_fields` already picks it
-    up for, instead of being stopped one step earlier.
+    refused for emitting it.
+
+    Widening the allow-list is only half of accepting a property, though: the
+    constructor call below names its kwargs by hand, so a key admitted here and
+    not read there would be taken from the provider and dropped on the floor.
+    `_unconsumed_intent_fields` is what stops that half-wiring from being silent.
     """
     return tuple(schema["properties"])
 
 
 QUERY_INTENT_FIELDS = _intent_field_names(QUERY_INTENT_SCHEMA)
+
+# The names `_parse_query_intent_object` actually reads out of the payload. This
+# list cannot be derived -- it mirrors the hand-written kwargs of the QueryIntent
+# construction below, which is the thing being checked -- but it does not have to
+# be trusted: `_unconsumed_intent_fields` holds it against the schema.
+_PARSED_INTENT_FIELDS = frozenset(
+    {
+        "kind",
+        "subject",
+        "relation",
+        "object",
+        "relation_candidates",
+        "operator",
+        "value_type",
+        "value",
+        "reason",
+    }
+)
+
+
+def _unconsumed_intent_fields(field_names: tuple[str, ...]) -> frozenset[str]:
+    """Allow-listed names the parser would accept as keys but never read."""
+    return frozenset(field_names) - _PARSED_INTENT_FIELDS
 
 
 def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
@@ -504,6 +530,22 @@ def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
 
 
 def _parse_query_intent_object(data: Any) -> QueryIntent:
+    unconsumed = _unconsumed_intent_fields(QUERY_INTENT_FIELDS)
+    if unconsumed:
+        # Deliberately not one of the exceptions `parse_query_intent` converts to
+        # LLMError. Nothing a provider can send causes this -- the allow-list is
+        # derived from a module constant -- so it is a half-finished schema
+        # change, and reporting it as "output did not match schema" would pin a
+        # local wiring bug on the provider and send the reader hunting the wrong
+        # thing. Failing here rather than skipping the name is the same call made
+        # for the dataclass in `__post_init__`: a property the parser accepts but
+        # never reads is taken from the provider and silently discarded, which is
+        # the hole of #298 moved one step along rather than closed.
+        raise RuntimeError(
+            "query intent schema has properties the parser never reads: "
+            f"{', '.join(sorted(unconsumed))}; add them to the QueryIntent "
+            "construction in _parse_query_intent_object"
+        )
     if not isinstance(data, dict):
         raise TypeError("query intent output must be an object")
     allowed = set(QUERY_INTENT_FIELDS)

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -495,8 +495,10 @@ QUERY_INTENT_FIELDS = _intent_field_names(QUERY_INTENT_SCHEMA)
 
 # The names `_parse_query_intent_object` actually reads out of the payload. This
 # list cannot be derived -- it mirrors the hand-written kwargs of the QueryIntent
-# construction below, which is the thing being checked -- but it does not have to
-# be trusted: `_unconsumed_intent_fields` holds it against the schema.
+# construction below -- and it does have to be trusted: it is held against the
+# schema, not against the kwargs below, so adding a name here without wiring the
+# kwarg re-opens the silent drop the import check exists to prevent. Deriving the
+# construction itself is what would remove the need to trust it.
 _PARSED_INTENT_FIELDS = frozenset(
     {
         "kind",
@@ -513,7 +515,11 @@ _PARSED_INTENT_FIELDS = frozenset(
 
 
 def _unconsumed_intent_fields(field_names: tuple[str, ...]) -> frozenset[str]:
-    """Allow-listed names the parser would accept as keys but never read."""
+    """Allow-listed names `_PARSED_INTENT_FIELDS` does not claim the parser reads.
+
+    "Does not claim" rather than "does not read": the comparison is against that
+    list, not against the construction it mirrors.
+    """
     return frozenset(field_names) - _PARSED_INTENT_FIELDS
 
 

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -475,17 +475,20 @@ def _attribute_relation_candidates(label: str) -> tuple[str, ...]:
     return (normalized,)
 
 
-QUERY_INTENT_FIELDS = (
-    "kind",
-    "subject",
-    "relation",
-    "object",
-    "relation_candidates",
-    "operator",
-    "value_type",
-    "value",
-    "reason",
-)
+def _intent_field_names(schema: dict[str, Any]) -> tuple[str, ...]:
+    """The property names the parser will accept, in schema order.
+
+    `_parse_query_intent_object` rejects any key outside this allow-list, so a
+    hand-written copy of it turns a property added to the schema into an
+    "unexpected fields" error -- the provider is told to emit the key and then
+    refused for emitting it. Deriving it means a new property reaches the
+    normalisation and enum checks that `_nullable_string_fields` already picks it
+    up for, instead of being stopped one step earlier.
+    """
+    return tuple(schema["properties"])
+
+
+QUERY_INTENT_FIELDS = _intent_field_names(QUERY_INTENT_SCHEMA)
 
 
 def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -517,6 +517,25 @@ def _unconsumed_intent_fields(field_names: tuple[str, ...]) -> frozenset[str]:
     return frozenset(field_names) - _PARSED_INTENT_FIELDS
 
 
+# Checked once, at import, rather than per parse. Both halves of the comparison
+# are module constants, so a mismatch is a half-finished schema change and cannot
+# be provoked by anything a provider sends -- which is also why it must not be
+# raised from inside the parse path, where `parse_query_intent` converts
+# KeyError/TypeError/ValueError into LLMError and would report a local wiring bug
+# as "the provider violated the schema", sending the reader after the wrong
+# thing. Failing here rather than skipping the name is the call `__post_init__`
+# makes for the dataclass: a property the parser admits but never reads is taken
+# from the provider and silently discarded, which is the hole of #298 moved one
+# step along rather than closed.
+_UNREAD_INTENT_FIELDS = _unconsumed_intent_fields(QUERY_INTENT_FIELDS)
+if _UNREAD_INTENT_FIELDS:
+    raise RuntimeError(
+        "query intent schema has properties the parser never reads: "
+        f"{', '.join(sorted(_UNREAD_INTENT_FIELDS))}; add them to the QueryIntent "
+        "construction in _parse_query_intent_object"
+    )
+
+
 def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
     """Parse constrained JSON provider output into an internal query intent."""
     try:
@@ -530,22 +549,6 @@ def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
 
 
 def _parse_query_intent_object(data: Any) -> QueryIntent:
-    unconsumed = _unconsumed_intent_fields(QUERY_INTENT_FIELDS)
-    if unconsumed:
-        # Deliberately not one of the exceptions `parse_query_intent` converts to
-        # LLMError. Nothing a provider can send causes this -- the allow-list is
-        # derived from a module constant -- so it is a half-finished schema
-        # change, and reporting it as "output did not match schema" would pin a
-        # local wiring bug on the provider and send the reader hunting the wrong
-        # thing. Failing here rather than skipping the name is the same call made
-        # for the dataclass in `__post_init__`: a property the parser accepts but
-        # never reads is taken from the provider and silently discarded, which is
-        # the hole of #298 moved one step along rather than closed.
-        raise RuntimeError(
-            "query intent schema has properties the parser never reads: "
-            f"{', '.join(sorted(unconsumed))}; add them to the QueryIntent "
-            "construction in _parse_query_intent_object"
-        )
     if not isinstance(data, dict):
         raise TypeError("query intent output must be an object")
     allowed = set(QUERY_INTENT_FIELDS)


### PR DESCRIPTION
Refs #298

`query_intent.py` kept two hand-written copies of `QUERY_INTENT_SCHEMA`'s property
names. This derives them, and makes the half-wired states that derivation exposes
fail loudly instead of quietly.

## Closed

**The name lists.** `_NULLABLE_STRING_FIELDS`, `QUERY_INTENT_COMPARISON_DOMAINS`,
`QUERY_INTENT_BLANK_NULLABLE_FIELDS` and `QUERY_INTENT_FIELDS` are now derived
from the schema. The derivations take the schema as an argument rather than
reading the module constant, which is what makes them testable against a
synthetic schema: an inline comprehension over the real constant has the same
extension as the hand list it replaced, so nothing could tell the two apart.

The predicate is `set(type) == {"string", "null"}`, not `"null" in type` — the
looser form also matches `relation_candidates` (`["array", "null"]`) and the
three target properties (`["object", "null"]`), whose values are not strings and
must not be trimmed or blank-normalised as though they were.

**The silent drop.** Deriving the allow-list alone moved the failure rather than
closing it. The `QueryIntent` construction names its kwargs by hand, so a
property added to the schema stopped being refused as an unexpected field and
started being *accepted and discarded*: a blank or off-enum value came back as
`None` instead of being rejected. That is quieter and worse than the error it
replaced. The module now refuses to import while it admits a name it never reads.

**Diagnosis attribution.** That failure is raised at import, outside the parse
path entirely, and with a type `parse_query_intent`'s
`except (KeyError, TypeError, ValueError)` does not convert. Both halves of the
comparison are module constants, so no provider output can reach it; reporting it
as `LLMError: query intent output did not match schema` would pin a local wiring
bug on the provider and send the reader after the wrong thing.

## Not closed — why this is `Refs` and not `Closes`

The issue's acceptance is that adding a property to the schema makes it
blank-rejecting **with no further action**. That is not what this branch
delivers. The parser kwarg and the dataclass field are still wired by hand:

```
schema + dataclass field only, parser not wired
  -> RuntimeError: query intent schema has properties the parser never reads: unit;
     add them to the QueryIntent construction in _parse_query_intent_object

after wiring the kwarg
  blank  -> LLMError: unit must be one of kg, m, got ''
  'lb'   -> LLMError: unit must be one of kg, m, got 'lb'
  'kg'   -> ACCEPTED, unit='kg'
```

So what changed is silent-discard to loud-failure, not manual to automatic.
Completing the acceptance means deriving the construction itself, which is left
as follow-up (see below).

## Known trap

`_PARSED_INTENT_FIELDS` — the list of names the parser actually reads — is held
against the *schema*, not against the kwargs it mirrors. Adding a name to it
without wiring the corresponding kwarg brings the silent drop straight back, with
the guard quiet and the suite green (reproduced with a `locale` property during
review). Reaching that state means ignoring an error message that names the fix,
so it is narrow rather than likely, but it is real and the code comments say so.

## Non-vacuity

Every guard here was checked by reverting the fix and confirming the test goes
red, not merely by watching it pass.

| Mutation | Result |
| --- | --- |
| M1 derivation → the four-name hand list | 3 failed |
| M2 predicate → `"null" in type` | 21 failed |
| M3 drop `reason` from the dataclass | 1 failed |
| M4 allow-list → the nine-name hand list | 4 failed |
| M6 delete the import-time guard | 1 failed |
| M7 derivation → an extensionally identical nine-name literal | 1 failed |
| M8 guard hard-wired to always raise | package unimportable |

**M7 is the load-bearing one.** Replacing the derivation with a literal that has
exactly today's value still goes red, which is what distinguishes a real
derivation from a hand list that happens to agree. An earlier version of this
test asserted `"unit" in _intent_field_names(synthetic)` — a property of the
derivation rather than of the parser — and passed while the silent drop was live;
the current test builds the module against a synthetic schema and so exercises
what the derivation is for. M8 is why there is a second test pinning that the
guard still passes on the real schema: a guard wired to always raise would
otherwise satisfy the first one while making the package unimportable.

The tests load an isolated module copy via `spec_from_file_location` rather than
`importlib.reload`; a failed reload leaves the real module half-rebuilt, and even
a successful one swaps the identity of `QueryIntent`/`IntentTarget` out from under
every test that imported them, breaking dataclass equality later in the session.

## Blast radius

If the guard fires, `verinote.pipeline` and anything importing through it fail to
load (`import verinote` itself still works). The schema is consumed only at import
(`schema.py:131`) and the four adapters only read it, so there is no path by which
it changes at runtime — this is a development-time failure only. The traceback is
four frames and its last line names the missing property and the function to fix.

## Verification

`1236 passed`, `ruff check` clean.

## Follow-up

Derive the construction itself so `_PARSED_INTENT_FIELDS` can go away: a
field-to-parser dispatch table (`_INTENT_FIELD_PARSERS`) would make the list *be*
the construction rather than a claim about it, removing both the trap above and
the manual wiring step. That is what would complete the issue's acceptance.
