### PR TITLE
fix(#286): surface dead-rule warnings on the production report path

### DIFF
--- a/tests/test_dead_rule_warn.py
+++ b/tests/test_dead_rule_warn.py
@@ -8,7 +8,11 @@ without the optional pyrewire engine installed.
 import pytest
 
 from verinote.engine import DEFAULT_POLICY, compile_dl, run_check
+from verinote.engine.duckdb_backend import run_check_duckdb
 from verinote.engine.wirelog import dead_rule_warnings
+from verinote.pipeline.query_candidate_eval import RELATION_DECL
+from verinote.pipeline.verify import policy_path, verify
+from verinote.store import Store
 
 
 def test_default_policy_flags_unused_functional_relations():
@@ -112,3 +116,140 @@ def test_run_check_surfaces_dead_rule_as_nonblocking_finding():
     assert rep.errors == 0
     assert rep.warnings >= 1
     assert any("WARN dead_rule" in f for f in rep.findings)
+
+
+# --- Production path (DuckDB) -------------------------------------------------
+# The tests above exercise the pure helper; these exercise the wiring #286 adds
+# to `duckdb_backend._collect_report`, the path every real report goes through.
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def test_duckdb_production_path_surfaces_dead_rule_with_consistent_count():
+    """The production report path now emits the dead-rule WARN #245 could not.
+
+    This is the regression the issue asks for, and unlike the pyrewire-gated
+    legacy test above it actually runs in CI. It also pins the three-locations
+    count invariant: the `warnings: N` baked into the report body must match the
+    `warnings` field exactly, or the merge updated the WARN line but not the
+    count.
+    """
+    pytest.importorskip("duckdb")
+    rep = run_check_duckdb(
+        [
+            {"subject": "Org", "relation": "established_on", "object": "2020"},
+            {"subject": "Org", "relation": "is_a", "object": "company"},
+        ]
+    )
+
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings >= 1
+    assert any("WARN dead_rule" in f for f in rep.findings)
+    assert f"warnings: {rep.warnings}  facts:" in rep.text
+
+
+def test_verify_end_to_end_surfaces_dead_rule_for_recorded_policy(tmp_path):
+    """The issue's headline acceptance criterion, through the real `verify()`."""
+    pytest.importorskip("duckdb")
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    path = policy_path(s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl functional(rel: symbol)\n"
+        'functional("acquired_on").\n'
+        ".decl error_functional_conflict(subject: symbol, rel: symbol)\n"
+        "error_functional_conflict(S, R) :- "
+        "relation(S, R, A), relation(S, R, B), functional(R), A != B.\n",
+        encoding="utf-8",
+    )
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings == 1
+    assert any('dead_rule: policy declares functional("acquired_on")' in f for f in rep.findings)
+    s.close()
+
+
+def test_verify_aliased_fact_reads_canonical_relation_not_raw(tmp_path):
+    """The canonical-field guard: an aliased fact must not read as a dead rule.
+
+    "설립" is a shipped alias of `established_on`, canonicalized at read time. The
+    dead-rule check reads each fact's canonical `relation`, so
+    `functional("established_on")` is seen as alive. Had it read `relation_raw`
+    (still "설립"), established_on would be falsely flagged dead — this test fails
+    in exactly that case. born_on/died_on stay genuinely unused, proving the
+    detector ran rather than silently doing nothing.
+    """
+    pytest.importorskip("duckdb")
+    s = _store(tmp_path)
+    s.add_fact("Org", "설립", "2020", status="confirmed")
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert not any('functional("established_on")' in f for f in rep.findings)
+    assert any('dead_rule: policy declares functional("born_on")' in f for f in rep.findings)
+    s.close()
+
+
+def test_duckdb_zero_input_is_never_flagged_as_dead():
+    """An empty KB is no engine input, not a dead policy — the guard holds here."""
+    pytest.importorskip("duckdb")
+    rep = run_check_duckdb([], policy_dl=DEFAULT_POLICY)
+
+    assert rep.ok is True
+    assert not any("dead_rule" in f for f in rep.findings)
+
+
+def test_duckdb_rule_less_relation_decl_emits_no_dead_rule():
+    """`ask`/`query_candidate_eval` pass RELATION_DECL: it must stay inert.
+
+    A bare `relation/3` decl references no relation literal, so dead-rule
+    detection is empty by construction — the query paths never start emitting
+    this note even over real facts.
+    """
+    pytest.importorskip("duckdb")
+    rep = run_check_duckdb(
+        [
+            {"subject": "Org", "relation": "established_on", "object": "2020"},
+            {"subject": "Org", "relation": "is_a", "object": "company"},
+        ],
+        policy_dl=RELATION_DECL,
+    )
+
+    assert rep.ok is True
+    assert not any("dead_rule" in f for f in rep.findings)
+
+
+def test_duckdb_conflict_and_dead_rule_coexist_without_suppression():
+    """A blocking ERROR and a non-blocking dead-rule WARN must both survive.
+
+    This is the only shape that can catch a false-*suppression* merge bug: every
+    other production-path test has `errors == 0`, so none of them could prove a
+    dead-rule note fails to accidentally clear a real gate. established_on is used
+    (its conflict is real and blocks); born_on/died_on are unused (dead notes).
+    """
+    pytest.importorskip("duckdb")
+    rep = run_check_duckdb(
+        [
+            {"subject": "Org", "relation": "established_on", "object": "2020"},
+            {"subject": "Org", "relation": "established_on", "object": "2021"},
+            {"subject": "Org", "relation": "is_a", "object": "company"},
+        ]
+    )
+
+    assert rep.ok is False
+    assert rep.errors >= 1
+    assert rep.warnings >= 1
+    assert "ERROR functional_conflict: Org established_on" in rep.findings
+    assert any(f.startswith("WARN dead_rule:") for f in rep.findings)

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -13,6 +13,14 @@ def _duckdb():
     return pytest.importorskip("duckdb")
 
 
+def _warn_dead_functional(relation: str) -> str:
+    """The report line for a `functional("rel")` decl no engine fact satisfies."""
+    return (
+        f'WARN dead_rule: policy declares functional("{relation}") '
+        "but no engine fact uses that relation"
+    )
+
+
 def test_duckdb_backend_missing_duckdb_is_blocking(monkeypatch):
     real_import = builtins.__import__
 
@@ -44,8 +52,15 @@ def test_duckdb_backend_default_policy_flags_functional_conflict():
     assert rep.engine_available is True
     assert rep.ok is False
     assert rep.errors == 1
-    assert rep.warnings == 0
-    assert rep.findings == ["ERROR functional_conflict: Org established_on"]
+    # established_on IS used (so it is live), but the default policy also declares
+    # born_on/died_on functional and no fact uses them: dead rules that surface as
+    # non-blocking WARNs beside the real conflict (issue #286).
+    assert rep.warnings == 2
+    assert rep.findings == [
+        "ERROR functional_conflict: Org established_on",
+        _warn_dead_functional("born_on"),
+        _warn_dead_functional("died_on"),
+    ]
     assert "backend: DuckDB" in rep.text
     assert "--- policy input ---" in rep.text
     assert "--- fact input ---" in rep.text
@@ -69,7 +84,14 @@ def test_duckdb_backend_compares_equivalent_atom_string_and_number_terms():
     )
 
     assert rep.ok is False
