### PR TITLE
fix(#293): make a blank VERINOTE_BASE_URL mean the same thing to every provider

### DIFF
--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -291,3 +291,27 @@ def test_settings_file_base_url_reaches_cloud_client(tmp_path, monkeypatch, prov
     adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
 
     assert recorded["base_url"] == "https://llm.internal/v1"
+
+
+@pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
+def test_whitespace_only_saved_base_url_reaches_cloud_client_as_none(tmp_path, monkeypatch, provider):
+    record, adapter_cls = _CLOUD_ADAPTERS[provider]
+    recorded = record(monkeypatch)
+    monkeypatch.delenv("VERINOTE_BASE_URL", raising=False)
+    save_settings(tmp_path, provider=provider, model="m", base_url="   ")
+
+    adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
+
+    assert recorded["base_url"] is None
+
+
+@pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
+def test_padded_base_url_reaches_cloud_client_trimmed(tmp_path, monkeypatch, provider):
+    record, adapter_cls = _CLOUD_ADAPTERS[provider]
+    recorded = record(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", provider)
+    monkeypatch.setenv("VERINOTE_BASE_URL", "  https://llm.internal/v1  ")
+
+    adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
+
+    assert recorded["base_url"] == "https://llm.internal/v1"

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from verinote.config import Config
+from verinote.config import Config, save_settings
 from verinote.llm.anthropic_adapter import AnthropicAdapter
 from verinote.llm.base import LLMError
 from verinote.llm.openai_adapter import OpenAIAdapter
@@ -213,3 +213,81 @@ def test_anthropic_adapter_prompt_validation_error_is_llm_error(tmp_path, monkey
         AnthropicAdapter(_cfg(tmp_path, provider="anthropic")).translate_query(
             question="Who?", qid=3
         )
+
+
+def _record_openai_client(monkeypatch) -> dict:
+    recorded: dict = {}
+
+    class _Completions:
+        def create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content='{"facts":[]}'))]
+            )
+
+    def _factory(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=_factory))
+    return recorded
+
+
+def _record_anthropic_client(monkeypatch) -> dict:
+    recorded: dict = {}
+
+    class _Messages:
+        def create(self, **kwargs):
+            return SimpleNamespace(content=[SimpleNamespace(type="tool_use", input={"facts": []})])
+
+    def _factory(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(messages=_Messages())
+
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(Anthropic=_factory))
+    return recorded
+
+
+_CLOUD_ADAPTERS = {
+    "openai": (_record_openai_client, OpenAIAdapter),
+    "anthropic": (_record_anthropic_client, AnthropicAdapter),
+}
+
+
+@pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
+def test_empty_base_url_env_reaches_cloud_client_as_none(tmp_path, monkeypatch, provider):
+    # `is None`, not falsy: an empty string is falsy too, so a truthiness check
+    # here would pass against the very bug this guards.
+    record, adapter_cls = _CLOUD_ADAPTERS[provider]
+    recorded = record(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", provider)
+    monkeypatch.setenv("VERINOTE_BASE_URL", "")
+
+    adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
+
+    assert recorded["base_url"] is None
+
+
+@pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
+def test_custom_base_url_reaches_cloud_client_verbatim(tmp_path, monkeypatch, provider):
+    record, adapter_cls = _CLOUD_ADAPTERS[provider]
+    recorded = record(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", provider)
+    monkeypatch.setenv("VERINOTE_BASE_URL", "https://llm.internal/v1")
+
+    adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
+
+    assert recorded["base_url"] == "https://llm.internal/v1"
+
+
+@pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
+def test_settings_file_base_url_reaches_cloud_client(tmp_path, monkeypatch, provider):
+    # No env at all: a self-hosted endpoint configured through the Settings UI
+    # must still reach the SDK.
+    record, adapter_cls = _CLOUD_ADAPTERS[provider]
+    recorded = record(monkeypatch)
+    monkeypatch.delenv("VERINOTE_BASE_URL", raising=False)
+    save_settings(tmp_path, provider=provider, model="m", base_url="https://llm.internal/v1")
+
+    adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
+
+    assert recorded["base_url"] == "https://llm.internal/v1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,27 @@ def test_empty_base_url_is_unset_for_every_provider(tmp_path, monkeypatch, provi
     assert Config.for_root(tmp_path).base_url is None
 
 
+def test_whitespace_only_saved_base_url_reads_as_unset(tmp_path, monkeypatch):
+    # The Settings UI is the other door into the same bug: normalising only the
+    # env source leaves a blank saved value reaching the SDK verbatim.
+    monkeypatch.delenv("VERINOTE_BASE_URL", raising=False)
+    save_settings(tmp_path, provider="openai", model="m", base_url="   ")
+    assert Config.for_root(tmp_path).base_url is None
+
+
+def test_padded_base_url_env_is_trimmed(tmp_path, monkeypatch):
+    # Judging on the trimmed text but returning the raw one would yield a URL
+    # with embedded spaces that no endpoint answers.
+    monkeypatch.setenv("VERINOTE_BASE_URL", "  https://llm.internal/v1  ")
+    assert Config.for_root(tmp_path).base_url == "https://llm.internal/v1"
+
+
+def test_padded_saved_base_url_is_trimmed(tmp_path, monkeypatch):
+    monkeypatch.delenv("VERINOTE_BASE_URL", raising=False)
+    save_settings(tmp_path, provider="openai", model="m", base_url="  https://llm.internal/v1  ")
+    assert Config.for_root(tmp_path).base_url == "https://llm.internal/v1"
+
+
 def test_empty_provider_env_falls_back_instead_of_failing(tmp_path, monkeypatch):
     # Behaviour change: this used to reach the factory as "" and blow up with
     # `unknown VERINOTE_PROVIDER=''`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,29 @@ def test_empty_provider_env_falls_back_instead_of_failing(tmp_path, monkeypatch)
     assert Config.for_root(tmp_path).provider == "ollama"
 
 
+def test_whitespace_only_provider_env_falls_back(tmp_path, monkeypatch):
+    # The normalisation is not base_url-only: narrowing it to that one setting
+    # would leave a blank provider reaching normalize_provider as "   ".
+    monkeypatch.setenv("VERINOTE_PROVIDER", "   ")
+    assert Config.for_root(tmp_path).provider == "anthropic"
+
+    save_settings(tmp_path, provider="ollama", model="llama3.1")
+    assert Config.for_root(tmp_path).provider == "ollama"
+
+
+def test_padded_provider_env_is_trimmed(tmp_path, monkeypatch):
+    # normalize_provider strips dashes and underscores but not whitespace, so
+    # an untrimmed "  ollama  " reaches dispatch as an unknown provider.
+    monkeypatch.setenv("VERINOTE_PROVIDER", "  ollama  ")
+    assert Config.for_root(tmp_path).provider == "ollama"
+
+
+def test_padded_model_env_is_trimmed(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    monkeypatch.setenv("VERINOTE_MODEL", "  gpt-4o  ")
+    assert Config.for_root(tmp_path).model == "gpt-4o"
+
+
 def test_empty_model_env_falls_back_to_provider_default(tmp_path, monkeypatch):
     monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
     monkeypatch.setenv("VERINOTE_MODEL", "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 import sys
 
+import pytest
+
 from verinote.config import (
     Config,
     PROVIDERS,
@@ -33,6 +35,61 @@ def test_env_overrides_saved_settings(tmp_path, monkeypatch):
     save_settings(tmp_path, provider="openai", model="gpt-4o")
     monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
     assert Config.for_root(tmp_path).provider == "ollama"
+
+
+def test_empty_base_url_env_reads_as_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_BASE_URL", "")
+    assert Config.for_root(tmp_path).base_url is None
+
+
+def test_empty_base_url_env_falls_back_to_saved_settings(tmp_path, monkeypatch):
+    # The point of the normalisation: an empty env var is *unset*, so the next
+    # source in the precedence chain wins. Nulling it out would pass the test
+    # above and still be wrong here.
+    save_settings(tmp_path, provider="openai", model="gpt-4o", base_url="http://saved:1234")
+    monkeypatch.setenv("VERINOTE_BASE_URL", "")
+    assert Config.for_root(tmp_path).base_url == "http://saved:1234"
+
+
+def test_whitespace_only_base_url_env_reads_as_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_BASE_URL", "   ")
+    assert Config.for_root(tmp_path).base_url is None
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDERS))
+def test_empty_base_url_is_unset_for_every_provider(tmp_path, monkeypatch, provider):
+    # The whole point of #293: one empty value, one meaning, whatever the
+    # provider. claudecli never reads base_url at all, so this config-layer
+    # assertion is the only meaningful guard for it.
+    save_settings(tmp_path, provider=provider, model="m")
+    monkeypatch.setenv("VERINOTE_BASE_URL", "")
+    assert Config.for_root(tmp_path).base_url is None
+
+
+def test_empty_provider_env_falls_back_instead_of_failing(tmp_path, monkeypatch):
+    # Behaviour change: this used to reach the factory as "" and blow up with
+    # `unknown VERINOTE_PROVIDER=''`.
+    monkeypatch.setenv("VERINOTE_PROVIDER", "")
+    assert Config.for_root(tmp_path).provider == "anthropic"
+
+    save_settings(tmp_path, provider="ollama", model="llama3.1")
+    assert Config.for_root(tmp_path).provider == "ollama"
+
+
+def test_empty_model_env_falls_back_to_provider_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    monkeypatch.setenv("VERINOTE_MODEL", "")
+    assert Config.for_root(tmp_path).model == "gpt-4o"
+
+
+def test_custom_base_url_env_survives_normalisation(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_BASE_URL", "https://llm.internal/v1")
+    assert Config.for_root(tmp_path).base_url == "https://llm.internal/v1"
+
+
+def test_custom_base_url_from_settings_file_survives_normalisation(tmp_path):
+    save_settings(tmp_path, provider="openai", model="gpt-4o", base_url="https://llm.internal/v1")
+    assert Config.for_root(tmp_path).base_url == "https://llm.internal/v1"
 
 
 def test_default_model_when_nothing_set(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,7 +257,7 @@ def test_read_settings_broken_json_warns_with_path(tmp_path, capsys):
     err = capsys.readouterr().err
     assert str(tmp_path / "config.json") in err
     assert "not valid JSON" in err
-    assert "provider and model" in err
+    assert "saved runtime settings" in err
 
 
 def test_read_settings_invalid_utf8_warns(tmp_path, capsys):

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from verinote.config import Config
+from verinote.config import Config, save_settings
 from verinote.llm.base import LLMError
 from verinote.llm.ollama_adapter import OllamaAdapter
 from verinote.prompts import save_prompt_override
@@ -196,3 +196,55 @@ def test_ollama_prompt_validation_error_is_llm_error(tmp_path):
 
     with pytest.raises(LLMError, match="\\{max_facts\\}"):
         OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+
+def _record_request_url(monkeypatch) -> list:
+    """Capture the URL actually requested, not the adapter's attribute."""
+    urls = []
+
+    def fake_urlopen(req, *, timeout):
+        urls.append(req.full_url)
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    return urls
+
+
+def test_empty_base_url_env_still_requests_localhost(tmp_path, monkeypatch):
+    urls = _record_request_url(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
+    monkeypatch.setenv("VERINOTE_BASE_URL", "")
+
+    OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
+
+    assert urls == ["http://localhost:11434/api/chat"]
+
+
+def test_custom_base_url_env_reaches_the_request_url(tmp_path, monkeypatch):
+    urls = _record_request_url(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
+    monkeypatch.setenv("VERINOTE_BASE_URL", "https://llm.internal/v1")
+
+    OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
+
+    assert urls == ["https://llm.internal/v1/api/chat"]
+
+
+def test_trailing_slash_is_still_stripped(tmp_path, monkeypatch):
+    urls = _record_request_url(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
+    monkeypatch.setenv("VERINOTE_BASE_URL", "https://llm.internal/")
+
+    OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
+
+    assert urls == ["https://llm.internal/api/chat"]
+
+
+def test_settings_file_base_url_reaches_the_request_url(tmp_path, monkeypatch):
+    urls = _record_request_url(monkeypatch)
+    monkeypatch.delenv("VERINOTE_BASE_URL", raising=False)
+    save_settings(tmp_path, provider="ollama", model="qwen3:8b", base_url="https://llm.internal/v1")
+
+    OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
+
+    assert urls == ["https://llm.internal/v1/api/chat"]

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -248,3 +248,24 @@ def test_settings_file_base_url_reaches_the_request_url(tmp_path, monkeypatch):
     OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
 
     assert urls == ["https://llm.internal/v1/api/chat"]
+
+
+def test_whitespace_only_saved_base_url_still_requests_localhost(tmp_path, monkeypatch):
+    # Without normalising the saved source too, this requests '   /api/chat'.
+    urls = _record_request_url(monkeypatch)
+    monkeypatch.delenv("VERINOTE_BASE_URL", raising=False)
+    save_settings(tmp_path, provider="ollama", model="qwen3:8b", base_url="   ")
+
+    OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
+
+    assert urls == ["http://localhost:11434/api/chat"]
+
+
+def test_padded_base_url_env_does_not_break_the_request_url(tmp_path, monkeypatch):
+    urls = _record_request_url(monkeypatch)
+    monkeypatch.setenv("VERINOTE_PROVIDER", "ollama")
+    monkeypatch.setenv("VERINOTE_BASE_URL", "  https://llm.internal/v1  ")
+
+    OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
+
+    assert urls == ["https://llm.internal/v1/api/chat"]

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -4,14 +4,16 @@
 Resolved so nothing about the active provider is hard-coded — this is the
 anti-lock-in seam. Precedence (highest first): environment variable, then the
 saved non-secret settings file (`<root>/config.json`, written by the Settings
-UI), then a built-in default. A blank (empty or whitespace-only) value counts
-as unset, so `VERINOTE_BASE_URL=` means the same thing to every provider. Where
-it lands differs by setting: the provider, model, and base URL walk the full
-chain, while the numeric and boolean settings drop straight to the built-in
-default without consulting the saved file. The API key is **only** ever read
-from the environment — it is never persisted to or read from the settings file,
-and it skips this normalisation entirely, so a blank `VERINOTE_API_KEY` reaches
-the provider as-is for it to reject.
+UI), then a built-in default. A blank (empty or whitespace-only) provider,
+model, or base URL value counts as unset and falls through the chain, so
+`VERINOTE_BASE_URL=` means the same thing to every provider. Numeric and boolean
+settings use the environment value when present, otherwise the saved file, then
+the default; if the selected value is blank or an invalid number, numeric
+parsers fall back to the default, while the boolean parser treats recognised
+truthy strings as true and everything else as false. The API key is **only**
+ever read from the environment — it is never persisted to or read from the
+settings file, and it skips this normalisation entirely, so a blank
+`VERINOTE_API_KEY` reaches the provider as-is for it to reject.
 
 The active KB root is stored in a platform-native app config file when the web
 UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
@@ -211,11 +213,11 @@ def _settings_path(root: Path) -> Path:
 
 
 def read_settings(root: Path) -> dict:
-    """Read non-secret settings (provider/model/base_url), or {} if absent/bad."""
+    """Read saved non-secret runtime settings, or {} if absent/bad."""
     path = _settings_path(root)
     if not path.is_file():
         return {}
-    consequence = "provider and model will fall back to defaults"
+    consequence = "saved runtime settings will fall back to defaults"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except OSError as err:

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -4,11 +4,14 @@
 Resolved so nothing about the active provider is hard-coded — this is the
 anti-lock-in seam. Precedence (highest first): environment variable, then the
 saved non-secret settings file (`<root>/config.json`, written by the Settings
-UI), then a built-in default. An environment variable set to an empty (or
-whitespace-only) value counts as unset and falls through to the next source, so
-`VERINOTE_BASE_URL=` means the same thing to every provider. The API key is
-**only** ever read from the environment — it is never persisted to or read from
-the settings file.
+UI), then a built-in default. A blank (empty or whitespace-only) value counts
+as unset, so `VERINOTE_BASE_URL=` means the same thing to every provider. Where
+it lands differs by setting: the provider, model, and base URL walk the full
+chain, while the numeric and boolean settings drop straight to the built-in
+default without consulting the saved file. The API key is **only** ever read
+from the environment — it is never persisted to or read from the settings file,
+and it skips this normalisation entirely, so a blank `VERINOTE_API_KEY` reaches
+the provider as `""` for it to reject.
 
 The active KB root is stored in a platform-native app config file when the web
 UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
@@ -264,16 +267,20 @@ def save_settings(
 def _pick(env: str, saved: str | None, default: str | None) -> str | None:
     """Resolve one setting: environment, then the saved file, then the default.
 
-    An empty or whitespace-only environment value means *unset*, so it falls
-    through to the saved value rather than being passed on as `""`. That is
-    what the rest of this module already does, and it is what `export VAR=` in
-    a CI or Docker env file means. A value that is set is returned verbatim.
+    A blank (empty or whitespace-only) value means *unset* from either source,
+    so it falls through rather than being passed on as `""`. That is what the
+    rest of this module already does, and it is what `export VAR=` in a CI or
+    Docker env file means. A value that is used is trimmed: judging on the
+    trimmed text but returning the raw one would let `" https://x "` through as
+    a URL that no endpoint answers.
     """
-    value = os.environ.get(env)
-    if value is not None and value.strip():
-        return value
-    if saved:
-        return saved
+    for candidate in (os.environ.get(env), saved):
+        # A hand-edited config.json can hold a non-string here; leave those
+        # alone rather than crashing on `.strip()`.
+        if isinstance(candidate, str):
+            candidate = candidate.strip()
+        if candidate:
+            return candidate
     return default
 
 

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -4,8 +4,11 @@
 Resolved so nothing about the active provider is hard-coded — this is the
 anti-lock-in seam. Precedence (highest first): environment variable, then the
 saved non-secret settings file (`<root>/config.json`, written by the Settings
-UI), then a built-in default. The API key is **only** ever read from the
-environment — it is never persisted to or read from the settings file.
+UI), then a built-in default. An environment variable set to an empty (or
+whitespace-only) value counts as unset and falls through to the next source, so
+`VERINOTE_BASE_URL=` means the same thing to every provider. The API key is
+**only** ever read from the environment — it is never persisted to or read from
+the settings file.
 
 The active KB root is stored in a platform-native app config file when the web
 UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
@@ -259,8 +262,15 @@ def save_settings(
 
 
 def _pick(env: str, saved: str | None, default: str | None) -> str | None:
+    """Resolve one setting: environment, then the saved file, then the default.
+
+    An empty or whitespace-only environment value means *unset*, so it falls
+    through to the saved value rather than being passed on as `""`. That is
+    what the rest of this module already does, and it is what `export VAR=` in
+    a CI or Docker env file means. A value that is set is returned verbatim.
+    """
     value = os.environ.get(env)
-    if value is not None:
+    if value is not None and value.strip():
         return value
     if saved:
         return saved

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -11,7 +11,7 @@ chain, while the numeric and boolean settings drop straight to the built-in
 default without consulting the saved file. The API key is **only** ever read
 from the environment — it is never persisted to or read from the settings file,
 and it skips this normalisation entirely, so a blank `VERINOTE_API_KEY` reaches
-the provider as `""` for it to reject.
+the provider as-is for it to reject.
 
 The active KB root is stored in a platform-native app config file when the web
 UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
@@ -275,8 +275,9 @@ def _pick(env: str, saved: str | None, default: str | None) -> str | None:
     a URL that no endpoint answers.
     """
     for candidate in (os.environ.get(env), saved):
-        # A hand-edited config.json can hold a non-string here; leave those
-        # alone rather than crashing on `.strip()`.
+        # A hand-edited config.json can hold a non-string here. Passing those
+        # through untouched is what this function has always done; normalising
+        # them is a separate question from the blank-value one.
         if isinstance(candidate, str):
             candidate = candidate.strip()
         if candidate:


### PR DESCRIPTION
`export VERINOTE_BASE_URL=` currently means a different thing to every provider. This makes a blank value mean *unset*, everywhere.

Closes #293

## Commit title correction

The title of `48e9e40` says `VERINOTE_*`, which overclaims. The change applies to the three settings that go through `_pick`: **`VERINOTE_PROVIDER`, `VERINOTE_MODEL`, and `VERINOTE_BASE_URL`**. The other environment readers are untouched. Amending was off the table once the branch had review history, so the correction lives here.

## What was broken

The four adapters each did something different with `""`:

| adapter | behaviour with `base_url=""` |
|---|---|
| `openai_adapter.py` | passes `""` straight to the SDK |
| `anthropic_adapter.py` | passes `""` straight to the SDK |
| `ollama_adapter.py` | `""` is falsy, so it silently uses localhost |
| `claude_cli_adapter.py` | never reads `base_url` at all |

Measured against the installed anthropic SDK: `base_url=""` fails at request time with `APIConnectionError: Connection error.` — an opaque error that names no cause. `base_url=None` resolves to `https://api.anthropic.com` **and honours the SDK's own `ANTHROPIC_BASE_URL`**. So an empty string does not just fail; it disables the SDK's own environment handling.

The cause was one place. `_pick` tested the environment with `is not None`, so `""` passed through. The module's other five readers already treat blank as unset (`local_root`, `active_root`, `_llm_timeout_seconds`, `_pick_int`, `_pick_bool`), and both write paths already normalise (`save_settings`, `web/app.py`). `_pick` was the lone exception.

## What changed, and why it took three commits

Review found the second half of the bug twice. That is what the three commits are.

1. **`48e9e40`** — normalise the environment source. **But the `saved` branch was still `if saved:`**, so the fix covered half the read path and the same bug walked back in through the Settings UI: `save_settings(base_url="   ")` produced an ollama request to `'   /api/chat'`.

2. **`75b4f2d`** — fold both sources into one loop and trim the value that is used. Judging on the trimmed text while returning the raw one is its own bug: `"  https://x/v1  "` builds `'...v1  /api/chat'`.

3. **`d8f9671`** — guard the provider and model halves. Narrowing the trim to `env == "VERINOTE_BASE_URL"` with a single line left **all ~30 tests green**: `_pick` serves three settings, but every mutant so far had aimed at `base_url`.

`_pick` now reads:

```python
for candidate in (os.environ.get(env), saved):
    if isinstance(candidate, str):
        candidate = candidate.strip()
    if candidate:
        return candidate
return default
```

No adapter source changed. The `isinstance` check preserves the existing pass-through for a non-string value in a hand-edited `config.json`.

## Backward compatibility

No working configuration breaks. The only users relying on a blank value today are on ollama, and their behaviour is unchanged (localhost either way). anthropic and openai users are broken today and are fixed here.

`VERINOTE_PROVIDER=""` now falls back instead of raising `unknown VERINOTE_PROVIDER=''`. That is an improvement, not a loss of safety: a typo does not produce a blank value, so `opnai` still fails loudly.

## Known remaining inconsistency

The module still has two rules after this branch. `_pick` falls back to the saved file on a blank env value; **`_pick_int` and `_pick_bool` skip the saved file and go straight to the built-in default.** Measured: saved `chunk_chars=450` with `VERINOTE_EXTRACTION_CHUNK_CHARS=""` yields **300**, while the same shape on `VERINOTE_MODEL=""` yields the saved value. The new module docstring spells this split out, so it is documented rather than hidden — but it is not unified. Left as follow-up.

## Verification

`1262 passed`, 0 failed. `ruff check .` clean.

Seven mutants, all red (unmutated copy of the same tree: 73 passed):

| mutant | result |
|---|---|
| revert `_pick` entirely | 23 failed |
| normalise but never fall back | 9 failed |
| judge on trimmed text, return raw | 7 failed |
| revert the `saved` branch only | 5 failed |
| restrict the trim to `VERINOTE_BASE_URL` | 3 failed |
| `openai_adapter` regains `or ""` | 2 failed |
| ollama default becomes `127.0.0.1` | 2 failed |

The adapter-layer guards assert `recorded["base_url"] is None` rather than a falsy check — `""` is falsy too, so a truthiness assertion would pass against the very bug. The ollama guards capture the **requested URL**, not the adapter attribute.

Three reverse guards confirm the normalisation is not over-constrained, so self-hosted endpoints still work: a custom endpoint reaches openai/anthropic verbatim and ollama as `https://llm.internal/v1/api/chat`, trailing-slash stripping survives, and a `config.json`-only endpoint still reaches the adapter with no env set at all.

## Follow-ups (not filed here)

- Non-string config values belong in `read_settings` type validation — that is the boundary where untrusted JSON arrives, and it already warns-and-ignores a non-dict. Fixing it in `_pick` would miss `_pick_int`/`_pick_bool` and the direct `saved.get()` call sites.
- `VERINOTE_API_KEY=""` bypasses `_pick` and is read directly.
- The `_pick_int`/`_pick_bool` saved-skipping described above.

Deliberately **not** doing base_url format validation: there is no clean boundary for a valid endpoint (self-hosted, ports, sockets), and with blank values gone the remaining failures already point at their cause. It would be exactly the over-constraint the reverse guards exist to prevent.
