### PR TITLE
fix(#287): block auto-accept when a rival candidate contradicts a functional value

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -4,6 +4,7 @@ from verinote.pipeline.acceptance import (
     apply_auto_accept_recommendations,
     RULE_NAME,
 )
+from verinote.pipeline.corroboration import store_single_valued_conflicts
 from verinote.store import Store
 
 
@@ -49,6 +50,29 @@ def _done_job(store: Store, source_id: int) -> int:
     store.mark_chunk_done(chunk_id, candidates=1)
     store.finish_extraction_job(job_id)
     return job_id
+
+
+def _corroborated_candidate(store, subject, relation, value, source_paths):
+    """Add one candidate per path (each a distinct done-job source) for one value.
+
+    Returns the first candidate's id. With two paths the value is corroborated
+    (two distinct sources); with one path it is a weakly-sourced single witness.
+    """
+    first_id = None
+    for path in source_paths:
+        source_id = store.add_source(path)
+        job_id = _done_job(store, source_id)
+        fact_id = store.add_fact(
+            subject,
+            relation,
+            value,
+            status="candidate",
+            source_id=source_id,
+            job_id=job_id,
+        )
+        if first_id is None:
+            first_id = fact_id
+    return first_id
 
 
 def test_accept_recommendation_requires_distinct_completed_source_support(tmp_path):
@@ -283,3 +307,134 @@ def test_apply_auto_accept_promotes_only_eligible_facts_and_records_rule_event(t
     ]
     assert events[-1]["actor"] == "rule"
     assert events[-1]["rule_name"] == RULE_NAME
+
+
+def test_auto_accept_never_promotes_two_conflicting_values_in_one_batch(tmp_path):
+    # Issue #287 done-criterion: two contradictory values on a functional
+    # relation, each corroborated by two distinct done-job sources, all
+    # candidates. Neither may auto-promote — they mutually block, order-free.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    year_2024 = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2024",
+        ["sources/a1.txt", "sources/a2.txt"],
+    )
+    year_2025 = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2025",
+        ["sources/b1.txt", "sources/b2.txt"],
+    )
+
+    applied = apply_auto_accept_recommendations(s)
+
+    assert applied == []
+    assert s.get_fact(year_2024)["status"] == "candidate"
+    assert s.get_fact(year_2025)["status"] == "candidate"
+
+
+def test_auto_accept_never_leaves_the_kb_failing_its_own_policy(tmp_path):
+    # Issue #287 done-criterion: after auto-accept runs, the KB must not hold two
+    # accepted values for a single-valued relation — its own functional_conflict
+    # policy would flag exactly that.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    _corroborated_candidate(
+        s, "Sample Report", "published_year", "2024",
+        ["sources/a1.txt", "sources/a2.txt"],
+    )
+    _corroborated_candidate(
+        s, "Sample Report", "published_year", "2025",
+        ["sources/b1.txt", "sources/b2.txt"],
+    )
+
+    apply_auto_accept_recommendations(s)
+
+    assert store_single_valued_conflicts(s) == []
+
+
+def test_accept_recommendation_flags_conflict_from_rival_candidate(tmp_path):
+    # The new arm: a corroborated CANDIDATE rival (not just an engine-tier fact)
+    # now blocks the target directly.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    target = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2024",
+        ["sources/a1.txt", "sources/a2.txt"],
+    )
+    _corroborated_candidate(
+        s, "Sample Report", "published_year", "2025",
+        ["sources/b1.txt", "sources/b2.txt"],
+    )
+
+    recommendation = accept_recommendation(s, target)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "single_valued_conflict" in recommendation.reasons
+
+
+def test_accept_recommendation_weakly_sourced_rival_candidate_still_blocks(tmp_path):
+    # Ratified conservatism: even a single-source rival candidate withholds the
+    # target — the rule refuses to adjudicate any contested value.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    target = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2024",
+        ["sources/a1.txt", "sources/a2.txt"],
+    )
+    _corroborated_candidate(
+        s, "Sample Report", "published_year", "2025", ["sources/b1.txt"]
+    )
+
+    recommendation = accept_recommendation(s, target)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "single_valued_conflict" in recommendation.reasons
+
+
+def test_accept_recommendation_rival_without_source_does_not_block(tmp_path):
+    # The `fact.source` conjunct: a rival value with no source cannot witness, so
+    # it does not block. The target stays eligible.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    target = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2024",
+        ["sources/a1.txt", "sources/a2.txt"],
+    )
+    s.add_fact("Sample Report", "published_year", "2025", status="candidate")
+
+    recommendation = accept_recommendation(s, target)
+
+    assert recommendation is not None
+    assert recommendation.eligible is True
+    assert "single_valued_conflict" not in recommendation.reasons
+
+
+def test_rejecting_one_rival_unblocks_auto_accept_of_the_other(tmp_path):
+    # Resolution / starvation guard: while both stand, both are withheld. A human
+    # rejecting the wrong value supersedes it (it witnesses on neither tier), and
+    # the survivor auto-promotes on the next apply. The loser is a single row so
+    # one reject_fact removes the whole contested value.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    survivor = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2024",
+        ["sources/a1.txt", "sources/a2.txt"],
+    )
+    loser = _corroborated_candidate(
+        s, "Sample Report", "published_year", "2025", ["sources/b1.txt"]
+    )
+
+    assert apply_auto_accept_recommendations(s) == []
+
+    s.reject_fact(loser)
+    applied = apply_auto_accept_recommendations(s)
+
+    # The survivor value promotes (both its corroborating rows are same-valued, so
+    # promoting both is no conflict); the rejected loser is not resurrected.
+    applied_ids = {recommendation.fact_id for recommendation in applied}
+    assert survivor in applied_ids
+    assert loser not in applied_ids
+    assert s.get_fact(survivor)["status"] == "accepted"
+    assert s.get_fact(loser)["status"] == "superseded"
+    assert store_single_valued_conflicts(s) == []

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -183,10 +183,41 @@ class _RecommendationEngine:
         ]
 
     def _has_single_valued_conflict(self, target: _FactView) -> bool:
