### PR TITLE
fix(#329): retire a confirmed fact's citation when its source text changes

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -832,3 +832,78 @@ def test_a_stale_bit_is_inert_once_a_fact_leaves_needs_review(tmp_path):
     assert recommendation is not None
     assert recommendation.eligible is True
     assert recommendation.support_sources == ("sources/a.txt", "sources/b.txt")
+
+
+def _done_job_at_artifact(store, *, source_id, artifact_id):
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="sample-model",
+        total_chunks=1,
+    )
+    store.finish_extraction_job(job_id)
+    return job_id
+
+
+def test_swept_fact_reobserved_then_auto_accepted_via_corroboration(tmp_path):
+    # The full cycle the sweep finally makes reachable (#329 x #264, INTENDED, not
+    # a defect): the real sweep demotes a confirmed citation as stale; its content
+    # later returns and note_fact_reobserved clears the stale bit; because two
+    # OTHER live sources still corroborate the triple, #264's auto-accept promotes
+    # it straight to `accepted` (not `confirmed` -- a machine trust tier keeps
+    # provenance honest) with no human re-click. Asserted to happen, not guarded.
+    _write_policy(tmp_path)  # born_in is not functional: no single-valued block
+    s = _store(tmp_path)
+
+    src_a = s.add_source("sources/a.txt")
+    a_old = s.add_source_artifact(
+        source_id=src_a, kind="original_text", path="sources/a-v1.txt", checksum="a1"
+    )
+    a_new = s.add_source_artifact(
+        source_id=src_a, kind="original_text", path="sources/a-v2.txt", checksum="a2"
+    )
+    a_old_job = _done_job_at_artifact(s, source_id=src_a, artifact_id=a_old)
+    a_fact = s.add_fact(
+        "Ada", "born_in", "London",
+        status="confirmed", source_id=src_a, job_id=a_old_job,
+    )
+    s.add_fact_evidence(fact_id=a_fact, source_id=src_a, artifact_id=a_old, snippet="London")
+
+    for path in ("sources/b.txt", "sources/c.txt"):
+        witness = s.add_source(path)
+        job = _done_job(s, witness)
+        s.add_fact(
+            "Ada", "born_in", "London",
+            status="confirmed", source_id=witness, job_id=job,
+        )
+
+    # A re-extracts at the new artifact: a Paris candidate anchors there (the whiff
+    # guard), and A's London has no anchor at a_new -> the sweep demotes it.
+    a_job = _done_job_at_artifact(s, source_id=src_a, artifact_id=a_new)
+    paris = s.add_fact(
+        "Ada", "born_in", "Paris", status="candidate", source_id=src_a, job_id=a_job
+    )
+    s.add_fact_evidence(fact_id=paris, source_id=src_a, artifact_id=a_new, snippet="Paris")
+
+    demoted = s.surface_stale_engine_facts(a_job)
+    assert [d["id"] for d in demoted] == [a_fact]
+    assert s.get_fact(a_fact)["status"] == "needs_review"
+    assert s.get_fact(a_fact)["stale"] == 1
+
+    # A's content returns to London: a later clean run re-observes it and clears
+    # the stale bit without touching the human's needs_review status.
+    a_back = s.add_source_artifact(
+        source_id=src_a, kind="original_text", path="sources/a-v3.txt", checksum="a3"
+    )
+    a_job_back = _done_job_at_artifact(s, source_id=src_a, artifact_id=a_back)
+    s.note_fact_reobserved(
+        fact_id=a_fact, source_id=src_a, artifact_id=a_back, job_id=a_job_back
+    )
+    assert s.get_fact(a_fact)["stale"] == 0
+    assert s.get_fact(a_fact)["status"] == "needs_review"
+
+    apply_auto_accept_recommendations(s)
+
+    # Witness-eligible again + corroborated by B and C -> promoted to `accepted`.
+    assert s.get_fact(a_fact)["status"] == "accepted"

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -716,3 +716,119 @@ def test_only_auto_accept_fact_writes_the_accepted_status():
     assert path.name == "db.py"
     preceding_defs = [line for line in lines[:lineno] if line.lstrip().startswith("def ")]
     assert preceding_defs[-1].strip().startswith("def auto_accept_fact(")
