### PR TITLE
fix(#275, #290): CLI KB contract — no scaffolding on no-op paths, refuse init over a foreign database

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -997,6 +997,94 @@ def test_init_still_scaffolds_a_database_that_merely_has_no_schema(tmp_path, mon
     assert (root / "policy" / "logic-policy.dl").is_file()
 
 
+def _tables(db_path) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+    finally:
+        conn.close()
+
+
+def test_init_refuses_a_foreign_facts_table(tmp_path, monkeypatch, capsys):
+    # A `facts` table that is not verinote's must stop init BEFORE any write: the
+    # load-bearing assertion is that the foreign file is left byte-for-byte as it
+    # was, because `executescript` autocommits per statement and would otherwise
+    # scatter verinote's tables into it before crashing on the mismatch (#290).
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "foreign"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE facts(a, b)")
+    conn.commit()
+    conn.close()
+
+    assert cli.main(["init", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert "is not a verinote KB" in err
+    assert cli.KB_ALIEN_FACTS in err
+    assert "Traceback" not in err
+    assert _tables(db) == {"facts"}  # nothing verinote added
+    assert not (root / "policy").exists()
+
+
+def test_init_refuses_a_partial_schema(tmp_path, monkeypatch, capsys):
+    # A verinote-shaped `facts` alone is a partial schema, not an empty slot:
+    # `IF NOT EXISTS` would complete it while writing over the user's file.
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts(id INTEGER PRIMARY KEY, subject, relation, object, status)"
+    )
+    conn.commit()
+    conn.close()
+
+    assert cli.main(["init", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert "is not a verinote KB" in err
+    assert cli.KB_PARTIAL_SCHEMA in err
+    assert _tables(db) == {"facts"}
+
+
+def test_init_seed_on_a_foreign_facts_table_writes_nothing(tmp_path, monkeypatch, capsys):
+    # `--seed` must not reach `_seed`: the refusal returns before the store is
+    # ever opened, so no demo facts land in the foreign database.
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "foreign"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE facts(a, b)")
+    conn.commit()
+    conn.close()
+
+    assert cli.main(["init", str(root), "--seed"]) == 1
+
+    assert "is not a verinote KB" in capsys.readouterr().err
+    assert _tables(db) == {"facts"}
+    assert list(sqlite3.connect(db).execute("SELECT * FROM facts")) == []
+
+
+def test_init_twice_is_idempotent(tmp_path, monkeypatch, capsys):
+    # A healthy, already-initialised KB re-init'd is a no-op re-init, not a refusal.
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "kb"
+
+    assert cli.main(["init", str(root)]) == 0
+    capsys.readouterr()
+
+    assert cli.main(["init", str(root)]) == 0
+    assert "is not a verinote KB" not in capsys.readouterr().err
+
+
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Windows forbids `?` in paths")
 def test_kb_schema_probe_survives_a_uri_metacharacter_in_the_path(tmp_path):
     """A `?` in the root must not truncate the SQLite URI we probe the schema with.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -511,8 +511,13 @@ def test_query_mixed_outcomes_exits_nonzero_with_split(
 
 
 def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
+    # A real KB with nothing pending keeps the existing diagnosis; only the
+    # no-KB path routes through the #275 refusal.
     _env(monkeypatch, tmp_path)
+    Store(tmp_path / "kb.sqlite").init_schema()
+
     rc = cli.main(["query"])
+
     assert rc == 1
     assert "no pending or failed questions" in capsys.readouterr().err
 
@@ -675,8 +680,12 @@ def test_query_prints_ambiguous_outcome(tmp_path, monkeypatch, capsys):
 
 
 def test_repair_no_review_required_errors(tmp_path, monkeypatch, capsys):
+    # As above: the existing message belongs to the KB-exists path.
     _env(monkeypatch, tmp_path)
+    Store(tmp_path / "kb.sqlite").init_schema()
+
     rc = cli.main(["repair"])
+
     assert rc == 1
     assert "no review_required questions" in capsys.readouterr().err
 
@@ -1587,3 +1596,146 @@ def test_read_only_commands_refuse_core_tables_when_facts_lacks_id(
     tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
     conn.close()
     assert tables == {"facts", "review_log", "runs", "sources"}
+
+
+# --- #275: decide there is nothing to do before scaffolding a KB -----------
+
+
+def test_query_with_no_argument_creates_no_kb(tmp_path, monkeypatch, capsys):
+    """No question and no KB means no work — and so no scaffolding (#275)."""
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["query"]) == 1
+
+    assert not (workdir / "data").exists()
+    assert not (workdir / "data" / "kb.sqlite").exists()
+    assert "no KB" in capsys.readouterr().err
+
+
+def test_repair_creates_no_kb_when_there_is_none(tmp_path, monkeypatch, capsys):
+    # `repair` takes no arguments, so a missing KB is always a no-op.
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["repair"]) == 1
+
+    assert not (workdir / "data").exists()
+    assert "no KB" in capsys.readouterr().err
+
+
+def test_sync_with_nothing_to_sync_creates_no_kb(tmp_path, monkeypatch, capsys):
+    # No path, no KB, no source files. Sync keeps its OWN diagnosis here — the
+    # user's problem is that there is nothing to sync, not that a KB is missing.
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["sync"]) == 1
+
+    assert not (workdir / "data").exists()
+    assert not (workdir / "data" / "kb.sqlite").exists()
+    err = capsys.readouterr().err
+    assert "no sources to sync" in err
+    assert "no KB" not in err
+
+
+def test_sync_scaffolds_when_source_files_exist_without_a_kb(tmp_path, monkeypatch):
+    # The workflow the guard must not break: drop files under sources/ and sync.
+    # There IS work to do, so scaffolding the KB is legitimate.
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "work"
+    sources = workdir / "data" / "sources"
+    sources.mkdir(parents=True)
+    (sources / "x.txt").write_text("body", encoding="utf-8")
+    monkeypatch.chdir(workdir)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: (_ for _ in ()).throw(LLMError("provider down")),
+    )
+
+    cli.main(["sync"])
+
+    # It got past the guard and opened the KB — that is what is being pinned.
+    assert (workdir / "data" / "kb.sqlite").is_file()
+
+
+def test_sync_with_a_path_argument_still_scaffolds(tmp_path, monkeypatch):
+    # An explicit path is work by itself, so the guard must not fire on it.
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    note = workdir / "note.txt"
+    note.write_text("body", encoding="utf-8")
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: (_ for _ in ()).throw(LLMError("provider down")),
+    )
+
+    cli.main(["sync", str(note)])
+
+    assert (workdir / "data" / "kb.sqlite").is_file()
+
+
+def test_sync_on_an_existing_kb_with_no_sources_keeps_its_message(
+    tmp_path, monkeypatch, capsys
+):
+    # With a KB present the guard cannot fire, so the existing
+    # open-resolve-refuse path runs and its message is unchanged.
+    _env(monkeypatch, tmp_path)
+    Store(tmp_path / "kb.sqlite").init_schema()
+    (tmp_path / "sources").mkdir()
+
+    assert cli.main(["sync"]) == 1
+
+    assert "no sources to sync" in capsys.readouterr().err
+
+
+def test_query_with_a_question_still_creates_a_kb(tmp_path, monkeypatch):
+    # A question is real work, so scaffolding is the point. rc is 1 here per the
+    # #243 contract (the translation fails); the KB creation is what matters.
+    _isolated(monkeypatch, tmp_path)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: (_ for _ in ()).throw(LLMError("provider down")),
+    )
+
+    cli.main(["query", "What is X?"])
+
+    db_path = workdir / "data" / "kb.sqlite"
+    assert db_path.is_file()
+    store = Store(db_path)
+    assert [q["text"] for q in store.questions()] == ["What is X?"]
+    store.close()
+
+
+def test_query_with_a_saved_active_kb_elsewhere_creates_nothing_in_cwd(
+    tmp_path, monkeypatch, capsys
+):
+    """The guard judges the RESOLVED cfg.db_path, not the directory you stand in.
+
+    #185 adjacency: with no VERINOTE_ROOT and a saved active KB pointing
+    elsewhere, `verinote query` must work against that KB and leave the cwd
+    untouched — never scaffolding a stray `./data` beside the user.
+    """
+    _isolated(monkeypatch, tmp_path)
+    existing = _existing_kb(tmp_path)
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert cli.main(["query"]) == 1
+
+    assert not (workdir / "data").exists()
+    # It reached the real (saved) KB rather than refusing it.
+    assert "no pending or failed questions" in capsys.readouterr().err
+    assert (existing / "kb.sqlite").is_file()

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -125,14 +125,32 @@ def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
     # made — so overwriting it is not ours to choose. Refuse, and say what to do.
     # A readable database with no schema is the opposite case: filling it in is
     # exactly what `init` is for, so that one is left to proceed.
