### PR TITLE
fix(#240): resume a rolled-back extraction job, and stop reviving superseded ones

### DIFF
--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -188,6 +188,43 @@ def test_sync_resumes_rolled_back_job_without_redoing_done_chunks(
     assert "sync complete: 5 candidate(s)" in out
 
 
+def test_sync_reports_a_resumed_run_that_fails_everything_as_failed_not_incomplete(
+    tmp_path, monkeypatch, capsys
+):
+    """A resumed job's OWN history must not soften this run's own total failure.
+
+    `_halted_job` leaves a job with one chunk done and zero failed (a clean
+    halt, not a chunk failure) — eligible for resume. If THIS run then fails
+    every remaining chunk, the job's cumulative `completed_chunks` is still 1
+    (from before), but this run completed none and produced nothing: the
+    "sync failed" / "sync incomplete" choice must be judged on what THIS run
+    did, not smoothed over by a resumed job's earlier, unrelated success.
+    """
+    job_id = _halted_job(tmp_path, monkeypatch)
+
+    class _AlwaysFailingClient:
+        name = "fake"
+
+        def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+            raise LLMError("provider down")
+
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _AlwaysFailingClient())
+
+    assert cli.main(["sync"]) == 1
+
+    jobs = _jobs(tmp_path)
+    assert [int(job["id"]) for job in jobs] == [job_id]  # still resumed, not replaced
+    assert int(jobs[0]["completed_chunks"]) == 1  # unchanged: this run finished none
+
+    out, err = capsys.readouterr()
+    # This run's own contribution is honestly zero, not the job's stale total.
+    assert "0 candidate(s) this run" in out
+    assert f"resumed job #{job_id}: 1 candidate(s) in total" in out
+    # The judged-on-this-run-alone outcome: every chunk THIS run touched failed.
+    assert "sync failed" in err
+    assert "sync incomplete" not in err
+
+
 # --- the chunk a resume can never reach -------------------------------------
 
 
@@ -459,6 +496,27 @@ def test_sync_leaves_a_running_job_alone(tmp_path, monkeypatch, capsys):
     store.close()
     err = capsys.readouterr().err
     assert f"extraction job #{job_id} is already running" in err
+
+
+def test_sync_skips_a_job_claimed_between_plan_and_process(tmp_path, monkeypatch, capsys):
+    """Plan sees `pending`; another worker wins the claim first; sync skips cleanly (#240).
+
+    The plan-time `busy_job_id` branch only catches a job already `running` when the
+    plan is drawn. A job still `pending` at plan time can be claimed by a competing
+    worker in the window before `process_extraction_job` runs; the raised
+    `ExtractionJobBusyError` must be the same skip, never a crash or a failure.
+    """
+    job_id = _halted_job(tmp_path, monkeypatch)
+    monkeypatch.setattr(Store, "claim_pending_extraction_job", lambda self, jid: False)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RefusingClient())
+
+    assert cli.main(["sync"]) == 0  # skipped cleanly: no crash, no non-zero exit
+
+    err = capsys.readouterr().err
+    assert f"extraction job #{job_id} is already running" in err
+    jobs = _jobs(tmp_path)
+    assert [int(job["id"]) for job in jobs] == [job_id]  # no replacement job created
+    assert jobs[0]["status"] == "pending"  # left untouched for its real owner
 
 
 # --- D, F, G: the superseded job is dead, and all three readers agree --------

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -23,7 +23,7 @@ import pytest
 
 import verinote.cli as cli
 from verinote.engine import DEFAULT_POLICY
-from verinote.llm.base import ExtractedFact
+from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline import create_chunked_extraction_job
 from verinote.pipeline.policy_state import POLICY_RELPATH
 from verinote.store import Store
@@ -54,10 +54,17 @@ class _RecordingClient:
 
     name = "fake"
 
-    def __init__(self, *, delete_policy_on_call: int | None = None, policy_path=None):
+    def __init__(
+        self,
+        *,
+        delete_policy_on_call: int | None = None,
+        policy_path=None,
+        fail_on_call: int | None = None,
+    ):
         self.seen: list[str] = []
         self._delete_on = delete_policy_on_call
         self._policy_path = policy_path
+        self._fail_on = fail_on_call
 
     @property
     def markers(self) -> list[str]:
@@ -65,6 +72,8 @@ class _RecordingClient:
 
     def extract_facts(self, *, source_text: str, schema_hint: str = ""):
         self.seen.append(source_text)
+        if self._fail_on is not None and len(self.seen) == self._fail_on:
+            raise LLMError("provider down")  # transient: the chunk goes `failed`
         if self._delete_on is not None and len(self.seen) == self._delete_on:
             self._policy_path.unlink()
         return [ExtractedFact(source_text.split()[0], "seen_in", "source", 0.9)]
@@ -179,6 +188,49 @@ def test_sync_resumes_rolled_back_job_without_redoing_done_chunks(
     assert "sync complete: 5 candidate(s)" in out
 
 
+# --- the chunk a resume can never reach -------------------------------------
+
+
+def test_sync_retries_a_chunk_that_failed_before_the_halt(tmp_path, monkeypatch):
+    """A `failed` chunk must not be stranded by resuming (regression, review).
+
+    `reset_running_chunks` rewinds only `running`; `next_pending_chunk` claims
+    only `pending`. A chunk left `failed` by a transient provider error is
+    NEITHER, so a resumed job walks straight past it and calls the source done.
+    Its text never reaches the LLM again and the facts it would have produced are
+    lost silently — `sync` exits 0 and the job reads `done`.
+
+    Before this branch, re-syncing rebuilt the job from scratch and the failed
+    chunk went out again. Resuming removed that recovery path, so the resume
+    predicate has to decline any job carrying a failed chunk and let the old
+    full-re-extraction behaviour stand.
+    """
+    _ingest(tmp_path, monkeypatch)
+    policy = tmp_path / POLICY_RELPATH
+    # `alpha` lands, `bravo` hits a transient provider error, `charlie` halts.
+    first = _RecordingClient(
+        fail_on_call=2, delete_policy_on_call=3, policy_path=policy
+    )
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: first)
+    assert cli.main(["sync"]) == 2
+    stalled = _jobs(tmp_path)[0]
+    assert stalled["status"] == "pending"
+    assert int(stalled["completed_chunks"]) == 1
+    assert int(stalled["failed_chunks"]) == 1  # `bravo`, and nothing will retry it
+    policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+
+    second = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: second)
+    assert cli.main(["sync"]) == 0
+
+    # THE ASSERTION: the failed chunk was tried again. Which route delivers it —
+    # a fresh job or a retry inside the old one — is not this test's business.
+    assert "bravo" in second.markers
+    store = _store(tmp_path)
+    assert {f["subject"] for f in store.facts()} == set(MARKERS)
+    store.close()
+
+
 # --- B, C: the reverse — a job that no longer describes the work is replaced --
 
 