+
+
+# --- #329: stale facts are witness-ineligible until their source supports them --
+
+
+def _mark_stale(store, fact_id):
+    """Demote a fact exactly as Unit 3's sweep eventually will: needs_review + stale."""
+    store._conn.execute(
+        "UPDATE facts SET status = 'needs_review', stale = 1 WHERE id = ?", (fact_id,)
+    )
+
+
+def test_stale_fact_is_never_re_promoted_even_with_other_live_witnesses(tmp_path):
+    # #329 Gap 1: a stale fact must not re-promote ITSELF however many live
+    # witnesses its value keeps. It is excluded from its own support set, yet two
+    # other distinct sources remain -- so only recommend()'s own stale guard blocks
+    # it; the _supporting_facts exclusion alone would leak here.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    stale_fact = _corroborated_candidate(
+        s,
+        "Report",
+        "published_year",
+        "2024",
+        ["sources/a.txt", "sources/b.txt", "sources/c.txt"],
+    )
+    _mark_stale(s, stale_fact)
+
+    recommendation = accept_recommendation(s, stale_fact)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "stale_citation" in recommendation.reasons
+    # Two other live, distinct-source witnesses remain: the block is the stale
+    # guard's doing, not a shortage of corroboration.
+    assert len(recommendation.support_sources) == 2
+
+    apply_auto_accept_recommendations(s)
+    assert s.get_fact(stale_fact)["status"] == "needs_review"
+    assert stale_fact not in [f["id"] for f in s.facts(statuses=engine_statuses())]
+
+
+def test_a_stale_witness_does_not_corroborate_another_fact(tmp_path):
+    # #329: a live candidate whose value is witnessed only by {stale A, itself}
+    # loses its corroboration once A is excluded, dropping to a lone source.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    stale_fact = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    live_fact = next(f["id"] for f in s.facts() if f["id"] != stale_fact)
+    _mark_stale(s, stale_fact)
+
+    recommendation = accept_recommendation(s, live_fact)
+
+    assert recommendation is not None
+    assert recommendation.eligible is False
+    assert "insufficient_distinct_source_support" in recommendation.reasons
+    # Only the live fact's own source is left standing.
+    assert recommendation.support_sources == ("sources/b.txt",)
+
+
+def test_a_stale_witness_lapses_a_dependent_accepted_facts_basis(tmp_path):
+    # #329 x #264, an intentional cascade (NOT a regression): two corroborated
+    # candidates auto-accept; one is then demoted stale, so the survivor's live
+    # distinct-source count drops below two and #264's existing machinery retracts
+    # it to needs_review.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    survivor = _corroborated_candidate(
+        s, "Report", "published_year", "2024", ["sources/a.txt", "sources/b.txt"]
+    )
+    apply_auto_accept_recommendations(s)
+    accepted = _accepted_ids(s)
+    assert len(accepted) == 2 and survivor in accepted
+    other = next(fact_id for fact_id in accepted if fact_id != survivor)
+
+    _mark_stale(s, other)
+    applied = apply_auto_accept_recommendations(s)
+
+    assert applied == []
+    assert s.get_fact(survivor)["status"] == "needs_review"
+    events = [
+        e for e in s.fact_events(survivor) if e["event_type"] == "auto_accept_retracted"
+    ]
+    assert len(events) == 1
+    assert json.loads(events[0]["after_json"])["reasons"] == [
+        "insufficient_distinct_source_support"
+    ]
+
+
+def test_a_stale_bit_is_inert_once_a_fact_leaves_needs_review(tmp_path):
+    # The guards key on needs_review specifically, so a human confirm leaves any
+    # lingering stale=1 bit inert: the confirmed fact still corroborates normally
+    # and supplies the second distinct witness a candidate needs.
+    _write_policy(tmp_path)
+    s = _store(tmp_path)
+    source_a = s.add_source("sources/a.txt")
+    source_b = s.add_source("sources/b.txt")
+    job_a = _done_job(s, source_a)
+    job_b = _done_job(s, source_b)
+    confirmed_stale = s.add_fact(
+        "Report", "published_year", "2024",
+        status="confirmed", source_id=source_a, job_id=job_a,
+    )
+    s._conn.execute("UPDATE facts SET stale = 1 WHERE id = ?", (confirmed_stale,))
+    candidate = s.add_fact(
+        "Report", "published_year", "2024",
+        status="candidate", source_id=source_b, job_id=job_b,
+    )
+
+    recommendation = accept_recommendation(s, candidate)
+
+    assert recommendation is not None
+    assert recommendation.eligible is True
+    assert recommendation.support_sources == ("sources/a.txt", "sources/b.txt")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1827,3 +1827,47 @@ def test_query_with_a_saved_active_kb_elsewhere_creates_nothing_in_cwd(
     # It reached the real (saved) KB rather than refusing it.
     assert "no pending or failed questions" in capsys.readouterr().err
     assert (existing / "kb.sqlite").is_file()
+
+
+def test_sync_returns_a_stale_confirmed_fact_to_review(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    # #329 end to end through the CLI: a confirmed citation whose source text has
+    # since changed is returned to the review queue, and cmd_sync's per-source line
+    # reports it.
+    _env(monkeypatch, tmp_path)
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    sid = s.add_source("sources/a.txt", kind="text")
+    old = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    london = s.add_fact("Ada", "born_in", "London", status="confirmed", source_id=sid)
+    s.add_fact_evidence(fact_id=london, source_id=sid, artifact_id=old, snippet="London")
+    # The edited text is the source's current artifact; its file is on disk so the
+    # no-path sync resolves and re-extracts it.
+    art_dir = tmp_path / "artifacts" / "sources" / str(sid)
+    art_dir.mkdir(parents=True, exist_ok=True)
+    (art_dir / "v2.txt").write_text("Ada was born in Paris.", encoding="utf-8")
+    s.add_source_artifact(
+        source_id=sid,
+        kind="original_text",
+        path=f"artifacts/sources/{sid}/v2.txt",
+        checksum="v2",
+    )
+    s.close()
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("Ada", "born_in", "Paris", 0.9)]),
+    )
+
+    rc = cli.main(["sync"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 confirmed fact(s) returned to review" in out
+    s2 = Store(tmp_path / "kb.sqlite")
+    london_row = next(f for f in s2.facts() if f["object"] == "London")
+    assert london_row["status"] == "needs_review"
+    assert london_row["stale"] == 1
+    assert london_row["id"] in [f["id"] for f in s2.review_queue()]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -993,6 +993,95 @@ def test_process_extraction_job_dedupes_chunk_facts_by_source(tmp_path, fake_cli
     assert len(s.facts()) == 1
 
 
+def _extract_one_chunk_at_artifact(s, client, *, source_id, artifact_id, chunk):
+    """Run a fresh one-chunk chunked job over `chunk` at `artifact_id`."""
+    job_id = s.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="m",
+        total_chunks=1,
+    )
+    s.add_source_chunks(job_id=job_id, source_id=source_id, chunks=[chunk])
+    return process_extraction_job(s, client, job_id=job_id)
+
+
+def test_process_extraction_job_reanchors_a_reobserved_fact_at_the_new_artifact(
+    tmp_path, fake_client
+):
+    # #329 Part A: a clean re-extraction re-hits an existing confirmed fact.
+    # reconcile_fact inserts nothing on the hit, so the only way the run leaves a
+    # trace at the new artifact is note_fact_reobserved anchoring fresh evidence
+    # there -- and it must do so without disturbing the human's confirm.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_one = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    fact = ExtractedFact("alpha", "seen_in", "source", 0.9)
+
+    first = _extract_one_chunk_at_artifact(
+        s, fake_client([fact]), source_id=sid, artifact_id=artifact_one, chunk="alpha"
+    )
+    assert first.candidates == 1
+    [row] = s.facts()
+    s.toggle_review(row["id"])  # a human confirms it -- the #329 trust tier
+    assert s.get_fact(row["id"])["status"] == "confirmed"
+
+    artifact_two = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    second = _extract_one_chunk_at_artifact(
+        s, fake_client([fact]), source_id=sid, artifact_id=artifact_two, chunk="alpha"
+    )
+
+    assert second.candidates == 0  # a dedupe hit, nothing created
+    assert len(s.facts()) == 1
+    # Re-anchoring evidence never touches the fact's status.
+    assert s.get_fact(row["id"])["status"] == "confirmed"
+    evidence = s.fact_evidence(row["id"])
+    assert {e["artifact_id"] for e in evidence} == {artifact_one, artifact_two}
+
+
+def test_process_extraction_job_does_not_reanchor_a_superseded_fact(
+    tmp_path, fake_client
+):
+    # A superseded (human-rejected) fact is never re-anchored: reconcile_fact
+    # records its suppression event and the hit branch leaves evidence untouched,
+    # so the new artifact gets no anchor (mirrors reextraction_suppressed --
+    # event only, no evidence).
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_one = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    fact = ExtractedFact("alpha", "seen_in", "source", 0.9)
+
+    _extract_one_chunk_at_artifact(
+        s, fake_client([fact]), source_id=sid, artifact_id=artifact_one, chunk="alpha"
+    )
+    [row] = s.facts()
+    s.reject_fact(row["id"])
+    assert s.get_fact(row["id"])["status"] == "superseded"
+
+    artifact_two = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    second = _extract_one_chunk_at_artifact(
+        s, fake_client([fact]), source_id=sid, artifact_id=artifact_two, chunk="alpha"
+    )
+
+    assert second.candidates == 0
+    evidence = s.fact_evidence(row["id"])
+    assert {e["artifact_id"] for e in evidence} == {artifact_one}  # no anchor at v2
+    events = [
+        e
+        for e in s.fact_events(row["id"])
+        if e["event_type"] == "reextraction_suppressed"
+    ]
+    assert len(events) == 1
+
+
 def test_extract_source_does_not_resurrect_a_rejected_fact(tmp_path, fake_client):
     # The headline #160 regression: a human rejects an extracted fact, then the
     # same source is synced again. The rejection is terminal, so the re-sync must

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,8 +11,22 @@ from verinote.pipeline import (
     process_extraction_job,
     sync_sources,
 )
+from verinote.pipeline.query import query_path
+from verinote.pipeline.verify import verify
 from verinote.store import Store
 from verinote.engine.terms import Atom, Compound, StringLit
+
+
+_BORN_IN_QUERY = (
+    ".decl answer_q1(value: symbol)\n"
+    'answer_q1(O) :- relation("Ada", "born_in", O).\n'
+)
+
+
+def _write_born_in_query(root):
+    path = query_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_BORN_IN_QUERY, encoding="utf-8")
 
 
 def _store(tmp_path) -> Store:
@@ -1208,3 +1222,167 @@ def test_sync_records_suppression_event_when_reextracting_rejected_fact(
     ]
     assert len(events) == 1
     assert json.loads(events[0]["after_json"])["run_id"] == result.run_id
+
+
+# --- #329 Part B: the staleness sweep, end to end ----------------------------
+
+
+def test_stale_confirmed_fact_is_demoted_after_the_source_text_changes(
+    tmp_path, fake_client
+):
+    # THE primary repro: confirm "Ada born_in London" -> edit the source to Paris
+    # -> a clean re-extraction -> the sweep returns London to review (stale=1) and
+    # the engine stops verifying it, while Paris sits as a fresh candidate.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    art_london = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    _extract_one_chunk_at_artifact(
+        s,
+        fake_client([ExtractedFact("Ada", "born_in", "London", 0.9)]),
+        source_id=sid,
+        artifact_id=art_london,
+        chunk="Ada was born in London.",
+    )
+    [fact] = s.facts()
+    s.toggle_review(fact["id"])  # a human confirms it
+    assert s.get_fact(fact["id"])["status"] == "confirmed"
+    _write_born_in_query(tmp_path)
+    assert verify(s).answers == ["q1: London"]
+
+    art_paris = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    outcome = _extract_one_chunk_at_artifact(
+        s,
+        fake_client([ExtractedFact("Ada", "born_in", "Paris", 0.9)]),
+        source_id=sid,
+        artifact_id=art_paris,
+        chunk="Ada was born in Paris.",
+    )
+
+    demoted = s.surface_stale_engine_facts(outcome.job_id)
+
+    assert [d["object"] for d in demoted] == ["London"]
+    london = next(f for f in s.facts() if f["object"] == "London")
+    paris = next(f for f in s.facts() if f["object"] == "Paris")
+    assert london["status"] == "needs_review" and london["stale"] == 1
+    assert paris["status"] == "candidate"
+    # The engine no longer returns London, and Paris is not yet engine-tier.
+    assert verify(s).answers == []
+
+
+def test_unchanged_source_resync_demotes_nothing(tmp_path, fake_client):
+    # The load-bearing anti-thrash regression: re-syncing an UNCHANGED source (the
+    # ordinary case) re-observes its confirmed fact at the same content-addressed
+    # artifact, so the sweep finds current evidence and demotes nothing. Without
+    # this the whole design would oscillate under normal operation.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    art = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a.txt", checksum="v1"
+    )
+    london = ExtractedFact("Ada", "born_in", "London", 0.9)
+    _extract_one_chunk_at_artifact(
+        s, fake_client([london]), source_id=sid, artifact_id=art, chunk="London body."
+    )
+    [fact] = s.facts()
+    s.toggle_review(fact["id"])
+    assert s.get_fact(fact["id"])["status"] == "confirmed"
+
+    outcome = _extract_one_chunk_at_artifact(
+        s, fake_client([london]), source_id=sid, artifact_id=art, chunk="London body."
+    )
+    demoted = s.surface_stale_engine_facts(outcome.job_id)
+
+    assert demoted == []
+    assert s.get_fact(fact["id"])["status"] == "confirmed"
+    assert s.get_fact(fact["id"])["stale"] == 0
+
+
+def test_a_run_with_a_failed_chunk_demotes_nothing(tmp_path, fake_client):
+    # Criterion 2 from the issue: a run with ANY failed chunk finishes 'failed' and
+    # is self-gated out of staleness judgment entirely -- a partially-failed run
+    # must never sweep away a confirmed fact just because it did not re-see it.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    art_old = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    _extract_one_chunk_at_artifact(
+        s,
+        fake_client([ExtractedFact("alpha", "seen_in", "source", 0.9)]),
+        source_id=sid,
+        artifact_id=art_old,
+        chunk="alpha",
+    )
+    [fact] = s.facts()
+    s.toggle_review(fact["id"])
+    assert s.get_fact(fact["id"])["status"] == "confirmed"
+
+    art_new = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    job_id = s.create_extraction_job(
+        source_id=sid, artifact_id=art_new, provider="fake", model="m", total_chunks=1
+    )
+    s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["bad"])
+    result = process_extraction_job(s, _ChunkAwareClient(), job_id=job_id)
+    assert result.failed_chunks == 1
+    assert s.get_extraction_job(job_id)["status"] == "failed"
+
+    assert s.surface_stale_engine_facts(job_id) == []
+    assert s.get_fact(fact["id"])["status"] == "confirmed"
+    assert s.get_fact(fact["id"])["stale"] == 0
+
+
+def test_multi_source_demotes_only_the_edited_source_and_a_witness_still_answers(
+    tmp_path, fake_client
+):
+    # Same triple confirmed from source A and B; A's text is edited away. Only A's
+    # citation is demoted (facts are source-scoped), B's is untouched, and the
+    # engine still answers because B remains a live witness.
+    s = _store(tmp_path)
+    london = ExtractedFact("Ada", "born_in", "London", 0.9)
+    src_a = s.add_source("sources/a.txt")
+    a_old = s.add_source_artifact(
+        source_id=src_a, kind="original_text", path="sources/a-v1.txt", checksum="a1"
+    )
+    _extract_one_chunk_at_artifact(
+        s, fake_client([london]), source_id=src_a, artifact_id=a_old, chunk="A: London."
+    )
+    a_fact = s.facts()[0]
+    s.toggle_review(a_fact["id"])
+
+    src_b = s.add_source("sources/b.txt")
+    b_art = s.add_source_artifact(
+        source_id=src_b, kind="original_text", path="sources/b.txt", checksum="b1"
+    )
+    _extract_one_chunk_at_artifact(
+        s, fake_client([london]), source_id=src_b, artifact_id=b_art, chunk="B: London."
+    )
+    b_fact = next(f for f in s.facts() if f["source_id"] == src_b)
+    s.toggle_review(b_fact["id"])
+
+    _write_born_in_query(tmp_path)
+    assert verify(s).answers == ["q1: London"]
+
+    a_new = s.add_source_artifact(
+        source_id=src_a, kind="original_text", path="sources/a-v2.txt", checksum="a2"
+    )
+    outcome = _extract_one_chunk_at_artifact(
+        s,
+        fake_client([ExtractedFact("Ada", "born_in", "Paris", 0.9)]),
+        source_id=src_a,
+        artifact_id=a_new,
+        chunk="A: Paris.",
+    )
+
+    demoted = s.surface_stale_engine_facts(outcome.job_id)
+
+    assert [d["id"] for d in demoted] == [a_fact["id"]]
+    assert s.get_fact(a_fact["id"])["status"] == "needs_review"
+    assert s.get_fact(b_fact["id"])["status"] == "confirmed"  # the witness is untouched
+    # The engine still answers London -- through B, the live witness.
+    assert verify(s).answers == ["q1: London"]

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -853,6 +853,7 @@ FACT_TRANSITION_METHODS = frozenset(
         "auto_accept_fact",
         "auto_retract_fact",
         "reject_fact",
+        "surface_stale_engine_facts",
         "toggle_review",
     }
 )