-    if cfg.db_path.is_file() and _kb_schema_problem(cfg.db_path) == KB_UNREADABLE:
-        print(
-            f"cannot initialise {cfg.root}: {cfg.db_path} exists and is {KB_UNREADABLE}. "
-            "If it is a damaged KB, restore it from backup; if it is not a KB at all, "
-            "move it aside and run this again.",
-            file=sys.stderr,
-        )
-        return 1
+    if cfg.db_path.is_file():
+        problem = _kb_schema_problem(cfg.db_path)
+        if problem == KB_UNREADABLE:
+            print(
+                f"cannot initialise {cfg.root}: {cfg.db_path} exists and is {KB_UNREADABLE}. "
+                "If it is a damaged KB, restore it from backup; if it is not a KB at all, "
+                "move it aside and run this again.",
+                file=sys.stderr,
+            )
+            return 1
+        # A foreign `facts` table or a partial/foreign core schema is not ours to
+        # scaffold into either (#290). `init_schema()` is CREATE TABLE IF NOT
+        # EXISTS, so it skips the foreign table and then fails on the mismatch —
+        # but `executescript` under `isolation_level=None` autocommits each
+        # statement, so by the time it raises it has already written the rest of
+        # verinote's tables into the user's database, with nothing to roll them
+        # back. Refusing here keeps that mutation from ever starting. Only
+        # KB_NO_SCHEMA (a readable db with no `facts` table — init's whole
+        # purpose) and a healthy KB (None — an idempotent re-init) may proceed.
+        if problem is not None and problem != KB_NO_SCHEMA:
+            print(
+                f"cannot initialise {cfg.root}: {cfg.db_path} is not a verinote KB "
+                f"({problem}); move it aside and run this again.",
+                file=sys.stderr,
+            )
+            return 1
     cfg.root.mkdir(parents=True, exist_ok=True)
     store = _store(cfg)
     if args.seed:

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -429,6 +429,17 @@ def _rel_to_root(root: Path, p: Path) -> str:
         return str(p)
 
 
