### PR TITLE
fix(#261): order answer buckets by question number, not by digit sort

### DIFF
--- a/tests/test_answer_qid_order.py
+++ b/tests/test_answer_qid_order.py
@@ -72,10 +72,13 @@ def test_wirelog_answers_order_across_the_hundreds_boundary():
 # from reaching the answer collectors. Ordering it must not cost the report its
 # `ok` (duckdb turns the exception into an internal engine error, which flips the
 # review gate) nor raise out of wirelog, which collects outside any try.
-_NON_NUMERIC_POLICY = (
-    _RELATION_DECL + ".decl answer_qfoo(value: symbol)\n"
-    'answer_qfoo(O) :- relation("Ada", "born_in", O).\n'
-)
+#
+# `12abc` is here for the anchor: a qid that *starts* numeric is the only shape an
+# unanchored `[0-9]+` match still calls numeric, and `int("12abc")` then raises.
+# All-alphabetic qids like `foo` never reach that branch, so they cannot cover it.
+_NON_NUMERIC_QIDS = ["foo", "12abc"]
+_NON_NUMERIC_POLICY = _RELATION_DECL + _query_for(_NON_NUMERIC_QIDS)
+_NON_NUMERIC_ANSWERS = ["q12abc: London", "qfoo: London"]
 
 
 def test_duckdb_keeps_a_non_numeric_answer_predicate_clean():
@@ -83,7 +86,7 @@ def test_duckdb_keeps_a_non_numeric_answer_predicate_clean():
     rep = run_check_duckdb(_FACTS, policy_dl=_NON_NUMERIC_POLICY)
 
     assert rep.ok is True
-    assert rep.answers == ["qfoo: London"]
+    assert rep.answers == _NON_NUMERIC_ANSWERS
 
 
 def test_wirelog_keeps_a_non_numeric_answer_predicate_clean():
@@ -91,18 +94,13 @@ def test_wirelog_keeps_a_non_numeric_answer_predicate_clean():
     rep = _wirelog_check(policy_dl=_NON_NUMERIC_POLICY)
 
     assert rep.ok is True
-    assert rep.answers == ["qfoo: London"]
+    assert rep.answers == _NON_NUMERIC_ANSWERS
 
 
-_MIXED_POLICY = (
-    _RELATION_DECL
-    + _query_for(range(1, 13))
-    + ".decl answer_qfoo(value: symbol)\n"
-    'answer_qfoo(O) :- relation("Ada", "born_in", O).\n'
-    ".decl answer_qbar(value: symbol)\n"
-    'answer_qbar(O) :- relation("Ada", "born_in", O).\n'
+_MIXED_POLICY = _RELATION_DECL + _query_for(
+    list(range(1, 13)) + ["foo", "bar", "12abc"]
 )
-_MIXED_ORDER = [f"q{n}" for n in range(1, 13)] + ["qbar", "qfoo"]
+_MIXED_ORDER = [f"q{n}" for n in range(1, 13)] + ["q12abc", "qbar", "qfoo"]
 
 
 def test_duckdb_sorts_numeric_answers_before_non_numeric_ones():

--- a/tests/test_answer_qid_order.py
+++ b/tests/test_answer_qid_order.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Answer buckets are ordered by question number, not by how the digits sort.
+
+Every ordering guard here uses more than nine questions on purpose: with q1..q9
+string order and numeric order agree, so a smaller fixture would pass against
+the very bug this file locks.
+"""
+
+import pytest
+
+from verinote.engine.duckdb_backend import run_check_duckdb
+from verinote.engine.wirelog import compile_dl, run_check
+
+_FACTS = [{"subject": "Ada", "relation": "born_in", "object": "London"}]
+_RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+
+
+def _duckdb():
+    return pytest.importorskip("duckdb")
+
+
+def _pyrewire():
+    return pytest.importorskip("pyrewire")
+
+
+def _query_for(qids):
+    """Build query rules answering `born_in` once per question id."""
+    return "".join(
+        f".decl answer_q{qid}(value: symbol)\n"
+        f'answer_q{qid}(O) :- relation("Ada", "born_in", O).\n'
+        for qid in qids
+    )
+
+
+def _qids_in_order(rep):
+    return [answer.split(":")[0] for answer in rep.answers]
+
+
+def _wirelog_check(query_dl=None, policy_dl=None):
+    return run_check(compile_dl(_FACTS), policy_dl=policy_dl, query_dl=query_dl)
+
+
+def test_duckdb_answers_order_by_question_number():
+    _duckdb()
+    rep = run_check_duckdb(_FACTS, query_dl=_query_for(range(1, 13)))
+
+    assert _qids_in_order(rep) == [f"q{n}" for n in range(1, 13)]
+
+
+def test_duckdb_answers_order_across_the_hundreds_boundary():
+    _duckdb()
+    rep = run_check_duckdb(_FACTS, query_dl=_query_for([9, 10, 99, 100, 101]))
+
+    assert _qids_in_order(rep) == ["q9", "q10", "q99", "q100", "q101"]
+
+
+def test_wirelog_answers_order_by_question_number():
+    _pyrewire()
+    rep = _wirelog_check(query_dl=_query_for(range(1, 13)))
+
+    assert _qids_in_order(rep) == [f"q{n}" for n in range(1, 13)]
+
+
+def test_wirelog_answers_order_across_the_hundreds_boundary():
+    _pyrewire()
+    rep = _wirelog_check(query_dl=_query_for([9, 10, 99, 100, 101]))
+
+    assert _qids_in_order(rep) == ["q9", "q10", "q99", "q100", "q101"]
+
+
+# A policy is user-authored, so nothing stops a `answer_q<non-numeric>` relation
+# from reaching the answer collectors. Ordering it must not cost the report its
+# `ok` (duckdb turns the exception into an internal engine error, which flips the
+# review gate) nor raise out of wirelog, which collects outside any try.
+_NON_NUMERIC_POLICY = (
+    _RELATION_DECL + ".decl answer_qfoo(value: symbol)\n"
+    'answer_qfoo(O) :- relation("Ada", "born_in", O).\n'
+)
+
+
+def test_duckdb_keeps_a_non_numeric_answer_predicate_clean():
+    _duckdb()
+    rep = run_check_duckdb(_FACTS, policy_dl=_NON_NUMERIC_POLICY)
+
+    assert rep.ok is True
+    assert rep.answers == ["qfoo: London"]
+
+
+def test_wirelog_keeps_a_non_numeric_answer_predicate_clean():
+    _pyrewire()
+    rep = _wirelog_check(policy_dl=_NON_NUMERIC_POLICY)
+
+    assert rep.ok is True
+    assert rep.answers == ["qfoo: London"]
+
+
+_MIXED_POLICY = (
+    _RELATION_DECL
+    + _query_for(range(1, 13))
+    + ".decl answer_qfoo(value: symbol)\n"
+    'answer_qfoo(O) :- relation("Ada", "born_in", O).\n'
+    ".decl answer_qbar(value: symbol)\n"
+    'answer_qbar(O) :- relation("Ada", "born_in", O).\n'
+)
+_MIXED_ORDER = [f"q{n}" for n in range(1, 13)] + ["qbar", "qfoo"]
+
+
+def test_duckdb_sorts_numeric_answers_before_non_numeric_ones():
+    _duckdb()
+    rep = run_check_duckdb(_FACTS, policy_dl=_MIXED_POLICY)
+
+    assert _qids_in_order(rep) == _MIXED_ORDER
+
+
+def test_wirelog_sorts_numeric_answers_before_non_numeric_ones():
+    _pyrewire()
+    rep = _wirelog_check(policy_dl=_MIXED_POLICY)
+
+    assert _qids_in_order(rep) == _MIXED_ORDER

--- a/tests/test_answer_qid_order.py
+++ b/tests/test_answer_qid_order.py
@@ -9,7 +9,7 @@ the very bug this file locks.
 import pytest
 
 from verinote.engine.duckdb_backend import run_check_duckdb
-from verinote.engine.wirelog import compile_dl, run_check
+from verinote.engine.wirelog import answer_bucket_sort_key, compile_dl, run_check
 
 _FACTS = [{"subject": "Ada", "relation": "born_in", "object": "London"}]
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
@@ -115,3 +115,22 @@ def test_wirelog_sorts_numeric_answers_before_non_numeric_ones():
     rep = _wirelog_check(policy_dl=_MIXED_POLICY)
 
     assert _qids_in_order(rep) == _MIXED_ORDER
+
+
+# `answer_bucket_sort_key` calls `int(qid)` for every all-digit qid, but `int()`
+# refuses a string longer than `sys.get_int_max_str_digits()` (4300 by default)
+# and raises ValueError. A qid is user-authored, so an `answer_q<thousands of
+# digits>` predicate reaches the sort: it has to land in the trailing bucket like
+# any malformed qid, not blow up the whole answer ordering. 5000 clears 4300.
+_OVERLONG_NUMERIC_QID = "1" * 5000
+
+
+def test_overlong_numeric_qid_sorts_last_instead_of_raising():
+    key = answer_bucket_sort_key(_OVERLONG_NUMERIC_QID)
+
+    assert key[0] == answer_bucket_sort_key("12abc")[0]
+    assert key[0] > answer_bucket_sort_key("9999")[0]
+
+
+def test_answer_bucket_sort_key_orders_small_numbers_numerically():
+    assert answer_bucket_sort_key("2")[1] < answer_bucket_sort_key("10")[1]

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 from verinote.engine.terms import Atom, Compound, StringLit
 from verinote.pipeline.query import query_path
-from verinote.pipeline.report_trace import report_trace
+from verinote.pipeline.report_trace import AnswerTrace, _qid_sort_key, report_trace
 from verinote.pipeline.verify import verify
 from verinote.store import Store, db as store_db
 
@@ -360,3 +360,27 @@ def test_report_trace_dedupes_render_alike_heads_by_engine_identity(tmp_path):
         ("1", "f(x)", [fact_id]),
         ("1", "f(x)", [fact_id]),
     ]
+
+
+def test_report_trace_sorts_an_overlong_qid_last_without_crashing():
+    """A user-authored `answer_q<thousands of digits>` rule must not 500 /report.
+
+    `trace.qid` is the `[0-9]+` capture of `_ANSWER_RE`, so a policy can make it
+    longer than `int()` accepts (`sys.get_int_max_str_digits()`, 4300 by default).
+    The answer sort has to survive that, parking the answer after the numbered
+    ones the way the query-answer line's `answer_bucket_sort_key` already does.
+    """
+    overlong = "1" * 5000
+
+    # The guard itself: no raise, and a trailing bucket that outranks any number.
+    assert _qid_sort_key(overlong) > _qid_sort_key("999999")
+
+    def _trace(qid: str, value: str) -> AnswerTrace:
+        return AnswerTrace(
+            qid=qid, value=value, display_value=value, facts=(), conflicted=False
+        )
+
+    traces = [_trace(overlong, "z"), _trace("10", "b"), _trace("2", "a")]
+    ordered = sorted(traces, key=lambda t: (*_qid_sort_key(t.qid), t.value))
+
+    assert [t.qid for t in ordered] == ["2", "10", overlong]

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -41,6 +41,7 @@ from verinote.engine.wirelog import (
     DEFAULT_POLICY,
     NO_FINDINGS_TEXT,
     FindingRow,
+    answer_bucket_sort_key,
 )
 
 _ERROR_PREFIX = "error_"
@@ -459,7 +460,9 @@ def _collect_report(
 
     answers = [
         f"q{qid}: {', '.join(sorted(vals))}"
-        for qid, vals in sorted(answers_by_q.items())
+        for qid, vals in sorted(
+            answers_by_q.items(), key=lambda item: answer_bucket_sort_key(item[0])
+        )
     ]
     rendered_errors = sorted(f"ERROR {derived.text}" for derived in errors)
     rendered_warnings = sorted(f"WARN {derived.text}" for derived in warnings)

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -39,6 +39,20 @@ from verinote.engine.terms import StringLit, escape_string_value
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
 _ANSWER_PREFIX = "answer_q"
+# A qid is the question's INTEGER primary key rendered as text, so it has to sort
+# by number: plain string order puts q10 ahead of q2. `[0-9]+` matches what
+# `_ANSWER_DECL` accepts — `str.isdigit()` would let through digits like "²" that
+# `int()` then rejects. A policy is user-authored, so a non-numeric
+# `answer_q*` relation does reach here; park those after the numbered ones
+# instead of raising.
+_NUMERIC_QID = re.compile(r"[0-9]+\Z")
+
+
+def answer_bucket_sort_key(qid: str) -> tuple[int, int, str]:
+    """Order answer buckets by question number, not by how the digits sort."""
+    if _NUMERIC_QID.fullmatch(qid):
+        return (0, int(qid), qid)
+    return (1, 0, qid)
 
 # Shipped default policy. `verinote init` scaffolds a copy to
 # `<root>/policy/logic-policy.dl`; edit that copy per-KB.
@@ -524,7 +538,10 @@ def run_check(
     errors.sort()
     warnings.sort()
     answers = [
-        f"q{qid}: {', '.join(sorted(vals))}" for qid, vals in sorted(answers_by_q.items())
+        f"q{qid}: {', '.join(sorted(vals))}"
+        for qid, vals in sorted(
+            answers_by_q.items(), key=lambda item: answer_bucket_sort_key(item[0])
+        )
     ]
     # A dead-rule note is a statement about the *policy*, not a derived tuple:
     # nothing fired, so there is no row behind it and it gets no `FindingRow`.

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -51,7 +51,14 @@ _NUMERIC_QID = re.compile(r"[0-9]+\Z")
 def answer_bucket_sort_key(qid: str) -> tuple[int, int, str]:
     """Order answer buckets by question number, not by how the digits sort."""
     if _NUMERIC_QID.fullmatch(qid):
-        return (0, int(qid), qid)
+        # All-digits does not guarantee `int()` succeeds: past
+        # `sys.get_int_max_str_digits()` (4300 by default) it raises ValueError.
+        # A qid is user-authored, so park a pathologically long number in the
+        # trailing bucket alongside malformed qids rather than crash the sort.
+        try:
+            return (0, int(qid), qid)
+        except ValueError:
+            pass
     return (1, 0, qid)
 
 # Shipped default policy. `verinote init` scaffolds a copy to

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -147,12 +147,25 @@ def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
                     conflicted=any(fact.conflicted for fact in trace_facts),
                 )
             )
-    return tuple(sorted(traces, key=lambda trace: (int(trace.qid), trace.value)))
+    return tuple(
+        sorted(traces, key=lambda trace: (*_qid_sort_key(trace.qid), trace.value))
+    )
 
 
 def _answer_qid(predicate: str) -> str | None:
     match = _ANSWER_RE.fullmatch(predicate)
     return match.group("qid") if match else None
+
+
+def _qid_sort_key(qid: str) -> tuple[int, int]:
+    # `_ANSWER_RE` guarantees all-digits but not that `int()` accepts them: past
+    # `sys.get_int_max_str_digits()` (4300 by default) it raises ValueError. Mirror
+    # `answer_bucket_sort_key`: park a pathologically long qid in a trailing bucket
+    # so it sorts after every parseable one instead of 500ing /report mid-sort.
+    try:
+        return (0, int(qid))
+    except ValueError:
+        return (1, 0)
 
 
 def _direct_relation_atom(body: tuple[AtomExpr | Comparison, ...]) -> AtomExpr | None:


### PR DESCRIPTION
Closes #261

The answers section sorted qid **strings**, so past nine questions `q10` came before `q2`. Both engine backends shared the bug.

## The issue's safety claim is wrong — this is the core of the PR

The issue says the parser enforces `answer_q[0-9]+`, so `int()` is safe. It is not. `_ANSWER_DECL` only checks the **LLM-proposed query snippet** inside `validate_query()`; both answer collectors filter the combined `policy_dl + query_dl` program with nothing but `startswith("answer_q")`. **A policy is user-authored**, so a non-numeric qid does reach the sort. Measured: a policy declaring `.decl answer_qfoo(value: symbol)` returns `ok=True, answers=['qfoo: London']` today.

Taking the issue's proposed `key=lambda kv: int(kv[0])` would have broken policies that pass right now:

- **duckdb**: the collector runs inside `except Exception -> _internal_engine_error`, so the report becomes `ok=False` with `"ERROR internal engine error: invalid literal for int()"` — **the review gate flips**.
- **wirelog**: the comprehension sits outside any `try` (the `try` wraps only the pyrewire session), so the `ValueError` traceback escapes.

Fixing a display-order bug would have taken down the verdict itself. The reviewer confirmed both failure modes by running them independently.

## The fix

One shared key function in `wirelog.py`, used at both sort sites:

```python
_NUMERIC_QID = re.compile(r"[0-9]+\Z")

def answer_bucket_sort_key(qid: str) -> tuple[int, int, str]:
    if _NUMERIC_QID.fullmatch(qid):
        return (0, int(qid), qid)
    return (1, 0, qid)
```

- Sort sites: `engine/duckdb_backend.py` and `engine/wirelog.py`. duckdb already imports from wirelog, so there is **no new module and no change to the dependency direction**; the key function has exactly one owner.
- **Render format `q{qid}:` is unchanged** — only the sort key moved. Zero migration. Zero-padding was rejected: qid is `questions.id`, an INTEGER primary key, and `ask.py`'s `^q\d+:\s*` plus ~20 existing assertions are tied to the current format.
- **`str.isdigit()` is deliberately not used**: `"²".isdigit()` is True but `int("²")` raises. `[0-9]+` matches the "numeric qid" definition `_ANSWER_DECL` and `_ANSWER_RE` already use, so the two cannot drift.
- **Why `q12abc` sorts as non-numeric rather than parsing a `12` prefix**: prefix-parsing would fold `answer_q12` and `answer_q12abc` into **the same bucket, merging answers from two different predicates under one `q12:` label** — worse than a wrong order. qid renders a question's INTEGER PK, and `12abc` is not any PK. Placing it after the numbered buckets is deterministic and safe.

## Regression guards — `tests/test_answer_qid_order.py` (new file)

Every ordering guard uses **more than nine questions** (1..12, and the boundary 9/10/99/100/101). With q1..q9 string order and numeric order agree, so a smaller fixture would pass against the very bug being fixed. Guards assert the **actual output order**, not that a sort function was called.

### Mutation evidence

| # | Mutant | Result |
|---|---|---|
| M1 | revert the duckdb sort site **only** | 3 failed, 5 passed — duckdb guards red, **wirelog guards stay green** |
| M2 | revert the wirelog sort site **only** | 3 failed, 5 passed — wirelog guards red, **duckdb guards stay green** |
| M3 | delete the non-numeric branch | 4 failed (`invalid literal for int(): 'foo'`) |
| M4 | **the issue's proposed naive `int()`** at both sites | 4 failed, 4 passed — all four ordering guards green, **only the non-numeric guards red** |
| M5 | swap the numeric / non-numeric ranks | 2 failed (`At index 0 diff: 'q12abc' != 'q1'`) |

**M1 and M2 staying green for each other** is the proof that the two sort sites are locked independently — a guard set that passes when only one site is fixed would not protect both.

**M4 is the sole proof that the non-numeric guards earn their place**: the ordering guards cannot tell the difference, only the non-numeric ones can.

## The second lesson: the anchor guard

Review found that loosening `_NUMERIC_QID` to `r"[0-9]+"` with `.match` revives `ValueError: invalid literal for int() with base 10: '12abc'` — **while all eight guards stayed green.** The non-numeric guards were all purely alphabetic (`foo`/`bar`), and an alphabetic qid never reaches the branch the anchor defends. Five mutations had passed because every one of them touched a line of code.

> **Guard strength is input coverage x assertion strength, and line-level mutation audits only the second factor.** Anchors are especially exposed: without one, nothing about the output changes until that single shape arrives, so even outcome-based guards miss it.

The second commit adds `q12abc` alongside the existing `foo`/`bar` (it does not replace them — M3 still fails on `'foo'`, so the all-alphabetic case remains covered). With it, the loosened-anchor mutant goes red on four guards.

## Verification

- `pytest tests -q -rs` -> **1237 passed**, no skip section (skip 0)
- `ruff check .` -> All checks passed

## Follow-up (not filed here)

The qid format for `answer_q` is defined **twice and inconsistently**: the engine collectors accept anything via `startswith("answer_q")`, while the contract (`_ANSWER_DECL`, `_ANSWER_RE`) requires `answer_q[0-9]+\Z`. The non-numeric fallback branch in this PR is a downstream symptom of that split, as is the fact that a non-numeric qid is silently dropped from Traceability while a `qfoo: ` prefix leaks to the user. Whether a non-numeric `answer_q*` is an answer at all or a policy-validation error is a contract question, not a display-order one, and is out of scope here. It is being filed separately as a single issue so the split itself gets addressed rather than one symptom at a time.