@@ -944,6 +945,20 @@ def test_no_public_transition_revives_a_superseded_fact(tmp_path):
     assert store.get_fact(fact_id)["status"] == "superseded"
     log_before = _actions(store, fact_id)
 
+    # surface_stale_engine_facts sweeps a source over its latest completed job, so
+    # give this source one whose current artifact even anchors the superseded fact:
+    # superseded is not engine-tier, so the sweep must skip it rather than revive it.
+    artifact_id = store.add_source_artifact(
+        source_id=source_id, kind="original_text", path="sources/rejected.txt", checksum="r1"
+    )
+    store.add_fact_evidence(
+        fact_id=fact_id, source_id=source_id, artifact_id=artifact_id, snippet="x"
+    )
+    stale_job = store.create_extraction_job(
+        source_id=source_id, artifact_id=artifact_id, provider="fake", model="m", total_chunks=1
+    )
+    store.finish_extraction_job(stale_job)
+
     routes = {
         "accept_fact": lambda: store.accept_fact(fact_id),
         "accept_review_facts_for_source": lambda: store.accept_review_facts_for_source(
@@ -952,6 +967,7 @@ def test_no_public_transition_revives_a_superseded_fact(tmp_path):
         "auto_accept_fact": lambda: store.auto_accept_fact(fact_id, rule_name="r"),
         "auto_retract_fact": lambda: store.auto_retract_fact(fact_id, rule_name="r"),
         "reject_fact": lambda: store.reject_fact(fact_id),
+        "surface_stale_engine_facts": lambda: store.surface_stale_engine_facts(stale_job),
         "toggle_review": lambda: store.toggle_review(fact_id),
     }
     assert set(routes) == FACT_TRANSITION_METHODS

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -543,6 +543,232 @@ def test_note_fact_reobserved_clears_stale_on_the_new_anchor_path(tmp_path):
     assert s.get_fact(fact_id)["status"] == "needs_review"
 
 
+# --- surface_stale_engine_facts (#329 Part B) --------------------------------
+
+
+def _stale_parts(store):
+    """A confirmed engine-tier fact anchored ONLY at an old artifact (the stale
+    citation), a survivor confirmed fact anchored at the NEW artifact (satisfies
+    the empty/whiff guard and must never be swept), and the two artifact ids."""
+    sid = store.add_source("sources/a.txt")
+    old = store.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    new = store.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    stale = store.add_fact("Ada", "born_in", "London", status="confirmed", source_id=sid)
+    store.add_fact_evidence(fact_id=stale, source_id=sid, artifact_id=old, snippet="London")
+    survivor = store.add_fact("Ada", "lived_in", "Paris", status="confirmed", source_id=sid)
+    store.add_fact_evidence(
+        fact_id=survivor, source_id=sid, artifact_id=new, snippet="Paris"
+    )
+    return sid, old, new, stale, survivor
+
+
+def _done_job_at(store, *, source_id, artifact_id):
+    """A completed, clean job over `artifact_id` — `finish` forces status='done'
+    with failed_chunks=0, the authoritative clean-run signal the sweep gates on."""
+    job_id = store.create_extraction_job(
+        source_id=source_id,
+        artifact_id=artifact_id,
+        provider="fake",
+        model="m",
+        total_chunks=1,
+    )
+    store.finish_extraction_job(job_id)
+    return job_id
+
+
+def test_surface_stale_demotes_a_confirmed_fact_with_no_current_evidence(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    job = _done_job_at(s, source_id=sid, artifact_id=new)
+
+    demoted = s.surface_stale_engine_facts(job)
+
+    assert [d["id"] for d in demoted] == [stale]
+    # status AND stale flip together — the invariant both witness guards depend on.
+    row = s.get_fact(stale)
+    assert row["status"] == "needs_review"
+    assert row["stale"] == 1
+    # the survivor has evidence at the current artifact and is left untouched.
+    survivor_row = s.get_fact(survivor)
+    assert survivor_row["status"] == "confirmed"
+    assert survivor_row["stale"] == 0
+
+
+def test_surface_stale_demotes_an_accepted_fact_too(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    s._conn.execute("UPDATE facts SET status = 'accepted' WHERE id = ?", (stale,))
+    job = _done_job_at(s, source_id=sid, artifact_id=new)
+
+    demoted = s.surface_stale_engine_facts(job)
+
+    assert [d["id"] for d in demoted] == [stale]
+    row = s.get_fact(stale)
+    assert row["status"] == "needs_review"
+    assert row["stale"] == 1
+
+
+def test_surface_stale_never_touches_a_superseded_fact(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    gone = s.add_fact("Ada", "died_in", "Rome", status="candidate", source_id=sid)
+    s.add_fact_evidence(fact_id=gone, source_id=sid, artifact_id=old, snippet="Rome")
+    s.reject_fact(gone)  # a human's terminal rejection
+    job = _done_job_at(s, source_id=sid, artifact_id=new)
+
+    demoted = s.surface_stale_engine_facts(job)
+
+    assert gone not in [d["id"] for d in demoted]
+    assert s.get_fact(gone)["status"] == "superseded"
+    assert s.get_fact(gone)["stale"] == 0
+
+
+def test_surface_stale_guarded_update_noops_on_a_concurrent_status_change(tmp_path):
+    # The cross-connection race: a human reject lands on another connection after
+    # the sweep read the row but before its guarded UPDATE. The guard's WHERE
+    # status = <observed> then finds rowcount 0, so stale is NEVER stamped on a
+    # fact that did not actually transition (the Gap-1 re-promotion invariant).
+    db = tmp_path / "kb.sqlite"
+    sweeping = Store(db)
+    sweeping.init_schema()
+    other = Store(db)
+    sid, old, new, stale, survivor = _stale_parts(sweeping)
+    job = _done_job_at(sweeping, source_id=sid, artifact_id=new)
+
+    real_get_fact = sweeping.get_fact
+    interleaved = []
+
+    def reject_once_after_the_read(target_id):
+        row = real_get_fact(target_id)
+        if target_id == stale and not interleaved:
+            interleaved.append(True)
+            other.reject_fact(stale)  # the other connection's human rejects it
+        return row
+
+    sweeping.get_fact = reject_once_after_the_read
+    demoted = sweeping.surface_stale_engine_facts(job)
+
+    assert interleaved, "the concurrent reject never landed — the test proves nothing"
+    assert demoted == []  # the guard refused the stale write
+    assert other.get_fact(stale)["status"] == "superseded"
+    assert other.get_fact(stale)["stale"] == 0  # never stamped on a non-transition
+
+
+def test_surface_stale_returns_empty_when_the_job_artifact_is_null(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    # A completed job with no artifact of its own cannot define "current artifact".
+    null_job = s.create_extraction_job(
+        source_id=sid, artifact_id=None, provider="fake", model="m", total_chunks=1
+    )
+    s.finish_extraction_job(null_job)
+
+    assert s.surface_stale_engine_facts(null_job) == []
+    assert s.get_fact(stale)["status"] == "confirmed"
+
+
+def test_surface_stale_returns_empty_for_a_non_done_job(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    running = s.create_extraction_job(
+        source_id=sid, artifact_id=new, provider="fake", model="m", total_chunks=1
+    )
+    s.mark_extraction_job_running(running)
+    assert s.get_extraction_job(running)["status"] == "running"
+
+    assert s.surface_stale_engine_facts(running) == []
+    assert s.get_fact(stale)["status"] == "confirmed"
+
+
+def test_surface_stale_returns_empty_when_failed_chunks_is_nonzero(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    job = _done_job_at(s, source_id=sid, artifact_id=new)
+    # The belt: a 'done' row that still carries a nonzero failed_chunks counter is
+    # refused even though status=='done' (a state fail_extraction_job can leave).
+    s._conn.execute("UPDATE extraction_jobs SET failed_chunks = 1 WHERE id = ?", (job,))
+
+    assert s.surface_stale_engine_facts(job) == []
+    assert s.get_fact(stale)["status"] == "confirmed"
+
+
+def test_surface_stale_returns_empty_when_not_the_latest_job(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    done = _done_job_at(s, source_id=sid, artifact_id=new)
+    # A newer job supersedes it: the older done job ran over a now-superseded view.
+    s.create_extraction_job(
+        source_id=sid, artifact_id=new, provider="fake", model="m", total_chunks=1
+    )
+
+    assert s.surface_stale_engine_facts(done) == []
+    assert s.get_fact(stale)["status"] == "confirmed"
+
+
+def test_surface_stale_returns_empty_when_no_evidence_anchors_the_current_artifact(
+    tmp_path,
+):
+    # The empty/whiff guard: a source edited to empty (or a total LLM whiff) leaves
+    # NO anchor at the current artifact, so nothing is swept on pure absence.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    old = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    new = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    stale = s.add_fact("Ada", "born_in", "London", status="confirmed", source_id=sid)
+    s.add_fact_evidence(fact_id=stale, source_id=sid, artifact_id=old, snippet="London")
+    job = _done_job_at(s, source_id=sid, artifact_id=new)  # no anchor at `new`
+
+    assert s.surface_stale_engine_facts(job) == []
+    assert s.get_fact(stale)["status"] == "confirmed"
+
+
+def test_surface_stale_excludes_a_fact_with_only_null_artifact_evidence(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    # A legacy/non-chunked fact whose ONLY evidence carries a NULL artifact_id has
+    # no artifact baseline to judge staleness against and is never swept.
+    legacy = s.add_fact("Legacy", "is_a", "Fact", status="confirmed", source_id=sid)
+    s.add_fact_evidence(fact_id=legacy, source_id=sid, artifact_id=None, snippet="x")
+    job = _done_job_at(s, source_id=sid, artifact_id=new)
+
+    demoted = [d["id"] for d in s.surface_stale_engine_facts(job)]
+
+    assert legacy not in demoted
+    assert s.get_fact(legacy)["status"] == "confirmed"
+    # the genuinely stale fact still demotes, proving the sweep did run.
+    assert stale in demoted
+
+
+def test_surface_stale_emits_a_stale_citation_surfaced_event(tmp_path):
+    s = _store(tmp_path)
+    sid, old, new, stale, survivor = _stale_parts(s)
+    job = _done_job_at(s, source_id=sid, artifact_id=new)
+
+    s.surface_stale_engine_facts(job)
+
+    events = [
+        e for e in s.fact_events(stale) if e["event_type"] == "stale_citation_surfaced"
+    ]
+    assert len(events) == 1
+    assert events[0]["actor"] == "system"
+    assert events[0]["job_id"] == job  # keyed to THIS sweep's job, not the origin
+    assert events[0]["source_id"] == sid
+    # the untouched survivor gets no such event.
+    assert [
+        e
+        for e in s.fact_events(survivor)
+        if e["event_type"] == "stale_citation_surfaced"
+    ] == []
+
+
 def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):
     s = _store(tmp_path)
     sid = s.add_source("sources/report.pdf", kind="binary")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import json
+import sqlite3
 
 import pytest
 
@@ -434,6 +435,112 @@ def test_note_fact_reobserved_anchors_each_distinct_artifact(tmp_path):
     evidence = s.fact_evidence(fact_id)
     assert len(evidence) == 2
     assert {e["artifact_id"] for e in evidence} == {artifact_one, artifact_two}
+
+
+def _fact_columns(store) -> set[str]:
+    return {row["name"] for row in store._conn.execute("PRAGMA table_info(facts)")}
+
+
+def test_fresh_facts_table_has_the_stale_column(tmp_path):
+    # #329: a fresh DB built straight from schema.sql carries the staleness flag.
+    s = _store(tmp_path)
+    assert "stale" in _fact_columns(s)
+
+
+def test_migration_adds_the_stale_column_to_a_legacy_facts_table(tmp_path):
+    # A pre-#329 KB predates the column; reopening must migrate it in so a fresh
+    # and a migrated DB expose the same `facts` schema. Mirrors the term_token
+    # legacy-migration guard, and the column here (unlike term_token) is NOT NULL,
+    # so every backfilled row must land a concrete 0 rather than NULL.
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.execute(
+        """
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY,
+            subject TEXT NOT NULL,
+            relation TEXT NOT NULL,
+            object TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'candidate',
+            confidence REAL NOT NULL DEFAULT 0.0,
+            source_id INTEGER,
+            run_id INTEGER,
+            note TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    conn.execute("INSERT INTO facts(subject, relation, object) VALUES('A', 'is_a', 'B')")
+    conn.commit()
+    conn.close()
+
+    reopened = _store(tmp_path)
+    try:
+        assert "stale" in _fact_columns(reopened)
+        row = reopened._conn.execute("SELECT stale FROM facts").fetchone()
+        assert row["stale"] == 0
+    finally:
+        reopened.close()
+
+
+def test_note_fact_reobserved_clears_stale_on_the_existing_anchor_path(tmp_path):
+    # The drop-then-revert regression: a fact demoted stale=1 whose content returns
+    # at an artifact it was ALREADY anchored to. The anchor exists, so the method
+    # early-returns False with no new row -- yet it must still clear the stale bit,
+    # and must leave the human's needs_review status untouched.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a.txt"
+    )
+    fact_id = s.add_fact("A", "is_a", "B", source_id=sid)
+    assert (
+        s.note_fact_reobserved(fact_id=fact_id, source_id=sid, artifact_id=artifact_id)
+        is True
+    )
+    # Simulate Unit 3's future sweep demoting the citation as stale.
+    s._conn.execute(
+        "UPDATE facts SET status = 'needs_review', stale = 1 WHERE id = ?", (fact_id,)
+    )
+
+    reobserved = s.note_fact_reobserved(
+        fact_id=fact_id, source_id=sid, artifact_id=artifact_id
+    )
+
+    assert reobserved is False  # anchor already present -- no new row
+    assert len(s.fact_evidence(fact_id)) == 1
+    assert s.get_fact(fact_id)["stale"] == 0  # cleared despite the early return
+    assert s.get_fact(fact_id)["status"] == "needs_review"  # status left to the human
+
+
+def test_note_fact_reobserved_clears_stale_on_the_new_anchor_path(tmp_path):
+    # A stale fact re-observed at a genuinely NEW artifact both anchors fresh
+    # evidence and clears the stale bit.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_one = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    artifact_two = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    fact_id = s.add_fact("A", "is_a", "B", source_id=sid)
+    assert (
+        s.note_fact_reobserved(fact_id=fact_id, source_id=sid, artifact_id=artifact_one)
+        is True
+    )
+    s._conn.execute(
+        "UPDATE facts SET status = 'needs_review', stale = 1 WHERE id = ?", (fact_id,)
+    )
+
+    reobserved = s.note_fact_reobserved(
+        fact_id=fact_id, source_id=sid, artifact_id=artifact_two
+    )
+
+    assert reobserved is True  # a new anchor at the new artifact
+    assert len(s.fact_evidence(fact_id)) == 2
+    assert s.get_fact(fact_id)["stale"] == 0
+    assert s.get_fact(fact_id)["status"] == "needs_review"
 
 
 def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -380,6 +380,62 @@ def test_fact_evidence_rejects_mismatched_chunk_source(tmp_path):
         )
 
 
+def test_note_fact_reobserved_is_idempotent_per_artifact(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_id = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a.txt"
+    )
+    fact_id = s.add_fact("A", "is_a", "B", source_id=sid)
+
+    assert (
+        s.note_fact_reobserved(
+            fact_id=fact_id, source_id=sid, artifact_id=artifact_id, snippet="A is a B"
+        )
+        is True
+    )
+    # A second re-observation of the same (fact, artifact) pair anchors nothing.
+    assert (
+        s.note_fact_reobserved(
+            fact_id=fact_id, source_id=sid, artifact_id=artifact_id, snippet="A is a B"
+        )
+        is False
+    )
+
+    evidence = s.fact_evidence(fact_id)
+    assert len(evidence) == 1
+    assert evidence[0]["artifact_id"] == artifact_id
+
+
+def test_note_fact_reobserved_anchors_each_distinct_artifact(tmp_path):
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    artifact_one = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    artifact_two = s.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v2.txt", checksum="v2"
+    )
+    fact_id = s.add_fact("A", "is_a", "B", source_id=sid)
+
+    assert (
+        s.note_fact_reobserved(
+            fact_id=fact_id, source_id=sid, artifact_id=artifact_one
+        )
+        is True
+    )
+    assert (
+        s.note_fact_reobserved(
+            fact_id=fact_id, source_id=sid, artifact_id=artifact_two
+        )
+        is True
+    )
+
+    evidence = s.fact_evidence(fact_id)
+    assert len(evidence) == 2
+    assert {e["artifact_id"] for e in evidence} == {artifact_one, artifact_two}
+
+
 def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):
     s = _store(tmp_path)
     sid = s.add_source("sources/report.pdf", kind="binary")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2874,3 +2874,164 @@ def test_test_connection_surfaces_llm_error(tmp_path, monkeypatch, fake_client):
     r = c.post("/settings/test")
     assert r.status_code == 502
     assert "connection failed: no key" in r.text
+
+
+def test_worker_demotes_a_stale_fact_and_does_not_re_promote_it_same_request(
+    tmp_path, monkeypatch, fake_client
+):
+    # #329 web path: overwriting a source's text (a new artifact + a fresh job) runs
+    # the sweep as a sibling of extraction, returning the now-unsupported confirmed
+    # citation to review. The stale flag plus exclude_fact_ids keep the SAME
+    # request's auto-accept pass from immediately re-promoting it, even though two
+    # other sources still corroborate the value.
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+        auto_accept_recommendations=True,
+    )
+    policy = tmp_path / POLICY_RELPATH
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        src_a = store.add_source("sources/a.txt")
+        old = store.add_source_artifact(
+            source_id=src_a, kind="original_text", path="sources/a-v1.txt", checksum="a1"
+        )
+        new = store.add_source_artifact(
+            source_id=src_a, kind="original_text", path="sources/a-v2.txt", checksum="a2"
+        )
+        old_job = store.create_extraction_job(
+            source_id=src_a, artifact_id=old, provider="anthropic", model="m", total_chunks=1
+        )
+        oc = store.add_source_chunks(
+            job_id=old_job, source_id=src_a, chunks=["London body"]
+        )[0]
+        store.mark_extraction_job_running(old_job)
+        store.mark_chunk_running(oc)
+        store.mark_chunk_done(oc, candidates=1)
+        store.finish_extraction_job(old_job)
+        london_a = store.add_fact(
+            "Ada", "born_in", "London",
+            status="confirmed", source_id=src_a, job_id=old_job,
+        )
+        store.add_fact_evidence(
+            fact_id=london_a, source_id=src_a, artifact_id=old, snippet="London"
+        )
+        # Two other sources corroborate the value, so it WOULD be auto-accept
+        # eligible were it not stale + excluded this pass.
+        for path in ("sources/b.txt", "sources/c.txt"):
+            witness = store.add_source(path)
+            wj = store.create_extraction_job(
+                source_id=witness, provider="anthropic", model="m", total_chunks=1
+            )
+            wc = store.add_source_chunks(job_id=wj, source_id=witness, chunks=["x"])[0]
+            store.mark_extraction_job_running(wj)
+            store.mark_chunk_running(wc)
+            store.mark_chunk_done(wc, candidates=1)
+            store.finish_extraction_job(wj)
+            store.add_fact(
+                "Ada", "born_in", "London",
+                status="confirmed", source_id=witness, job_id=wj,
+            )
+        # The overwrite: a pending job at the NEW artifact whose text says Paris.
+        new_job = store.create_extraction_job(
+            source_id=src_a, artifact_id=new, provider="anthropic", model="m", total_chunks=1
+        )
+        store.add_source_chunks(
+            job_id=new_job, source_id=src_a, chunks=["Ada was born in Paris."]
+        )
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("Ada", "born_in", "Paris", 0.9)]),
+    )
+
+    create_app(cfg)  # resumes the pending job -> _start_source_extraction
+
+    def swept():
+        assert _job_row(cfg, new_job)["status"] == "done"
+        with Store(cfg.db_path) as store:
+            store.init_schema()
+            london = next(
+                f for f in store.facts()
+                if f["object"] == "London" and f["source_id"] == src_a
+            )
+            assert london["status"] == "needs_review" and london["stale"] == 1
+
+    _wait_for(swept)
+    time.sleep(0.2)  # let an unguarded re-promotion land, if the wiring regressed
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        london = next(
+            f for f in store.facts()
+            if f["object"] == "London" and f["source_id"] == src_a
+        )
+        assert london["status"] == "needs_review"  # demoted, not re-promoted
+        assert london["stale"] == 1
+        paris = next(f for f in store.facts() if f["object"] == "Paris")
+        assert paris["status"] == "candidate"
+
+
+def test_worker_leaves_a_done_job_done_when_the_stale_sweep_raises(
+    tmp_path, monkeypatch, fake_client
+):
+    # #329 exception-safety: the sweep is a sibling call inside the worker's
+    # try/except, so WITHOUT the local guard a sweep error would reach the outer
+    # `except Exception -> fail_extraction_job` and retroactively flip a completed
+    # extraction to `failed` (the "KB lies about its own run state" class #194/#239
+    # closed). The local guard must keep an already-`done` job `done`.
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    policy = tmp_path / POLICY_RELPATH
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        sid = store.add_source("sources/a.txt")
+        art = store.add_source_artifact(
+            source_id=sid, kind="original_text", path="sources/a.txt", checksum="v1"
+        )
+        job_id = store.create_extraction_job(
+            source_id=sid, artifact_id=art, provider="anthropic", model="m", total_chunks=1
+        )
+        store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["some text"])
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+
+    def boom(self, job_id):
+        raise RuntimeError("sweep exploded")
+
+    monkeypatch.setattr(store_db.Store, "surface_stale_engine_facts", boom)
+
+    create_app(cfg)  # resumes the pending job -> _start_source_extraction
+
+    def job_finished():
+        assert _job_row(cfg, job_id)["status"] == "done"
+
+    _wait_for(job_finished)
+    time.sleep(0.2)  # let a late fail_extraction_job land, if the guard regressed
+    row = _job_row(cfg, job_id)
+    assert row["status"] == "done"  # the sweep error did NOT flip it to failed
+    assert row["failed_chunks"] == 0
+    # extraction genuinely completed; only the (now contained) sweep failed.
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        assert any(f["subject"] == "A" for f in store.facts())

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -66,6 +66,7 @@ class _SourceSyncOutcome:
     message: str = ""
     job_total_candidates: int | None = None
     resumed_job_id: int | None = None
+    stale_surfaced: int = 0
 
 
 @dataclass(frozen=True)
@@ -517,7 +518,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         process_extraction_job,
         sync_sources,
     )
-    from verinote.pipeline.policy_state import PolicyMissingError
+    from verinote.pipeline.policy_state import assert_writable, PolicyMissingError
     from verinote.prompts import PromptError
 
     def extraction_schema_hint() -> str:
@@ -645,6 +646,22 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     if outcome.failed_chunks
                     else ""
                 )
+                # A clean run is the only one allowed to judge staleness: a source
+                # whose text changed under a confirmed/accepted citation returns
+                # that citation to review (#329). The store method re-verifies the
+                # clean-run gate authoritatively; this `failed_chunks == 0` is only
+                # the fast path, and a partial run must never sweep. The sweep is a
+                # SIBLING of `process_extraction_job` (separation of concerns:
+                # extraction stays a pure primitive, while the demoted count is
+                # needed here for the per-source line); unlike the web worker, this
+                # try has no `fail_extraction_job` path, so no local guard is owed.
+                # `assert_writable` first so a policy lost post-completion routes to
+                # the PolicyMissingError handler below rather than demoting facts
+                # against a halted KB (#194) — the store trusts its caller for this.
+                stale_surfaced = 0
+                if outcome.failed_chunks == 0:
+                    assert_writable(store)
+                    stale_surfaced = len(store.surface_stale_engine_facts(job_id))
                 # `outcome.candidates` is the job's running total, which for a
                 # continued (resumed OR retried) job counts candidates an earlier,
                 # interrupted run already extracted — using it here would credit
@@ -667,6 +684,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                             else None
                         ),
                         resumed_job_id=continued_job_id,
+                        stale_surfaced=stale_surfaced,
                     )
                 )
                 total += outcome.run_candidates
@@ -709,6 +727,11 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
             )
         else:
             print(f"  {outcome.source_path}: {outcome.candidates} candidate(s)")
+        if outcome.stale_surfaced:
+            print(
+                f"  {outcome.source_path}: {outcome.stale_surfaced} confirmed "
+                f"fact(s) returned to review — source text no longer supports them"
+            )
     for source in result.blocked:
         # The give-up signal #323 adds: a job whose chunk has exhausted its retries
         # will never make progress on its own, so name it on stderr and point at

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -175,6 +175,7 @@ class _FactView:
     relation: str
     object: str
     status: str
+    stale: bool
     source: str
     job_id: int | None
     canonical_relation: str
@@ -217,6 +218,12 @@ class _RecommendationEngine:
                 reasons.append("source_analysis_incomplete")
         if self._has_single_valued_conflict(target):
             reasons.append("single_valued_conflict")
+        # A fact the staleness sweep demoted must never re-promote ITSELF, even
+        # when its value keeps other live witnesses -- the _supporting_facts
+        # exclusion alone leaks here, because excluding the stale fact from its own
+        # support set still leaves >=2 other distinct sources (#329 Gap 1).
+        if target.stale and target.status == "needs_review":
+            reasons.append("stale_citation")
 
         return AcceptRecommendation(
             fact_id=target.id,
@@ -233,6 +240,12 @@ class _RecommendationEngine:
             fact
             for fact in self.facts
             if (is_review_eligible(fact.status) or is_engine_input(fact.status))
+            # A fact the staleness sweep demoted (its source text no longer
+            # supports it) stays review-eligible by status but must not corroborate
+            # any value while it awaits a human -- #329. Conditioning on
+            # needs_review keeps the flag inert the moment a human confirms or
+            # rejects, so no explicit clear is owed on those transitions.
+            and not (fact.stale and fact.status == "needs_review")
             and fact.subject == target.subject
             and fact.canonical_relation == target.canonical_relation
             and fact.object_key == target.object_key
@@ -323,6 +336,7 @@ def _view_fact(
         relation=relation,
         object=str(row["object"]),
         status=str(row["status"]),
+        stale=bool(row["stale"]),
         source=str(row["source_path"] or "").strip(),
         job_id=int(row["job_id"]) if row["job_id"] is not None else None,
         canonical_relation=canonical,

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -573,6 +573,19 @@ def _extract_chunk(
             note=f.note,
         )
         if not result.created:
+            # A non-superseded dedupe hit re-anchors the existing fact at this
+            # run's artifact so a later staleness check can tell a fact this run
+            # re-observed from one an edit silently dropped; a superseded hit is
+            # left to reconcile_fact's suppression event, never re-anchored.
+            if result.matched_status != "superseded" and artifact_id is not None:
+                store.note_fact_reobserved(
+                    fact_id=result.fact_id,
+                    source_id=source_id,
+                    artifact_id=artifact_id,
+                    job_id=job_id,
+                    chunk_id=chunk_id,
+                    snippet=source_text,
+                )
             continue
         store.add_fact_evidence(
             fact_id=result.fact_id,

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1081,6 +1081,56 @@ class Store:
             )
             return int(cur.fetchone()[0])
 
+    def note_fact_reobserved(
+        self,
+        *,
+        fact_id: int,
+        source_id: int,
+        artifact_id: int,
+        job_id: int | None = None,
+        chunk_id: int | None = None,
+        snippet: str = "",
+    ) -> bool:
+        """Anchor an already-stored fact's citation at the artifact a re-extraction
+        run just re-observed it in.
+
+        A dedupe hit inserts nothing (`reconcile_fact`), so absent this the only
+        evidence tying a fact to a run is the fresh-insert anchor from whichever
+        run first extracted it — leaving a fact a later edit genuinely dropped and
+        one merely re-observed indistinguishable. Writing an anchor at the current
+        artifact repairs the citation surface directly (provenance reads
+        `fact_evidence`), not just "we saw it again".
+
+        Idempotent per (fact_id, artifact_id): chunk overlap re-hits a
+        boundary-straddling triple within one run and every re-sync re-hits every
+        surviving triple, so a naive insert would pile up duplicate anchors. There
+        is no `UNIQUE(fact_id, artifact_id)` on `fact_evidence` to lean on, so the
+        existence check and the insert both run under `self._lock` (re-entrant, so
+        `add_fact_evidence` re-acquiring it is safe) — no concurrent caller can
+        slip an anchor of the same pair between the check and the write. Returns
+        True only when a new anchor was written, False when the pair already had
+        one.
+        """
+        with self._lock:
+            existing = self._conn.execute(
+                "SELECT 1 FROM fact_evidence "
+                "WHERE fact_id = ? AND artifact_id = ? LIMIT 1",
+                (fact_id, artifact_id),
+            ).fetchone()
+            if existing is not None:
+                return False
+            self.add_fact_evidence(
+                fact_id=fact_id,
+                source_id=source_id,
+                artifact_id=artifact_id,
+                job_id=job_id,
+                chunk_id=chunk_id,
+                evidence_kind="chunk",
+                locator="chunk",
+                snippet=snippet,
+            )
+            return True
+
     def fact_evidence(self, fact_id: int) -> list[sqlite3.Row]:
         """Evidence anchors for one fact, oldest first."""
         return list(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1110,8 +1110,25 @@ class Store:
         slip an anchor of the same pair between the check and the write. Returns
         True only when a new anchor was written, False when the pair already had
         one.
+
+        Independently of anchor novelty, every call clears a `stale=1` flag back
+        to 0 without touching `status`: a re-observation is itself proof the source
+        still carries the fact, so it regains witness-eligibility even on the
+        early-return path where no new anchor is written. That path is load-bearing,
+        not incidental — a fact demoted as stale whose content later returns at an
+        artifact it was already anchored to (content-addressed, so the same
+        artifact_id recurs) finds its anchor present and would otherwise stay
+        `stale=1` forever. Status is left alone so a human's `needs_review` stays
+        theirs to resolve.
         """
         with self._lock:
+            # Clear staleness on EVERY re-observation, before the anchor branch, so
+            # the restore is decoupled from whether a new row is written (see
+            # docstring). The guarded WHERE keeps the common non-stale case a no-op.
+            self._conn.execute(
+                "UPDATE facts SET stale = 0 WHERE id = ? AND stale = 1",
+                (fact_id,),
+            )
             existing = self._conn.execute(
                 "SELECT 1 FROM fact_evidence "
                 "WHERE fact_id = ? AND artifact_id = ? LIMIT 1",
@@ -2081,6 +2098,10 @@ class Store:
             )
         if "term_token" not in fact_columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN term_token TEXT")
+        if "stale" not in fact_columns:
+            self._conn.execute(
+                "ALTER TABLE facts ADD COLUMN stale INTEGER NOT NULL DEFAULT 0"
+            )
         # Created here rather than in schema.sql: that script runs before the
         # ALTER above, so on a legacy DB the term_token column this index needs
         # does not exist yet. By this point it always does.

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1779,6 +1779,139 @@ class Store:
             )
             return after
 
+    def surface_stale_engine_facts(self, job_id: int) -> list[sqlite3.Row]:
+        """Demote engine-tier facts a source's current artifact no longer supports.
+
+        The retirement path for a `confirmed`/`accepted` citation whose source
+        text changed under it (#329). Re-extraction inserts the new text's facts
+        as fresh candidates but leaves the old engine-tier fact feeding inference,
+        so the KB keeps citing a source for content it no longer contains. This
+        returns each such fact to `needs_review` (a re-review, the same landing
+        `toggle_review` uses — never `superseded`, which would forge a human
+        rejection) and flags it `stale = 1` so it stops witnessing corroboration
+        until a human or a later re-observation resolves it.
+
+        Self-gating — this does NOT trust its caller. It reads the job row itself
+        and returns `[]` unless EVERY guard holds:
+          * the job exists;
+          * `job.artifact_id IS NOT NULL` — with no current artifact there is no
+            baseline to judge "evidence at the current artifact" against;
+          * `job.status == 'done'` — the authoritative clean-run signal.
+            `fail_extraction_job` sets `status='failed'` WITHOUT touching
+            `failed_chunks`, so a job failed through an exception handler can carry
+            a stale `failed_chunks == 0`; `status == 'done'` is what `_refresh_
+            extraction_job(final=True)` only ever lands when nothing failed, so it
+            is the real gate and the counter check below is a cheap extra belt;
+          * `failed_chunks == 0` — the belt;
+          * `job_id` is the LATEST job for its source — an older `done` job ran
+            over an older, now-superseded artifact, so its re-observations are
+            themselves stale; a source whose newest job failed is simply not
+            judged until a clean run on its current artifact lands;
+          * at least one `fact_evidence` row anchors `job.artifact_id` for this
+            source — the empty/whiff guard. An artifact edited to empty (or a
+            transient converter yielding "") finishes `done, total=0` cleanly;
+            sweeping on pure absence would flag every engine-tier fact of the
+            source. Requiring a real anchor (a fresh insert OR a Part-A
+            re-observation) at the current artifact subsumes the empty-artifact
+            case, a total LLM whiff, and the real edit — and a source edited to
+            genuinely zero facts is deliberately never swept (safety over
+            liveness: keep a human's decision rather than destroy it on an
+            ambiguous empty signal).
+
+        Per-fact eligibility, within a source that passed the gates:
+        `status IN ENGINE_STATUSES` AND at least one `fact_evidence` row with a
+        non-NULL `artifact_id` (legacy/non-chunked facts write NULL-artifact
+        evidence and have no artifact baseline, so they are never swept) AND NO
+        `fact_evidence` row at `job.artifact_id` specifically — that absence is
+        the staleness signal.
+
+        Demotion is one guarded UPDATE per fact — `status='needs_review',
+        stale=1` together, conditional on the status observed at read time (the
+        `auto_retract_fact`/`accept_review_facts_for_source` idiom). A concurrent
+        human accept/reject/supersede landing on another connection wins cleanly:
+        the guard's rowcount is 0 and nothing is written, so `stale` is never
+        stamped on a fact that did not actually transition — the invariant both
+        witness guards (`recommend`, `_supporting_facts`) depend on. `superseded`
+        is structurally excluded (never in `ENGINE_STATUSES`). Each real demotion
+        emits a `stale_citation_surfaced` fact_event keyed to THIS sweep's job
+        (its own vocabulary, distinct from #264's retraction events), and the
+        demoted rows are returned so a same-request auto-accept pass can exclude
+        them.
+        """
+        with self._lock:
+            job = self.get_extraction_job(job_id)
+            if job is None:
+                return []
+            artifact_id = job["artifact_id"]
+            if artifact_id is None:
+                return []
+            if job["status"] != "done" or int(job["failed_chunks"]) != 0:
+                return []
+            source_id = int(job["source_id"])
+            latest = self._conn.execute(
+                "SELECT MAX(id) AS max_id FROM extraction_jobs WHERE source_id = ?",
+                (source_id,),
+            ).fetchone()
+            if latest is None or latest["max_id"] is None:
+                return []
+            if int(latest["max_id"]) != job_id:
+                return []
+            anchored = self._conn.execute(
+                "SELECT 1 FROM fact_evidence "
+                "WHERE source_id = ? AND artifact_id = ? LIMIT 1",
+                (source_id, artifact_id),
+            ).fetchone()
+            if anchored is None:
+                return []
+            placeholders, statuses = _status_filter(ENGINE_STATUSES)
+            eligible = list(
+                self._conn.execute(
+                    "SELECT f.id FROM facts f "
+                    f"WHERE f.source_id = ? AND f.status IN ({placeholders}) "
+                    "AND EXISTS (SELECT 1 FROM fact_evidence e "
+                    "WHERE e.fact_id = f.id AND e.artifact_id IS NOT NULL) "
+                    "AND NOT EXISTS (SELECT 1 FROM fact_evidence e "
+                    "WHERE e.fact_id = f.id AND e.artifact_id = ?) "
+                    "ORDER BY f.id",
+                    (source_id, *statuses, artifact_id),
+                )
+            )
+            demoted: list[sqlite3.Row] = []
+            for row in eligible:
+                fact_id_i = int(row["id"])
+                before = self.get_fact(fact_id_i)
+                if before is None:
+                    continue
+                observed = before["status"]
+                if observed not in ENGINE_STATUSES:
+                    # A human accept keeps it engine-tier (still eligible), but a
+                    # reject/supersede lands it outside the tier between the
+                    # snapshot and here; their decision stands and we skip it.
+                    continue
+                cursor = self._conn.execute(
+                    "UPDATE facts SET status = 'needs_review', stale = 1, "
+                    "updated_at = datetime('now') WHERE id = ? AND status = ?",
+                    (fact_id_i, observed),
+                )
+                if cursor.rowcount == 0:
+                    # The row moved on another connection between the read and the
+                    # write; the guard refuses, so stale is never stamped on a
+                    # fact that did not transition.
+                    continue
+                after = self.get_fact(fact_id_i)
+                self._add_fact_event(
+                    fact_id=fact_id_i,
+                    event_type="stale_citation_surfaced",
+                    actor="system",
+                    source_id=source_id,
+                    job_id=job_id,
+                    before=before,
+                    after=after,
+                )
+                if after is not None:
+                    demoted.append(after)
+            return demoted
+
     def amend_fact(
         self,
         fact_id: int,

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -108,6 +108,7 @@ CREATE TABLE IF NOT EXISTS facts (
     job_id     INTEGER REFERENCES extraction_jobs(id) ON DELETE SET NULL,
     note       TEXT NOT NULL DEFAULT '',
     term_token TEXT,
+    stale      INTEGER NOT NULL DEFAULT 0,  -- 1 = source text no longer supports this fact (witness-ineligible pending review; #329)
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -758,7 +758,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
                     client = get_client(cfg)
-                    process_extraction_job(
+                    result = process_extraction_job(
                         worker_store,
                         client,
                         job_id=job_id,
@@ -766,8 +766,48 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         retry=retry,
                         retry_max_attempts=retry_max_attempts,
                     )
+                    # A clean run judges staleness: a confirmed/accepted citation
+                    # whose source text changed under it returns to review (#329).
+                    # The sweep is a SIBLING of `process_extraction_job`, not folded
+                    # inside it, for separation of concerns: extraction stays a pure
+                    # primitive, while the sweep's return value (the demoted fact
+                    # ids) is needed HERE to thread into `exclude_fact_ids` below.
+                    # Sibling placement does not by itself avoid the outer `except
+                    # Exception -> fail_extraction_job` — this call still sits in the
+                    # same try — so the local guard below is what actually keeps a
+                    # sweep error from retroactively flipping an already-`done` job
+                    # to `failed`. `assert_writable` runs first (and OUTSIDE that
+                    # guard) so a policy that vanished post-completion routes to the
+                    # PolicyMissingError handler instead of demoting facts against a
+                    # halted KB (#194) — the store layer trusts its caller for this,
+                    # exactly as `process_extraction_job` and auto-accept do.
+                    demoted_ids: tuple[int, ...] = ()
+                    if result.failed_chunks == 0:
+                        assert_writable(worker_store)
+                        try:
+                            demoted_ids = tuple(
+                                int(row["id"])
+                                for row in worker_store.surface_stale_engine_facts(job_id)
+                            )
+                        except Exception:  # noqa: BLE001 - a sweep error must not fail a done job
+                            # The sweep does no LLM/network I/O, so a raise here is a
+                            # rare sqlite/WAL-lock-class error. Contain it: the
+                            # extraction genuinely succeeded, so leave the job `done`
+                            # and take no demotions this pass rather than letting the
+                            # outer handler bury a completed run as `failed`.
+                            logger.warning(
+                                "stale-citation sweep failed for job %s; leaving it done",
+                                job_id,
+                                exc_info=True,
+                            )
                     if cfg.auto_accept_recommendations:
-                        apply_auto_accept_recommendations(worker_store)
+                        # Exclude just-demoted facts so THIS request's auto-accept
+                        # pass can't demote-then-immediately-re-promote them. Part
+                        # C's `stale` flag is what blocks re-promotion on later
+                        # syncs; this only ever covered the same-pass case.
+                        apply_auto_accept_recommendations(
+                            worker_store, exclude_fact_ids=demoted_ids
+                        )
             except PolicyMissingError as e:
                 # ORDER IS LOAD-BEARING — this must stay ABOVE `except Exception`.
                 # The worker runs outside the request middleware, so a halt surfaces
@@ -777,11 +817,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # `failed` state nothing resumes. So this handler writes NOTHING and
                 # only logs. (#194)
                 #
-                # It catches halts from two places, and they leave the job in
+                # It catches halts from three places, and they leave the job in
                 # different states: `process_extraction_job` has already rolled a
-                # mid-job halt back to `pending`, while `apply_auto_accept_
-                # recommendations` halts *after* the job finished `done`, with no
-                # rollback at all. The message must therefore not assert a rollback
+                # mid-job halt back to `pending`, while the pre-sweep
+                # `assert_writable` and `apply_auto_accept_recommendations` both halt
+                # *after* the job finished `done`, with no rollback at all. The
+                # message must therefore not assert a rollback
                 # — a log line claiming one for a `done` job would be the same class
                 # of falsehood this change removes. Whoever rewinds, rewinds; this
                 # handler reports.


### PR DESCRIPTION
## Summary

A source's `confirmed`/human-accepted fact currently has no retirement path when the source text that supported it later changes: re-extraction inserts the new text's facts as fresh candidates, but the old fact stays `confirmed` and keeps feeding the engine — the KB ends up citing a source for content it no longer contains. Triggered by the single most ordinary workflow (edit a source, resync), no special precondition. Closes #329 in three atomic commits, produced via `/implementation-flow` (architect + critic design consensus → implementer → code-reviewer → architect + critic audit, all voices required to CONCUR/APPROVE — Unit 3 required one revision cycle after Phase 4 caught a false safety claim in a commit message, fixed for real rather than just reworded).

**Commit 1** (`note_fact_reobserved`) closes the prerequisite gap: a re-extraction run that merely re-observes an existing fact (a dedupe hit) previously left no trace, making a genuinely-dropped fact and a merely-re-observed one indistinguishable. This anchors a `fact_evidence` row at the current artifact on every non-superseded hit, self-healing under LLM non-determinism.

**Commit 2** adds a `facts.stale` column and two witness-exclusion guards in the acceptance engine, so a demoted citation can't silently re-promote itself or inflate another fact's corroboration on a later sync — closing a durability gap that would otherwise have made the fix reversible on any multi-source KB. `note_fact_reobserved` clears the flag on any re-observation (not just a newly-inserted one), closing a drop-then-revert edge case caught during Unit 2's own audit.

**Commit 3** adds the actual sweep (`surface_stale_engine_facts`) and wires it into the CLI and web sync paths. The sweep is fully self-gating (never trusts its caller): it demotes a source's `confirmed`/`accepted` facts to `needs_review` only after a clean, complete re-extraction on the source's current artifact, and only for facts with no evidence anchored there. `superseded` is never touched, under any circumstance.

## Test plan
- [x] Full suite: 1479 passed, 7 skipped (independently re-run by three separate review passes)
- [x] `ruff check` clean
- [x] Primary end-to-end repro against the real engine: confirm "Ada born_in London" → edit source to "Paris" → sync → London demoted to `needs_review`/`stale=1`, Paris is `candidate`, engine no longer returns London
- [x] Anti-thrash regression: an unchanged-source resync demotes nothing (the load-bearing false-positive-bomb guard)
- [x] Multi-source: editing one source's citation away doesn't touch a still-valid citation of the same fact from another source
- [x] A run with any failed chunk never triggers staleness judgment (depends on #323's failure classification)
- [x] The `stale` flag durably blocks re-promotion on later syncs, not just the same request
- [x] A sweep-side exception can never retroactively flip an already-completed extraction job to `failed` (regression added during Unit 3's revision cycle)

Two adjacent bugs discovered during design/review were filed separately rather than folded in: #339 (the reanalyze route hard-deletes confirmed/superseded facts with no status filter) and #340 (the pre-existing, identical exception-flip exposure in `apply_auto_accept_recommendations`, #329's own sweep just fixed its copy of this pattern).