-    assert rep.findings == ["ERROR functional_conflict: ada born_on"]
+    # born_on is used (the conflict is real and collapses to one ERROR); the
+    # default policy's other functional decls, established_on/died_on, are unused
+    # dead rules and surface as non-blocking WARNs (issue #286).
+    assert rep.findings == [
+        "ERROR functional_conflict: ada born_on",
+        _warn_dead_functional("died_on"),
+        _warn_dead_functional("established_on"),
+    ]
 
 
 def test_duckdb_backend_treats_equal_number_and_string_values_as_equal():
@@ -131,11 +153,18 @@ def test_duckdb_backend_consistent_kb_is_ok():
         ]
     )
 
+    # No functional conflict, so the gate stays open — but the shipped default
+    # policy declares born_on/died_on functional and no fact uses them, so a
+    # consistent KB now surfaces its own unused declarations as WARNs rather than
+    # reading as a clean bill of health (issue #286).
     assert rep.ok is True
     assert rep.errors == 0
-    assert rep.warnings == 0
-    assert rep.findings == []
-    assert "no findings" in rep.text
+    assert rep.warnings == 2
+    assert rep.findings == [
+        _warn_dead_functional("born_on"),
+        _warn_dead_functional("died_on"),
+    ]
+    assert "no findings" not in rep.text
 
 
 def test_duckdb_backend_warn_is_non_blocking():

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -22,6 +22,24 @@ _CONFLICT_FACTS = [
 _OTHER_FACTS = [{"subject": "Org", "relation": "is_a", "object": "company"}]
 
 
+def _warn_dead_functional(relation: str) -> str:
+    """The report line for a `functional("rel")` decl no engine fact satisfies."""
+    return (
+        f'WARN dead_rule: policy declares functional("{relation}") '
+        "but no engine fact uses that relation"
+    )
+
+
+# The conflict facts use only established_on, so the default policy's other two
+# functional decls (born_on/died_on) are unused dead rules that surface as
+# non-blocking WARNs beside the real conflict (issue #286).
+_CONFLICT_FINDINGS = [
+    "ERROR functional_conflict: Org established_on",
+    _warn_dead_functional("born_on"),
+    _warn_dead_functional("died_on"),
+]
+
+
 def _duckdb():
     return pytest.importorskip("duckdb")
 
@@ -33,7 +51,7 @@ def test_cache_reloads_after_a_failed_reload(monkeypatch):
         # 1) Load the conflict facts cleanly: the conflict is detected.
         first = cache.run_check(_CONFLICT_FACTS)
         assert first.ok is False
-        assert first.findings == ["ERROR functional_conflict: Org established_on"]
+        assert first.findings == _CONFLICT_FINDINGS
 
         # 2) Inject a one-shot failure into the reload triggered by different
         #    facts. The DELETE clears the base relation, then the load raises,
@@ -54,6 +72,6 @@ def test_cache_reloads_after_a_failed_reload(monkeypatch):
         monkeypatch.undo()
         again = cache.run_check(_CONFLICT_FACTS)
         assert again.ok is False
-        assert again.findings == ["ERROR functional_conflict: Org established_on"]
+        assert again.findings == _CONFLICT_FINDINGS
     finally:
         cache.close()

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -42,6 +42,7 @@ from verinote.engine.wirelog import (
     NO_FINDINGS_TEXT,
     FindingRow,
     answer_bucket_sort_key,
+    dead_rule_warnings,
 )
 
 _ERROR_PREFIX = "error_"
@@ -464,8 +465,17 @@ def _collect_report(
             answers_by_q.items(), key=lambda item: answer_bucket_sort_key(item[0])
         )
     ]
