### PR TITLE
fix(#239, #243): CLI rc contract — sync/query exit nonzero on hard failure and report honestly

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,9 +441,11 @@ def test_query_persists_translation_failure_reason(tmp_path, monkeypatch, capsys
 
     rc = cli.main(["query", "What is the sample answer?"])
 
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "q1: translation_failed - provider unavailable" in out
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "q1: translation_failed - provider unavailable" in captured.out
+    assert "translated 0 question(s), 1 failed" in captured.out
+    assert "provider unavailable" in captured.err
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
     assert q["status"] == "translation_failed"
@@ -461,14 +463,51 @@ def test_query_persists_get_client_failure_reason(tmp_path, monkeypatch, capsys)
 
     rc = cli.main(["query", "What is the sample answer?"])
 
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "q1: translation_failed - missing provider credentials" in out
+    # Every question is marked translation_failed on a get_client failure, so the
+    # run is a total failure: rc 1, with the reason surfaced and the count split.
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "q1: translation_failed - missing provider credentials" in captured.out
+    assert "translated 0 question(s), 1 failed" in captured.out
+    assert "missing provider credentials" in captured.err
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
     assert q["status"] == "translation_failed"
     assert q["reason"] == "missing provider credentials"
     assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
+
+
+def test_query_mixed_outcomes_exits_nonzero_with_split(
+    tmp_path, monkeypatch, capsys, fake_client, intent_payload
+):
+    # One question translates, one fails: rc 1 (any failure), and the summary
+    # splits the counts so the translated one is not hidden and the failure is
+    # not hidden behind it.
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.add_fact("Sample Subject", "is_a", "Synthetic Answer", status="confirmed")
+    store.add_question("What is Sample Subject?")
+    store.add_question("Please fail this question?")
+    store.close()
+
+    def intent_for(question):
+        if "fail" in question:
+            raise LLMError("provider rejected this question")
+        return intent_payload("lookup_object", subject="Sample Subject", relation="is_a")
+
+    monkeypatch.setattr(
+        "verinote.llm.get_client", lambda cfg: fake_client(intent=intent_for)
+    )
+
+    rc = cli.main(["query"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "q1: translated" in captured.out
+    assert "q2: translation_failed" in captured.out
+    assert "translated 1 question(s), 1 failed" in captured.out
+    assert "provider rejected this question" in captured.err
 
 
 def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,131 @@ def test_sync_surfaces_llm_error(tmp_path, monkeypatch, capsys, fake_client):
     assert "extraction failed: provider down" in capsys.readouterr().err
 
 
+def test_sync_total_chunk_failure_exits_nonzero(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "note.txt"
+    src.write_text("body text", encoding="utf-8")
+    assert cli.main(["ingest", str(src)]) == 0
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(error=LLMError("provider down")),
+    )
+
+    rc = cli.main(["sync"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "chunk(s) failed" in captured.err
+    assert "provider down" in captured.err
+    assert "sync complete" not in captured.out
+
+
+def test_sync_partial_chunk_failure_exits_nonzero(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "40")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+    src = tmp_path / "note.txt"
+    src.write_text(
+        "alpha beta gamma delta epsilon\n\nzeta eta theta iota kappa",
+        encoding="utf-8",
+    )
+    assert cli.main(["ingest", str(src)]) == 0
+
+    class _FlakyClient:
+        # Fails the first chunk's extraction, succeeds after: one failed chunk
+        # plus at least one completed chunk is the partial-failure shape.
+        def __init__(self):
+            self.calls = 0
+
+        def extract_facts(self, *, source_text, schema_hint=""):
+            self.calls += 1
+            if self.calls == 1:
+                raise LLMError("first chunk hiccup")
+            return [ExtractedFact("A", "is_a", "B", 0.9)]
+
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _FlakyClient())
+
+    rc = cli.main(["sync"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "1 candidate(s)" in captured.out
+    assert "sync incomplete" in captured.err
+    assert "sync failed" not in captured.err
+
+
+def test_sync_mixed_success_and_total_source_failure_is_incomplete(
+    tmp_path, monkeypatch, capsys
+):
+    # A run where one source fully succeeds with real candidates and another
+    # totally fails is NOT a total failure: it must read "sync incomplete", so
+    # the real candidates already on stdout are not disowned by a "failed" verdict.
+    _env(monkeypatch, tmp_path)
+    good = tmp_path / "good.txt"
+    good.write_text("good source body", encoding="utf-8")
+    bad = tmp_path / "bad.txt"
+    bad.write_text("fail marker body", encoding="utf-8")
+    assert cli.main(["ingest", str(good)]) == 0
+    assert cli.main(["ingest", str(bad)]) == 0
+
+    class _KeyedClient:
+        # Keyed on chunk content: every chunk of the "fail" source raises, the
+        # other source yields one fact.
+        def extract_facts(self, *, source_text, schema_hint=""):
+            if "fail" in source_text:
+                raise LLMError("provider down on this source")
+            return [ExtractedFact("A", "is_a", "B", 0.9)]
+
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _KeyedClient())
+
+    rc = cli.main(["sync"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "good.txt: 1 candidate(s)" in captured.out
+    assert "sync incomplete" in captured.err
+    assert "sync failed" not in captured.err
+    assert "reviewable" in captured.err
+    assert "Analysis failed" in captured.err
+
+
+def test_sync_all_complete_zero_candidates_is_success(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "note.txt"
+    src.write_text("body text", encoding="utf-8")
+    assert cli.main(["ingest", str(src)]) == 0
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: fake_client([]))
+
+    rc = cli.main(["sync"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "sync complete" in captured.out
+    assert "0 candidate(s)" in captured.out
+
+
+def test_sync_empty_source_is_success(tmp_path, monkeypatch, capsys, fake_client):
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "blank.txt"
+    src.write_text("   \n   \n", encoding="utf-8")
+    assert cli.main(["ingest", str(src)]) == 0
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+
+    rc = cli.main(["sync"])
+
+    # Zero chunks means zero failed chunks: an empty source is a clean success,
+    # never a total failure.
+    assert rc == 0
+    assert "sync failed" not in capsys.readouterr().err
+
+
 def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client, intent_payload):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -44,10 +44,31 @@ class _SourceInput:
 
 
 @dataclass(frozen=True)
+class _SourceSyncOutcome:
+    """One source's result from a single sync invocation.
+
+    Counts are this-run counts: `cmd_sync` creates a fresh extraction job per
+    invocation, so `completed_chunks`/`failed_chunks` describe only what this run
+    did, never a source's historical jobs. `message` is the job's own bounded
+    status line, carried only when this run had a failed chunk.
+    """
+
+    source_path: str
+    candidates: int
+    completed_chunks: int
+    failed_chunks: int
+    message: str = ""
+
+
+@dataclass(frozen=True)
 class _SyncSummary:
-    per_source: list[tuple[str, int]]
+    per_source: list[_SourceSyncOutcome]
     total: int
     run_id: int
+
+    @property
+    def failed_sources(self) -> list[_SourceSyncOutcome]:
+        return [outcome for outcome in self.per_source if outcome.failed_chunks > 0]
 
 
 def _store(cfg: Config) -> Store:
@@ -487,13 +508,40 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     job_id=job_id,
                     schema_hint=extraction_schema_hint(),
                 )
-                per_source.append((source.source_path, outcome.candidates))
+                # The job message is already the bounded honest failure line
+                # ("Analysis failed: N chunk(s) failed, D/T complete: <error>");
+                # carry it verbatim rather than re-deriving it, and only when this
+                # run failed a chunk. Full per-chunk detail lives on the web UI.
+                message = (
+                    store.get_extraction_job(job_id)["message"]
+                    if outcome.failed_chunks
+                    else ""
+                )
+                per_source.append(
+                    _SourceSyncOutcome(
+                        source_path=source.source_path,
+                        candidates=outcome.candidates,
+                        completed_chunks=outcome.completed_chunks,
+                        failed_chunks=outcome.failed_chunks,
+                        message=message,
+                    )
+                )
                 total += outcome.candidates
                 run_id = job_id
             result = _SyncSummary(per_source=per_source, total=total, run_id=run_id)
         else:
+            # The legacy path has no chunk concept: any failure there raises
+            # LLMError and exits rc 1 below, so every outcome reaching here is a
+            # success with zero completed/failed chunks.
             pairs = [(source.source_path, source.text) for source in sources]
-            result = sync_sources(store, client, pairs, provider=cfg.provider, model=cfg.model)
+            legacy = sync_sources(store, client, pairs, provider=cfg.provider, model=cfg.model)
+            result = _SyncSummary(
+                per_source=[
+                    _SourceSyncOutcome(path, n, 0, 0) for path, n in legacy.per_source
+                ],
+                total=legacy.total,
+                run_id=legacy.run_id,
+            )
     except PolicyMissingError as exc:
         # The policy vanished after the command's preflight — mid-job (the worker's
         # write boundary re-raises this after rolling the job back to `pending`) or
@@ -507,8 +555,37 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         print(f"extraction failed: {e}", file=sys.stderr)
         store.close()
         return 1
-    for src, n in result.per_source:
-        print(f"  {src}: {n} candidate(s)")
+    for outcome in result.per_source:
+        print(f"  {outcome.source_path}: {outcome.candidates} candidate(s)")
+    failed = result.failed_sources
+    if failed:
+        # Successes stayed visible on stdout above; the failures and the shape of
+        # the run go to stderr, and the run exits rc 1 (a hard failure) — the
+        # "sync complete" line below is the ONLY path that says success, so a
+        # "0 candidate(s)" reader can never mistake a broken run for a clean one.
+        for outcome in failed:
+            print(outcome.message, file=sys.stderr)
+        # "sync failed" is reserved for a run that produced nothing at all: the
+        # whole run's total is zero AND every failed source completed no chunk. A
+        # mixed run (some source succeeded with real candidates while another
+        # totally failed) is NOT a total failure — it takes the "incomplete"
+        # branch below, whose reassurance covers the candidates already on stdout.
+        if result.total == 0 and all(
+            outcome.completed_chunks == 0 for outcome in failed
+        ):
+            print(
+                f"sync failed: {len(failed)} source(s) extracted nothing — every "
+                "chunk failed; see the message(s) above and `verinote ui` for detail",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"sync incomplete: {len(failed)} source(s) had failed chunk(s); the "
+                "candidate(s) printed above are real and reviewable at `verinote ui`",
+                file=sys.stderr,
+            )
+        store.close()
+        return 1
     print(
         f"sync complete: {result.total} candidate(s) from {len(result.per_source)} "
         f"source(s) (run #{result.run_id}) — review at `verinote ui`"

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -643,8 +643,31 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
         results = translate_questions(store, client, root=cfg.root)
     for r in results:
         print(f"  {format_question_outcome(r)}")
-    print(f"translated {len(results)} question(s) -> {cfg.root / 'facts' / 'query.dl'}")
+    translated = sum(1 for r in results if r["status"] == "translated")
+    failures = [r for r in results if r["status"] == "translation_failed"]
+    # review_required/no_answer/ambiguous are durable review verdicts, not
+    # failures (#296): a question legitimately ending there is not a broken run.
+    # They count as neither translated nor failed — but surface their number, so
+    # a run made only of them does not read as a silent "translated 0" success.
+    for_review = sum(
+        1 for r in results if r["status"] in {"review_required", "no_answer", "ambiguous"}
+    )
+    # "translated {n} question(s)" is preserved verbatim as the prefix (callers
+    # and tests read it); n is the count that genuinely translated, not the total.
+    summary = f"translated {translated} question(s)"
+    if failures:
+        summary += f", {len(failures)} failed"
+    if for_review:
+        summary += f", {for_review} for review"
+    summary += f" -> {cfg.root / 'facts' / 'query.dl'}"
+    print(summary)
     print("run the check to see answers (`verinote ui` → Report)")
+    if failures:
+        # Any translation_failed is a hard failure (#243): exit rc 1 and put the
+        # first failure's bounded reason on stderr so a non-web user sees why.
+        print(failures[0]["reason"], file=sys.stderr)
+        store.close()
+        return 1
     store.close()
     return 0
 


### PR DESCRIPTION
Closes #239. Closes #243.

같은 rc-계약 가족의 두 CLI 거짓말을 하나의 철학으로 닫는다: **rc 는 하드 실패의 존재에 키잉하고(있으면 1), 요약은 모든 버킷을 항상 보고한다.** rc 2 는 preflight/halted-KB 전용(#246 관례)으로 유지한다.

## 커밋

1. **`fix(#239): exit nonzero and report the reason when sync chunks fail`** — `cmd_sync` 가 `ChunkedExtractionResult.failed_chunks/completed_chunks` 를 버리고 청크 전멸에도 "sync complete" rc 0 을 내던 문제. `_SourceSyncOutcome` 로 소스별 this-run 카운트를 운반하고(재개 경로와 무관한 fresh job 카운트), 실패 소스마다 잡의 기존 "Analysis failed: N chunk(s) failed, D/T complete: ..." 한 줄을 stderr 로 표면화한다. 분류: 실패 청크 0 → rc 0("sync complete"는 이 경로에서만 출력; 빈 소스·후보 0 포함), run 전체가 아무것도 못 냄 → "sync failed", 그 외 → "sync incomplete"(+"위 후보들은 실재하며 리뷰 가능"). 혼합 실행(성공 소스 + 전멸 소스)이 "sync failed"로 읽히던 초안은 감사에서 잡혀 amend 됐다. legacy `sync_sources` 경로는 실패가 LLMError 로 전파되어 이미 rc 1 — 의미 변경 없음.
2. **`fix(#243): exit nonzero and split the count when query translations fail`** — `cmd_query` 가 `translation_failed` 도 "translated N" 에 세고 항상 rc 0 을 내던 문제. translated 는 status=='translated' 만 세고, 실패가 있으면 ", K failed", durable 검토 판정(review_required/no_answer/ambiguous — #296 계약대로 실패가 아님)이 있으면 ", M for review" 를 덧붙인다. rc 는 두 분기(정상/get_client 실패) 공통 tail 에서 계산 — get_client 실패 분기의 rc 0 fall-through 제거. 이슈의 문자적 "0개 성공 시"보다 강한 any-failure→rc1 로 통일했고 커밋 본문에 근거를 남겼다.

## 검증

- 전체 스위트 1359 passed / 7 skipped, `ruff check .` clean.
- 헤드라인 테스트들은 수정 전 코드에서 red 임을 확인(리뷰어가 561eb72^/사전 코드 대비 검증).
- 저장소 내부에 rc 0 을 가정하는 sync/query 자동화 소비자 없음(전수 grep). 외부 스크립트에는 breaking change — rc 의미가 정직해지는 방향.
- 컨센서스 플로우: 커밋별 리뷰 APPROVE + architect/critic 감사 CONCUR (Unit 1 은 1회 수정 사이클 — 혼합 실행 문구).
