### PR TITLE
fix(#225): mark the current page in the nav with aria-current

### DIFF
--- a/tests/test_nav_active_state.py
+++ b/tests/test_nav_active_state.py
@@ -28,9 +28,16 @@ NAV_ANCHOR = re.compile(r"<a\b([^>]*)>", re.S)
 HREF = re.compile(r'href="([^"]*)"')
 # Any spelling of the attribute counts as a claim of "this is the current page".
 ARIA_CURRENT = re.compile(r'aria-current\s*=\s*"page"')
+HEADER_BLOCK = re.compile(r"<header\b[^>]*>(.*?)</header>", re.S)
+FILTERS_NAV = re.compile(r'<nav\b[^>]*class="filters"[^>]*>(.*?)</nav>', re.S)
 
 
-CURRENT_SELECTOR = r'nav\s+a\[aria-current\s*=\s*"page"\]'
+# The active-page rule is scoped to the header nav (#225): review.html reuses
+# aria-current="page" on its own filter badges, so the marker alone cannot select
+# the rule -- the `header` ancestor is what keeps it off those badges.
+CURRENT_SELECTOR = r'header\s+nav\s+a\[aria-current\s*=\s*"page"\]'
+# The pre-scoping selector, which matched a current link in *any* nav.
+UNSCOPED_CURRENT_SELECTOR = r'nav\s+a\[aria-current\s*=\s*"page"\]'
 BASE_SELECTOR = r"nav\s+a"
 # Properties that cannot mark the link on their own: colour ones fail #226, and
 # spacing only makes room for a marker (padding under a `border-bottom: 0` draws
@@ -185,4 +192,42 @@ def test_current_link_is_marked_off_a_non_colour_channel() -> None:
     assert channels, (
         "the current nav link is distinguished by colour alone: "
         f"{_declarations(body)} leaves every non-colour channel at its `nav a` value"
+    )
+
+
+def test_active_style_is_scoped_to_the_header_nav(tmp_path) -> None:
+    """The header's active-page style must not bleed onto review.html's filters (#225).
+
+    review.html marks its active review filter with the same `aria-current="page"`
+    the header nav uses, but that <nav class="filters"> renders in <main>, outside
+    the <header>. An unscoped `nav a[aria-current="page"]` rule would therefore
+    paint the header-only weight/underline/padding onto the filter badge too, and
+    -- outspecifying plain `.badge` -- distort its pill. Scoping the rule under
+    `header` is what keeps the two navs apart, so this locks that scope in.
+    """
+    client = _client(tmp_path)
+    html = client.get("/review").text
+
+    # The overlap that makes a bleed possible is real: the header nav marks a
+    # current link, and so does the filters nav -- which sits outside the header.
+    header = HEADER_BLOCK.search(html)
+    assert header, "the review page renders no <header>"
+    assert ARIA_CURRENT.search(header.group(1)), "the header nav marks no current link"
+
+    filters = FILTERS_NAV.search(html)
+    assert filters, 'the review page renders no <nav class="filters">'
+    assert ARIA_CURRENT.search(filters.group(1)), (
+        'the active review filter should carry aria-current="page"'
+    )
+    assert filters.start() >= header.end(), "the filters nav is not outside the <header>"
+
+    # So the guard lives in the CSS: the active-page rule is scoped to the header
+    # nav, and no unscoped `nav a[aria-current]` rule survives to reach .filters.
+    assert _rule_body(CURRENT_SELECTOR) is not None, (
+        'app.css has no `header nav a[aria-current="page"]` rule -- the active-page '
+        "style is not scoped to the header nav"
+    )
+    assert _rule_body(UNSCOPED_CURRENT_SELECTOR) is None, (
+        'an unscoped `nav a[aria-current="page"]` rule also styles the active review '
+        "filter badge, not just the header nav"
     )

--- a/tests/test_nav_active_state.py
+++ b/tests/test_nav_active_state.py
@@ -30,6 +30,47 @@ HREF = re.compile(r'href="([^"]*)"')
 ARIA_CURRENT = re.compile(r'aria-current\s*=\s*"page"')
 
 
+CURRENT_SELECTOR = r'nav\s+a\[aria-current\s*=\s*"page"\]'
+BASE_SELECTOR = r"nav\s+a"
+# Properties that cannot mark the link on their own: colour ones fail #226, and
+# spacing only makes room for a marker (padding under a `border-bottom: 0` draws
+# nothing at all).
+UNMARKING_PROPERTIES = frozenset({
+    "color", "background", "background-color", "border-color",
+    "padding", "padding-top", "padding-bottom", "padding-left", "padding-right",
+    "margin", "margin-top", "margin-bottom", "margin-left", "margin-right",
+})
+LENGTH = re.compile(r"(?<![\w.])(\d*\.?\d+)(?:px|rem|em|%)?(?![\w.])")
+
+
+def _rule_body(selector: str) -> str | None:
+    """The declarations of the rule whose selector list is exactly `selector`."""
+    css = CSS_PATH.read_text(encoding="utf-8")
+    match = re.search(rf"(?:^|\}}|\n)\s*{selector}\s*\{{([^}}]*)\}}", css)
+    return match.group(1) if match else None
+
+
+def _declarations(body: str) -> dict[str, str]:
+    decls = {}
+    for chunk in body.split(";"):
+        prop, sep, value = chunk.partition(":")
+        if sep:
+            decls[prop.strip().lower()] = " ".join(value.split())
+    return decls
+
+
+def _is_visible(prop: str, value: str) -> bool:
+    """Whether the declaration actually renders differently from the nav default."""
+    if prop == "font-weight":
+        return value == "bold" or (value.isdigit() and int(value) > 400)
+    if prop.startswith(("border", "outline")) or prop == "box-shadow":
+        # `border-bottom: 0` and `0px solid var(--accent)` both draw nothing.
+        return any(float(n) > 0 for n in LENGTH.findall(value)) if LENGTH.search(value) else False
+    if prop.startswith("text-decoration"):
+        return value not in {"none", "initial"}
+    return value not in {"normal", "none", "initial", "inherit", "unset", "auto"}
+
+
 def _client(tmp_path) -> TestClient:
     cfg = Config(
         root=tmp_path, db_path=tmp_path / "kb.sqlite",
@@ -78,6 +119,19 @@ def test_dashboard_is_not_current_on_other_pages(tmp_path) -> None:
     assert "/" not in _current(client.get("/sources").text)
 
 
+def test_subpath_keeps_its_section_current(tmp_path) -> None:
+    """`/sources/…` is still the Sources section, so the parent link stays current.
+
+    A missing source makes the handler re-render the sources page in place rather
+    than redirect, which is what leaves the request on the sub-path.
+    """
+    client = _client(tmp_path)
+    response = client.post("/sources/999/reanalyze")
+    assert response.status_code == 404
+    assert response.url.path == "/sources/999/reanalyze", "the handler redirected away"
+    assert _current(response.text) == ["/sources"]
+
+
 def test_page_outside_the_nav_marks_nothing(tmp_path) -> None:
     """A fact's provenance page extends base.html but has no nav entry of its own."""
     client = _client(tmp_path)
@@ -88,7 +142,30 @@ def test_page_outside_the_nav_marks_nothing(tmp_path) -> None:
 
 def test_stylesheet_styles_the_current_link() -> None:
     """Without a rule, the attribute is invisible to anyone not using a screen reader."""
-    css = CSS_PATH.read_text(encoding="utf-8")
-    assert re.search(r'nav\s+a\[aria-current\s*=\s*"page"\]', css), (
+    assert _rule_body(CURRENT_SELECTOR) is not None, (
         "app.css has no rule selecting the current nav link"
+    )
+
+
+def test_current_link_is_marked_off_a_non_colour_channel() -> None:
+    """#226 has verdicts leaning on colour alone; the nav must not repeat it.
+
+    A rule that merely *exists* is no guard -- declarations restating the `nav a`
+    defaults (`font-weight: 400; border-bottom: 0`) render pixel-identically. So
+    this checks the rule moves some non-colour channel off its baseline value.
+    """
+    body = _rule_body(CURRENT_SELECTOR)
+    assert body is not None, "app.css has no rule selecting the current nav link"
+    baseline = _declarations(_rule_body(BASE_SELECTOR) or "")
+
+    channels = [
+        prop
+        for prop, value in _declarations(body).items()
+        if prop not in UNMARKING_PROPERTIES
+        and baseline.get(prop) != value
+        and _is_visible(prop, value)
+    ]
+    assert channels, (
+        "the current nav link is distinguished by colour alone: "
+        f"{_declarations(body)} leaves every non-colour channel at its `nav a` value"
     )

--- a/tests/test_nav_active_state.py
+++ b/tests/test_nav_active_state.py
@@ -41,6 +41,11 @@ UNMARKING_PROPERTIES = frozenset({
     "margin", "margin-top", "margin-bottom", "margin-left", "margin-right",
 })
 LENGTH = re.compile(r"(?<![\w.])(\d*\.?\d+)(?:px|rem|em|%)?(?![\w.])")
+# A border draws nothing without a style: the used width of `none`/`hidden` is 0,
+# and a bare `border-bottom-width` never gets one.
+BORDER_STYLE = re.compile(
+    r"(?<![\w-])(?:solid|dashed|dotted|double|groove|ridge|inset|outset)(?![\w-])"
+)
 
 
 def _rule_body(selector: str) -> str | None:
@@ -59,13 +64,25 @@ def _declarations(body: str) -> dict[str, str]:
     return decls
 
 
+def _has_positive_length(value: str) -> bool:
+    return any(float(n) > 0 for n in LENGTH.findall(value))
+
+
 def _is_visible(prop: str, value: str) -> bool:
     """Whether the declaration actually renders differently from the nav default."""
+    if prop.endswith("-color"):
+        # Recolouring a channel is not marking it: `text-decoration-color` under
+        # the base `text-decoration: none` tints a line that is never drawn.
+        return False
     if prop == "font-weight":
         return value == "bold" or (value.isdigit() and int(value) > 400)
-    if prop.startswith(("border", "outline")) or prop == "box-shadow":
-        # `border-bottom: 0` and `0px solid var(--accent)` both draw nothing.
-        return any(float(n) > 0 for n in LENGTH.findall(value)) if LENGTH.search(value) else False
+    if prop == "box-shadow":
+        # The one box channel with no style keyword to require.
+        return _has_positive_length(value)
+    if prop.startswith(("border", "outline")):
+        # `border-bottom: 0`, `2px none var(--accent)` and a bare
+        # `border-bottom-width: 2px` all draw nothing.
+        return _has_positive_length(value) and bool(BORDER_STYLE.search(value))
     if prop.startswith("text-decoration"):
         return value not in {"none", "initial"}
     return value not in {"normal", "none", "initial", "inherit", "unset", "auto"}

--- a/tests/test_nav_active_state.py
+++ b/tests/test_nav_active_state.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Regression lock on the nav's active-page marker (#225).
+
+The nav used to render ten identical links, so nothing told you which page you
+were on. The fix marks the current one with `aria-current="page"`.
+
+The links are read back out of the rendered nav rather than hardcoded here, so
+a link added to base.html is covered without touching this file.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from verinote.config import Config  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+CSS_PATH = Path(__file__).resolve().parents[1] / "verinote" / "web" / "static" / "app.css"
+
+NAV_BLOCK = re.compile(r"<nav\b[^>]*>(.*?)</nav>", re.S)
+NAV_ANCHOR = re.compile(r"<a\b([^>]*)>", re.S)
+HREF = re.compile(r'href="([^"]*)"')
+# Any spelling of the attribute counts as a claim of "this is the current page".
+ARIA_CURRENT = re.compile(r'aria-current\s*=\s*"page"')
+
+
+def _client(tmp_path) -> TestClient:
+    cfg = Config(
+        root=tmp_path, db_path=tmp_path / "kb.sqlite",
+        provider="anthropic", model="m", api_key=None, base_url=None,
+    )
+    app = create_app(cfg)
+    client = TestClient(app)
+    store = app.state.store
+    client.fact_id = store.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
+    return client
+
+
+def _nav_links(html: str) -> list[tuple[str, bool]]:
+    """Every nav anchor as (href, is_current), in document order."""
+    block = NAV_BLOCK.search(html)
+    assert block, "the page renders no <nav> at all"
+    links = []
+    for attrs in NAV_ANCHOR.findall(block.group(1)):
+        href = HREF.search(attrs)
+        assert href, f"nav anchor without an href: {attrs!r}"
+        links.append((href.group(1), bool(ARIA_CURRENT.search(attrs))))
+    assert links, "the <nav> renders no links"
+    return links
+
+
+def _current(html: str) -> list[str]:
+    return [href for href, is_current in _nav_links(html) if is_current]
+
+
+def test_each_nav_destination_marks_its_own_link(tmp_path) -> None:
+    client = _client(tmp_path)
+    hrefs = [href for href, _ in _nav_links(client.get("/").text)]
+
+    for href in hrefs:
+        response = client.get(href)
+        assert response.status_code == 200, f"GET {href} -> {response.status_code}"
+        assert _current(response.text) == [href], (
+            f"GET {href} should mark exactly that link as current, "
+            f"got {_current(response.text)}"
+        )
+
+
+def test_dashboard_is_not_current_on_other_pages(tmp_path) -> None:
+    """`/` is a prefix of every path, so a prefix match would light it up everywhere."""
+    client = _client(tmp_path)
+    assert "/" not in _current(client.get("/sources").text)
+
+
+def test_page_outside_the_nav_marks_nothing(tmp_path) -> None:
+    """A fact's provenance page extends base.html but has no nav entry of its own."""
+    client = _client(tmp_path)
+    response = client.get(f"/facts/{client.fact_id}/provenance")
+    assert response.status_code == 200
+    assert _current(response.text) == []
+
+
+def test_stylesheet_styles_the_current_link() -> None:
+    """Without a rule, the attribute is invisible to anyone not using a screen reader."""
+    css = CSS_PATH.read_text(encoding="utf-8")
+    assert re.search(r'nav\s+a\[aria-current\s*=\s*"page"\]', css), (
+        "app.css has no rule selecting the current nav link"
+    )

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -37,8 +37,12 @@ header { display: flex; align-items: center; gap: 1.5rem;
 nav a { color: var(--muted); text-decoration: none; margin-right: 1rem; }
 nav a:hover { color: var(--fg); }
 /* The current page (#225). Colour alone would not carry it -- #226 -- so the
-   weight and the underline mark it on a non-colour channel too. */
-nav a[aria-current="page"] { color: var(--fg); font-weight: 600;
+   weight and the underline mark it on a non-colour channel too. Scoped to the
+   header nav: review.html's <nav class="filters"> marks its own active badge
+   with the same aria-current="page", and an unscoped `nav a[...]` would paint
+   this header-only weight/border/padding onto that badge -- outspecifying its
+   `.badge` pill -- so the rule must not reach any nav outside the header. */
+header nav a[aria-current="page"] { color: var(--fg); font-weight: 600;
   border-bottom: 2px solid var(--accent); padding-bottom: .2rem; }
 main { max-width: 1000px; margin: 0 auto; padding: 1.6rem 1.4rem; }
 main.chooser { max-width: 560px; padding-top: 12vh; }

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -36,6 +36,10 @@ header { display: flex; align-items: center; gap: 1.5rem;
 .brand { font-weight: 700; letter-spacing: .02em; color: var(--fg); text-decoration: none; }
 nav a { color: var(--muted); text-decoration: none; margin-right: 1rem; }
 nav a:hover { color: var(--fg); }
+/* The current page (#225). Colour alone would not carry it -- #226 -- so the
+   weight and the underline mark it on a non-colour channel too. */
+nav a[aria-current="page"] { color: var(--fg); font-weight: 600;
+  border-bottom: 2px solid var(--accent); padding-bottom: .2rem; }
 main { max-width: 1000px; margin: 0 auto; padding: 1.6rem 1.4rem; }
 main.chooser { max-width: 560px; padding-top: 12vh; }
 h1 { font-size: 1.4rem; } h2 { font-size: 1.05rem; margin-top: 1.8rem; }

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -10,17 +10,26 @@
 <body>
   <header>
     <a class="brand" href="/">verinote</a>
+    {% set nav_links = [
+      ("/", "Dashboard"),
+      ("/sources", "Sources"),
+      ("/review", "Review"),
+      ("/workbench", "Workbench"),
+      ("/ask", "Ask"),
+      ("/questions", "Questions"),
+      ("/report", "Report"),
+      ("/analytics", "Analytics"),
+      ("/prompts", "Prompts"),
+      ("/settings", "Settings"),
+    ] %}
+    {# `/` matches exactly; a prefix match there would light Dashboard up on every
+       page. Sub-paths (`/sources/…`) keep their section link current. Pages under
+       no nav entry (e.g. a fact's provenance) leave every link inactive. #}
+    {% set path = request.url.path %}
     <nav>
-      <a href="/">Dashboard</a>
-      <a href="/sources">Sources</a>
-      <a href="/review">Review</a>
-      <a href="/workbench">Workbench</a>
-      <a href="/ask">Ask</a>
-      <a href="/questions">Questions</a>
-      <a href="/report">Report</a>
-      <a href="/analytics">Analytics</a>
-      <a href="/prompts">Prompts</a>
-      <a href="/settings">Settings</a>
+      {% for href, label in nav_links %}
+      <a href="{{ href }}"{% if path == href or (href != "/" and path.startswith(href ~ "/")) %} aria-current="page"{% endif %}>{{ label }}</a>
+      {% endfor %}
     </nav>
   </header>
   <main>


### PR DESCRIPTION
nav 는 링크 10개를 똑같이 렌더해서 지금 어느 페이지를 보고 있는지 알려주지 않았다. 현재 페이지 링크에 `aria-current="page"` 를 붙이고, 스타일로도 구분한다.

**Refs #225** — `Closes` 가 아니다. 이슈의 (a) active state 만 구현했다. **(b) nav 그룹핑, (c) 대기 건수 배지는 후속**이다. 이슈의 "검증" 절이 건수 가시성까지 요구하므로 이 PR 만으로는 이슈가 닫히지 않는다.

## 구현

- `base.html` 의 nav 만 링크 목록 위 for-loop 로 바꿨다. `app.py` **무변경** — Starlette `Jinja2Templates.TemplateResponse` 가 `context.setdefault("request", request)` 를 하고 `app.py` 의 `TemplateResponse` 18곳이 전부 `request` 를 첫 인자로 넘기므로, `request.url.path` 는 이미 모든 템플릿에서 쓸 수 있었다. 이슈가 지목한 "공통 컨텍스트 주입 지점 부재"는 (a) 에는 해당하지 않았다.
- 매칭 규칙: `/` 는 정확 일치만 (prefix 로 하면 전 페이지에서 Dashboard 가 켜진다), 나머지는 `path == href or path.startswith(href + "/")` 로 `/sources/…` 에서 Sources 가 유지된다. nav 항목이 없는 base 상속 페이지(fact provenance)에서는 아무것도 활성이 아니다 — 근거 없이 섹션에 귀속시키지 않는다.
- 표시는 색 + 비색상 채널(굵기·밑줄)을 함께 쓴다. #226 이 열려 있어 색 단독은 금지다. 색은 `var(--*)` 로만 써서 `tests/test_theme.py` 의 팔레트 가드를 지킨다.

## nav 를 쓰지 않는 화면

`kb_select.html` 과 `policy_halted.html` 은 `base.html` 을 상속하지 않으므로 이 개선이 붙지 않는다. 이는 결함이 아니라 **의도**다 — KB 가 선택되지 않은 상태에서는 nav 목적지가 전부 무효이고, 정지(halt) 화면은 fail-closed 라 쓰기 경로로 가는 링크를 주면 안 된다.

다만 관련해서 별개의 문제가 있다: **halt 중에도 GET 은 통과하므로 사용자는 평범한 nav 를 보며 돌아다니게 되는데, 정지 상태가 공통 크롬에 드러나지 않는다.** 이 PR 의 범위 밖이고 별도 이슈로 다룬다.

## 가드가 세 라운드에 걸쳐 메워진 경과

이 PR 이 커밋 3개인 이유이고, 이 레인이 배운 것은 **가드가 선언의 존재가 아니라 렌더 결과를 물어야 한다**는 것이다.

1. `1c7eb04` 최초 구현. 두 가지가 무가드였다. 하위경로 동작은 **커밋 메시지가 주장했을 뿐 테스트가 없었다** — prefix 절을 통째로 지워도 전체 스위트가 green 이었다. 코드가 실제로 지키는 것보다 넓게 주장한 셈이고, 이것 자체가 결함이다. CSS 가드도 규칙이 **존재하는지**만 확인했다.
2. `c6207b6` 하위경로 가드를 추가하고 CSS 가드를 선언 내용 검사로 바꿨다. 이 과정에서 `padding` 을 시각 채널로 잘못 인정해 무효과 뮤턴트가 통과하는 것을 발견해 제외했다 — 0폭 테두리 밑의 padding 은 아무것도 그리지 않는다.
3. `4a8a2eb` `-color` 접미사와 `border-style` 미검사 구멍을 메웠다. `border-bottom: 2px none`, 맨 `border-bottom-width: 2px`, `text-decoration-color` 가 모두 픽셀상 기본 링크와 동일한데 통과했다. 특히 마지막은 **#226 을 고치려는 사람이 "밑줄을 넣는다"고 착각해 쓸 수 있는 값**이라, 색만 바꾸고 가드에서 green 을 받는 것이 정확히 #226 이 막으려는 상황이었다.

## 이 가드가 못 잡는 것

`box-shadow: 0 2px 0 transparent` (투명 그림자, 실제로는 아무것도 그려지지 않음)는 여전히 green 이다. `box-shadow` 분기는 요구할 style 키워드가 없어 길이만 보기 때문이다. `-color` 하위속성과 달리 "투명색을 유일한 표시 수단으로 쓰는" 형태라 실수로 도달할 경로가 없어 보강하지 않았다. `border` 계열은 style 키워드 요구로 막혀 있다.

## 검증

뮤테이션 (모두 `git archive` 사본에서 실행):

| 뮤턴트 | 결과 |
|---|---|
| M1 조건분기 제거 | red |
| M2 전 링크에 무조건 `aria-current` | red |
| M3 루트 예외 없는 `startswith` | red |
| M4 CSS 규칙 삭제 | red |
| M5 prefix 절 삭제 | red |
| M6 `font-weight: 400; border-bottom: 0` | red |
| M6b `border-bottom: 0px solid var(--accent)` | red |
| M6c `border-bottom: 2px none var(--accent)` | red |
| M6d `border-bottom-width: 2px` 단독 | red |
| M6e `text-decoration-color` 단독 | red |
| M7 `text-decoration: underline` 단독 | **green** (밑줄만으로 표시하는 정당한 구현을 막지 않는다) |

전체 스위트 `1235 passed`, `ruff check .` clean.

Refs #225