+    present_relations = {
+        bare_label(_coerce_fact_term(row["relation"])) for row in facts
+    }
+    dead = dead_rule_warnings(policy_dl, present_relations)
+
     rendered_errors = sorted(f"ERROR {derived.text}" for derived in errors)
-    rendered_warnings = sorted(f"WARN {derived.text}" for derived in warnings)
+    # A dead-rule note describes the policy, not a derived tuple: it merges into
+    # the warning lines and the count, but gets no `FindingRow` (nothing fired
+    # behind it), mirroring the legacy wirelog path.
+    warning_lines = sorted([derived.text for derived in warnings] + dead)
+    rendered_warnings = [f"WARN {line}" for line in warning_lines]
     findings = rendered_errors + rendered_warnings
     finding_rows = [
         derived.finding_row(f"ERROR {derived.text}")
@@ -474,7 +484,8 @@ def _collect_report(
         derived.finding_row(f"WARN {derived.text}")
         for derived in sorted(warnings)
     ]
-    summary = f"errors: {len(errors)}  warnings: {len(warnings)}  facts: {len(facts)}"
+    warning_count = len(warning_lines)
+    summary = f"errors: {len(errors)}  warnings: {warning_count}  facts: {len(facts)}"
     body = "\n".join(findings) if findings else NO_FINDINGS_TEXT
     if answers:
         body += "\n\n--- answers ---\n" + "\n".join(answers)
@@ -488,7 +499,7 @@ def _collect_report(
     return CheckReport(
         ok=not errors,
         errors=len(errors),
-        warnings=len(warnings),
+        warnings=warning_count,
         answers=answers,
         text=f"backend: DuckDB\n{summary}\n\n{body}{debug}",
         findings=findings,


### PR DESCRIPTION
## Summary

#245 added `wirelog.dead_rule_warnings` — detects a policy rule that references a relation absent from the engine's input facts (a "dead rule": compiles fine, matches nothing, nobody is told) — but only wired it into a legacy verification path. The production path everyone actually uses (`verify()` → `duckdb_backend`) never called it, so a real KB with a dead policy rule showed a green "ok" report with zero warning. Per the issue's own text, this is "the worst failure mode this repo defines" — a false all-clear. Closes #286 and, per its own scope, #245.

`_collect_report` now computes the present-relation set from each fact's **canonical** `relation` field (never `relation_raw`), which is the field `engine_relation_rows` populates via read-time alias canonicalization — the same field the conflict-detection loader (`_load_relation_facts`) already reads from the same `fact_rows` list, so the two checks structurally cannot disagree about vocabulary, and this fix is correctness-independent of the separate, unrelated #252 (a write-time canonicalization bug). The warning count feeds three places in `_collect_report` (the rendered WARN lines, an embedded summary string, and the `CheckReport.warnings` field); all three now derive from one merged count so they cannot drift. Dead-rule notes get no `FindingRow` (nothing fired behind them, mirroring the legacy path) and never affect `errors`/`ok` — a dead rule is a non-blocking note, exactly like every other warning.

Four existing tests asserted the exact behavior this fixes (a KB on the implicit default policy showing zero warnings, when its unused `born_on`/`died_on` functional declarations are themselves dead rules) — updated to assert the new WARNs explicitly rather than narrowed to dodge them, turning them into live acceptance coverage of the shipped default policy.

## Test plan
- [x] Full suite: 1485 passed, 7 skipped (was 1479; +6 new tests, 4 updated in place)
- [x] `ruff check` clean (pinned to the exact CI version)
- [x] Alias false-positive guard: a fact written using a shipped alias is correctly read as live evidence, not flagged dead (mutation-tested: fails if `relation_raw` is substituted for the canonical field)
- [x] Count-consistency guard: the embedded summary text and the `warnings` field can never diverge (mutation-tested)
- [x] Conflict + dead-rule coexistence: a real functional conflict and a dead-rule warning present simultaneously — the only test shape that can catch a false-suppression bug, since every simpler test has zero pre-existing errors
- [x] Query paths (`ask`, `query_candidate_eval`) remain inert — they pass a rule-less policy declaration and cannot start emitting dead-rule noise
- [x] Zero-input KB is never flagged
- [x] End-to-end via the real `verify()` with a recorded policy