+        """True when another fact witnesses a rival value on a functional relation.
+
+        A rival is admitted by EXACTLY the filter `_supporting_facts` uses to
+        admit a witness FOR the value: review-eligible or engine-tier, and
+        source-backed. The symmetry is the point (#287). Scanning only the engine
+        tier here let a fact corroborate a value while being unable to speak
+        against a contradicting one, so two mutually-contradictory corroborated
+        candidates never saw each other and BOTH auto-promoted — leaving the KB
+        failing its own functional_conflict policy with no human in the loop.
+
+        With the filters aligned, any contested value is withheld: neither rival
+        is eligible, in either evaluation order, so nothing promotes. Withholding
+        all of them is the rule's charter, not timidity — promoting either would
+        silently adjudicate an evidential conflict, and "oldest id wins" was
+        rejected precisely because a deterministic rule must not pick a truth. The
+        `fact.id == target.id` guard keeps a fact from counting as its own rival.
+
+        The deadlock is a human's to break, and the path is already wired:
+        rejecting the wrong value supersedes it (it then witnesses on neither
+        tier), which unblocks the survivor on the next `_maybe_apply_auto_accept`
+        cascade that every review decision triggers. Residual limitation, out of
+        scope here: a second DB connection could still race this snapshot — the
+        write-time re-check in `auto_accept_fact` re-reads only the engine tier,
+        so two candidates promoted concurrently on separate connections are not
+        caught by it. Closing that needs write-time atomicity, not this filter.
+        """
         if target.canonical_relation not in self.single_valued:
             return False
         for fact in self.facts:
-            if not is_engine_input(fact.status):
+            if fact.id == target.id:
+                continue
+            if not (
+                (is_review_eligible(fact.status) or is_engine_input(fact.status))
+                and fact.source
+            ):
                 continue
             if fact.subject != target.subject:
                 continue


### PR DESCRIPTION
Closes #287.

auto-accept 가 배치 전체를 pre-accept 스냅샷 하나로 판정해, functional 로 선언된 관계에서도 모순된 두 값을 같은 배치에서 함께 승격하던 버그를 닫는다. #257 종료 이후 이 코드는 리뷰 결정마다(web/app.py:376, 944), 그리고 추출 잡 완료 시(755) 돌기 때문에 노출면이 이슈 접수 시점보다 넓어진 상태였다.

## 수정 — "2a" (architect·critic 조정 끝에 비준)

`_has_single_valued_conflict` 하나만 바꾼다: 라이벌 판정 필터를 engine-tier 전용에서 **`_supporting_facts` 와 문자 그대로 동일한 필터** `(is_review_eligible or is_engine_input) and fact.source` 로 대칭화. 이슈가 문서화한 비대칭 — "미검토 candidate 는 auto-accept 를 지지할 수 있지만 절대 막을 수는 없다" — 을 근본에서 닫는다: 값을 **위해** 증언할 수 있는 사실은 같은 무게로 라이벌 값에 **맞서** 증언한다.

- 모순된 두 candidate 는 서로를 차단 → 순서 무관하게 **둘 다 보류**, 사람이 판정한다. "낮은 id 승리"(적용마다 재평가안)는 결정적 규칙이 진실을 고르는 꼴이라 기각.
- 수정이 공유 엔진 `recommend()` 에 있으므로 리뷰 페이지 배지·단일 사실 경로·배치 적용이 구조적으로 일치한다(배지는 eligible 인데 배치는 보류하는 드리프트 불가능).
- 해소 경로는 이미 배선돼 있다: 잘못된 라이벌을 reject → superseded(어느 티어도 아님) → 생존 값이 결정 직후 `_maybe_apply_auto_accept` 캐스케이드에서 자동 승격. `test_rejecting_one_rival_unblocks_auto_accept_of_the_other` 가 이 기아 방지 계약을 핀으로 고정.
- 비준된 보수성: 단일 소스 라이벌도(소스가 있으면) 차단한다 — 경합 중인 functional 값이 사람에게 가는 것은 규칙이 일하는 것이지 griefing 이 아니다. 소스 없는 라이벌은 차단하지 않는다(`fact.source` 컨졍트, 지지 필터와 동일).
- 잔여 한계(커밋 본문에 기록): 별도 DB 커넥션은 여전히 스냅샷과 경합 가능(write-time 재확인은 티어만 본다) — write-time 원자성은 별개 작업.

## 검증

- 이슈가 done-criterion 으로 명명한 두 테스트를 작성해 포함(`tests/test_repro_guards.py` 는 레포에 존재하지 않아 일반 테스트로 랜딩): 배치가 둘 다 승격하지 않음 / KB 가 자기 정책의 ERROR 상태가 되지 않음. 구현자·critic 이 각각 독립적으로 수정 전 red / 수정 후 green 확인.
- 전체 스위트 1365 passed / 7 skipped, ruff clean. 기존 테스트 플립 0건(같은 값 코로보레이션·confirmed 라이벌 경로 불변).
- 컨센서스: 리뷰 APPROVE + architect/critic 감사 CONCUR. #310/#311 에 하드 의존성(superseded 는 양 티어 밖) 코멘트 기록.
