### PR TITLE
fix(#221): tell a rule's auto-accept apart from a person's confirm in the badge

### DIFF
--- a/tests/test_badge_actor_css.py
+++ b/tests/test_badge_actor_css.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Regression lock on the accepted-vs-confirmed badge (#221).
+
+`confirmed` and `accepted` are different events: `accept_fact()` records a person's
+call (actor defaults to the user), `auto_accept_fact()` records a rule's
+(`actor="rule"`, with a rule_name). Both land in `ENGINE_STATUSES`, so a
+rule-accepted fact reasons with exactly the authority of a human-accepted one --
+yet app.css styled them with a single shared rule and fact_row.html shows no actor,
+so the review screen gave the reader no way to tell which had happened.
+
+These tests pin the distinction the way #226 demands it be pinned:
+
+1. **The two badges are genuinely different rules**, compared by parsed declaration
+   set rather than "a rule exists" -- two rules with identical bodies would still be
+   the bug.
+2. **The difference is not colour alone.** Colour properties are stripped before the
+   comparison, so "fix" the bug by re-tinting one badge and this stays red. #226 is
+   about verdicts that depend on colour alone; this is the guard that stops #221's
+   fix from reopening it.
+3. **Both stay in the ok tone**, which is what the issue asked for -- the actor is
+   the difference, not the verdict.
+4. **The glyph carries empty alt text**, so it never leaks into a screen reader's
+   reading of the badge (the badge text already says "accepted").
+5. **`.badge-confirmed` carries no glyph.** That class doubles as a generic ok chip
+   ("covered" on the dashboard, "OK" in the report), so an approval mark there would
+   land on text that is not an accept decision at all.
+6. **The template still emits `badge-{{ status }}`**, without which the CSS is dead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WEB = Path(__file__).resolve().parents[1] / "verinote" / "web"
+CSS_PATH = WEB / "static" / "app.css"
+TEMPLATES = WEB / "templates"
+
+# Properties that carry colour and nothing else. Stripped before the "are they really
+# different" comparison so a colour-only distinction cannot satisfy it.
+COLOUR_PROPERTIES = ("color", "border-color", "background")
+
+
+def _read_css() -> str:
+    return CSS_PATH.read_text(encoding="utf-8")
+
+
+def _strip_comments(css: str) -> str:
+    return re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+
+
+def _declarations(selector: str, css: str) -> dict[str, str]:
+    """Parsed `property -> value` for the flat rule whose selector is exactly `selector`.
+
+    Returns `{}` when no such rule exists -- so the pre-fix state, where neither
+    `.badge-confirmed` nor `.badge-accepted` appeared alone (both lived in one grouped
+    selector), reads as two identical empty sets and fails the difference tests.
+    """
+    css = _strip_comments(css)
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", css):
+        if " ".join(match.group(1).split()) != selector:
+            continue
+        declarations: dict[str, str] = {}
+        for chunk in match.group(2).split(";"):
+            prop, sep, value = chunk.partition(":")
+            if sep:
+                declarations[" ".join(prop.split())] = " ".join(value.split())
+        return declarations
+    return {}
+
+
+def _without_colour(declarations: dict[str, str]) -> dict[str, str]:
+    return {
+        prop: value
+        for prop, value in declarations.items()
+        if not prop.startswith(COLOUR_PROPERTIES)
+    }
+
+
+def test_confirmed_and_accepted_are_not_the_same_rule() -> None:
+    """The whole point of #221: a rule's pass must not look like a person's pass."""
+    css = _read_css()
+    confirmed = _declarations(".badge-confirmed", css)
+    accepted = _declarations(".badge-accepted", css)
+
+    assert accepted, (
+        "app.css defines no standalone .badge-accepted rule; a rule-accepted fact "
+        "renders identically to a human-confirmed one, which is bug #221"
+    )
+    assert confirmed != accepted, (
+        f".badge-confirmed and .badge-accepted carry identical declarations "
+        f"({confirmed}); the reviewer cannot tell who passed the fact"
+    )
+
+
+def test_the_difference_is_not_colour_alone() -> None:
+    """Re-tinting one badge is not a fix -- #226 rejects verdicts that ride on colour.
+
+    Strip the colour properties from both rules; something must still separate them,
+    either a non-colour declaration or the `::before` glyph. Greyscale printouts and
+    colour-blind readers get the distinction either way.
+    """
+    css = _read_css()
+    confirmed = _without_colour(_declarations(".badge-confirmed", css))
+    accepted = _without_colour(_declarations(".badge-accepted", css))
+    glyph = _declarations(".badge-accepted::before", css)
+
+    assert confirmed != accepted or "content" in glyph, (
+        "with colour removed, .badge-confirmed and .badge-accepted are indistinguishable "
+        f"({confirmed}) and .badge-accepted::before sets no content -- the actor would be "
+        "readable by hue alone, which is exactly what #226 says must not happen"
+    )
+
+
+def test_both_stay_in_the_ok_tone() -> None:
+    """Both statuses are passes; the issue asked for the same ok tone, actor aside.
+
+    Also blocks the escape hatch of splitting them by moving `accepted` onto the warn
+    or danger palette, which would read as a worse verdict rather than a different actor.
+    """
+    css = _read_css()
+    for selector in (".badge-confirmed", ".badge-accepted"):
+        declarations = _declarations(selector, css)
+        assert declarations.get("color") == "var(--ok)", (
+            f"{selector} left the ok tone (color={declarations.get('color')!r}); "
+            "both statuses are passes, so the actor must be the only difference"
+        )
+        assert declarations.get("border-color") == "var(--ok)", (
+            f"{selector} left the ok tone (border-color="
+            f"{declarations.get('border-color')!r})"
+        )
+
+
+def test_accepted_glyph_has_empty_alt_text() -> None:
+    """The glyph is decorative; the badge text already announces "accepted".
+
+    `content: "..." / ""` gives the pseudo-element an empty accessible name, following
+    `.term-term::before` (#222). Without the empty alt, screen readers would read a
+    stray gear character into the middle of the status.
+    """
+    css = _read_css()
+    content = _declarations(".badge-accepted::before", css).get("content")
+
+    assert content, ".badge-accepted::before sets no content; the actor glyph is gone"
+    assert re.search(r'/\s*""\s*$', content), (
+        f".badge-accepted::before content is {content!r}, with no `/ \"\"` alt text; "
+        "the decorative glyph would be announced as part of the status"
+    )
+
+
+def test_confirmed_carries_no_actor_glyph() -> None:
+    """`.badge-confirmed` doubles as a generic ok chip, so a glyph there misfires.
+
+    dashboard.html renders "covered" and report.html renders "OK" with this class.
+    Neither is an accept decision, so an approval mark on them would claim something
+    the data does not say.
+    """
+    css = _strip_comments(_read_css())
+
+    assert not re.search(r"\.badge-confirmed\s*::?before\s*\{", css), (
+        "app.css gives .badge-confirmed a ::before glyph, which would also stamp the "
+        "dashboard's 'covered' chip and the report's 'OK' chip -- neither is an accept"
+    )
+
+
+def test_templates_still_emit_the_status_badge_class() -> None:
+    """CSS is dead unless the markup keeps deriving the class from the status string."""
+    html = (TEMPLATES / "partials" / "fact_row.html").read_text(encoding="utf-8")
+
+    assert re.search(r"badge-\{\{\s*f\[['\"]status['\"]\]\s*\}\}", html), (
+        "fact_row.html no longer emits badge-{{ f['status'] }}; .badge-accepted and "
+        ".badge-confirmed would have nothing to style"
+    )

--- a/tests/test_badge_actor_css.py
+++ b/tests/test_badge_actor_css.py
@@ -14,13 +14,16 @@ These tests pin the distinction the way #226 demands it be pinned:
    set rather than "a rule exists" -- two rules with identical bodies would still be
    the bug.
 2. **The difference is not colour alone.** Colour properties are stripped before the
-   comparison, so "fix" the bug by re-tinting one badge and this stays red. #226 is
-   about verdicts that depend on colour alone; this is the guard that stops #221's
-   fix from reopening it.
+   comparison -- including the shorthands that smuggle a colour in beside geometry, so
+   `border: 1px solid <hue>` cannot pass itself off as a non-colour channel. "Fix" the
+   bug by re-tinting one badge and this stays red. #226 is about verdicts that depend
+   on colour alone; this is the guard that stops #221's fix from reopening it.
 3. **Both stay in the ok tone**, which is what the issue asked for -- the actor is
    the difference, not the verdict.
-4. **The glyph carries empty alt text**, so it never leaks into a screen reader's
-   reading of the badge (the badge text already says "accepted").
+4. **The glyph is drawn and carries empty alt text.** Empty alt keeps it out of a
+   screen reader's reading of the badge (which already says "accepted"); checking that
+   the drawn half is non-empty stops `content: "" / ""` -- a declaration that satisfies
+   every other assertion while painting nothing -- from passing as a fix.
 5. **`.badge-confirmed` carries no glyph.** That class doubles as a generic ok chip
    ("covered" on the dashboard, "OK" in the report), so an approval mark there would
    land on text that is not an accept decision at all.
@@ -36,9 +39,12 @@ WEB = Path(__file__).resolve().parents[1] / "verinote" / "web"
 CSS_PATH = WEB / "static" / "app.css"
 TEMPLATES = WEB / "templates"
 
-# Properties that carry colour and nothing else. Stripped before the "are they really
-# different" comparison so a colour-only distinction cannot satisfy it.
-COLOUR_PROPERTIES = ("color", "border-color", "background")
+# Shorthands that can carry a colour alongside other values. Stripped whole, because a
+# colour-only edit hides inside them: `border: 1px solid var(--muted)` changes nothing
+# but the hue, yet reads as a non-colour declaration if compared verbatim. Stripping
+# more than strictly necessary only makes the guard stricter -- a real non-colour
+# channel has to survive as a longhand (`border-style`) to count.
+COLOUR_SHORTHANDS = frozenset({"border", "outline", "box-shadow", "text-shadow"})
 
 
 def _read_css() -> str:
@@ -69,12 +75,39 @@ def _declarations(selector: str, css: str) -> dict[str, str]:
     return {}
 
 
+def _carries_colour(prop: str) -> bool:
+    """True for any property whose value can encode a colour.
+
+    Covers the longhands (`color`, `border-color`, `border-top-color`, `background*`)
+    and the shorthands that bundle a colour with geometry. Deliberately *not* a
+    `startswith("border")` test: `border-style` is the non-colour channel this whole
+    guard exists to protect, so folding it in would gut the comparison.
+    """
+    return (
+        prop == "color"
+        or prop.endswith("-color")
+        or prop.startswith("background")
+        or prop in COLOUR_SHORTHANDS
+    )
+
+
 def _without_colour(declarations: dict[str, str]) -> dict[str, str]:
     return {
-        prop: value
-        for prop, value in declarations.items()
-        if not prop.startswith(COLOUR_PROPERTIES)
+        prop: value for prop, value in declarations.items() if not _carries_colour(prop)
     }
+
+
+def _glyph_of(declarations: dict[str, str]) -> str:
+    """The drawn part of a `content` declaration, with the `/ alt-text` half removed.
+
+    `content: "" / ""` is a *blank* pseudo-element: the declaration exists and the raw
+    string is truthy, but nothing is painted. Splitting the alt text off and unquoting
+    what remains is what separates "a content property is present" from "a glyph is
+    actually drawn" -- the distinction a no-op mutant slips through.
+    """
+    content = declarations.get("content", "")
+    drawn = content.split("/")[0].strip() if "/" in content else content.strip()
+    return drawn.strip("\"'").strip()
 
 
 def test_confirmed_and_accepted_are_not_the_same_rule() -> None:
@@ -97,17 +130,17 @@ def test_the_difference_is_not_colour_alone() -> None:
     """Re-tinting one badge is not a fix -- #226 rejects verdicts that ride on colour.
 
     Strip the colour properties from both rules; something must still separate them,
-    either a non-colour declaration or the `::before` glyph. Greyscale printouts and
-    colour-blind readers get the distinction either way.
+    either a non-colour declaration or a `::before` glyph that actually draws something.
+    Greyscale printouts and colour-blind readers get the distinction either way.
     """
     css = _read_css()
     confirmed = _without_colour(_declarations(".badge-confirmed", css))
     accepted = _without_colour(_declarations(".badge-accepted", css))
-    glyph = _declarations(".badge-accepted::before", css)
+    glyph = _glyph_of(_declarations(".badge-accepted::before", css))
 
-    assert confirmed != accepted or "content" in glyph, (
+    assert confirmed != accepted or glyph, (
         "with colour removed, .badge-confirmed and .badge-accepted are indistinguishable "
-        f"({confirmed}) and .badge-accepted::before sets no content -- the actor would be "
+        f"({confirmed}) and .badge-accepted::before draws no glyph -- the actor would be "
         "readable by hue alone, which is exactly what #226 says must not happen"
     )
 
@@ -137,11 +170,19 @@ def test_accepted_glyph_has_empty_alt_text() -> None:
     `content: "..." / ""` gives the pseudo-element an empty accessible name, following
     `.term-term::before` (#222). Without the empty alt, screen readers would read a
     stray gear character into the middle of the status.
+
+    The drawn half is checked separately from the alt half, because `content: "" / ""`
+    satisfies both "the property is set" and "the alt text is empty" while painting
+    nothing at all -- the badges would be pixel-identical with every test still green.
     """
     css = _read_css()
     content = _declarations(".badge-accepted::before", css).get("content")
 
     assert content, ".badge-accepted::before sets no content; the actor glyph is gone"
+    assert _glyph_of({"content": content}), (
+        f".badge-accepted::before content is {content!r}, which draws nothing; an empty "
+        "glyph leaves the rule-accepted badge visually identical to the confirmed one"
+    )
     assert re.search(r'/\s*""\s*$', content), (
         f".badge-accepted::before content is {content!r}, with no `/ \"\"` alt text; "
         "the decorative glyph would be announced as part of the status"

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -88,7 +88,21 @@ th { color: var(--muted); font-weight: 600; font-size: .85rem; }
 .badge { padding: .1rem .5rem; border-radius: 999px; font-size: .78rem; border: 1px solid var(--line); }
 .badge-candidate { color: var(--muted); }
 .badge-needs_review { color: var(--warn); border-color: var(--warn); }
-.badge-confirmed, .badge-accepted { color: var(--ok); border-color: var(--ok); }
+/* Who let the fact through matters as much as that it got through (#221).
+   `confirmed` is a person's call (accept_fact, actor defaults to the user);
+   `accepted` is a rule's (auto_accept_fact, actor="rule") -- and both enter the
+   engine at the same tier, so the reviewer has to be able to tell them apart.
+   Both keep the ok tone because both are passes; only the rule-made one is
+   marked, by a gear and a dashed border. Two non-colour channels on purpose: a
+   glyph font renders differently per platform, and the border shape survives
+   greyscale the way .badge-superseded's line-through does. */
+.badge-confirmed { color: var(--ok); border-color: var(--ok); }
+.badge-accepted { color: var(--ok); border-color: var(--ok); border-style: dashed; }
+/* `/ ""` is the pseudo-element alt-text: the gear is a decorative actor marker, so
+   it gets an empty accessible name and stays out of the VoiceOver/NVDA reading --
+   the badge text already says "accepted", so the glyph is a purely visual channel. */
+.badge-accepted::before { content: "⚙" / ""; color: var(--muted); font-size: .72em;
+  margin-right: .28rem; vertical-align: .08em; }
 .badge-superseded { color: var(--danger); border-color: var(--danger); text-decoration: line-through; }
 .badge-question-pending { color: var(--muted); }
 .badge-question-translated { color: var(--ok); border-color: var(--ok); }


### PR DESCRIPTION
Closes #221

## What

`confirmed` (a person clicked Accept) and `accepted` (a rule auto-promoted the fact) were styled by a single rule — `.badge-confirmed, .badge-accepted { color: var(--ok); border-color: var(--ok); }` — so the review screen rendered the two identically. The reviewer could not tell which had happened.

`.badge-accepted` is now split out and carries two non-colour channels: `border-style: dashed` and a `::before { content: "⚙" / "" }` glyph. Both badges keep `var(--ok)`. No new tokens, no template change — `badge-{{ f['status'] }}` already emits the two classes separately, so the styling stays derived from the status string.

## Why the two states differ

`confirmed` is written by `accept_fact()` in `verinote/store/db.py`, whose audit-log actor defaults to the human user. `accepted` is written by `auto_accept_fact()` with `actor="rule"` and a `rule_name`. Both are in `ENGINE_STATUSES`, so a rule-promoted fact reasons with exactly the authority of a human-accepted one — which is what makes the visual collapse worth fixing rather than cosmetic.

## Why `.badge-confirmed` gets no glyph

That class is reused as a generic ok chip: `dashboard.html:52` renders "covered" with it and `report.html:12` renders "OK". Stamping an approval mark there would put an accept glyph on text that records no accept decision. The symmetric `✓` the issue sketches belongs with #226's global glyph mapping.

## Not colour alone

#226 is open on verdicts that depend on colour alone, so the load-bearing guard asserts that **the two declaration sets still differ once every colour property is stripped**. A fix that only re-tints one badge is red.

## The guard was defeated twice before it held

This is the part worth reading.

1. **An inert declaration plus a blank glyph passed.** `font-style: normal` (the inherited default, so no visual effect) together with `content: "" / ""` gave **6 passed while the two badges were pixel-identical**. The cause was `assert content` treating the string `'"" / ""'` as truthy — "the property is set" is not "a glyph is drawn". Fixed by splitting the `/ ""` alt half off and asserting the drawn half is non-empty.

2. **A colour hidden in a shorthand slipped through.** `border: 1px solid var(--muted)` changes nothing but the hue, yet was counted as a non-colour difference because stripping only looked at `color` / `border-color` / `background`. Fixed by stripping the shorthands too. Deliberately **not** via `startswith("border")` — that would strip `border-style` as well, gutting the very channel the guard protects.

## Mutation evidence

Each mutant was applied to a `git archive` export, never the worktree.

| Mutant | Change | Result |
|---|---|---|
| A | revert to the one grouped rule, glyph deleted | 4 failed |
| B | difference made colour-only | 3 failed |
| F | inert declaration + blank glyph | 1 failed (was **6 passed** before the fix) |
| G | colour hidden in the `border` shorthand | 3 failed (`..._not_colour_alone` was **green** before the fix) |

All five mutants left the remaining 1228–1231 tests passing, so the new guards are what catch them.

## Verification

`1235 passed`; `ruff check` clean.

## Known limitation

`.badge` (line 88) and `.badge-accepted` (line 100) have equal specificity, so `border-style: dashed` wins on source order alone. Reordering the badge block would silently drop the dashed border and leave only the glyph — and the guard would still be green, because its assertion is a disjunction that the glyph alone satisfies. The practical blast radius is small, but it is a real property of this guard rather than something the tests rule out.

## Follow-up (noted, not filed)

The `_declarations()` helper ignores `@media` nesting, and the same helper is duplicated across `tests/test_term_css.py`, `tests/test_theme.py`, and this file. The light palette already lives inside a media query, so if any of these rules moved into one, all three files would quietly parse `{}` and pass.
