### PR TITLE
fix(#264): retract rule-accepted facts whose corroboration basis lapsed

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
+import json
+import pathlib
+import re
+
 from verinote.pipeline.acceptance import (
     accept_recommendation,
     apply_auto_accept_recommendations,
     RULE_NAME,
 )
 from verinote.pipeline.corroboration import store_single_valued_conflicts
-from verinote.store import Store
+from verinote.store import Store, engine_statuses
 
 
 def _store(tmp_path) -> Store:
@@ -438,3 +442,277 @@ def test_rejecting_one_rival_unblocks_auto_accept_of_the_other(tmp_path):
     assert s.get_fact(survivor)["status"] == "accepted"
     assert s.get_fact(loser)["status"] == "superseded"
     assert store_single_valued_conflicts(s) == []
+
+
+# --- #264: retract rule-accepted facts whose corroboration basis lapsed ----
+
+
+def _accepted_ids(store):
+    return [f["id"] for f in store.facts(statuses=["accepted"])]
+
+
+def test_apply_retracts_a_rule_accepted_fact_after_its_basis_lapses(tmp_path):
+    # #264 headline: two same-triple corroborated candidates auto-accept; a human
+    # rejects one source's row; the value now has a single source and must return
+    # to review (out of the engine tier), with an auditable retraction event.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    survivor = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+    accepted = _accepted_ids(s)
+    assert len(accepted) == 2 and survivor in accepted
+
+    other = next(fact_id for fact_id in accepted if fact_id != survivor)
+    s.reject_fact(other)
+
+    applied = apply_auto_accept_recommendations(s)
+
+    assert applied == []
+    assert s.get_fact(survivor)["status"] == "needs_review"
+    assert survivor not in [f["id"] for f in s.facts(statuses=engine_statuses())]
+    events = [
+        e for e in s.fact_events(survivor) if e["event_type"] == "auto_accept_retracted"
+    ]
+    assert len(events) == 1
+    assert events[0]["actor"] == "rule"
+    assert events[0]["rule_name"] == RULE_NAME
+    payload = json.loads(events[0]["after_json"])
+    assert payload["reasons"] == ["insufficient_distinct_source_support"]
+    assert payload["remaining_support_sources"] == ["sources/a.txt"]
+    assert payload["remaining_support_fact_ids"] == [survivor]
+    assert payload["canonical_relation"] == "published_year"
+
+
+def test_repeated_apply_passes_do_not_rethrash_a_retracted_fact(tmp_path):
+    # Idempotence: retraction and promotion share the one `< 2` threshold, so a
+    # retracted fact is neither re-promoted (its support is still short, so
+    # recommend() marks insufficient_distinct_source_support) nor re-retracted
+    # (its snapshot status is needs_review, not accepted) — however many passes
+    # run. This pins the commit's anti-oscillation claim in both directions.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    survivor = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+    other = next(fact_id for fact_id in _accepted_ids(s) if fact_id != survivor)
+    s.reject_fact(other)
+    apply_auto_accept_recommendations(s)
+    assert s.get_fact(survivor)["status"] == "needs_review"
+
+    assert apply_auto_accept_recommendations(s) == []
+    assert apply_auto_accept_recommendations(s) == []
+
+    assert s.get_fact(survivor)["status"] == "needs_review"
+    assert (
+        len(
+            [
+                e
+                for e in s.fact_events(survivor)
+                if e["event_type"] == "auto_accept_retracted"
+            ]
+        )
+        == 1
+    )
+
+
+def test_apply_does_not_retract_a_human_confirmed_fact(tmp_path):
+    # A confirmed fact is a human ratification; a lapsed basis never retracts it.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/a.txt")
+    job_id = _done_job(s, source_id)
+    fact_id = s.add_fact(
+        "Report", "published_year", "2024",
+        status="confirmed", source_id=source_id, job_id=job_id,
+    )
+
+    apply_auto_accept_recommendations(s)
+
+    assert s.get_fact(fact_id)["status"] == "confirmed"
+    assert [
+        e for e in s.fact_events(fact_id) if e["event_type"] == "auto_accept_retracted"
+    ] == []
+
+
+def test_apply_leaves_a_still_corroborated_accepted_fact_untouched(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+
+    applied = apply_auto_accept_recommendations(s)
+
+    assert applied == []
+    accepted = s.facts(statuses=["accepted"])
+    assert len(accepted) == 2
+    for fact in accepted:
+        assert [
+            e for e in s.fact_events(fact["id"])
+            if e["event_type"] == "auto_accept_retracted"
+        ] == []
+
+
+def test_apply_does_not_retract_when_a_same_triple_reextraction_is_still_running(tmp_path):
+    # No oscillation: the count is job-independent, so a fresh same-triple
+    # candidate whose job is still RUNNING never triggers retraction. A job-based
+    # trigger would flag the accepted value as incomplete and yank it mid-analysis.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    accepted = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+
+    source_c = s.add_source("sources/c.txt")
+    running_job = s.create_extraction_job(
+        source_id=source_c, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = s.add_source_chunks(
+        job_id=running_job, source_id=source_c, chunks=["body"]
+    )[0]
+    s.mark_extraction_job_running(running_job)
+    s.mark_chunk_running(chunk_id)
+    s.add_fact(
+        "Report", "published_year", "2024",
+        status="candidate", source_id=source_c, job_id=running_job,
+    )
+
+    apply_auto_accept_recommendations(s)
+
+    assert s.get_fact(accepted)["status"] == "accepted"
+    assert [
+        e for e in s.fact_events(accepted) if e["event_type"] == "auto_accept_retracted"
+    ] == []
+
+
+def test_apply_does_not_retract_an_accepted_fact_over_a_rival_candidate(tmp_path):
+    # Retraction is basis-only, never conflict-based: a new weakly-sourced rival
+    # candidate is withheld from promotion (#287) but must not yank the accepted
+    # value, whose own two sources still stand.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    accepted = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+    _corroborated_candidate(s, "Report", "published_year", "2025", ["sources/c.txt"])
+
+    applied = apply_auto_accept_recommendations(s)
+
+    assert applied == []
+    assert s.get_fact(accepted)["status"] == "accepted"
+    accepted_rows = s.facts(statuses=["accepted"])
+    assert {f["object"] for f in accepted_rows} == {"2024"}
+    for fact in accepted_rows:
+        assert [
+            e for e in s.fact_events(fact["id"])
+            if e["event_type"] == "auto_accept_retracted"
+        ] == []
+
+
+def test_apply_does_not_retract_an_excluded_fact(tmp_path):
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    survivor = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+    other = next(fact_id for fact_id in _accepted_ids(s) if fact_id != survivor)
+    s.reject_fact(other)
+
+    apply_auto_accept_recommendations(s, exclude_fact_ids=[survivor])
+
+    assert s.get_fact(survivor)["status"] == "accepted"
+    assert [
+        e for e in s.fact_events(survivor) if e["event_type"] == "auto_accept_retracted"
+    ] == []
+
+
+def test_apply_retract_and_rival_promotion_do_not_race_in_one_pass(tmp_path):
+    # One-snapshot determinism: X is retracted (basis lapsed) but its review-tier
+    # rival Y is NOT promoted in the same pass — the snapshot still shows X
+    # accepted, so Y stays blocked (#287); Y's promotion is deferred to the next
+    # cascade.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_x = s.add_source("sources/x.txt")
+    job_x = _done_job(s, source_x)
+    x = s.add_fact(
+        "Report", "published_year", "2024",
+        status="accepted", source_id=source_x, job_id=job_x,
+    )
+    y = _corroborated_candidate(
+        s, "Report", "published_year", "2025", ["sources/y1.txt", "sources/y2.txt"]
+    )
+
+    applied = apply_auto_accept_recommendations(s)
+
+    assert [recommendation.fact_id for recommendation in applied] == []
+    assert s.get_fact(x)["status"] == "needs_review"
+    assert s.get_fact(y)["status"] == "candidate"
+
+
+def test_apply_retracts_an_accepted_fact_amended_to_a_new_value(tmp_path):
+    # Amend-of-accepted: changing the object moves the fact off the triple its
+    # corroborators support, so its basis lapses and the next pass retracts it.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    _corroborated_candidate(
+        s, "Report", "published_year", "2024",
+        ["sources/a.txt", "sources/b.txt", "sources/c.txt"],
+    )
+    apply_auto_accept_recommendations(s)
+    accepted = s.facts(statuses=["accepted"])
+    assert len(accepted) == 3
+    amended = accepted[0]["id"]
+    s.amend_fact(amended, subject="Report", relation="published_year", obj="2099")
+    assert s.get_fact(amended)["status"] == "accepted"
+
+    apply_auto_accept_recommendations(s)
+
+    assert s.get_fact(amended)["status"] == "needs_review"
+    assert [
+        e for e in s.fact_events(amended) if e["event_type"] == "auto_accept_retracted"
+    ] != []
+    survivors = s.facts(statuses=["accepted"])
+    assert len(survivors) == 2
+    assert {f["object"] for f in survivors} == {"2024"}
+
+
+def test_only_auto_accept_fact_writes_the_accepted_status():
+    """STATIC SOURCE CHECK, not a proof (invariant guard until #292).
+
+    auto_retract_fact relies on `accepted` meaning "rule-promoted, not
+    human-ratified", which holds only while exactly one production path writes
+    that status — auto_accept_fact — and no set_status call passes it.
+
+    This greps the source for the realistic regression: a literal
+    `SET status = 'accepted'` added elsewhere, or a literal
+    `set_status(..., 'accepted')`. It CANNOT see an indirect write such as
+    `set_status(fact_id, some_var)` where the variable happens to hold
+    "accepted", because that is invisible to a text scan. Retiring set_status —
+    which is what would make the invariant structural rather than conventional —
+    is #292's scope. Do not read a pass here as a guarantee.
+    """
+    verinote_root = pathlib.Path(__file__).resolve().parent.parent / "verinote"
+    writes = []
+    set_status_accepted = re.compile(r"set_status\([^)]*accepted")
+    for path in sorted(verinote_root.rglob("*.py")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for lineno, line in enumerate(lines, 1):
+            if "SET status = 'accepted'" in line:
+                writes.append((path, lineno, lines))
+        assert not set_status_accepted.search("\n".join(lines)), (
+            f"{path} calls set_status with 'accepted'"
+        )
+
+    assert len(writes) == 1, f"unexpected accepted-status writes: {[w[:2] for w in writes]}"
+    path, lineno, lines = writes[0]
+    assert path.name == "db.py"
+    preceding_defs = [line for line in lines[:lineno] if line.lstrip().startswith("def ")]
+    assert preceding_defs[-1].strip().startswith("def auto_accept_fact(")

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -1037,7 +1037,13 @@ class _AlwaysEligibleEngine:
     Stands in for the engine the real one is one refactor away from being: cache
     the policy, or move functional relations into a table, and `_engine` stops
     touching `load_policy` — the accident that refuses a halted KB today.
+
+    `facts` is the snapshot the reconciler's retraction pass walks. Empty here:
+    this stub reads nothing, so it offers no accepted fact to retract, and the
+    pass iterates nothing rather than needing any further stub member.
     """
+
+    facts = ()
 
     def recommend(self, row):
         return AcceptRecommendation(

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -742,3 +742,84 @@ def test_reject_that_really_transitions_still_runs_auto_accept(tmp_path):
     assert store.get_fact(target)["status"] == "superseded"
     assert store.get_fact(eligible)["status"] == "accepted"
     assert resp.headers.get("HX-Refresh") == "true"
+
+
+# --- #264: guarded auto-retract of rule-accepted facts --------------------
+
+
+def test_auto_retract_demotes_a_rule_accepted_fact(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("sources/a.txt")
+    fact_id = s.add_fact(
+        "Report", "author", "Kim", status="accepted", source_id=source_id
+    )
+
+    after = s.auto_retract_fact(fact_id, rule_name="corroborated_no_conflict")
+
+    # Leaves the engine tier, back into the human review queue.
+    assert after is not None
+    assert after["status"] == "needs_review"
+    assert s.get_fact(fact_id)["status"] == "needs_review"
+    # Dual audit write: a review_log action and a rule-actor fact_event.
+    assert "auto_retracted" in _actions(s, fact_id)
+    events = [e for e in s.fact_events(fact_id) if e["event_type"] == "auto_retracted"]
+    assert len(events) == 1
+    assert events[0]["actor"] == "rule"
+    assert events[0]["rule_name"] == "corroborated_no_conflict"
+
+
+def test_auto_retract_refuses_a_confirmed_fact(tmp_path):
+    # A human ratification (confirmed) outranks the rule — untouchable.
+    s = _store(tmp_path)
+    fact_id = s.add_fact("Report", "author", "Kim", status="confirmed")
+
+    assert s.auto_retract_fact(fact_id, rule_name="corroborated_no_conflict") is None
+    assert s.get_fact(fact_id)["status"] == "confirmed"
+    assert "auto_retracted" not in _actions(s, fact_id)
+
+
+@pytest.mark.parametrize("status", ["superseded", "candidate", "needs_review"])
+def test_auto_retract_refuses_non_accepted_statuses(tmp_path, status):
+    s = _store(tmp_path)
+    fact_id = s.add_fact("Report", "author", "Kim", status=status)
+
+    assert s.auto_retract_fact(fact_id, rule_name="corroborated_no_conflict") is None
+    assert s.get_fact(fact_id)["status"] == status
+    assert "auto_retracted" not in _actions(s, fact_id)
+
+
+def test_auto_retract_missing_fact_returns_none(tmp_path):
+    s = _store(tmp_path)
+    assert s.auto_retract_fact(9999, rule_name="corroborated_no_conflict") is None
+
+
+def test_auto_retract_skips_when_the_fact_leaves_accepted_mid_transition(tmp_path):
+    """The cross-connection race, mirroring the auto_accept version.
+
+    The competing decision lands on another connection *after* the tier read,
+    where this instance's lock has no say — only the status condition on the
+    UPDATE stops the rule demoting a row that has already moved on.
+    """
+    db = tmp_path / "kb.sqlite"
+    retracting = _store_at(db)
+    other = _store_at(db)
+    fact_id = retracting.add_fact("Report", "author", "Kim", status="accepted")
+
+    real_get_fact = retracting.get_fact
+    interleaved = []
+
+    def move_once_after_the_read(target_id: int):
+        row = real_get_fact(target_id)
+        if not interleaved:
+            interleaved.append(True)
+            # Another connection supersedes the fact inside the window.
+            other.reject_fact(fact_id)
+        return row
+
+    retracting.get_fact = move_once_after_the_read
+    row = retracting.auto_retract_fact(fact_id, rule_name="corroborated_no_conflict")
+
+    assert interleaved, "the competing decision never landed — the test proves nothing"
+    assert row is None
+    assert other.get_fact(fact_id)["status"] == "superseded"
+    assert "auto_retracted" not in _actions(other, fact_id)

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -63,13 +63,29 @@ def accept_recommendations_for(
 def apply_auto_accept_recommendations(
     store: Store, *, exclude_fact_ids: Iterable[int] = ()
 ) -> list[AcceptRecommendation]:
-    """Promote every eligible candidate to `accepted` — never on a halted KB.
+    """The rule's reconciler: one policy snapshot, two guarded writes — never on a halted KB.
+
+    Promotes every eligible review-tier candidate to `accepted` AND retracts every
+    rule-accepted fact whose corroboration basis has lapsed (fewer than two
+    distinct source witnesses) back to `needs_review`. Both directions belong to
+    the rule alone: `auto_accept_fact` only touches review-tier rows and
+    `auto_retract_fact` only touches `accepted` — the rule's own tier — so a
+    human's `confirmed`/`superseded` is structurally unreachable from here.
+
+    Both passes are judged off snapshots taken before any write in this call (and
+    so identical — nothing writes between them), which makes the outcome
+    order-independent: the two guarded writes touch disjoint rows (review-tier vs
+    `accepted`), and a fact retracted in this pass is still `accepted` in the
+    snapshot, so a review-tier rival of a retracted value stays blocked by it
+    (#287) and its promotion is deferred to the next cascade rather than racing
+    this one.
 
     `exclude_fact_ids` holds facts a human has just decided on in this same
     request. The rule still runs for everything else, because that decision may
     have unblocked siblings; it just doesn't get to re-decide the fact the human
-    aimed at. Without this, demoting a corroborated fact to the review tier hands
-    it straight back to the rule that promotes corroborated review-tier facts.
+    aimed at, in either direction. Without this, demoting a corroborated fact to
+    the review tier hands it straight back to the rule that promotes corroborated
+    review-tier facts.
 
     A halted KB already stops this today, but only by COINCIDENCE: `_engine` builds
     its single-valued set from `store_functional_relations`, which calls
@@ -86,6 +102,19 @@ def apply_auto_accept_recommendations(
     """
     assert_writable(store)
     excluded = {int(fact_id) for fact_id in exclude_fact_ids}
+    # Retraction is judged off a snapshot taken before any promotion write, so
+    # both passes see the same pre-write state. That is what makes the pass
+    # order-independent: a fact retracted below is still `accepted` in this
+    # snapshot, so a review-tier rival stays blocked by it (#287) and its
+    # promotion defers to the next cascade rather than racing this one.
+    #
+    # Promotion keeps flowing through the module-level `accept_recommendations`
+    # (its own read-only pre-write snapshot, identical because nothing writes
+    # between the two reads) rather than reusing this engine directly. That is
+    # deliberate: it is the seam the cross-connection race guard is exercised
+    # through, where a reject can be injected between the snapshot and the write.
+    retraction_engine = _engine(store)
+
     applied = []
     for recommendation in accept_recommendations(store).values():
         if not recommendation.eligible or recommendation.fact_id in excluded:
@@ -108,6 +137,34 @@ def apply_auto_accept_recommendations(
             },
         )
         applied.append(recommendation)
+
+    # Retraction walks the snapshot taken above — before any write of this pass —
+    # so the statuses it reads are the ones promotion was judged against.
+    for view in retraction_engine.facts:
+        if view.status != "accepted" or view.id in excluded:
+            continue
+        if not retraction_engine.basis_lapsed(view):
+            continue
+        # `auto_retract_fact` only touches `accepted`, so a human decision that
+        # landed after the snapshot wins the guarded UPDATE (returns None) and
+        # the audit event is skipped with it.
+        if store.auto_retract_fact(view.id, rule_name=RULE_NAME) is None:
+            continue
+        remaining = retraction_engine._supporting_facts(view)
+        store.add_fact_event(
+            fact_id=view.id,
+            event_type="auto_accept_retracted",
+            actor="rule",
+            rule_name=RULE_NAME,
+            after={
+                "reasons": ["insufficient_distinct_source_support"],
+                "remaining_support_sources": sorted(
+                    {fact.source for fact in remaining if fact.source}
+                ),
+                "remaining_support_fact_ids": sorted(fact.id for fact in remaining),
+                "canonical_relation": view.canonical_relation,
+            },
+        )
     return applied
 
 
@@ -181,6 +238,24 @@ class _RecommendationEngine:
             and fact.object_key == target.object_key
             and fact.source
         ]
+
+    def basis_lapsed(self, target: _FactView) -> bool:
+        """True when a rule-accepted fact no longer has 2+ distinct source witnesses.
+
+        The exact complement of promotion's `insufficient_distinct_source_support`
+        threshold, and deliberately COUNT-ONLY: no `_job_done` gate, no
+        `source_missing` gate. Those job-based signals flap while a source is being
+        re-extracted — a fresh same-triple candidate with a still-RUNNING job joins
+        the support set the instant it lands — so gating retraction on them would
+        yank a healthy accepted fact mid-analysis. The distinct-source count is
+        job-independent and monotone under transient extraction: it falls only when
+        support is DURABLY lost (a reject→superseded, an amend-away, a deleted
+        source), which is exactly when a rule-accepted value should return to
+        review. Mirroring promotion's threshold exactly also forecloses thrash — a
+        fact retracted here fails the same `< 2` test if re-evaluated for promotion,
+        so it cannot oscillate.
+        """
+        return len({fact.source for fact in self._supporting_facts(target) if fact.source}) < 2
 
     def _has_single_valued_conflict(self, target: _FactView) -> bool:
         """True when another fact witnesses a rival value on a functional relation.

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1550,6 +1550,49 @@ class Store:
             )
             return after
 
+    def auto_retract_fact(self, fact_id: int, *, rule_name: str) -> sqlite3.Row | None:
+        """Demote a rule-accepted fact back to `needs_review` (the rule's reversal).
+
+        The mirror of `auto_accept_fact`. `status='accepted'` is written by that
+        method alone — human promotions always land `confirmed` — so `accepted`
+        means "rule-promoted and not since human-ratified", and it is the ONLY
+        status this transition can act on. `confirmed` (a human ratified it),
+        `superseded` (a human's terminal rejection), and the review-tier statuses
+        are all structurally unreachable here: a rule must never overrule human
+        judgment, and there is nothing for the rule to retract in a row it did not
+        promote.
+
+        The landing is `needs_review`, not another status, for a specific reason:
+        the fact leaves the engine tier (its corroboration basis lapsed, so it
+        must stop feeding inference) and re-enters the human review queue, where a
+        later re-promotion is possible if the basis returns — exactly the
+        engine→needs_review demotion `toggle_review` already performs. `candidate`
+        would misrepresent a once-reviewed fact as un-reviewed fresh extraction;
+        `superseded` would forge a human rejection the rule has no standing to make.
+
+        As in `auto_accept_fact`, the status condition lives IN the UPDATE: a
+        human's competing decision can arrive on another connection where this
+        instance's lock has no say, so a rowcount of 0 means the fact already left
+        `accepted` and we return None, letting the caller skip the audit for a
+        write that never happened.
+        """
+        with self._lock:
+            before = self.get_fact(fact_id)
+            if before is None or before["status"] != "accepted":
+                return None
+            cursor = self._conn.execute(
+                "UPDATE facts SET status = 'needs_review', updated_at = datetime('now') "
+                "WHERE id = ? AND status = 'accepted'",
+                (fact_id,),
+            )
+            if cursor.rowcount == 0:
+                return None
+            after = self.get_fact(fact_id)
+            self._log(
+                fact_id, "auto_retracted", before, after, actor="rule", rule_name=rule_name
+            )
+            return after
+
     def amend_fact(
         self,
         fact_id: int,


### PR DESCRIPTION
Closes #264.

auto-accept 는 승격 전용이었다 — 규칙이 올린 사실의 근거가 나중에 사라져도 (코로보레이션 소스가 거부되거나 amend 로 지형이 바뀌어도) accepted 로 엔진에 남아 리포트의 전제가 됐다. #287(같은 게이트의 승격 방향)이 먼저 랜딩됐고, 이 PR 은 그 **거울상**을 닫는다.

## 설계의 척추 — `status == 'accepted'` 자체가 술어다

`UPDATE facts SET status = 'accepted'` 는 프로덕션에 **정확히 한 곳**(`auto_accept_fact`)뿐이고, 사람의 승격은 언제나 `confirmed` 로 떨어진다. 따라서 **`accepted` ⟺ 규칙이 올렸고 아직 사람이 비준하지 않았다.** 감사 로그를 뒤질 필요가 없고, "사람 판단은 절대 자동 강등하지 않는다"가 파이프라인이 아니라 **스토어 계층에서 구조적으로** 보장된다. 이 전제를 지키는 정적 가드 테스트도 함께 넣었다(#292 가 set_status 를 은퇴시키면 관례가 아니라 구조가 된다).

## 커밋

1. **`feat(#264): add a guarded auto-retract transition for rule-accepted facts`** — `auto_retract_fact` 는 `auto_accept_fact` 의 정확한 대칭: 상태 조건이 UPDATE 안에 있어(`WHERE id = ? AND status = 'accepted'`) 다른 커넥션의 사람 결정이 경합에서 이기고, rowcount 0 이면 감사 기록도 건너뛴다. `confirmed`·`superseded`·리뷰 티어 행은 도달 불가능. 착지는 `needs_review` — 엔진 티어를 떠나(이게 실제 수정) 리뷰 큐로 돌아가고, 근거가 회복되면 재승격 가능하다.

2. **`fix(#264): retract rule-accepted facts whose corroboration basis lapsed`** — `apply_auto_accept_recommendations` 가 규칙의 **reconciler** 가 된다: 승격 패스(불변) + 철회 패스. 트리거는 **오직 서로 다른 지지 소스 수 < 2** — 승격 임계값의 정확한 여집합이라 promote↔demote 진동이 원천 봉쇄된다. 잡 상태(`source_analysis_incomplete`)는 **의도적으로 트리거에서 제외**: 재추출 중 같은 triple 의 새 candidate 가 running 잡을 달고 들어오면 신호가 요동쳐 건강한 사실이 분석 도중 철회됐다 재승격되는데, 지지 소스 수는 잡과 무관하고 일시적 추출에 대해 단조라 **지속적인 근거 상실**(reject→superseded, amend, 소스 삭제)만 임계를 넘는다.

## 결정론

두 엔진 스냅샷은 모두 **쓰기 이전**에 잡히고, 더 강한 성질이 성립한다: `_supporting_facts` 는 review-eligible **또는** engine-input 을 지지자로 인정하는데, 이 패스가 하는 두 쓰기(candidate→accepted, accepted→needs_review)는 **양쪽 다 행을 인정 집합 안에 남긴다.** 따라서 패스 도중 어떤 지지 수도 변하지 않고, 스냅샷 타이밍과 무관하게 판정이 뒤집히지 않는다 — 연쇄 철회도 구조적으로 불가능하다.

## 범위 밖 (커밋 본문에 기록)

- **충돌 기반 철회**: #287 의 2a 필터에서는 약하게 뒷받침된 라이벌 candidate 하나도 증인이 된다. 그것이 accepted 값을 끌어내리게 하면 환각 한 건으로 견고한 값을 엔진에서 몰아낼 수 있다. v1 에서 배제.
- 사람이 `confirmed` 한 사실의 자동 강등(설계·스토어 가드 양쪽에서 불가), 같은 요청 안의 HX-Refresh 표시 지연(다음 로드에서 해소되는 표시 문제), 가드된 UPDATE 를 넘는 커넥션 간 원자성, 다중 패스 캐스케이드(다음 캐스케이드로 이월).
- 알려진 v1 여백: auto-accept 된 사실을 사람이 "핀" 할 전용 수단이 없다(`accept_fact` 는 엔진 티어에서 no-op). toggle→accept 로 `confirmed` 를 만들면 영구 보호된다.

## 검증

- 전체 1382 passed / 7 skipped, ruff clean. 철회를 주장하는 테스트들은 수정 전 red 임을 구현자·critic 이 각각 확인.
- 테스트: 헤드라인(지지자 reject → 생존 사실이 needs_review + 이벤트 + 엔진 이탈), 사람 confirmed 보호, 여전히 코로보레이트된 사실 불변, **무진동**(running 잡 candidate 는 철회 유발 안 함), 충돌은 철회 안 함, exclude 준수, 단일 스냅샷 결정론, amend 후 철회, **멱등성**(반복 패스가 재승격도 재철회도 하지 않음), 그리고 `accepted` 유일 기록자 정적 불변식 가드.
- 컨센서스: 커밋별 리뷰 APPROVE + architect/critic 감사 CONCUR. Unit 2 는 2회 수정 사이클을 거쳤다 — 테스트 더블 때문에 프로덕션에 들어간 `isinstance` 분기가 향후 리팩터링에서 **조용히 철회 기능을 끌 수 있다**는 이유로 제거를 요구했다(tiers.py 의 "조용한 오답보다 크래시가 싸다").