+def _source_dir_files(cfg: Config) -> list[Path]:
+    """Loose source files under `<root>/sources` — the unregistered-input path.
+
+    Shared with `cmd_sync`'s no-op guard so the guard and the resolver can never
+    disagree about what counts as a syncable file. `Path.glob` yields nothing for
+    a missing directory, so this is safe on an empty or absent root.
+    """
+    sources_dir = cfg.root / "sources"
+    return sorted(sources_dir.glob("*.txt")) + sorted(sources_dir.glob("*.md"))
+
+
 def _resolve_sources(cfg: Config, store: Store, path: str | None) -> list[_SourceInput]:
     """Resolve a file path or registered text artifacts to extraction inputs."""
     if path:
@@ -449,11 +460,9 @@ def _resolve_sources(cfg: Config, store: Store, path: str | None) -> list[_Sourc
     if inputs:
         return inputs
 
-    sources_dir = cfg.root / "sources"
-    files = sorted(sources_dir.glob("*.txt")) + sorted(sources_dir.glob("*.md"))
     return [
         _SourceInput(_rel_to_root(cfg.root, f), f.read_text(encoding="utf-8"))
-        for f in files
+        for f in _source_dir_files(cfg)
     ]
 
 
@@ -472,6 +481,28 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
             return cfg.extraction_schema_hint()
         except PromptError as exc:
             raise LLMError(str(exc)) from exc
+
+    # No path, no KB, and no source files: there is nothing to sync, so refuse
+    # before `_store()` — `Store()` mkdirs the parent and connects in its
+    # constructor, so a no-op run otherwise leaves a stray `data/` and an empty
+    # kb.sqlite behind (#275). Deferring `init_schema` alone would not help.
+    #
+    # This asks sync's own question, not "is there a KB?": a user with no KB but
+    # files under `sources/` proceeds and scaffolds exactly as before, which is
+    # why the source-file check is part of the condition rather than a call to
+    # `_require_existing_kb` — whose "no KB at {root}" would be a false
+    # diagnosis here. The message below is unchanged from today; the only
+    # difference is that nothing is left behind.
+    #
+    # The glob is the COMPLETE verdict, not a partial restatement of
+    # `_resolve_sources`: registered artifacts live in the KB, so with no KB
+    # there can be none and the resolver would fall through to this same shared
+    # helper. When a KB does exist this cannot fire, so the existing
+    # open-resolve-refuse path is untouched (opening an existing KB creates
+    # nothing).
+    if not args.path and not cfg.db_path.is_file() and not _source_dir_files(cfg):
+        print(f"no sources to sync (looked under {cfg.root / 'sources'})", file=sys.stderr)
+        return 1
 
     store = _store(cfg)
     try:
@@ -615,6 +646,15 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
     from verinote.pipeline import translate_questions, write_query_file
 
+    # With no question there is nothing to add, so a missing KB means there is
+    # nothing to do at all — refuse before `_store()` scaffolds one (#275). With
+    # a question, `add_question` below is real work and scaffolding is the point,
+    # so `verinote query "..."` in a fresh directory still creates its KB.
+    if not args.question:
+        refusal = _require_existing_kb(cfg)
+        if refusal is not None:
+            return refusal
+
     store = _store(cfg)
     if args.question:
         store.add_question(args.question)
@@ -679,6 +719,12 @@ def _short_error(exc: BaseException) -> str:
 def cmd_repair(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
     from verinote.pipeline import repair_questions
+
+    # `repair` takes no arguments, so it can never have work to do without an
+    # existing KB — refuse before `_store()` scaffolds one (#275).
+    refusal = _require_existing_kb(cfg)
+    if refusal is not None:
+        return refusal
 
     store = _store(cfg)
     pending = [q for q in store.questions() if q["status"] == "review_required"]


### PR DESCRIPTION
Closes #275. Closes #290.

`#247`/PR #274 가 읽기 전용 명령(`status`/`coverage`)에 세운 계약 — "사용할 수 없는/없는 KB 는 traceback 없이 거부하고 파일을 건드리지 않는다" — 이 쓰기 명령과 `init` 에는 아직 없던 두 구멍을 닫는다.

## 커밋

1. **`fix(#275): decide there is nothing to do before scaffolding a KB`** — `query`/`repair`/`sync` 가 "할 일 없음" 판정을 내리기 **전에** `_store(cfg)` 를 호출해 왔다. `Store.__init__` 자체가 `mkdir`+`connect` 를 하므로(스캐폴드는 `init_schema` 가 아니라 생성자다), 세 명령 모두 판정을 store 생성 **이전**으로 옮겼다:
   - `repair`: 인자가 없어 KB 없이는 절대 할 일이 없다 — 무조건 거부.
   - `query`: 질문 인자가 있으면 그 자체가 정당한 쓰기이므로, `not args.question` 일 때만 거부.
   - `sync`: `_require_existing_kb` 를 쓰지 않는다 — "KB 없음" 은 `sources/` 에 파일이 있으면 거짓 진단이 되기 때문이다. 대신 "인자 없음 ∧ KB 파일 없음 ∧ `sources/*.txt|*.md` 없음" 삼중 조건으로, 기존 "no sources to sync" 문구를 그대로 유지한다. 이 글롭은 `_resolve_sources` 의 폴백과 **완전히 같은 판정**이다(등록된 아티팩트는 KB 안에만 있으므로 KB 가 없으면 반드시 없다) — 그래서 `_source_dir_files(cfg)` 헬퍼 하나를 두 곳에서 공유해 절대 어긋나지 않게 했다.
   - 부수적으로: 기존 테스트 두 개(`test_query_no_pending_errors`, `test_repair_no_review_required_errors`)가 사실은 KB 없이 돌고 있어 이 버그를 조용히 실행하며 "KB 있음" 메시지를 주장하고 있었다. 진짜 KB 를 주고 이름 그대로 검증하게 고쳤다.

2. **`fix(#290): refuse to initialise over a database that is not verinote's`** — `init` 은 `_kb_schema_problem() == KB_UNREADABLE` 만 거부했다. 남의 `facts` 테이블(`KB_ALIEN_FACTS`) 이나 부분/이물 스키마(`KB_PARTIAL_SCHEMA`)는 통과해 `init_schema()` 의 뒷 문장에서 raw `sqlite3.OperationalError` 로 터졌다 — 그런데 `executescript` 는 문장마다 autocommit 하므로, 크래시 전에 이미 **verinote 테이블 6개를 남의 DB 에 심어 놓은 뒤**였다. 이제 규칙은 하나: `problem is not None and problem != KB_NO_SCHEMA` 면 거부. `KB_UNREADABLE` 분기는 메시지·rc 그대로, `mkdir()` 이전에 배치해 거부 시 아무것도 만들지 않는다.

## 설계 판단 (검증됨)

- **`KB_PARTIAL_SCHEMA` 는 마이그레이션 대상이 아니다.** `_KB_CORE_TABLES`(facts/review_log/runs/sources)는 스키마 역사 전체의 교집합으로 **의도적으로** 선정되어 있어 `job_id`/`term_token` 같은 마이그레이션 추가분은 절대 걸리지 않는다 — pre-job_id KB 를 직접 만들어 격리 환경에서 재현해 `None` 이 반환됨을 확인했다(critic 이 실측).
- **`sync` 도 같은 결함을 갖고 있어 범위에 포함시켰다.** KB 없이는 등록 아티팩트가 있을 수 없어 글롭 하나로 완전한 판정이 되므로, `_resolve_sources` 규칙을 부분 복제하는 드리프트 위험이 없다.

## 검증

- 전체 1394 passed / 7 skipped, ruff clean. 새 테스트들은 수정 전 코드에서 red(raw traceback·스캐폴드된 KB) 임을 확인.
- `#290` 테스트는 "traceback 없음" 보다 강한 **"이물 파일의 테이블 집합이 그대로다"** 를 단언 — 리뷰어가 미수정 코드에서 실제로 6개 테이블이 생기는 것을 재현해 이 단언이 회귀를 잡음을 검증.
- 컨센서스: 커밋별 리뷰 APPROVE + architect/critic 감사 CONCUR. `#275` 는 2회 수정 사이클(글롭 헬퍼 공유화, sync 오분류 메시지 정정)을 거쳤다.

## 사고 및 안전 조치

Phase 1 분석 중 한 에이전트가 `VERINOTE_ROOT` 를 고정하지 않고 라이브 CLI 명령을 실행해, `#185` 의 활성 루트 폴백으로 인해 명령이 사용자의 **실제 KB**(`~/verinote`)에 도달했다. 즉시 중단·자진 보고되었고, 사실 625건(변화 없음)·질문 상태·최신 이벤트 타임스탬프를 직접 대조해 **논리적 데이터 변경이 없음**을 확인했다(파일 mtime 만 이동 — 모든 verinote 명령이 수행하는 통상적 idempotent open). 이후 이 플로우 전체에 "고정된 루트 없이는 라이브 실행 금지" 규칙을 적용해 코드 리딩·격리 픽스처로 전환했다. 이 사고 자체가 `#275`/`#185` 가 존재해야 하는 이유를 실증한다.

## 후속

- `#335` — `init` 이 데이터를 보유한 `KB_PARTIAL_SCHEMA` 파일도 빈 스캐폴드-중단과 같은 "치워라" 문구로 거부한다(critic 제안, 메시지 품질 전용, `#290` 의 거부·rc·mutation 방지 자체는 이미 완료).