@@ -262,6 +314,97 @@ def test_sync_starts_a_new_job_when_the_artifact_changed_but_the_text_did_not(
     newest = next(job for job in jobs if int(job["id"]) == max(int(j["id"]) for j in jobs))
     assert int(newest["artifact_id"]) == new_artifact_id
     assert client.markers == list(MARKERS)  # nothing carried over from the old job
+
+
+def test_sync_re_extracts_a_source_whose_job_already_finished(tmp_path, monkeypatch):
+    """`pending` is the only resumable status — a `done` job is a decided outcome.
+
+    Sole guard for the status condition. One job, everything else matching, so
+    nothing else can reject it: drop the status check and `sync` resumes a job
+    with no pending chunks, finds nothing to do, and quietly becomes a no-op for
+    a source the user just asked to re-sync.
+    """
+    _ingest(tmp_path, monkeypatch)
+    first = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: first)
+    assert cli.main(["sync"]) == 0
+    finished = _jobs(tmp_path)[0]
+    assert finished["status"] == "done"
+    assert int(finished["failed_chunks"]) == 0
+
+    second = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: second)
+    assert cli.main(["sync"]) == 0
+
+    assert second.markers == list(MARKERS)  # re-syncing still re-extracts
+    job_ids = [int(job["id"]) for job in _jobs(tmp_path)]
+    assert len(job_ids) == 2
+    assert max(job_ids) != int(finished["id"])
+
+
+def test_sync_ignores_an_older_resumable_job_under_a_newer_one(tmp_path, monkeypatch):
+    """Sole guard for "newest job only" on the planning side.
+
+    The source carries an abandoned, perfectly resumable `pending` job *and* a
+    newer finished one. Only the newest job describes the source's current
+    analysis; reach past it to the older row and `sync` resumes work that a later
+    job already superseded, skipping the chunk that job had finished.
+    """
+    _ingest(tmp_path, monkeypatch)
+    policy = tmp_path / POLICY_RELPATH
+    stalled = _RecordingClient(delete_policy_on_call=2, policy_path=policy)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: stalled)
+    assert cli.main(["sync"]) == 2  # job #1: `alpha` done, rolled back to pending
+    policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+    store = _store(tmp_path)
+    source_id = int(store.sources()[0]["id"])
+    newer_job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        artifact_id=int(store.latest_source_text_artifact(source_id)["id"]),
+        source_text=_body(),
+        provider="anthropic",
+        model="m",
+        chunk_chars=60,
+        chunk_overlap_chars=0,
+    )
+    store.finish_extraction_job(newer_job_id)
+    store.close()
+
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+    assert cli.main(["sync"]) == 0
+
+    # The newest job is `done`, so this is a fresh extraction — not a resume of
+    # the stale job, which would have skipped `alpha`.
+    assert client.markers == list(MARKERS)
+    job_ids = [int(job["id"]) for job in _jobs(tmp_path)]
+    assert len(job_ids) == 3
+    assert max(job_ids) > newer_job_id
+
+
+def test_sync_starts_a_new_job_when_the_provider_changed(tmp_path, monkeypatch):
+    """Sole guard for the PROVIDER half of the provider/model condition.
+
+    The model name is unchanged, so a check that compares only the model waves
+    this through. Model names are not globally unique — the same string is served
+    by more than one provider — and a job resumed across that switch keeps a
+    `provider` column describing work the other provider did.
+    """
+    old_job_id = _halted_job(tmp_path, monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")  # same model name, new provider
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    job_ids = [int(job["id"]) for job in jobs]
+    assert len(job_ids) == 2
+    assert old_job_id != max(job_ids)
+    assert client.markers == list(MARKERS)  # nothing carried over
+    newest = next(job for job in jobs if int(job["id"]) == max(job_ids))
+    assert newest["provider"] == "openai" and newest["model"] == "m"
 
 
 def test_sync_starts_a_new_job_when_the_model_changed(tmp_path, monkeypatch):

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: MPL-2.0
+"""A rolled-back job is resumed, and a superseded one is left for dead (#240, #242).
+
+Two failures met at the same line of `cmd_sync`, which used to call
+`create_chunked_extraction_job` unconditionally:
+
+* #240 — a job halted mid-flight rolls back to `pending` with its finished chunks
+  intact, and every resume mechanism already works. Nothing asked for it, so the
+  next `sync` built a fresh job and paid the LLM again for chunks that were
+  already done.
+* #242 — the abandoned `pending` row is never cleaned up, so the UI launcher
+  revives it, the Sources page polls for it forever, and the re-analyse button
+  409s on it.
+
+WHAT THESE TESTS MEASURE IS THE CHUNK TEXT THE CLIENT SAW, not which branch ran.
+"Resume was taken" is cheap to satisfy and says nothing: a resume that re-sends
+chunk zero costs exactly what the bug cost. So the recording client below keeps
+every `source_text` it was handed, and the load-bearing assertion is that a
+finished chunk's text is absent from the second run.
+"""
+
+import pytest
+
+import verinote.cli as cli
+from verinote.engine import DEFAULT_POLICY
+from verinote.llm.base import ExtractedFact
+from verinote.pipeline import create_chunked_extraction_job
+from verinote.pipeline.policy_state import POLICY_RELPATH
+from verinote.store import Store
+
+MARKERS = ("alpha", "bravo", "charlie", "delta", "echo", "foxtrot")
+SECOND_MARKERS = ("golf", "hotel", "india", "juliett", "kilo", "lima")
+
+
+def _body(markers=MARKERS) -> str:
+    """Six paragraphs, each its own chunk under the 60-char chunk size below."""
+    return "\n\n".join(f"{marker} " + ("x " * 20) for marker in markers)
+
+
+def _env(monkeypatch, tmp_path, *, model: str = "m") -> None:
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+    monkeypatch.setenv("VERINOTE_MODEL", model)
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "60")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+
+
+class _RecordingClient:
+    """Records the text of every chunk it is asked to extract.
+
+    One fact per chunk, keyed on the chunk's leading marker, so a re-sent chunk
+    is visible in `markers` even though the store would dedupe its fact away.
+    """
+
+    name = "fake"
+
+    def __init__(self, *, delete_policy_on_call: int | None = None, policy_path=None):
+        self.seen: list[str] = []
+        self._delete_on = delete_policy_on_call
+        self._policy_path = policy_path
+
+    @property
+    def markers(self) -> list[str]:
+        return [text.split()[0] for text in self.seen]
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        self.seen.append(source_text)
+        if self._delete_on is not None and len(self.seen) == self._delete_on:
+            self._policy_path.unlink()
+        return [ExtractedFact(source_text.split()[0], "seen_in", "source", 0.9)]
+
+
+class _RefusingClient:
+    """Fails the test loudly if extraction is attempted at all."""
+
+    name = "fake"
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        raise AssertionError(f"extraction must not run; got chunk {source_text!r}")
+
+
+class _ThreadRecorder:
+    """Stands in for `threading` inside `verinote.web.app`.
+
+    Replacing the module reference in the app's namespace (not the real
+    `threading` module) makes "did the launcher start a worker?" a synchronous,
+    exact question — no sleeps, no joins, no flake.
+    """
+
+    def __init__(self):
+        self.started: list[str] = []
+
+    def Thread(self, *, target, name, daemon):  # noqa: N802 - mimics threading.Thread
+        recorder = self
+
+        class _Handle:
+            def start(self) -> None:
+                recorder.started.append(name)
+
+        return _Handle()
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def _ingest(tmp_path, monkeypatch, *, body: str = "", init: bool = True) -> None:
+    """Scaffold a KB and register `doc.txt` as a source with a text artifact."""
+    if init:
+        _env(monkeypatch, tmp_path)
+        assert cli.main(["init"]) == 0
+    source = tmp_path / "doc.txt"
+    source.write_text(body or _body(), encoding="utf-8")
+    assert cli.main(["ingest", str(source)]) == 0
+
+
+def _jobs(tmp_path) -> list:
+    store = _store(tmp_path)
+    try:
+        return list(store.source_extraction_jobs())
+    finally:
+        store.close()
+
+
+def _halted_job(tmp_path, monkeypatch) -> int:
+    """Drive a real mid-job halt: chunk `alpha` lands, then the policy vanishes.
+
+    Uses the production halt path rather than hand-writing a `pending` row, so the
+    fixture cannot drift away from the state `_halt_extraction_job` really leaves.
+    """
+    _ingest(tmp_path, monkeypatch)
+    policy = tmp_path / POLICY_RELPATH
+    client = _RecordingClient(delete_policy_on_call=2, policy_path=policy)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 2  # halted, rolled back to pending
+
+    jobs = _jobs(tmp_path)
+    assert len(jobs) == 1
+    assert jobs[0]["status"] == "pending"
+    assert int(jobs[0]["total_chunks"]) == len(MARKERS)
+    assert int(jobs[0]["completed_chunks"]) == 1
+    policy.write_text(DEFAULT_POLICY, encoding="utf-8")  # recovery
+    return int(jobs[0]["id"])
+
+
+# --- A: the fix itself — resume, and do not redo the finished chunk ----------
+
+
+def test_sync_resumes_rolled_back_job_without_redoing_done_chunks(
+    tmp_path, monkeypatch, capsys
+):
+    job_id = _halted_job(tmp_path, monkeypatch)
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    assert [int(job["id"]) for job in jobs] == [job_id]  # resumed, not replaced
+    assert jobs[0]["status"] == "done"
+    # THE ASSERTION THIS FILE EXISTS FOR: the finished chunk never reached the LLM
+    # again. A resume that re-sends it has fixed nothing.
+    assert "alpha" not in client.markers
+    assert client.markers == list(MARKERS[1:])
+
+    store = _store(tmp_path)
+    alpha = [f for f in store.facts() if f["subject"] == "alpha"]
+    assert len(alpha) == 1  # the halted run's fact survived, and was not duplicated
+    assert [f["subject"] for f in store.facts()] == list(MARKERS)
+    store.close()
+
+    out = capsys.readouterr().out
+    # Run scope and job scope are stated separately: this run wrote 5 of the 6.
+    assert "5 candidate(s) this run" in out
+    assert f"resumed job #{job_id}: 6 candidate(s) in total" in out
+    assert "sync complete: 5 candidate(s)" in out
+
+
+# --- B, C: the reverse — a job that no longer describes the work is replaced --
+
+
+def test_sync_starts_a_new_job_when_the_source_body_changed(tmp_path, monkeypatch):
+    old_job_id = _halted_job(tmp_path, monkeypatch)
+    _ingest(tmp_path, monkeypatch, body=_body(SECOND_MARKERS), init=False)
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 0
+
+    job_ids = [int(job["id"]) for job in _jobs(tmp_path)]
+    assert len(job_ids) == 2
+    assert old_job_id != max(job_ids)  # the stale job is no longer the newest
+    assert client.markers == list(SECOND_MARKERS)  # every new chunk was extracted
+
+
+def test_sync_starts_a_new_job_when_the_chunk_size_changed(tmp_path, monkeypatch):
+    """The chunk-text comparison is the only guard that catches this.
+
+    Same body, same artifact, same provider and model — every other condition
+    passes. What moved is the chunk boundaries, so the job's finished chunk no
+    longer covers the text the pending ones assume, and resuming would extract
+    the source under two different chunkings at once. Without this case the
+    comparison could be deleted outright and the suite would stay green.
+    """
+    old_job_id = _halted_job(tmp_path, monkeypatch)
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "200")
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    job_ids = [int(job["id"]) for job in jobs]
+    assert len(job_ids) == 2
+    assert old_job_id != max(job_ids)
+    newest = next(job for job in jobs if int(job["id"]) == max(job_ids))
+    assert int(newest["total_chunks"]) == 2  # re-chunked under the new size
+    # `alpha` was already done under the old chunking; the new job must still send
+    # it, because the chunk it now belongs to is not the chunk that finished.
+    assert client.markers == ["alpha", "echo"]
+
+
+def test_sync_starts_a_new_job_when_the_artifact_changed_but_the_text_did_not(
+    tmp_path, monkeypatch
+):
+    """Identical text, different artifact row — the artifact check earns its keep.
+
+    Artifacts are content-addressed per `(source_id, kind, checksum)`, so the same
+    body can legitimately exist twice under two kinds — a source re-ingested
+    through a converter that reproduces its text exactly. The chunks then match
+    and every other condition passes, but the job still points at the OLD
+    artifact, and a resumed job stamps that artifact onto the evidence of facts
+    extracted from the new one. The chunk comparison cannot see this; without
+    this case the artifact condition could be deleted and nothing would notice.
+    """
+    _halted_job(tmp_path, monkeypatch)
+    store = _store(tmp_path)
+    source_id = int(store.sources()[0]["id"])
+    old = store.latest_source_text_artifact(source_id)
+    reconverted = tmp_path / "artifacts" / "sources" / "doc-reconverted.txt"
+    reconverted.write_text(
+        (tmp_path / str(old["path"])).read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    new_artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path=str(reconverted.relative_to(tmp_path)),  # identical bytes, new row
+        checksum=str(old["checksum"]) + "-reconverted",
+    )
+    store.close()
+    assert new_artifact_id != int(old["id"])
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    assert len(jobs) == 2
+    newest = next(job for job in jobs if int(job["id"]) == max(int(j["id"]) for j in jobs))
+    assert int(newest["artifact_id"]) == new_artifact_id
+    assert client.markers == list(MARKERS)  # nothing carried over from the old job
+
+
+def test_sync_starts_a_new_job_when_the_model_changed(tmp_path, monkeypatch):
+    old_job_id = _halted_job(tmp_path, monkeypatch)
+    monkeypatch.setenv("VERINOTE_MODEL", "different-model")
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    job_ids = [int(job["id"]) for job in jobs]
+    assert len(job_ids) == 2
+    assert old_job_id != max(job_ids)
+    assert client.markers == list(MARKERS)  # nothing was carried over
+    newest = next(job for job in jobs if int(job["id"]) == max(job_ids))
+    assert newest["model"] == "different-model"
+
+
+# --- E: a job someone else is running is neither resumed nor replaced --------
+
+
+def test_sync_leaves_a_running_job_alone(tmp_path, monkeypatch, capsys):
+    _ingest(tmp_path, monkeypatch)
+    store = _store(tmp_path)
+    source_id = int(store.sources()[0]["id"])
+    artifact = store.latest_source_text_artifact(source_id)
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        artifact_id=int(artifact["id"]),
+        source_text=_body(),
+        provider="anthropic",
+        model="m",
+        chunk_chars=60,
+        chunk_overlap_chars=0,
+    )
+    store.mark_extraction_job_running(job_id)
+    store.close()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RefusingClient())
+
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    assert [int(job["id"]) for job in jobs] == [job_id]  # no replacement job
+    store = _store(tmp_path)
+    chunks = store.source_chunks(job_id)
+    # Not one chunk was claimed: resuming would have `reset_running_chunks` pull
+    # the other process's in-flight chunk back and send it to the LLM twice.
+    assert {chunk["status"] for chunk in chunks} == {"pending"}
+    assert {int(chunk["attempts"]) for chunk in chunks} == {0}
+    store.close()
+    err = capsys.readouterr().err
+    assert f"extraction job #{job_id} is already running" in err
+
+
+# --- D, F, G: the superseded job is dead, and all three readers agree --------
+
+
+def _superseded_pending_job(tmp_path, monkeypatch) -> tuple[int, int, int]:
+    """A source carrying an abandoned `pending` job plus a newer, finished one."""
+    _ingest(tmp_path, monkeypatch)
+    store = _store(tmp_path)
+    source_id = int(store.sources()[0]["id"])
+    artifact_id = int(store.latest_source_text_artifact(source_id)["id"])
+    kwargs = dict(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        source_text=_body(),
+        provider="anthropic",
+        model="m",
+        chunk_chars=60,
+        chunk_overlap_chars=0,
+    )
+    stale_job_id = create_chunked_extraction_job(store, **kwargs)
+    fresh_job_id = create_chunked_extraction_job(store, **kwargs)
+    store.finish_extraction_job(fresh_job_id)
+    assert store.get_extraction_job(stale_job_id)["status"] == "pending"
+    store.close()
+    return source_id, stale_job_id, fresh_job_id
+
+
+def _app(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi")
+    import verinote.web.app as webapp
+    from verinote.config import Config
+
+    recorder = _ThreadRecorder()
+    monkeypatch.setattr(webapp, "threading", recorder)
+    cfg = Config.for_root(tmp_path)
+    return webapp.create_app(cfg), recorder
+
+
+def test_launcher_does_not_revive_a_superseded_pending_job(tmp_path, monkeypatch):
+    """Starting the UI must not re-run a source another job already finished.
+
+    No HTTP request is made here — `create_app()` alone used to be enough. The
+    launcher runs outside the request middleware, so this is a write (and a bill)
+    triggered by nothing but opening the KB.
+    """
+    _superseded_pending_job(tmp_path, monkeypatch)
+
+    _, recorder = _app(tmp_path, monkeypatch)
+
+    assert recorder.started == []
+
+
+def test_sources_page_stops_polling_for_a_superseded_pending_job(tmp_path, monkeypatch):
+    """A dead `pending` row must not keep the page refreshing every 2 seconds."""
+    from fastapi.testclient import TestClient
+
+    _superseded_pending_job(tmp_path, monkeypatch)
+    app, _ = _app(tmp_path, monkeypatch)
+
+    with TestClient(app) as client:
+        body = client.get("/sources").text
+
+    assert 'hx-trigger="every 2s"' not in body
+
+
+def test_reanalyze_is_not_blocked_by_a_superseded_pending_job(tmp_path, monkeypatch):
+    """The one source whose analysis is stuck must still be re-analysable."""
+    from fastapi.testclient import TestClient
+
+    source_id, _, _ = _superseded_pending_job(tmp_path, monkeypatch)
+    app, recorder = _app(tmp_path, monkeypatch)
+    assert recorder.started == []
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/sources/{source_id}/reanalyze", follow_redirects=False
+        )
+
+    assert response.status_code == 303  # not the 409 "analysis already running"
+    # `reanalyze_source` clears the source's old jobs, so the proof that a fresh
+    # analysis was queued is the worker it launched — job ids are reused here.
+    jobs = _jobs(tmp_path)
+    assert [job["status"] for job in jobs] == ["pending"]
+    assert recorder.started == [f"verinote-source-extract-{int(jobs[0]['id'])}"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ import pytest
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline import (
     create_chunked_extraction_job,
+    ExtractionJobBusyError,
     extract_source,
     process_extraction_job,
     sync_sources,
@@ -877,6 +878,33 @@ def test_process_extraction_job_extracts_chunks_and_tracks_progress(tmp_path):
     assert [e["chunk_index"] for e in evidence] == [0, 1]
     assert {e["job_id"] for e in evidence} == {job_id}
     assert [e["snippet"] for e in evidence] == ["alpha", "beta"]
+
+
+def test_process_extraction_job_backs_off_when_already_claimed(tmp_path):
+    """A job another worker already owns raises `ExtractionJobBusyError` and is left
+    entirely alone — its in-flight chunk is not reset back to the queue (#240)."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    chunk_ids = s.add_source_chunks(
+        job_id=job_id, source_id=sid, chunks=["alpha", "beta"]
+    )
+    # The existing owner: the job is `running` with a chunk in flight.
+    s.mark_extraction_job_running(job_id)
+    s.mark_chunk_running(chunk_ids[0])
+    runs_before = s._conn.execute("SELECT COUNT(*) AS n FROM runs").fetchone()["n"]
+    client = _ChunkAwareClient()
+
+    with pytest.raises(ExtractionJobBusyError):
+        process_extraction_job(s, client, job_id=job_id)
+
+    assert s.source_chunks(job_id)[0]["status"] == "running"  # owner's chunk untouched
+    assert client.calls == 0  # the LLM was never reached
+    assert len(s.facts()) == 0  # no candidate facts written
+    runs_after = s._conn.execute("SELECT COUNT(*) AS n FROM runs").fetchone()["n"]
+    assert runs_after == runs_before  # no new run row opened
 
 
 def test_process_extraction_job_runs_focused_role_pass_with_original_note(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -666,6 +666,99 @@ def test_reset_running_chunks_makes_job_resumable(tmp_path):
     assert s.get_extraction_job(job_id)["status"] == "pending"
 
 
+def test_claim_pending_extraction_job_is_exclusive_across_connections(tmp_path):
+    """The `pending`->`running` flip is the ownership handshake: exactly one wins (#240)."""
+    db_path = tmp_path / "kb.sqlite"
+    store_a = Store(db_path)
+    store_a.init_schema()
+    sid = store_a.add_source("sources/a.txt")
+    job_id = store_a.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=1
+    )
+    store_a.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])
+    store_b = Store(db_path)  # a second process's connection to the same KB file
+
+    assert store_a.claim_pending_extraction_job(job_id) is True
+    assert store_b.claim_pending_extraction_job(job_id) is False
+
+    assert store_a.get_extraction_job(job_id)["status"] == "running"
+    started = list(
+        store_a._conn.execute(
+            "SELECT id FROM fact_events WHERE event_type = 'extraction_job_started'"
+        )
+    )
+    assert len(started) == 1  # only the winner recorded a claim
+    store_a.close()
+    store_b.close()
+
+
+def test_claim_pending_extraction_job_rejects_non_pending(tmp_path):
+    """Only `pending` is claimable; a decided or in-flight job is left untouched (#240)."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+
+    def _fresh_job(status_setup) -> int:
+        job_id = s.create_extraction_job(
+            source_id=sid, provider="fake", model="m", total_chunks=1
+        )
+        s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])
+        status_setup(job_id)
+        return job_id
+
+    def _started_count(job_id: int) -> int:
+        return len(
+            list(
+                s._conn.execute(
+                    "SELECT id FROM fact_events "
+                    "WHERE event_type = 'extraction_job_started' AND job_id = ?",
+                    (job_id,),
+                )
+            )
+        )
+
+    cases = {
+        "running": lambda jid: s.mark_extraction_job_running(jid),
+        "done": lambda jid: s.finish_extraction_job(jid),
+        "failed": lambda jid: s.fail_extraction_job(jid, "boom"),
+        "canceled": lambda jid: s._conn.execute(
+            "UPDATE extraction_jobs SET status = 'canceled' WHERE id = ?", (jid,)
+        ),
+    }
+    for status, setup in cases.items():
+        job_id = _fresh_job(setup)
+        before_started = _started_count(job_id)
+
+        assert s.claim_pending_extraction_job(job_id) is False, status
+
+        assert s.get_extraction_job(job_id)["status"] == status
+        assert _started_count(job_id) == before_started  # no new claim recorded
+
+
+def test_claim_pending_extraction_job_reclaims_a_stray_running_chunk(tmp_path):
+    """A claim reclaims a stray `running` chunk WITHOUT flipping the job back out of
+    `running` — the reason the claim uses a raw update, not `reset_running_chunks` (#240)."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    chunk_ids = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b"])
+    # A crash can leave the job `pending` (see rollback) with a chunk still
+    # `running`; force exactly that shape without disturbing the job status.
+    s._conn.execute(
+        "UPDATE source_chunks SET status = 'running' WHERE id = ?", (chunk_ids[0],)
+    )
+    assert s.get_extraction_job(job_id)["status"] == "pending"
+
+    assert s.claim_pending_extraction_job(job_id) is True
+
+    # `reset_running_chunks` would have `_refresh_extraction_job` recompute the job
+    # from its (now zero) running chunks and flip it straight back to `pending`.
+    assert s.get_extraction_job(job_id)["status"] == "running"
+    assert s.source_chunks(job_id)[0]["status"] == "pending"  # stray chunk reclaimed
+    assert s.next_pending_chunk(job_id)["id"] == chunk_ids[0]
+
+
 def _job_with_mixed_chunks(s, sid):
     """A job caught mid-flight: one chunk done, one failed, one in flight."""
     job_id = s.create_extraction_job(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -15,6 +15,7 @@ from verinote.config import Config  # noqa: E402
 from verinote.engine import DEFAULT_POLICY  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
+from verinote.pipeline import ExtractionJobBusyError  # noqa: E402
 from verinote.pipeline.policy_state import (  # noqa: E402
     POLICY_RELPATH,
     PolicyMissingError,
@@ -1121,6 +1122,9 @@ def test_create_app_resumes_pending_source_jobs(tmp_path, monkeypatch, fake_clie
         assert "Analysis complete: 1/1 chunk(s)" in c.get("/sources").text
 
     _wait_for(resumed)
+    # a `pending` job is resumed directly; only a genuinely-`running` one is rolled
+    # back first, so no rollback event should appear for a pending resume (#242).
+    assert "extraction_job_rolled_back" not in _job_event_types(cfg, job_id)
 
 
 def _job_kb(tmp_path, *, with_policy: bool):
@@ -1302,6 +1306,74 @@ def test_worker_still_fails_the_job_on_an_ordinary_error(tmp_path, monkeypatch, 
 
     _wait_for(failed)
     assert "boom" in _job_row(cfg, job_id)["message"]
+
+
+def test_worker_busy_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):
+    """A job another worker owns must not be buried in `failed` by this worker (#240).
+
+    `except ExtractionJobBusyError` must sit ABOVE `except Exception`: below it, the
+    generic handler calls `fail_extraction_job` — a write that corrupts a job this
+    process does not own. The right move is to touch the DB not at all.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    called = threading.Event()
+
+    def busy(*args, **kwargs):
+        called.set()
+        raise ExtractionJobBusyError(job_id)
+
+    monkeypatch.setattr(webapp, "process_extraction_job", busy)
+
+    create_app(cfg)
+
+    assert called.wait(timeout=2.0)
+    time.sleep(0.2)  # let a (wrong) `fail_extraction_job` land, if the branch were missing
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "pending", "a job owned by another worker was buried in `failed`"
+    assert "analysis failed" not in job["message"]
+    assert "extraction failed" not in job["message"]
+    assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
+
+
+def test_startup_revives_a_job_left_running_by_a_crash(tmp_path, monkeypatch, fake_client):
+    """A job a crash left `running` (with a `running` chunk) is revived to `done` (#242).
+
+    This is the ONE path that seeds a `running` job at startup — every other resume
+    test seeds `pending`. DB state cannot tell this zombie from a live owner, so the
+    resume loop rolls it back to `pending` first, which is what lets the new claim
+    take it and actually re-process the stranded chunk (rather than walk past it).
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)  # a pending job + recorded policy
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        store.mark_extraction_job_running(job_id)
+        chunk_id = store.source_chunks(job_id)[0]["id"]
+        store.mark_chunk_running(chunk_id)
+    assert _job_row(cfg, job_id)["status"] == "running"
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    c = TestClient(create_app(cfg))
+
+    def revived():
+        assert "is_a" in c.get("/review").text
+        assert _job_row(cfg, job_id)["status"] == "done"
+
+    _wait_for(revived)
+    # the stranded chunk was actually processed, not skipped, and the revival went
+    # through a rollback (only a genuinely-`running` job is rolled back first).
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        assert store.source_chunks(job_id)[0]["status"] == "done"
+    assert "extraction_job_rolled_back" in _job_event_types(cfg, job_id)
 
 
 def _auto_accept_kb(tmp_path):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -65,6 +65,7 @@ class _SourceSyncOutcome:
     failed_chunks: int
     message: str = ""
     job_total_candidates: int | None = None
+    resumed_job_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -495,6 +496,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
     from verinote.pipeline import (
         create_chunked_extraction_job,
+        ExtractionJobBusyError,
         plan_source_extraction,
         process_extraction_job,
         sync_sources,
@@ -546,7 +548,6 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         registered = [source for source in sources if source.source_id is not None]
         if registered:
             per_source = []
-            lines = []
             total = 0
             run_id = 0
             for source in registered:
@@ -580,12 +581,24 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                         chunk_chars=cfg.extraction_chunk_chars,
                         chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
                     )
-                outcome = process_extraction_job(
-                    store,
-                    client,
-                    job_id=job_id,
-                    schema_hint=extraction_schema_hint(),
-                )
+                try:
+                    outcome = process_extraction_job(
+                        store,
+                        client,
+                        job_id=job_id,
+                        schema_hint=extraction_schema_hint(),
+                    )
+                except ExtractionJobBusyError:
+                    # Job was `pending` at plan time but another worker claimed it
+                    # first. Same outcome as a plan-time `busy_job_id`: skip, never
+                    # a failure. (#240)
+                    print(
+                        f"skipping {source.source_path}: extraction job "
+                        f"#{job_id} is already running (another process "
+                        f"owns its chunks)",
+                        file=sys.stderr,
+                    )
+                    continue
                 # The job message is already the bounded honest failure line
                 # ("Analysis failed: N chunk(s) failed, D/T complete: <error>");
                 # carry it verbatim rather than re-deriving it, and only when this
@@ -607,7 +620,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     _SourceSyncOutcome(
                         source_path=source.source_path,
                         candidates=outcome.run_candidates,
-                        completed_chunks=outcome.completed_chunks,
+                        completed_chunks=outcome.run_chunks,
                         failed_chunks=outcome.failed_chunks,
                         message=message,
                         job_total_candidates=(
@@ -615,6 +628,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                             if plan.resume_job_id is not None
                             else None
                         ),
+                        resumed_job_id=plan.resume_job_id,
                     )
                 )
                 total += outcome.run_candidates
@@ -649,8 +663,9 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
     for outcome in result.per_source:
         if outcome.job_total_candidates is not None:
             print(
-                f"  {outcome.source_path}: {outcome.candidates} candidate(s) this "
-                f"run (resumed: {outcome.job_total_candidates} candidate(s) in total)"
+                f"  {outcome.source_path}: {outcome.candidates} "
+                f"candidate(s) this run (resumed job #{outcome.resumed_job_id}: "
+                f"{outcome.job_total_candidates} candidate(s) in total)"
             )
         else:
             print(f"  {outcome.source_path}: {outcome.candidates} candidate(s)")

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -47,10 +47,16 @@ class _SourceInput:
 class _SourceSyncOutcome:
     """One source's result from a single sync invocation.
 
-    Counts are this-run counts: `cmd_sync` creates a fresh extraction job per
-    invocation, so `completed_chunks`/`failed_chunks` describe only what this run
-    did, never a source's historical jobs. `message` is the job's own bounded
-    status line, carried only when this run had a failed chunk.
+    Counts are this-run counts: `completed_chunks`/`failed_chunks` describe only
+    what this run did, never a source's historical jobs. `candidates` is
+    likewise this run's own contribution (`run_candidates`, not a resumed job's
+    cumulative total) — crediting a resumed source with candidates an earlier,
+    interrupted run already extracted would report work this run did not do
+    (#240). `job_total_candidates` carries the job's cumulative count, set only
+    when this run resumed a prior job, so the per-source line can still say the
+    honest whole-job number without conflating it with this run's own count.
+    `message` is the job's own bounded status line, carried only when this run
+    had a failed chunk.
     """
 
     source_path: str
@@ -58,6 +64,7 @@ class _SourceSyncOutcome:
     completed_chunks: int
     failed_chunks: int
     message: str = ""
+    job_total_candidates: int | None = None
 
 
 @dataclass(frozen=True)
@@ -488,6 +495,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
     from verinote.pipeline import (
         create_chunked_extraction_job,
+        plan_source_extraction,
         process_extraction_job,
         sync_sources,
     )
@@ -538,10 +546,11 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         registered = [source for source in sources if source.source_id is not None]
         if registered:
             per_source = []
+            lines = []
             total = 0
             run_id = 0
             for source in registered:
-                job_id = create_chunked_extraction_job(
+                plan = plan_source_extraction(
                     store,
                     source_id=source.source_id,
                     artifact_id=source.artifact_id,
@@ -551,6 +560,26 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     chunk_chars=cfg.extraction_chunk_chars,
                     chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
                 )
+                if plan.busy_job_id is not None:
+                    print(
+                        f"skipping {source.source_path}: extraction job "
+                        f"#{plan.busy_job_id} is already running (another process "
+                        f"owns its chunks)",
+                        file=sys.stderr,
+                    )
+                    continue
+                job_id = plan.resume_job_id
+                if job_id is None:
+                    job_id = create_chunked_extraction_job(
+                        store,
+                        source_id=source.source_id,
+                        artifact_id=source.artifact_id,
+                        source_text=source.text,
+                        provider=cfg.provider,
+                        model=cfg.model,
+                        chunk_chars=cfg.extraction_chunk_chars,
+                        chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
+                    )
                 outcome = process_extraction_job(
                     store,
                     client,
@@ -566,16 +595,29 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     if outcome.failed_chunks
                     else ""
                 )
+                # `outcome.candidates` is the job's running total, which for a
+                # resumed job counts candidates an earlier, interrupted run
+                # already extracted — using it here would credit this sync with
+                # work it did not do (#240), and would also violate the
+                # this-run-only invariant #239's failed/incomplete decision below
+                # relies on. `run_candidates` is always this invocation's own
+                # contribution; the job total is still worth saying for a resumed
+                # source, so it rides along in `job_total_candidates` instead.
                 per_source.append(
                     _SourceSyncOutcome(
                         source_path=source.source_path,
-                        candidates=outcome.candidates,
+                        candidates=outcome.run_candidates,
                         completed_chunks=outcome.completed_chunks,
                         failed_chunks=outcome.failed_chunks,
                         message=message,
+                        job_total_candidates=(
+                            outcome.candidates
+                            if plan.resume_job_id is not None
+                            else None
+                        ),
                     )
                 )
-                total += outcome.candidates
+                total += outcome.run_candidates
                 run_id = job_id
             result = _SyncSummary(per_source=per_source, total=total, run_id=run_id)
         else:
@@ -605,7 +647,13 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         store.close()
         return 1
     for outcome in result.per_source:
-        print(f"  {outcome.source_path}: {outcome.candidates} candidate(s)")
+        if outcome.job_total_candidates is not None:
+            print(
+                f"  {outcome.source_path}: {outcome.candidates} candidate(s) this "
+                f"run (resumed: {outcome.job_total_candidates} candidate(s) in total)"
+            )
+        else:
+            print(f"  {outcome.source_path}: {outcome.candidates} candidate(s)")
     failed = result.failed_sources
     if failed:
         # Successes stayed visible on stdout above; the failures and the shape of

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -7,6 +7,7 @@ review gate sits between extract and compile and is driven from the web UI.
 
 from verinote.pipeline.extract import (
     ChunkedExtractionResult,
+    ExtractionJobBusyError,
     ExtractionJobPlan,
     SyncResult,
     create_chunked_extraction_job,
@@ -39,6 +40,7 @@ __all__ = [
     "sync_sources",
     "SyncResult",
     "ChunkedExtractionResult",
+    "ExtractionJobBusyError",
     "ExtractionJobPlan",
     "verify",
     "ingest_bytes",

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -7,9 +7,13 @@ review gate sits between extract and compile and is driven from the web UI.
 
 from verinote.pipeline.extract import (
     ChunkedExtractionResult,
+    ExtractionJobPlan,
     SyncResult,
     create_chunked_extraction_job,
     extract_source,
+    is_live_extraction_job,
+    latest_source_job_ids,
+    plan_source_extraction,
     process_extraction_job,
     sync_sources,
 )
@@ -28,10 +32,14 @@ from verinote.pipeline.verify import verify
 __all__ = [
     "extract_source",
     "create_chunked_extraction_job",
+    "plan_source_extraction",
     "process_extraction_job",
+    "is_live_extraction_job",
+    "latest_source_job_ids",
     "sync_sources",
     "SyncResult",
     "ChunkedExtractionResult",
+    "ExtractionJobPlan",
     "verify",
     "ingest_bytes",
     "ingest_file",

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -231,7 +231,16 @@ def plan_source_extraction(
       changed chunk size, overlap, or normalisation rule, any of which would make
       the finished chunks cover different text than the pending ones assume;
     * its provider and model match the ones this run would use. Resume across a
-      model change and the job row ends up mis-describing its own output.
+      model change and the job row ends up mis-describing its own output;
+    * NO CHUNK OF IT HAS FAILED. `reset_running_chunks` rewinds only `running`
+      and `next_pending_chunk` claims only `pending`, so a `failed` chunk is
+      invisible to both: a resume walks past it, reports `done`, and exits 0
+      while the text of that chunk never reaches the LLM again. Rebuilding the
+      job re-sends it, which is what re-syncing did before resuming existed —
+      so declining here preserves that recovery rather than inventing one. (A
+      narrower fix, retrying just the failed chunks via `retry_failed_chunks`,
+      would save the finished work too; that is a behaviour change and belongs
+      in its own issue.)
 
     A `running` job is neither resumed nor replaced. It may belong to a live UI
     worker, and resuming would have `reset_running_chunks` yank that worker's
@@ -248,6 +257,8 @@ def plan_source_extraction(
     if job["status"] == "running":
         return ExtractionJobPlan(busy_job_id=latest_id)
     if job["status"] != "pending":
+        return ExtractionJobPlan()
+    if int(job["failed_chunks"]) > 0:
         return ExtractionJobPlan()
     job_artifact_id = None if job["artifact_id"] is None else int(job["artifact_id"])
     if job_artifact_id != artifact_id:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -130,6 +130,141 @@ def extract_source(
     return inserted
 
 
+def _chunks_for(
+    source_text: str,
+    *,
+    chunk_chars: int | None = None,
+    chunk_overlap_chars: int | None = None,
+) -> list[str]:
+    """The chunks this config would split `source_text` into, right now.
+
+    Shared by job creation and `plan_source_extraction` so the resume check
+    compares a job's persisted chunks against text produced the *same* way. Two
+    call sites chunking "the same" text with hand-copied kwargs is how a resume
+    predicate silently starts approving jobs whose chunk boundaries have moved.
+    """
+    kwargs = {}
+    if chunk_chars is not None:
+        kwargs["max_chars"] = chunk_chars
+    if chunk_overlap_chars is not None:
+        kwargs["overlap_chars"] = chunk_overlap_chars
+    return chunk_text(normalize_for_extraction(source_text), **kwargs)
+
+
+def latest_source_job_ids(jobs: Iterable) -> dict[int, int]:
+    """Newest extraction job id per source, derived from the job rows themselves.
+
+    "This job has been superseded" is not a state worth storing — it is exactly
+    "a newer job exists for the same source", and a stored copy can drift out of
+    step with the rows it summarises while a derived one cannot. `sources_with_
+    counts` already reads a source's current analysis through the same `MAX(id)`
+    lens; this is that judgement, in Python, for callers that already hold the
+    rows.
+    """
+    latest: dict[int, int] = {}
+    for job in jobs:
+        source_id = int(job["source_id"])
+        job_id = int(job["id"])
+        if job_id > latest.get(source_id, 0):
+            latest[source_id] = job_id
+    return latest
+
+
+def is_live_extraction_job(job, latest_job_ids: dict[int, int]) -> bool:
+    """True when `job` is unfinished AND still its source's newest job.
+
+    An unfinished job that has been superseded is dead work: a `pending` row
+    nothing will ever process, left behind by a re-analysis that replaced it.
+    Treating it as live makes the UI poll forever, keeps the Sources page saying
+    "analysing", blocks the re-analyse button with a 409, and — worst — lets the
+    launcher start a second extraction over a source another job already
+    finished. One predicate so all four answers agree.
+    """
+    if job["status"] not in {"pending", "running"}:
+        return False
+    return int(job["id"]) == latest_job_ids.get(int(job["source_id"]))
+
+
+@dataclass(frozen=True)
+class ExtractionJobPlan:
+    """What a sync pass should do about one source's newest extraction job.
+
+    At most one field is set. `resume_job_id` picks a rolled-back job back up;
+    `busy_job_id` says another process owns it and this pass must keep its hands
+    off; neither means start a fresh job.
+    """
+
+    resume_job_id: int | None = None
+    busy_job_id: int | None = None
+
+
+def plan_source_extraction(
+    store: Store,
+    *,
+    source_id: int,
+    artifact_id: int | None,
+    source_text: str,
+    provider: str | None,
+    model: str | None,
+    chunk_chars: int | None = None,
+    chunk_overlap_chars: int | None = None,
+) -> ExtractionJobPlan:
+    """Decide whether a source's newest job can be resumed, must wait, or is stale.
+
+    A job rolled back to `pending` (see `_halt_extraction_job`) still holds every
+    chunk it finished, and the machinery to carry on already works —
+    `next_pending_chunk` skips `done` chunks, `reset_running_chunks` reclaims
+    in-flight ones, `candidate_count` accumulates. What was missing was anyone
+    asking for it, so every sync started from chunk zero and paid for the same
+    LLM calls twice.
+
+    Resuming is only honest when the job still describes the work in front of us,
+    so all of the following must hold:
+
+    * the job is `pending` — `done`/`failed`/`canceled` are decided outcomes;
+    * it is the source's newest job — an older one has been superseded;
+    * its artifact is the artifact we are about to extract. Artifacts are
+      content-addressed (`UNIQUE(source_id, kind, checksum)`), so a changed body
+      is a different `artifact_id`;
+    * its persisted chunks are exactly what this config would produce now. This
+      one carries most of the weight: it re-checks the body *and* catches a
+      changed chunk size, overlap, or normalisation rule, any of which would make
+      the finished chunks cover different text than the pending ones assume;
+    * its provider and model match the ones this run would use. Resume across a
+      model change and the job row ends up mis-describing its own output.
+
+    A `running` job is neither resumed nor replaced. It may belong to a live UI
+    worker, and resuming would have `reset_running_chunks` yank that worker's
+    in-flight chunk back into the queue — the same chunk sent to the LLM twice.
+    """
+    jobs = store.source_extraction_jobs()
+    latest_job_ids = latest_source_job_ids(jobs)
+    latest_id = latest_job_ids.get(source_id)
+    if latest_id is None:
+        return ExtractionJobPlan()
+    job = store.get_extraction_job(latest_id)
+    if job is None:
+        return ExtractionJobPlan()
+    if job["status"] == "running":
+        return ExtractionJobPlan(busy_job_id=latest_id)
+    if job["status"] != "pending":
+        return ExtractionJobPlan()
+    job_artifact_id = None if job["artifact_id"] is None else int(job["artifact_id"])
+    if job_artifact_id != artifact_id:
+        return ExtractionJobPlan()
+    if (job["provider"], job["model"]) != (provider, model):
+        return ExtractionJobPlan()
+    persisted = [str(row["text"]) for row in store.source_chunks(latest_id)]
+    current = _chunks_for(
+        source_text,
+        chunk_chars=chunk_chars,
+        chunk_overlap_chars=chunk_overlap_chars,
+    )
+    if persisted != current:
+        return ExtractionJobPlan()
+    return ExtractionJobPlan(resume_job_id=latest_id)
+
+
 def create_chunked_extraction_job(
     store: Store,
     *,
@@ -142,13 +277,11 @@ def create_chunked_extraction_job(
     chunk_overlap_chars: int | None = None,
 ) -> int:
     """Create a durable extraction job and its source chunks."""
-    kwargs = {}
-    if chunk_chars is not None:
-        kwargs["max_chars"] = chunk_chars
-    if chunk_overlap_chars is not None:
-        kwargs["overlap_chars"] = chunk_overlap_chars
-    analysis_text = normalize_for_extraction(source_text)
-    chunks = chunk_text(analysis_text, **kwargs)
+    chunks = _chunks_for(
+        source_text,
+        chunk_chars=chunk_chars,
+        chunk_overlap_chars=chunk_overlap_chars,
+    )
     job_id = store.create_extraction_job(
         source_id=source_id,
         artifact_id=artifact_id,
@@ -165,12 +298,22 @@ def create_chunked_extraction_job(
 
 @dataclass(frozen=True)
 class ChunkedExtractionResult:
-    """Outcome of processing one persisted extraction job."""
+    """Outcome of processing one persisted extraction job.
+
+    TWO SCOPES, KEPT APART — the same separation `_halt_extraction_job` insists on
+    for its summary. `candidates`/`completed_chunks`/`failed_chunks` are the
+    *job's* totals, cumulative across every resume; `run_candidates`/`run_chunks`
+    are what *this* call did. Once a job can be resumed the two diverge, and a
+    caller that prints the job total as "this run extracted N candidates" is
+    reporting work it did not do.
+    """
 
     job_id: int
     candidates: int = 0
     completed_chunks: int = 0
     failed_chunks: int = 0
+    run_candidates: int = 0
+    run_chunks: int = 0
 
 
 def process_extraction_job(
@@ -268,6 +411,8 @@ def process_extraction_job(
         candidates=int(final["candidate_count"]),
         completed_chunks=int(final["completed_chunks"]),
         failed_chunks=int(final["failed_chunks"]),
+        run_candidates=candidates,
+        run_chunks=run_chunks,
     )
 
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -26,6 +26,20 @@ from verinote.prompts import PromptError, render_prompt
 from verinote.store import Store
 from verinote.store.fact_input import structural_term
 
+
+class ExtractionJobBusyError(Exception):
+    """Another worker owns this extraction job; the caller must back off.
+
+    Deliberately NOT an `LLMError` or `PolicyMissingError`: the web worker turns
+    those into `fail_extraction_job`, a write that would corrupt a job another
+    worker legitimately owns. This says "someone else has it — touch nothing."
+    """
+
+    def __init__(self, job_id: int):
+        super().__init__(f"extraction job {job_id} is already owned by another worker")
+        self.job_id = job_id
+
+
 _NORMALIZATION_BRIDGE_RELATIONS = {
     "주체",
     "subject",
@@ -348,9 +362,9 @@ def process_extraction_job(
     KB that lies about its own state is what this change exists to stop. It would
     also make recovery depend on the web launcher: `_resume_source_extraction_jobs`
     is the only thing that revives a `running` job (and only when someone next
-    starts the UI), while `reset_running_chunks` below rewinds the *chunks* of a job
-    already being processed, not a job nobody is processing. `pending` is the state
-    that says what is true and that every resume path already understands.
+    starts the UI, by first rolling it back to `pending` so the ownership claim
+    below can take it). `pending` is the state that says what is true and that
+    every resume path already understands.
     """
     assert_writable(store)
     job = store.get_extraction_job(job_id)
@@ -360,8 +374,13 @@ def process_extraction_job(
     if source is None:
         raise LLMError(f"missing source for extraction job: {job_id}")
 
-    store.reset_running_chunks(job_id)
-    store.mark_extraction_job_running(job_id)
+    if not store.claim_pending_extraction_job(job_id):
+        # Another worker owns this job (a concurrent `verinote sync`, a second UI
+        # worker, or the startup resume loop). It may have a chunk in flight, so
+        # we must NOT reset its chunks — backing off is the whole point (#240). A
+        # `running` job reaches here only via the resume loop, which rolls a
+        # crashed job back to `pending` first, so this claim then succeeds.
+        raise ExtractionJobBusyError(job_id)
     run_id = store.add_run(provider=job["provider"], model=job["model"])
 
     candidates = 0

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -229,6 +229,11 @@ class Store:
         self._conn = sqlite3.connect(self.db_path, isolation_level=None, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON;")
+        # Two processes' guarded UPDATEs can land at the same instant (e.g. a sync
+        # and the UI startup worker both claiming one job). Without a busy timeout
+        # the loser raises `database is locked` immediately; with it, it waits
+        # briefly and then cleanly loses the CAS (`rowcount == 0`) instead.
+        self._conn.execute("PRAGMA busy_timeout = 5000")
         self._lock = threading.RLock()
         self._inference_cache: Any = None
         self._fact_terms: Any = None
@@ -693,6 +698,54 @@ class Store:
                     before=_job_event_payload(job),
                     after=_job_event_payload(after),
                 )
+
+    def claim_pending_extraction_job(self, job_id: int) -> bool:
+        """Atomically take ownership of a `pending` job for processing.
+
+        The `pending`->`running` flip IS the ownership handshake: exactly one
+        concurrent caller's UPDATE matches `status='pending'` (rowcount == 1) and
+        owns the job; every other caller — a second `verinote sync`, another UI
+        worker, a startup resume that arrives a moment later and sees `running` —
+        gets rowcount == 0 and MUST back off without touching the chunks, because
+        the owner may have one in flight and resetting it re-sends it to the LLM (#240).
+
+        Mirrors the fact-write CAS (`accept_fact`, `toggle_review`): conditional on
+        the exact status observed, a lost race writes nothing. Only `pending` is
+        claimable. A job a crashed worker left `running` is made claimable again by
+        rolling it back to `pending` first (see `_resume_source_extraction_jobs`),
+        never by adopting a `running` row here — that is what keeps the claim exclusive.
+        """
+        with self._lock:
+            before = self.get_extraction_job(job_id)
+            if before is None:
+                return False
+            cur = self._conn.execute(
+                "UPDATE extraction_jobs SET status = 'running', "
+                "message = 'Analyzing chunks...', updated_at = datetime('now') "
+                "WHERE id = ? AND status = 'pending'",
+                (job_id,),
+            )
+            if cur.rowcount == 0:
+                return False
+            # Now that we exclusively own it, reclaim any chunk a prior crashed run
+            # left `running`. RAW update, NOT `reset_running_chunks`: that helper ends
+            # in `_refresh_extraction_job`, which would recompute the job from its
+            # chunks and flip our just-set `running` back to `pending`. A claimed
+            # `pending` job has no `running` chunk in any real path, so this is a
+            # defensive no-op that preserves the invariant without disturbing status.
+            self._conn.execute(
+                "UPDATE source_chunks SET status = 'pending', error = '', "
+                "updated_at = datetime('now') WHERE job_id = ? AND status = 'running'",
+                (job_id,),
+            )
+            after = self.get_extraction_job(job_id)
+            if after is not None:
+                self._add_fact_event(
+                    fact_id=None, event_type="extraction_job_started", actor="system",
+                    source_id=int(after["source_id"]), job_id=job_id,
+                    before=_job_event_payload(before), after=_job_event_payload(after),
+                )
+            return True
 
     def mark_chunk_running(self, chunk_id: int) -> sqlite3.Row | None:
         with self._lock:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -35,6 +35,8 @@ from verinote.pipeline import (
     fact_trust_summary,
     IngestError,
     ingest_bytes,
+    is_live_extraction_job,
+    latest_source_job_ids,
     process_extraction_job,
     store_source,
     supported_suffixes,
@@ -722,7 +724,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
         jobs = store.source_extraction_jobs()
-        has_running_jobs = any(job["status"] in {"pending", "running"} for job in jobs)
+        latest_job_ids = latest_source_job_ids(jobs)
+        # A superseded `pending` row is dead work, and counting it here is what
+        # leaves the page polling every 2s forever and claiming an analysis is in
+        # flight when nothing is processing it.
+        has_running_jobs = any(is_live_extraction_job(job, latest_job_ids) for job in jobs)
         return templates.TemplateResponse(
             request,
             "sources.html",
@@ -824,8 +830,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         except PolicyMissingError as exc:
             logger.warning("not resuming extraction jobs: %s", exc)
             return
-        for job in app.state.store.source_extraction_jobs():
-            if job["status"] in {"pending", "running"}:
+        jobs = app.state.store.source_extraction_jobs()
+        latest_job_ids = latest_source_job_ids(jobs)
+        for job in jobs:
+            if is_live_extraction_job(job, latest_job_ids):
                 _start_source_extraction(int(job["id"]), app.state.cfg)
 
     @app.get("/", response_class=HTMLResponse)
@@ -891,10 +899,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         source = store.get_source(source_id)
         if source is None:
             return _sources(request, error="source not found", status_code=404)
+        jobs = store.source_extraction_jobs()
+        latest_job_ids = latest_source_job_ids(jobs)
+        # Only a LIVE job blocks re-analysis. A superseded `pending` row is not an
+        # analysis in progress, and treating it as one wedges this button shut for
+        # the one source whose analysis most needs redoing.
         if any(
             int(job["source_id"]) == source_id
-            and job["status"] in {"pending", "running"}
-            for job in store.source_extraction_jobs()
+            and is_live_extraction_job(job, latest_job_ids)
+            for job in jobs
         ):
             return _sources(
                 request,

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -32,6 +32,7 @@ from verinote.llm import LLMError, get_client
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
     create_chunked_extraction_job,
+    ExtractionJobBusyError,
     fact_trust_summary,
     IngestError,
     ingest_bytes,
@@ -777,6 +778,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # of falsehood this change removes. Whoever rewinds, rewinds; this
                 # handler reports.
                 logger.warning("extraction job %s halted (KB policy missing): %s", job_id, e)
+            except ExtractionJobBusyError:
+                # Another worker owns this job (a concurrent sync, a second UI
+                # worker, or another startup resume). It may have a chunk in
+                # flight; ANY write here — including `fail_extraction_job` — would
+                # corrupt a job we do not own. Log and leave it entirely. (#240)
+                logger.info(
+                    "extraction job %s already owned by another worker; not started here",
+                    job_id,
+                )
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
@@ -822,6 +832,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         Same predicate as the middleware and the CLI dispatch: one judgement,
         three enforcement points.
+
+        A job left `running` by a crash is rolled back to `pending` before it is
+        restarted, because `process_extraction_job` now claims only a `pending`
+        job (#240). SCOPE BOUNDARY (#242): DB state alone cannot tell a crashed
+        zombie from a job a DIFFERENT live process genuinely owns — SQLite has no
+        row-level liveness signal — so in that rare case this rollback still
+        resets that live job's in-flight chunk (exactly as today's unconditional
+        resume already does; not a regression introduced here). Closing it needs a
+        liveness lease (owner token + heartbeat, or a staleness threshold on
+        `updated_at`) and is filed as a follow-up, not solved here.
         """
         if app.state.store is None or app.state.cfg is None:
             return
@@ -833,8 +853,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         jobs = app.state.store.source_extraction_jobs()
         latest_job_ids = latest_source_job_ids(jobs)
         for job in jobs:
-            if is_live_extraction_job(job, latest_job_ids):
-                _start_source_extraction(int(job["id"]), app.state.cfg)
+            if not is_live_extraction_job(job, latest_job_ids):
+                continue
+            if job["status"] == "running":
+                app.state.store.rollback_extraction_job(
+                    int(job["id"]), "Resuming analysis interrupted by a restart."
+                )
+            _start_source_extraction(int(job["id"]), app.state.cfg)
 
     @app.get("/", response_class=HTMLResponse)
     def dashboard(request: Request):


### PR DESCRIPTION
Closes #240
Closes #242

## The cause was not what the issue described

The issue reads as a query-condition problem — as if `sync` looked for a resumable job and looked wrong. It didn't look at all. **`cmd_sync` had no code to find an existing job**; `cli.py` called `create_chunked_extraction_job` unconditionally, every time.

The resume machinery was already complete and already correct:

- `next_pending_chunk` skips `done` chunks
- `reset_running_chunks` reclaims chunks abandoned mid-flight
- `candidate_count` accumulates across runs

A job halted mid-flight rolls back to `pending` with its finished chunks intact, ready to be picked up. Nothing ever asked for it, so the next `sync` rebuilt the job from chunk zero and paid the provider a second time for work already done.

Note that `cli.py:293` in the issue body is stale — the unconditional create was at `cli.py:472`.

## The resume predicate

`plan_source_extraction` resumes only when the job still honestly describes the work in front of us. All of these must hold:

1. **`status == 'pending'`** — `done`/`failed`/`canceled` are decided outcomes, not interrupted ones.
2. **the source's newest job** — an older job has been superseded by a later one (see #242 below).
3. **`job.artifact_id == source.artifact_id`** — artifacts are content-addressed (`UNIQUE(source_id, kind, checksum)`), so a changed body means a different artifact id.
4. **the persisted chunk texts equal what this config would produce now** — compared against `chunk_text(normalize_for_extraction(text), ...)` under the current chunk size and overlap.
5. **`job.provider == cfg.provider and job.model == cfg.model`** — resume across a provider or model switch and the job row ends up describing output it did not produce.

**Condition 4 is the load-bearing one.** It subsumes condition 3 and also catches what no identity check can see: a changed chunk size, overlap, or normalisation rule. Resume across a re-chunking and the finished chunks no longer cover the text the pending chunks assume — part of the new body falls into no chunk at all and is **silently never extracted**. The failure mode is a quietly incomplete KB with a `done` job on top of it, which is exactly the class of lie this repo exists to prevent.

A `running` job is **neither resumed nor replaced**. It may belong to a live UI worker, and resuming would have `reset_running_chunks` yank that worker's in-flight chunk back into the queue — the same chunk sent to the LLM twice. `sync` skips it and says so on stderr.

## #242: derive "superseded", do not store it

The obvious fix was to retire the dead job by writing state — `fail_extraction_job(job_id, "superseded by ...")`. That was rejected. A job replaced by a newer one is not a *failure*, and the UI renders `failed` as **"Analysis failed"**. Storing that status would put a false sentence on the user's screen about a job that did nothing wrong.

"Superseded" is instead **derived**, because it is exactly equivalent to *a newer job exists for the same source*:

```python
def is_live_extraction_job(job, latest_job_ids) -> bool:
    if job["status"] not in {"pending", "running"}:
        return False
    return int(job["id"]) == latest_job_ids.get(int(job["source_id"]))
```

Stored state can drift out of step with the rows it summarises; a derived answer cannot be wrong by construction. `sources_with_counts` already reads a source's current analysis through the same `MAX(id)` lens (`db.py:386-389`), so this is existing idiom rather than a new one. It is also entirely read-only: **`db.py` is untouched by this PR.**

## Why the scope is slightly wider than #242's letter

The launcher was the reported symptom, but the same dead `pending` row is read in two more places, and leaving them would fix the triple-extraction while keeping two broken behaviours:

- `has_running_jobs` stays `True` forever, so `sources.html:18` **polls every 2 seconds indefinitely** and the page keeps saying an analysis is in progress when nothing is processing it.
- `reanalyze_source` **409s permanently** for that source. That is not cosmetic — the re-analyse button is dead for the one source whose analysis most needs redoing.

Same predicate, same defect, one line each. All three readers now share `is_live_extraction_job`, matching the "one judgement, three enforcement points" structure `_resume_source_extraction_jobs` already documents.

## Run-scope honesty

Once a job can span runs, `outcome.candidates` is a **job total**, not this run's output. A resumed job would report "69 candidate(s)" for a run that produced 55. `_halt_extraction_job`'s docstring already insists these two scopes stay grammatically apart; enabling resume without honouring that would have introduced a fresh instance of the misreporting this work exists to remove.

`ChunkedExtractionResult` now carries `run_candidates`/`run_chunks` beside the job totals, and the sync summary states them separately:

```
sources/doc.txt: 5 candidate(s) this run (resumed job #1: 6 candidate(s) in total)
```

## A regression this PR introduced, found in review

The first version of this PR **stranded chunks that had failed in an earlier run**, and it is worth being explicit about because it was not caught by the original test plan.

`reset_running_chunks` rewinds only `'running'` chunks. `next_pending_chunk` claims only `'pending'` ones. **A `failed` chunk is neither.** A resumed job walked straight past it, reported `done`, and exited 0 — the chunk's text never reached the provider again and the facts it would have produced were lost silently.

Reproduction (six chunks, `bravo` hits a transient provider error, the policy then vanishes mid-job):

```
run 2 sent: ['charlie', 'delta', 'echo', 'foxtrot']
bravo: gone for good.  sync exit code: 0
```

**`origin/main` recovers `bravo`**, because re-syncing rebuilt the job from scratch and re-sent every chunk. Resuming removed that recovery path. This branch created the regression; it did not inherit it.

The fix is deliberately conservative — `plan_source_extraction` declines any job carrying a failed chunk, so the existing full-re-extraction behaviour stands in exactly the case that needs it. The two commits are kept unsquashed so the history shows the CRITICAL surfacing and being closed.

### The cost of that fix, and the loop it creates

Both of these are consequences of choosing the conservative fix, and neither is hidden:

1. **One failed chunk re-bills every chunk.** A six-chunk source with a single failure re-sends all six to the provider on the next `sync`. This is a deliberate trade: correctness (no silently dropped chunk) over cost.

2. **A permanently failing chunk re-extracts the whole source on every `sync`, forever.** If 5 of 6 chunks succeed every time but one always fails, `failed_chunks > 0` forces a new job on the next run, and the next, indefinitely. Because #239 is still open this loop runs at **rc 0, silently**, which makes it an unbounded supplier of the duplicate-fact accumulation tracked in #160.

This matches today's behaviour on `main` (which always re-extracts in full), so it is not a regression. But it is a real exception to this PR's headline — "sync now resumes" holds *except* when a chunk has failed, and that exception has teeth.

**Follow-up (not filed here):** retrying only the failed chunks via `retry_failed_chunks` would preserve the finished work *and* dissolve loop 2, so the cost above and the loop have a single shared remedy. It interacts with #239 and #160.

## Tests

New `tests/test_job_resume.py`, 13 tests. **The instrumentation measures the chunk text the client actually received, not which branch executed** — "the resume branch ran" is cheap to satisfy and says nothing, since a resume that re-sends chunk zero costs exactly what the bug cost.

Route-level cases build their own `TestClient` and replace the `threading` reference inside the app's namespace, making "did the launcher start a worker?" synchronous and exact rather than sleep-dependent.

- 1242 passed
- `ruff check .` clean

Every branch of the predicate is covered by a mutant with a named killer; the three conditions that had no dedicated scenario in the original plan (status, newest-job, and the *provider* half of provider/model — the model half was already locked) were found unguarded in review and now each have one.
