### PR TITLE
fix(#294): move the trust-signal group label onto a role that may carry it

### DIFF
--- a/tests/test_trust_labels_a11y.py
+++ b/tests/test_trust_labels_a11y.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The trust-signal badges need a *group* label that assistive tech can reach (#294).
+
+The bunch used to sit in `<div class="trust-labels" aria-label="trust signals">`. A
+plain `<div>` has the implicit ARIA role ``generic``, and ``generic`` is
+*name-prohibited*: a conforming AT may drop an author-provided ``aria-label`` on it
+entirely, so the only thing announced was a run of loose badge words with nothing
+saying what they were signals *of*.
+
+This is a different contract from the triple slots in ``test_term_kind_a11y.py``,
+which is why it lives in its own file. There the label belongs to a *value* and the
+fix is to put the kind into a real text node; here the label names a *group*, and
+moving it into the visible text would just be noise on the page. The fix instead
+gives the label a host that is allowed to carry one -- ``role="list"`` -- and, because
+``list`` has required owned elements, marks each badge ``role="listitem"``.
+
+Parsing is stdlib ``html.parser`` on purpose; see the docstring of
+``test_term_kind_a11y.py`` for why an undeclared transitive ``lxml`` is not used.
+The assertions below deliberately go through the parsed DOM rather than substring
+checks on the markup: ``'aria-label="trust signals"' in html`` would still pass with
+the role stripped back off, i.e. it would pass on the bug this file exists to pin.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from verinote.config import Config  # noqa: E402
+from verinote.store.fact_input import structural_term  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+GROUP_CLASS = "trust-labels"
+
+# Roles that permit an author-provided accessible name and suit a bunch of labels.
+# ``generic`` (the implicit role of a bare div/span) is pointedly not among them.
+NAMING_ROLES = {"list", "group", "region"}
+
+# Tags whose implicit role is ``generic``. Naming them requires an explicit role.
+GENERIC_TAGS = {"div", "span"}
+
+NAME_ATTRS = ("aria-label", "aria-labelledby")
+
+# HTML void elements never get an end tag, so they must not enter the open-tag stack.
+VOID = {
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "link", "meta", "param", "source", "track", "wbr",
+}  # fmt: skip
+
+
+class _Markup(HTMLParser):
+    """Pull out the trust-label group, its direct children, and every named generic.
+
+    ``group`` is the attributes of the ``.trust-labels`` element, ``children`` the
+    attributes of each *direct* child element of it (nested descendants do not count
+    -- required owned elements are about the immediate children). ``named_generics``
+    collects every ``div``/``span`` that carries an accessible name without declaring
+    a role, which is exactly the name-prohibited pattern.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.group: dict[str, str] | None = None
+        self.children: list[dict[str, str]] = []
+        self.named_generics: list[tuple[str, dict[str, str]]] = []
+        self._stack: list[str] = []
+        self._group_depth: int | None = None
+
+    def handle_startendtag(self, tag: str, attrs) -> None:
+        self._record(tag, attrs)
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        self._record(tag, attrs)
+        if tag not in VOID:
+            self._stack.append(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in VOID or not self._stack:
+            return
+        self._stack.pop()
+        if self._group_depth is not None and len(self._stack) < self._group_depth:
+            self._group_depth = None
+
+    def _record(self, tag: str, attrs) -> None:
+        attributes = {k: (v or "") for k, v in attrs}
+        if tag in GENERIC_TAGS and "role" not in attributes:
+            if any(a in attributes for a in NAME_ATTRS):
+                self.named_generics.append((tag, attributes))
+        if self._group_depth is not None and len(self._stack) == self._group_depth:
+            self.children.append(attributes)
+        if GROUP_CLASS in (attributes.get("class") or "").split():
+            self.group = attributes
+            self._group_depth = len(self._stack) + 1
+
+
+def _parse(markup: str) -> _Markup:
+    parser = _Markup()
+    parser.feed(markup)
+    return parser
+
+
+def _client(tmp_path) -> TestClient:
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    app = create_app(cfg)
+    return TestClient(app)
+
+
+def _fact_with_signals(store) -> int:
+    """A fact with a source, so the page renders at least one trust label."""
+    sid = store.add_source("sources/x.txt", kind="text")
+    return store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="needs_review",
+        source_id=sid,
+    )
+
+
+def _provenance(tmp_path) -> str:
+    c = _client(tmp_path)
+    fid = _fact_with_signals(c.app.state.store)
+    return c.get(f"/facts/{fid}/provenance").text
+
+
+def test_trust_label_group_carries_a_name_on_a_role_that_permits_one(tmp_path) -> None:
+    """The group label must sit on a host that is allowed to have a name.
+
+    Both halves matter and neither is enough alone: an ``aria-label`` on a bare div
+    may be discarded, and a ``role="list"`` with no name is an unlabelled list.
+    """
+    group = _parse(_provenance(tmp_path)).group
+    assert group is not None, f"provenance renders no .{GROUP_CLASS} element"
+
+    name = next((group[a] for a in NAME_ATTRS if group.get(a)), None)
+    assert name, (
+        f".{GROUP_CLASS} has no accessible name ({', '.join(NAME_ATTRS)}); the badges "
+        "then read as loose words with nothing saying what they are signals of"
+    )
+    assert group.get("role") in NAMING_ROLES, (
+        f".{GROUP_CLASS} names itself {name!r} but its role is "
+        f"{group.get('role') or 'generic (no role attribute)'}, which prohibits an "
+        f"author-provided name -- an AT may drop the label. Use one of {NAMING_ROLES}."
+    )
+
+
+def test_trust_label_group_owns_listitems(tmp_path) -> None:
+    """A ``list`` has required owned elements; half the pattern is not the pattern.
+
+    ``role="list"`` whose children are role=generic spans is malformed: the container
+    announces a list and then owns nothing, so the count and position an AT reports
+    are wrong.
+    """
+    parsed = _parse(_provenance(tmp_path))
+    assert parsed.group is not None, f"provenance renders no .{GROUP_CLASS} element"
+    if parsed.group.get("role") != "list":
+        pytest.skip("group does not use role=list; owned-element rule does not apply")
+
+    assert parsed.children, (
+        f".{GROUP_CLASS} is role=list but rendered no child elements; this fixture "
+        "adds a source precisely so at least one trust label exists"
+    )
+    bad = [c for c in parsed.children if c.get("role") != "listitem"]
+    assert not bad, (
+        f".{GROUP_CLASS} is role=list but owns non-listitem children: {bad}. "
+        "role=list requires its direct children to be role=listitem."
+    )
+
+
+@pytest.mark.parametrize("page", ["review", "provenance"])
+def test_no_generic_element_carries_an_author_name(tmp_path, page) -> None:
+    """Generalises the #284 span pin: no name on anything still role=generic.
+
+    Stated as "a div/span with no ``role``" rather than "any ``div[aria-label]``" on
+    purpose. The fix above is a div with an aria-label -- a legitimate one, because it
+    declares ``role="list"`` and so is no longer generic. Banning the attribute
+    wholesale would fail on the fix itself; banning it *while generic* is the actual
+    rule, and it makes this class of defect structurally unable to come back.
+
+    ``<nav>``, ``<input>`` and ``<select>`` elsewhere in these templates are untouched:
+    their implicit roles permit a name, and they are not generic tags to begin with.
+    """
+    c = _client(tmp_path)
+    fid = _fact_with_signals(c.app.state.store)
+    markup = (
+        c.get("/review").text
+        if page == "review"
+        else c.get(f"/facts/{fid}/provenance").text
+    )
+
+    named = _parse(markup).named_generics
+    assert named == [], (
+        f"{page} names a role=generic element: {named}. A div/span with no explicit "
+        "role is role=generic, which is name-prohibited -- either give it a role that "
+        "permits a name, or put the text in a visually-hidden text node."
+    )

--- a/tests/test_trust_labels_a11y.py
+++ b/tests/test_trust_labels_a11y.py
@@ -43,6 +43,11 @@ NAMING_ROLES = {"list", "group", "region"}
 # Tags whose implicit role is ``generic``. Naming them requires an explicit role.
 GENERIC_TAGS = {"div", "span"}
 
+# Roles that prohibit an author-provided name. Declaring one of these *explicitly* is
+# no better than leaving the element generic -- the label is still free to be dropped
+# -- so "has a role attribute" is not on its own enough to clear the pin below.
+NAME_PROHIBITED_ROLES = {"generic", "presentation", "none", "paragraph"}
+
 NAME_ATTRS = ("aria-label", "aria-labelledby")
 
 # HTML void elements never get an end tag, so they must not enter the open-tag stack.
@@ -58,8 +63,9 @@ class _Markup(HTMLParser):
     ``group`` is the attributes of the ``.trust-labels`` element, ``children`` the
     attributes of each *direct* child element of it (nested descendants do not count
     -- required owned elements are about the immediate children). ``named_generics``
-    collects every ``div``/``span`` that carries an accessible name without declaring
-    a role, which is exactly the name-prohibited pattern.
+    collects every ``div``/``span`` that carries an accessible name while its role
+    prohibits one -- whether it left the role implicit or spelled out a
+    name-prohibited role such as ``presentation``.
     """
 
     def __init__(self) -> None:
@@ -87,7 +93,8 @@ class _Markup(HTMLParser):
 
     def _record(self, tag: str, attrs) -> None:
         attributes = {k: (v or "") for k, v in attrs}
-        if tag in GENERIC_TAGS and "role" not in attributes:
+        role = attributes.get("role", "").strip().lower()
+        if tag in GENERIC_TAGS and (not role or role in NAME_PROHIBITED_ROLES):
             if any(a in attributes for a in NAME_ATTRS):
                 self.named_generics.append((tag, attributes))
         if self._group_depth is not None and len(self._stack) == self._group_depth:
@@ -155,38 +162,52 @@ def test_trust_label_group_carries_a_name_on_a_role_that_permits_one(tmp_path) -
     )
 
 
-def test_trust_label_group_owns_listitems(tmp_path) -> None:
-    """A ``list`` has required owned elements; half the pattern is not the pattern.
+def test_trust_label_group_and_its_children_agree_on_being_a_list(tmp_path) -> None:
+    """Container and children must be a list together, or neither.
 
-    ``role="list"`` whose children are role=generic spans is malformed: the container
-    announces a list and then owns nothing, so the count and position an AT reports
-    are wrong.
+    Asserted in both directions, with no skip. Skipping when the container is not a
+    ``list`` would leave a real hole: switch the role to ``region`` and keep the
+    ``role="listitem"`` badges and you get **orphan listitems** -- items owned by no
+    list, which is malformed ARIA and makes an AT misreport their count and position.
+    That mutant passes guard 1 (``region`` permits a name), so a skip here means
+    nothing catches it. A skip also reads as a green tick in the summary line, which
+    is the property PR #273 set out to keep.
     """
     parsed = _parse(_provenance(tmp_path))
     assert parsed.group is not None, f"provenance renders no .{GROUP_CLASS} element"
-    if parsed.group.get("role") != "list":
-        pytest.skip("group does not use role=list; owned-element rule does not apply")
-
     assert parsed.children, (
-        f".{GROUP_CLASS} is role=list but rendered no child elements; this fixture "
-        "adds a source precisely so at least one trust label exists"
+        f".{GROUP_CLASS} rendered no child elements; this fixture adds a source "
+        "precisely so at least one trust label exists"
     )
-    bad = [c for c in parsed.children if c.get("role") != "listitem"]
-    assert not bad, (
-        f".{GROUP_CLASS} is role=list but owns non-listitem children: {bad}. "
-        "role=list requires its direct children to be role=listitem."
-    )
+
+    listitems = [c for c in parsed.children if c.get("role") == "listitem"]
+    if parsed.group.get("role") == "list":
+        others = [c for c in parsed.children if c.get("role") != "listitem"]
+        assert not others, (
+            f".{GROUP_CLASS} is role=list but owns non-listitem children: {others}. "
+            "role=list requires its direct children to be role=listitem."
+        )
+    else:
+        assert not listitems, (
+            f".{GROUP_CLASS} is role={parsed.group.get('role') or 'generic'} but owns "
+            f"role=listitem children: {listitems}. A listitem outside a list is "
+            "orphaned -- an AT reports its position and count against nothing."
+        )
 
 
 @pytest.mark.parametrize("page", ["review", "provenance"])
 def test_no_generic_element_carries_an_author_name(tmp_path, page) -> None:
-    """Generalises the #284 span pin: no name on anything still role=generic.
+    """Generalises the #284 span pin: no name on a role that prohibits one.
 
-    Stated as "a div/span with no ``role``" rather than "any ``div[aria-label]``" on
-    purpose. The fix above is a div with an aria-label -- a legitimate one, because it
-    declares ``role="list"`` and so is no longer generic. Banning the attribute
-    wholesale would fail on the fix itself; banning it *while generic* is the actual
-    rule, and it makes this class of defect structurally unable to come back.
+    Stated as "a div/span whose role prohibits a name" rather than "any
+    ``div[aria-label]``" on purpose. The fix above is a div with an aria-label -- a
+    legitimate one, because it declares ``role="list"``. Banning the attribute
+    wholesale would fail on the fix itself; banning it *where the role forbids it* is
+    the actual rule, and it makes this class of defect structurally unable to return.
+
+    Note it is not enough to ask whether a ``role`` attribute is merely *present*:
+    ``<div role="presentation" aria-label="...">`` has one and is still name-prohibited.
+    The role's value has to be checked against ``NAME_PROHIBITED_ROLES``.
 
     ``<nav>``, ``<input>`` and ``<select>`` elsewhere in these templates are untouched:
     their implicit roles permit a name, and they are not generic tags to begin with.
@@ -201,7 +222,8 @@ def test_no_generic_element_carries_an_author_name(tmp_path, page) -> None:
 
     named = _parse(markup).named_generics
     assert named == [], (
-        f"{page} names a role=generic element: {named}. A div/span with no explicit "
-        "role is role=generic, which is name-prohibited -- either give it a role that "
-        "permits a name, or put the text in a visually-hidden text node."
+        f"{page} names an element whose role prohibits a name: {named}. A div/span "
+        f"with no role is generic, and {sorted(NAME_PROHIBITED_ROLES)} are "
+        "name-prohibited too -- either give it a role that permits a name, or put the "
+        "text in a visually-hidden text node."
     )

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -8,9 +8,12 @@
 
 <section class="trust-block">
   <h2>Trust summary</h2>
-  <div class="trust-labels" aria-label="trust signals">
+  {# role=list, not a bare div: a div is role=generic, which is name-prohibited, so
+     the aria-label below would have been free to go unannounced (#294). list does
+     permit an author name -- and it owns listitems, hence the role on each badge. #}
+  <div class="trust-labels" role="list" aria-label="trust signals">
     {% for label in trust.trust_labels %}
-      <span class="badge trust-{{ label }}">{{ label|replace("_", " ") }}</span>
+      <span class="badge trust-{{ label }}" role="listitem">{{ label|replace("_", " ") }}</span>
     {% endfor %}
   </div>
   <table class="counts">


### PR DESCRIPTION
Closes #294

## The defect

`provenance.html:11` hung the group label on a host that is not allowed to carry one:

```html
<div class="trust-labels" aria-label="trust signals">
```

A `<div>` has the implicit ARIA role `generic`, and `generic` is **Name From: prohibited** — a conforming AT is free to ignore an author-provided `aria-label` on it. So the label was not merely redundant, it was droppable: the badges could be announced as a run of loose words with nothing saying what they were signals *of*.

The fix gives the label a host that may hold one, rather than moving the label:

```html
<div class="trust-labels" role="list" aria-label="trust signals">
  <span class="badge trust-…" role="listitem">…</span>
```

`role="listitem"` on the badges is not decoration — `list` has **required owned elements**, so the two go together or the container announces a list that owns nothing.

**No `app.css` change.** `role` attributes do not affect rendering, so `.trust-labels`' flex layout and `.badge` styling are untouched. Changed files are `provenance.html` plus one new test file.

**Why not `<ul>/<li>`?** WebKit strips list semantics from a list styled `list-style: none`, so the accessible-name problem would come back and an explicit `role="list"` would have to be re-added anyway — on top of needing list-marker resets in `app.css`.

**Scope.** A global search found `aria-label` in 10 places across the templates; the other 9 sit on hosts where naming is permitted (`<nav>`, `<select>`, `<input>`). Within that grep's range, this was the only one on a name-prohibited host.

## The guards were breached twice, and that is the point

The regression guards in `tests/test_trust_labels_a11y.py` were written first and then attacked. Two holes turned up, both worth recording:

1. **A conditional `pytest.skip` hid a real defect.** The owned-elements guard skipped itself when the container was not a `list`. Swap the role to `region` and keep the `role="listitem"` badges and the suite reported *3 passed, 1 skipped* — while the markup contained **orphan listitems**, items owned by no list, which makes an AT report position and count against something that does not exist. Guard 1 waves that mutant through because `region` does permit a name. Fixed by dropping the skip for an assertion in both directions: if the container is a `list`, every child is a `listitem`; if it is not, no child may be one. The file now has **zero skips**.

2. **The name-prohibited pin only checked that a `role` attribute was *present*.** So `<div role="presentation" aria-label="sneaky">` cleared it — *4 passed* — despite being exactly as unannounceable as a bare div. Fixed with a `NAME_PROHIBITED_ROLES` constant (`generic`, `presentation`, `none`, `paragraph`) checked against the role's value.

The pin is deliberately stated as "a div/span whose role prohibits a name" rather than "any `div[aria-label]`". The latter would fail on this very fix, which is a legitimately named div.

## Mutation testing

| Mutant | Result |
|---|---|
| M1 — remove `role="list"` | 3 failed |
| M2 — remove `aria-label` | 1 failed |
| M3 — remove `role="listitem"` | 1 failed |
| M4 — `role="region"`, keep listitems | 1 failed |
| M5 — add `<div role="presentation" aria-label="sneaky">` | 1 failed |

All five are red, and under each one **every other test in the suite still passes** — the new guards are what catch them, with nothing riding along.

M1–M3 are deletions of the prescribed markup; M4–M5 are substitutions. That distinction mattered here: a guard exercised only against deletion checks that the prescription is still present, and stays blind to a path that swaps it for something else. Both holes above were substitutions.

## Verification

- `PYTHONPATH=$PWD python -m pytest tests -q` → **1233 passed**, **zero skips** (confirmed with `-rs`)
- `ruff check .` → clean

## Follow-ups (not in this PR, no issues filed)

- `fact_row.html:19-40` renders the same badge bunch with **no group name at all** — same family of defect, separate change.
- Widening the pin's coverage from these 2 render paths to every template.
- The remaining name-prohibited roles in the spec (`caption`, `code`, `strong`, …), none of which the current templates use.
