### PR TITLE
fix(#160): do not resurrect rejected facts when a source is re-extracted

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -683,6 +683,19 @@ def test_seed_targets_the_named_root(tmp_path, monkeypatch, capsys):
     assert f"seeded demo facts into {root}" in capsys.readouterr().out
 
 
+def test_seed_run_twice_does_not_double_demo_facts(tmp_path):
+    # Seed routes through reconcile_fact, so a second seed over the same demo
+    # (source, triple) pairs re-hits the existing rows instead of duplicating them.
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+
+    cli._seed(store)
+    cli._seed(store)
+
+    assert len(store.facts()) == len(cli._DEMO_FACTS)
+    store.close()
+
+
 def test_init_help_does_not_promise_verinote_root_only(capsys):
     with pytest.raises(SystemExit):
         cli.main(["init", "--help"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -961,3 +961,94 @@ def test_process_extraction_job_dedupes_chunk_facts_by_source(tmp_path, fake_cli
 
     assert result.candidates == 1
     assert len(s.facts()) == 1
+
+
+def test_extract_source_does_not_resurrect_a_rejected_fact(tmp_path, fake_client):
+    # The headline #160 regression: a human rejects an extracted fact, then the
+    # same source is synced again. The rejection is terminal, so the re-sync must
+    # not bring the fact back as a fresh candidate.
+    s = _store(tmp_path)
+    facts = [ExtractedFact("A", "is_a", "B", 0.9, "n")]
+
+    run_one = s.add_run(provider="fake", model="m")
+    assert (
+        extract_source(
+            s,
+            fake_client(facts),
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_one,
+        )
+        == 1
+    )
+    [fact] = s.facts()
+    s.reject_fact(fact["id"])
+    assert s.get_fact(fact["id"])["status"] == "superseded"
+
+    run_two = s.add_run(provider="fake", model="m")
+    assert (
+        extract_source(
+            s,
+            fake_client(facts),
+            source_path="sources/x.txt",
+            source_text="...",
+            run_id=run_two,
+        )
+        == 0
+    )
+
+    rows = s.facts()
+    assert len(rows) == 1
+    assert rows[0]["id"] == fact["id"]
+    assert rows[0]["status"] == "superseded"
+
+
+def test_extract_source_reruns_add_no_duplicate_row_or_evidence(tmp_path, fake_client):
+    s = _store(tmp_path)
+    facts = [ExtractedFact("A", "is_a", "B", 0.9, "n")]
+
+    assert (
+        extract_source(
+            s, fake_client(facts), source_path="sources/x.txt", source_text="..."
+        )
+        == 1
+    )
+    evidence_before = s._conn.execute("SELECT COUNT(*) FROM fact_evidence").fetchone()[0]
+
+    assert (
+        extract_source(
+            s, fake_client(facts), source_path="sources/x.txt", source_text="..."
+        )
+        == 0
+    )
+
+    assert len(s.facts()) == 1
+    # A dedupe hit attaches no fresh evidence -- pins the no-evidence-on-hit rule.
+    assert (
+        s._conn.execute("SELECT COUNT(*) FROM fact_evidence").fetchone()[0]
+        == evidence_before
+    )
+
+
+def test_extract_source_rerun_still_inserts_a_genuinely_new_fact(tmp_path, fake_client):
+    s = _store(tmp_path)
+    first = [ExtractedFact("A", "is_a", "B", 0.9, "n")]
+    assert (
+        extract_source(
+            s, fake_client(first), source_path="sources/x.txt", source_text="..."
+        )
+        == 1
+    )
+
+    second = [
+        ExtractedFact("A", "is_a", "B", 0.9, "n"),
+        ExtractedFact("C", "is_a", "D", 0.8),
+    ]
+    assert (
+        extract_source(
+            s, fake_client(second), source_path="sources/x.txt", source_text="..."
+        )
+        == 1
+    )
+
+    assert {(f["subject"], f["object"]) for f in s.facts()} == {("A", "B"), ("C", "D")}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import json
+
 import pytest
 
 from verinote.llm.base import ExtractedFact, LLMError
@@ -1052,3 +1054,40 @@ def test_extract_source_rerun_still_inserts_a_genuinely_new_fact(tmp_path, fake_
     )
 
     assert {(f["subject"], f["object"]) for f in s.facts()} == {("A", "B"), ("C", "D")}
+
+
+def test_sync_records_suppression_event_when_reextracting_rejected_fact(
+    tmp_path, fake_client
+):
+    # End-to-end #160: sync, reject, sync again. The re-sync creates no candidate
+    # and records a reextraction_suppressed event on the original rejected fact.
+    s = _store(tmp_path)
+    facts = [ExtractedFact("A", "is_a", "B", 0.9, "n")]
+
+    sync_sources(
+        s,
+        fake_client(facts),
+        [("sources/x.txt", "...")],
+        provider="fake",
+        model="m",
+    )
+    [fact] = s.facts()
+    s.reject_fact(fact["id"])
+
+    result = sync_sources(
+        s,
+        fake_client(facts),
+        [("sources/x.txt", "...")],
+        provider="fake",
+        model="m",
+    )
+
+    assert result.total == 0
+    assert len(s.facts()) == 1
+    events = [
+        event
+        for event in s.fact_events(fact["id"])
+        if event["event_type"] == "reextraction_suppressed"
+    ]
+    assert len(events) == 1
+    assert json.loads(events[0]["after_json"])["run_id"] == result.run_id

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1085,3 +1085,21 @@ def test_existing_fact_for_source_is_scoped_to_the_source(tmp_path):
         )
         is None
     )
+
+
+def test_reconcile_fact_never_resurrects_a_legacy_superseded_row(tmp_path):
+    # A rejected fact whose row predates the term_token column (NULL token) must
+    # still be recognised on the fallback and left superseded -- never reinserted.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)
+    s.reject_fact(fact_id)
+    s._conn.execute("UPDATE facts SET term_token = NULL WHERE id = ?", (fact_id,))
+    before = len(s.facts())
+
+    result = s.reconcile_fact("A", "count", NumberLit(36), source_id=sid)
+
+    assert result == db.FactReconcileResult(
+        fact_id=fact_id, created=False, matched_status="superseded"
+    )
+    assert len(s.facts()) == before

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1103,3 +1103,122 @@ def test_reconcile_fact_never_resurrects_a_legacy_superseded_row(tmp_path):
         fact_id=fact_id, created=False, matched_status="superseded"
     )
     assert len(s.facts()) == before
+
+
+def _suppression_events(store, fact_id):
+    return [
+        event
+        for event in store.fact_events(fact_id)
+        if event["event_type"] == "reextraction_suppressed"
+    ]
+
+
+def test_reconcile_fact_records_suppression_event_on_superseded_hit(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    run_id = s.add_run(provider="fake", model="m")
+    fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)
+    s.reject_fact(fact_id)
+    before = len(s.facts())
+
+    result = s.reconcile_fact(
+        "A", "count", NumberLit(36), source_id=sid, run_id=run_id
+    )
+
+    assert result.created is False
+    assert result.matched_status == "superseded"
+    assert s.get_fact(fact_id)["status"] == "superseded"
+    assert len(s.facts()) == before
+
+    events = _suppression_events(s, fact_id)
+    assert len(events) == 1
+    assert events[0]["actor"] == "system"
+    assert events[0]["source_id"] == sid
+    assert json.loads(events[0]["after_json"]) == {
+        "status": "superseded",
+        "run_id": run_id,
+    }
+
+
+def test_reconcile_fact_emits_one_suppression_event_per_run(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)
+    s.reject_fact(fact_id)
+
+    run_one = s.add_run(provider="fake", model="m")
+    # Two hits in one run mimic chunk overlap re-extracting a boundary triple.
+    s.reconcile_fact("A", "count", NumberLit(36), source_id=sid, run_id=run_one)
+    s.reconcile_fact("A", "count", NumberLit(36), source_id=sid, run_id=run_one)
+    assert len(_suppression_events(s, fact_id)) == 1
+
+    run_two = s.add_run(provider="fake", model="m")
+    s.reconcile_fact("A", "count", NumberLit(36), source_id=sid, run_id=run_two)
+
+    events = _suppression_events(s, fact_id)
+    assert len(events) == 2
+    assert [json.loads(e["after_json"])["run_id"] for e in events] == [run_one, run_two]
+
+
+def test_reconcile_fact_seed_path_emits_suppression_event_each_time(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)
+    s.reject_fact(fact_id)
+
+    # run_id=None is the seed path: a re-seed is human-initiated and each is signal.
+    s.reconcile_fact("A", "count", NumberLit(36), source_id=sid)
+    s.reconcile_fact("A", "count", NumberLit(36), source_id=sid)
+
+    events = _suppression_events(s, fact_id)
+    assert len(events) == 2
+    assert {json.loads(e["after_json"])["run_id"] for e in events} == {None}
+
+
+def test_reconcile_fact_records_no_suppression_event_on_live_hit(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    run_id = s.add_run(provider="fake", model="m")
+    fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid, status="confirmed")
+
+    result = s.reconcile_fact(
+        "A", "count", NumberLit(36), source_id=sid, run_id=run_id
+    )
+
+    assert result.matched_status == "confirmed"
+    assert _suppression_events(s, fact_id) == []
+
+
+def test_reconcile_fact_created_path_records_only_candidate_created(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    run_id = s.add_run(provider="fake", model="m")
+
+    result = s.reconcile_fact(
+        "A", "count", NumberLit(36), source_id=sid, run_id=run_id
+    )
+
+    assert result.created is True
+    assert [e["event_type"] for e in s.fact_events(result.fact_id)] == [
+        "candidate_created"
+    ]
+
+
+def test_reconcile_fact_prefers_live_row_over_superseded_duplicate(tmp_path):
+    # A pre-fix source can hold both a live and a superseded row for one triple.
+    # Reconcile must return the live row and suppress nothing.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    run_id = s.add_run(provider="fake", model="m")
+    rejected = s.add_fact("A", "count", NumberLit(36), source_id=sid)
+    s.reject_fact(rejected)
+    live = s.add_fact("A", "count", NumberLit(36), source_id=sid, status="needs_review")
+
+    result = s.reconcile_fact(
+        "A", "count", NumberLit(36), source_id=sid, run_id=run_id
+    )
+
+    assert result.fact_id == live
+    assert result.matched_status == "needs_review"
+    assert _suppression_events(s, rejected) == []
+    assert _suppression_events(s, live) == []

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -4,6 +4,7 @@ import json
 import pytest
 
 from verinote.engine import compile_dl, coverage
+from verinote.engine.terms import Compound, NumberLit
 from verinote.store import Store, db, engine_statuses
 
 
@@ -1014,3 +1015,73 @@ def test_question_schema_migration_preserves_legacy_rows_and_adds_reason(tmp_pat
     row = s.questions()[0]
     assert row["status"] == "translation_failed"
     assert row["reason"] == "provider unavailable"
+
+
+def test_existing_fact_for_source_distinguishes_string_from_compound(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    s.add_fact("A", "at", "point(1, 2)", source_id=sid)
+
+    assert (
+        s.existing_fact_for_source(
+            source_id=sid,
+            subject="A",
+            relation="at",
+            obj=Compound("point", (NumberLit(1), NumberLit(2))),
+        )
+        is None
+    )
+
+
+def test_existing_fact_for_source_distinguishes_string_from_number(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    s.add_fact("A", "count", "36", source_id=sid)
+
+    assert (
+        s.existing_fact_for_source(
+            source_id=sid, subject="A", relation="count", obj=NumberLit(36)
+        )
+        is None
+    )
+
+
+def test_existing_fact_for_source_matches_identical_structural_triple(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact(
+        "A", "count", NumberLit(36), source_id=sid, status="needs_review"
+    )
+
+    existing = s.existing_fact_for_source(
+        source_id=sid, subject="A", relation="count", obj=NumberLit(36)
+    )
+    assert existing == db.ExistingFact(fact_id=fact_id, status="needs_review")
+
+
+def test_existing_fact_for_source_falls_back_for_legacy_null_token(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/sample.txt")
+    fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)
+    # A row written before the term_token column carries NULL there.
+    s._conn.execute("UPDATE facts SET term_token = NULL WHERE id = ?", (fact_id,))
+
+    existing = s.existing_fact_for_source(
+        source_id=sid, subject="A", relation="count", obj=NumberLit(36)
+    )
+    assert existing is not None
+    assert existing.fact_id == fact_id
+
+
+def test_existing_fact_for_source_is_scoped_to_the_source(tmp_path):
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    s.add_fact("A", "count", NumberLit(36), source_id=source_a)
+
+    assert (
+        s.existing_fact_for_source(
+            source_id=source_b, subject="A", relation="count", obj=NumberLit(36)
+        )
+        is None
+    )

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -159,7 +159,9 @@ def cmd_policy_reset(cfg: Config, args: argparse.Namespace) -> int:
 def _seed(store: Store) -> None:
     for subj, rel, obj, status, conf, src, note in _DEMO_FACTS:
         sid = store.add_source(src)
-        store.add_fact(subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note)
+        store.reconcile_fact(
+            subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note
+        )
 
 
 # The four ways an existing `kb.sqlite` can fail to be a usable KB. They are not

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -74,11 +74,17 @@ def extract_source(
     schema_hint: str = "",
     run_id: int | None = None,
 ) -> int:
-    """Run extraction for one source; insert candidates. Returns count inserted.
+    """Run extraction for one source; reconcile candidates. Returns count inserted.
 
     Newly extracted facts land as `candidate` — they only become engine input
     after passing the human review gate (see the web review queue). Each fact
     cites its `source` and (when given) the `run` that produced it.
+
+    Re-extraction reconciles rather than blind-inserting: a triple already stored
+    for this source (in any status, a human's rejection included) is left as it
+    is, so a re-sync never resurrects a rejected fact (#160). The returned count
+    is the rows actually inserted, not the number extracted — the run summary
+    must not claim candidates for triples that were suppressed.
     """
     analysis_text = normalize_for_extraction(source_text)
     facts = _extract_chunk_facts(
@@ -99,8 +105,9 @@ def extract_source(
     rows = _candidate_rows(facts, analysis_text, relation_aliases=aliases)
 
     source_id = store.add_source(source_path)
+    inserted = 0
     for subject, relation, obj, f in rows:
-        fact_id = store.add_fact(
+        result = store.reconcile_fact(
             subject,
             relation,
             obj,
@@ -110,14 +117,17 @@ def extract_source(
             run_id=run_id,
             note=f.note,
         )
+        if not result.created:
+            continue
         store.add_fact_evidence(
-            fact_id=fact_id,
+            fact_id=result.fact_id,
             source_id=source_id,
             evidence_kind="chunk",
             locator="source",
             snippet=analysis_text,
         )
-    return len(rows)
+        inserted += 1
+    return inserted
 
 
 def create_chunked_extraction_job(
@@ -332,14 +342,7 @@ def _extract_chunk(
     rows = _candidate_rows(facts, source_text, relation_aliases=aliases)
     inserted = 0
     for subject, relation, obj, f in rows:
-        if (
-            store.existing_fact_for_source(
-                source_id=source_id, subject=subject, relation=relation, obj=obj
-            )
-            is not None
-        ):
-            continue
-        fact_id = store.add_fact(
+        result = store.reconcile_fact(
             subject,
             relation,
             obj,
@@ -350,8 +353,10 @@ def _extract_chunk(
             job_id=job_id,
             note=f.note,
         )
+        if not result.created:
+            continue
         store.add_fact_evidence(
-            fact_id=fact_id,
+            fact_id=result.fact_id,
             source_id=source_id,
             artifact_id=artifact_id,
             job_id=job_id,

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -332,8 +332,11 @@ def _extract_chunk(
     rows = _candidate_rows(facts, source_text, relation_aliases=aliases)
     inserted = 0
     for subject, relation, obj, f in rows:
-        if store.fact_exists_for_source(
-            source_id=source_id, subject=subject, relation=relation, obj=obj
+        if (
+            store.existing_fact_for_source(
+                source_id=source_id, subject=subject, relation=relation, obj=obj
+            )
+            is not None
         ):
             continue
         fact_id = store.add_fact(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -885,6 +885,13 @@ class Store:
         the exact pre-token rendered-triple match. This preserves the old
         behaviour precisely where it is all we have -- a superseded legacy fact
         still matches and is never resurrected.
+
+        When pre-fix structural duplicates coexist for one source, a live row
+        wins over a superseded one (`status = 'superseded'` sorts last -- SQLite
+        orders false before true). This matters to `reconcile_fact`'s suppression
+        signal: it must report `superseded` only when a human's rejection is the
+        SOLE standing record of the triple. If any live row exists, the triple is
+        already in the review queue or the engine and nothing is being suppressed.
         """
         from verinote.store.duckdb_fact_terms import fact_term_token
 
@@ -894,7 +901,7 @@ class Store:
             "AND ((term_token IS NOT NULL AND term_token = ?) "
             "OR (term_token IS NULL AND subject = ? AND relation = ? "
             "AND object = ?)) "
-            "ORDER BY id LIMIT 1",
+            "ORDER BY (status = 'superseded'), id LIMIT 1",
             (
                 source_id,
                 fact_term_token(subject, relation, obj),
@@ -1094,12 +1101,33 @@ class Store:
         the safe direction (a new row, never a wrongly-suppressed one), but not a
         dedupe. Source-scoping is deliberate: the same triple from a different
         source is a distinct citation and must insert.
+
+        On a hit the matched row is left exactly as it stands: `note` and
+        `confidence` are deliberately NOT refreshed from the new extraction.
+        Refreshing them would clobber the human's review state and, worse, would
+        write to rejected facts — the very thing #160 is about.
+
+        When the hit is a superseded row (a human's rejection is the sole
+        standing record — see `existing_fact_for_source`'s ordering), a
+        `reextraction_suppressed` fact event is recorded so the suppression is
+        auditable. It is de-duplicated per `run_id`: chunk overlap re-extracts
+        boundary-straddling triples within one run, so without the guard every
+        such re-hit — and every fact on every re-sync — would emit again. A
+        seed has no run (`run_id` is None); a re-seed is a rare, human-initiated
+        act, so each occurrence is itself signal and is emitted unconditionally.
         """
         with self._lock:
             existing = self.existing_fact_for_source(
                 source_id=source_id, subject=subject, relation=relation, obj=obj
             )
             if existing is not None:
+                if existing.status == "superseded":
+                    self._record_reextraction_suppressed(
+                        fact_id=existing.fact_id,
+                        source_id=source_id,
+                        run_id=run_id,
+                        job_id=job_id,
+                    )
                 return FactReconcileResult(
                     fact_id=existing.fact_id,
                     created=False,
@@ -1117,6 +1145,35 @@ class Store:
                 note=note,
             )
             return FactReconcileResult(fact_id=fact_id, created=True, matched_status=None)
+
+    def _record_reextraction_suppressed(
+        self, *, fact_id: int, source_id: int | None, run_id: int | None, job_id: int | None
+    ) -> None:
+        """Log that re-extraction re-hit this superseded fact and inserted nothing.
+
+        Caller holds `self._lock` and has already established the fact is
+        superseded. When `run_id` is set the event is emitted at most once per
+        (fact_id, run_id): the `after_json` payload carries the run, so an
+        existing row for this run means overlap/re-sync has already recorded it.
+        A None `run_id` (the seed path) is emitted every time by design.
+        """
+        if run_id is not None:
+            already = self._conn.execute(
+                "SELECT 1 FROM fact_events "
+                "WHERE fact_id = ? AND event_type = 'reextraction_suppressed' "
+                "AND json_extract(after_json, '$.run_id') = ? LIMIT 1",
+                (fact_id, run_id),
+            ).fetchone()
+            if already is not None:
+                return
+        self._add_fact_event(
+            fact_id=fact_id,
+            event_type="reextraction_suppressed",
+            actor="system",
+            source_id=source_id,
+            job_id=job_id,
+            after={"status": "superseded", "run_id": run_id},
+        )
 
     def get_fact_terms(self, fact_id: int):
         """Return structural DuckDB terms for a fact metadata row."""

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -52,6 +52,22 @@ class FactDecision:
     @classmethod
     def unchanged(cls, fact: sqlite3.Row | None) -> "FactDecision":
         return cls(fact=fact, changed=False)
+
+
+@dataclass(frozen=True)
+class ExistingFact:
+    """A fact already stored under a source, identified for the extract dedupe.
+
+    Carries `status` alongside `fact_id` because the caller needs to know not
+    just that a match exists but what state it is in: a superseded prior fact
+    must still count as a match so extraction never re-inserts (and thereby
+    resurrects) it, and later units act on that status.
+    """
+
+    fact_id: int
+    status: str
+
+
 REVIEW_PAGE_SIZES = (25, 50, 100)
 DEFAULT_REVIEW_PAGE_SIZE = 50
 DEFAULT_REVIEW_SORT = "newest"
@@ -836,20 +852,45 @@ class Store:
                     after=_job_event_payload(after),
                 )
 
-    def fact_exists_for_source(
+    def existing_fact_for_source(
         self, *, source_id: int, subject: object, relation: object, obj: object
-    ) -> bool:
+    ) -> ExistingFact | None:
+        """Return a prior fact for this (source, triple), or None to insert.
+
+        Keyed on `term_token` -- the structural identity of the triple -- so
+        terms that merely *render* alike no longer collapse: a stored string
+        "36" and `NumberLit(36)`, or "point(1, 2)" and its `Compound`, have
+        distinct tokens and so are correctly treated as distinct facts. The
+        rendered-string key this replaces silently dropped such genuinely new
+        facts. The key is source-scoped on purpose: the same triple cited by a
+        different source is a different citation and must insert.
+
+        Legacy rows written before the token column carry NULL there; their
+        structural interpretation is unrecoverable, so for them we fall back to
+        the exact pre-token rendered-triple match. This preserves the old
+        behaviour precisely where it is all we have -- a superseded legacy fact
+        still matches and is never resurrected.
+        """
+        from verinote.store.duckdb_fact_terms import fact_term_token
+
         row = self._conn.execute(
-            "SELECT 1 FROM facts WHERE source_id = ? AND subject = ? "
-            "AND relation = ? AND object = ? LIMIT 1",
+            "SELECT id, status FROM facts "
+            "WHERE source_id = ? "
+            "AND ((term_token IS NOT NULL AND term_token = ?) "
+            "OR (term_token IS NULL AND subject = ? AND relation = ? "
+            "AND object = ?)) "
+            "ORDER BY id LIMIT 1",
             (
                 source_id,
+                fact_term_token(subject, relation, obj),
                 _display_fact_value(subject),
                 _display_fact_value(relation),
                 _display_fact_value(obj),
             ),
         ).fetchone()
-        return row is not None
+        if row is None:
+            return None
+        return ExistingFact(fact_id=int(row["id"]), status=str(row["status"]))
 
     # --- fact evidence ---------------------------------------------------
     def add_fact_evidence(
@@ -1698,6 +1739,13 @@ class Store:
             )
         if "term_token" not in fact_columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN term_token TEXT")
+        # Created here rather than in schema.sql: that script runs before the
+        # ALTER above, so on a legacy DB the term_token column this index needs
+        # does not exist yet. By this point it always does.
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_facts_source_term_token "
+            "ON facts(source_id, term_token)"
+        )
         self._conn.executescript(
             """
             CREATE TABLE IF NOT EXISTS fact_evidence (

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -68,6 +68,21 @@ class ExistingFact:
     status: str
 
 
+@dataclass(frozen=True)
+class FactReconcileResult:
+    """The outcome of reconciling one (source, triple) against what is stored.
+
+    `created` is the only field a caller needs to decide whether to attach
+    evidence or count an insert; `matched_status` carries the pre-existing row's
+    status on a dedupe hit so a caller (or a later audit) can tell a suppressed
+    duplicate of a live candidate apart from one that re-hit a rejected fact.
+    """
+
+    fact_id: int  # existing row on a hit, or the newly created row
+    created: bool  # True only when a new row was inserted
+    matched_status: str | None  # status of the pre-existing row on a dedupe hit
+
+
 REVIEW_PAGE_SIZES = (25, 50, 100)
 DEFAULT_REVIEW_PAGE_SIZE = 50
 DEFAULT_REVIEW_SORT = "newest"
@@ -1044,6 +1059,64 @@ class Store:
                     self._delete_fact_terms_quietly(fact_id)
                 raise
             return fact_id
+
+    def reconcile_fact(
+        self,
+        subject: object,
+        relation: object,
+        obj: object,
+        *,
+        status: str = "candidate",
+        confidence: float = 0.0,
+        source_id: int | None = None,
+        run_id: int | None = None,
+        job_id: int | None = None,
+        note: str = "",
+    ) -> FactReconcileResult:
+        """The one place a (source, triple) is reconciled before it is inserted.
+
+        Every fact insert that cites a source goes through here: chunked
+        extraction, `extract_source`, and the demo seed used to each decide for
+        themselves whether the triple was already present, and two of the three
+        did not decide at all — they blind-inserted. That is how a fact a human
+        had rejected came back, on the next sync, as a fresh candidate (#160). A
+        prior row for this (source, triple) — in *any* status, superseded
+        included — is a match: we return it and insert nothing, so a terminal
+        rejection is never resurrected.
+
+        The lookup and the insert both run under `self._lock` (re-entrant, so
+        `add_fact` re-acquiring it below is safe), which is what makes the
+        decision atomic against other callers sharing this lock: no second caller
+        can slip an insert of the same triple between our miss and our write.
+
+        Precondition: callers pass a concrete `source_id`. A NULL `source_id`
+        never matches an existing row and so always falls through to insert —
+        the safe direction (a new row, never a wrongly-suppressed one), but not a
+        dedupe. Source-scoping is deliberate: the same triple from a different
+        source is a distinct citation and must insert.
+        """
+        with self._lock:
+            existing = self.existing_fact_for_source(
+                source_id=source_id, subject=subject, relation=relation, obj=obj
+            )
+            if existing is not None:
+                return FactReconcileResult(
+                    fact_id=existing.fact_id,
+                    created=False,
+                    matched_status=existing.status,
+                )
+            fact_id = self.add_fact(
+                subject,
+                relation,
+                obj,
+                status=status,
+                confidence=confidence,
+                source_id=source_id,
+                run_id=run_id,
+                job_id=job_id,
+                note=note,
+            )
+            return FactReconcileResult(fact_id=fact_id, created=True, matched_status=None)
 
     def get_fact_terms(self, fact_id: int):
         """Return structural DuckDB terms for a fact metadata row."""

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -115,6 +115,9 @@ CREATE TABLE IF NOT EXISTS facts (
 CREATE INDEX IF NOT EXISTS idx_facts_status ON facts(status);
 CREATE INDEX IF NOT EXISTS idx_facts_review_status_id ON facts(status, id);
 CREATE INDEX IF NOT EXISTS idx_facts_triple ON facts(subject, relation, object);
+-- idx_facts_source_term_token is created in Store._ensure_schema_migrations,
+-- not here: on a legacy DB this script runs before term_token is added, so an
+-- index over that column here would fail on the very DBs that most need it.
 
 -- Source-backed evidence anchors for extracted facts. Chunk-level anchors are
 -- available for every chunked extraction; exact spans/table cells can be added


### PR DESCRIPTION
Closes #160.

재추출이 사람의 reject 를 부활시키던 문제를 세 개의 원자 커밋으로 닫는다. 유지보수자 코멘트로 갱신된 스코프(2026-07-13/14) 기준이다: 청크 경로에는 이미 dedupe 가 있었지만 키가 틀렸고, `extract_source`(sync)와 `_seed` 는 게이트 자체가 없었으며, 억제는 침묵이었다.

## 커밋

1. **`fix(#160): key the source dedupe on the structural term, not the rendered string`** — `fact_exists_for_source` 는 `_display_fact_value` 렌더링 문자열을 키로 써서 서로 다른 term 이 붕괴했다(`"36"` vs `NumberLit(36)`, `"point(1, 2)"` vs `Compound`). 이를 `existing_fact_for_source` 로 교체: `(source_id, term_token)` 키 + legacy NULL-token 행은 렌더링 폴백(부활 방지 계약이 신규 사실 수용보다 우선 — 구조 해석은 복구 불가능하므로 legacy 에 한해 옛 동작 유지). 인덱스는 legacy DB 에서 ALTER 이후에 만들어져야 하므로 schema.sql 이 아니라 `_ensure_schema_migrations` 에 산다.
2. **`fix(#160): route every fact insert through one source-triple reconcile`** — `Store.reconcile_fact` 가 유일한 결정 지점이 된다. 세 호출처(`_extract_chunk`, `extract_source`, `_seed`) 전부 통과; `add_fact` 의 프로덕션 호출자는 `reconcile_fact` 하나뿐임을 확인. 히트 시 삽입·evidence·상태 변경 없음. `extract_source` 는 실제 삽입 수를 반환해 run summary 의 과잉 주장을 제거.
3. **`feat(#160): record an event when re-extraction hits a superseded fact`** — 침묵 skip 제거. superseded 히트는 `reextraction_suppressed` fact_event(메타데이터만: status, run_id)를 남긴다. (fact_id, run_id)당 최대 1회(청크 오버랩·재sync 스팸 방지); seed 경로(run 없음)는 매회 기록. `existing_fact_for_source` 는 live 행을 superseded 중복보다 우선해, 신호는 사람의 reject 가 유일한 잔존 기록일 때만 발화한다.

## 검증

- 전체 스위트 1353 passed / 7 skipped, `ruff check .` clean.
- 헤드라인 회귀 테스트(sync → reject → sync)는 수정 전 코드에서 red 임을 격리 워크트리에서 확인.
- 컨센서스 플로우: 커밋별 리뷰 APPROVE + architect/critic 감사 CONCUR 3/3.

## 후속 (별도 이슈)

- #329 — 소스 텍스트가 바뀐 뒤 옛 텍스트의 confirmed 사실 retire/표면화 (#160 이 미룬 절반).
- #330 — Unit 3 의 `json_extract` 가 만든 암묵적 SQLite>=3.38 하한 (Python 필터링 교체 권장).
- NFC 정규화는 범위 외(#199-201): 이 PR 의 계약은 "바이트 동일 term 의 reject 는 부활하지 않는다"이다.
