### PR TITLE
fix(#252): store the source's own relation label, alias only at read time

### DIFF
--- a/tests/test_corroboration.py
+++ b/tests/test_corroboration.py
@@ -132,6 +132,25 @@ def test_store_corroboration_uses_joined_source_paths(tmp_path):
     ]
 
 
+def test_corroboration_merges_different_raw_aliases_for_one_relation(tmp_path):
+    # #252: facts are now stored with the raw label each source used, so two
+    # sources that said "설립" and "founded" for the same established_on relation
+    # must still count as one cross-source corroboration, not two. The grouping key
+    # canonicalizes the relation, mirroring `single_valued_conflicts`; before the
+    # fix this happened to work only because storage was already canonical.
+    s = _store(tmp_path)
+    a = s.add_source("sources/a.md")
+    b = s.add_source("sources/b.md")
+    s.add_fact("회사", "설립", "2020", status="confirmed", source_id=a)
+    s.add_fact("회사", "founded", "2020", status="confirmed", source_id=b)
+
+    support = store_corroboration(s)
+
+    assert [(x.subject, x.relation, x.object, x.source_count) for x in support] == [
+        ("회사", "established_on", "2020", 2)
+    ]
+
+
 def test_single_valued_conflicts_include_per_value_source_support():
     rows = [
         {

--- a/tests/test_engine_input.py
+++ b/tests/test_engine_input.py
@@ -26,11 +26,14 @@ from verinote.engine.policy_vocabulary import (
     FUNCTIONAL_CONFLICT_COLUMNS,
     FUNCTIONAL_CONFLICT_RULE,
 )
-from verinote.engine.terms import StringLit
+from verinote.engine.terms import StringLit, bare_label
+from verinote.llm.base import ExtractedFact
+from verinote.pipeline import extract_source
 from verinote.pipeline.engine_input import annotate_source_labels, engine_relation_rows
 from verinote.pipeline.query import query_path
 from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.verify import policy_path, verify
+from verinote.pipeline.workbench import trust_workbench
 from verinote.policy_defaults import RELATION_ALIASES_RELPATH
 from verinote.store import Store
 
@@ -241,6 +244,103 @@ def test_findings_name_the_conflicting_facts_in_the_source_s_own_words(tmp_path)
         f"(설립 #{first}=2020, founded #{second}=2021)"
     ]
     assert rep.findings[0] in rep.text
+
+
+def test_raw_alias_labels_survive_extraction_and_drive_read_time(tmp_path, fake_client):
+    """#252 end-to-end: extraction stores raw labels; read time canonicalizes them.
+
+    The regression this closes shipped precisely because #250's tests injected raw
+    labels with `add_fact`, bypassing extraction (the #241 mock gap). This drives
+    the real extractor: a source using both `설립` and `founded` for the functional
+    `established_on` relation must (1) be stored with those raw labels, (2) expose
+    them under `relation_raw` while the engine sees the canonical relation, (3)
+    surface the alias on the review badge, and (4) still be caught as one
+    functional conflict, named in the source's own words.
+    """
+    s = _store(tmp_path)
+    _write_policy(s, _FUNCTIONAL_POLICY.format(relation="established_on"))
+    client = fake_client(
+        [
+            ExtractedFact("회사", "설립", "2020", 0.9),
+            ExtractedFact("회사", "founded", "2021", 0.9),
+        ]
+    )
+
+    extract_source(
+        s,
+        client,
+        source_path="sources/x.txt",
+        source_text="회사는 2020년에 설립되었고 2021년 기록도 있다",
+    )
+
+    # (1) stored with the raw labels, not canonicalized to established_on.
+    stored = {(f["subject"], f["relation"], f["object"]) for f in s.facts()}
+    assert stored == {("회사", "설립", "2020"), ("회사", "founded", "2021")}
+
+    for fact in s.facts():
+        s.accept_fact(int(fact["id"]))
+
+    # (2) the engine sees the canonical relation; the raw label is preserved.
+    rows = engine_relation_rows(s)
+    assert {bare_label(row["relation"]) for row in rows} == {"established_on"}
+    assert {bare_label(row["relation_raw"]) for row in rows} == {"설립", "founded"}
+
+    # (3) the review badge fires — dead before the fix, when relation == canonical.
+    wb = trust_workbench(s)
+    badges = {
+        fact.relation_alias
+        for group in wb.conflicts
+        for value in group.values
+        for fact in value.facts
+    }
+    assert badges == {"설립 -> established_on", "founded -> established_on"}
+
+    # (4) one functional conflict, named in the source's own words.
+    rep = verify(s)
+    assert rep.errors == 1
+    conflict_findings = [f for f in rep.findings if "functional_conflict" in f]
+    assert len(conflict_findings) == 1
+    finding = conflict_findings[0]
+    assert "established_on" in finding
+    assert "설립" in finding and "founded" in finding
+
+
+def test_within_source_alias_variants_store_twice_without_false_conflict(
+    tmp_path, fake_client
+):
+    """#252 tradeoff: raw storage dedups per raw label, not per canonical relation.
+
+    Within one source the model may emit both `설립` and `founded` for the same
+    claim; they no longer merge at write time, so two candidate rows are stored.
+    This is an accepted, deliberate cost, not a bug: at read time both canonicalize
+    to `established_on` with the same value, so it is a redundant review candidate
+    and never a false conflict.
+    """
+    s = _store(tmp_path)
+    _write_policy(s, _FUNCTIONAL_POLICY.format(relation="established_on"))
+    client = fake_client(
+        [
+            ExtractedFact("회사", "설립", "2020", 0.9),
+            ExtractedFact("회사", "founded", "2020", 0.9),
+        ]
+    )
+
+    extract_source(
+        s,
+        client,
+        source_path="sources/x.txt",
+        source_text="회사는 2020년에 설립되었다",
+    )
+
+    stored = {(f["subject"], f["relation"], f["object"]) for f in s.facts()}
+    assert stored == {("회사", "설립", "2020"), ("회사", "founded", "2020")}
+
+    for fact in s.facts():
+        s.accept_fact(int(fact["id"]))
+
+    rep = verify(s)
+    assert rep.errors == 0
+    assert rep.ok is True
 
 
 def test_findings_name_canonical_and_aliased_facts_in_a_mixed_conflict(tmp_path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,8 +11,10 @@ from verinote.pipeline import (
     process_extraction_job,
     sync_sources,
 )
+from verinote.pipeline.extract import _canonical_fact
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import verify
+from verinote.policy_defaults import RELATION_ALIASES_RELPATH
 from verinote.store import Store
 from verinote.engine.terms import Atom, Compound, StringLit
 
@@ -33,6 +35,12 @@ def _store(tmp_path) -> Store:
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
     return s
+
+
+def _write_relation_aliases(root, body: str) -> None:
+    path = root / RELATION_ALIASES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
 
 
 def test_extract_source_persists_candidates_with_linkage(tmp_path, fake_client):
@@ -490,7 +498,9 @@ def test_extract_source_keeps_non_metric_korean_object_without_local_subject(
     )
 
     fact = s.facts()[0]
-    assert fact["relation"] == "provides"
+    # Stored with its raw label now that write-time aliasing is gone (#252);
+    # ``제공기능`` canonicalizes to ``provides`` only at read time.
+    assert fact["relation"] == "제공기능"
     assert fact["object"] == "샘플기능"
 
 
@@ -498,7 +508,8 @@ def test_extract_source_drops_reversed_role_designation(tmp_path, fake_client):
     # ``org 역할 person`` is the reversed shape of ``person 역할 role``: it names a
     # person as the OBJECT of a role designation even though that person holds a
     # role themselves in the same batch. Drop it; keep the correct direction.
-    # (역할 canonicalizes to ``role`` under the default relation aliases.)
+    # The filter still canonicalizes 역할 -> ``role`` to make the drop decision,
+    # but the kept fact is now stored with its raw ``역할`` label (#252).
     s = _store(tmp_path)
     run_id = s.add_run(provider="fake", model="m")
     client = fake_client(
@@ -522,8 +533,8 @@ def test_extract_source_drops_reversed_role_designation(tmp_path, fake_client):
     facts = {
         (str(f["subject"]), str(f["relation"]), str(f["object"])) for f in s.facts()
     }
-    assert ("샘플인물", "role", "샘플직책") in facts
-    assert ("샘플조직", "role", "샘플인물") not in facts
+    assert ("샘플인물", "역할", "샘플직책") in facts
+    assert ("샘플조직", "역할", "샘플인물") not in facts
 
 
 def test_extract_source_keeps_org_representative_role_fact(tmp_path, fake_client):
@@ -554,6 +565,112 @@ def test_extract_source_keeps_org_representative_role_fact(tmp_path, fake_client
         "대표",
         "샘플인물",
     )
+
+
+def test_extract_source_stores_raw_alias_labels(tmp_path, fake_client):
+    # #252: an aliased relation is stored with the label the source used, never
+    # overwritten by its canonical form — canonicalization is a read-time concern.
+    # `설립` and `founded` both alias to `established_on`, but storage keeps the raw
+    # words. `founded` (an ASCII alias KEY absent from the Korean source) also
+    # exercises the ascii-legitimacy filter: it must canonicalize its own decision
+    # so a real aliased fact is kept, not dropped as an unbacked hallucination.
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact("샘플회사", "설립", "2020", 0.9),
+            ExtractedFact("샘플회사", "founded", "2021", 0.9),
+        ]
+    )
+
+    n = extract_source(
+        s,
+        client,
+        source_path="sources/x.txt",
+        source_text="샘플회사는 2020년에 설립되었고 2021년 기록도 있다",
+        run_id=run_id,
+    )
+
+    assert n == 2
+    stored = {(f["subject"], f["relation"], f["object"]) for f in s.facts()}
+    assert stored == {
+        ("샘플회사", "설립", "2020"),
+        ("샘플회사", "founded", "2021"),
+    }
+
+
+def test_extract_source_keeps_aliased_ascii_relation_but_drops_hallucination(
+    tmp_path, fake_client
+):
+    # The ascii-legitimacy filter must separate an aliased key it should keep from
+    # a genuine hallucination it should drop (#252): `founded` aliases to a
+    # policy-backed relation and is kept raw, while `invented_by` is not an alias
+    # and is absent from the source, so it is still dropped. Proves the filter was
+    # made alias-aware, not simply disabled.
+    s = _store(tmp_path)
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client(
+        [
+            ExtractedFact("샘플회사", "founded", "2020", 0.9),
+            ExtractedFact("샘플회사", "invented_by", "누군가", 0.9),
+        ]
+    )
+
+    n = extract_source(
+        s,
+        client,
+        source_path="sources/x.txt",
+        source_text="샘플회사에 관한 국문 기록이다",
+        run_id=run_id,
+    )
+
+    assert n == 1
+    assert [(f["subject"], f["relation"], f["object"]) for f in s.facts()] == [
+        ("샘플회사", "founded", "2020")
+    ]
+
+
+def test_extract_source_keeps_aliased_hanja_relation(tmp_path, fake_client):
+    # A user-defined CJK/Hanja alias key (`設立` -> `established_on`) against a
+    # Hangul-only source must be kept and stored raw (#252). Before the fix the
+    # han-translation filter saw the raw `設立` — a CJK run absent from a Hangul
+    # source — and dropped it as a hallucinated translation; it must canonicalize
+    # the relation for that check so a legitimate aliased fact survives.
+    s = _store(tmp_path)
+    _write_relation_aliases(tmp_path, "- `設立` -> `established_on`\n")
+    run_id = s.add_run(provider="fake", model="m")
+    client = fake_client([ExtractedFact("샘플회사", "設立", "2020", 0.9)])
+
+    n = extract_source(
+        s,
+        client,
+        source_path="sources/x.txt",
+        source_text="샘플회사에 관한 국문 기록이다",
+        run_id=run_id,
+    )
+
+    assert n == 1
+    fact = s.facts()[0]
+    assert (fact["subject"], fact["relation"], fact["object"]) == (
+        "샘플회사",
+        "設立",
+        "2020",
+    )
+
+
+def test_canonical_fact_keeps_raw_relation_and_shape_normalization():
+    # #252 storage boundary: `_canonical_fact` no longer applies KB aliases, so an
+    # aliased relation is returned unchanged (raw). The two shape normalizations it
+    # is still responsible for stay intact: `_is_bad_spo_shape` drops a malformed
+    # fragment, and the hardcoded `값`/`value` family collapses to `value`.
+    aliased = ExtractedFact("샘플회사", "설립", "2020", 0.9)
+    assert _canonical_fact(aliased) is aliased
+
+    value_key = ExtractedFact("문서번호", "값", "A-001", 0.9)
+    assert _canonical_fact(value_key).relation == "value"
+
+    malformed = ExtractedFact("샘플", "판단 여부", "예", 0.9)
+    assert _canonical_fact(malformed) is None
 
 
 def test_extract_source_canonicalizes_generic_value_relation(tmp_path, fake_client):

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -243,8 +243,18 @@ def store_typed_relations(store: Store) -> dict[str, TypedRelationSpec]:
     return typed_relations(path.read_text(encoding="utf-8"))
 
 
-def corroboration(facts: Iterable[Mapping[str, object]]) -> list[FactSupport]:
-    """Return distinct-source support for confirmed/accepted SPO triples."""
+def corroboration(
+    facts: Iterable[Mapping[str, object]],
+    aliases: dict[str, str] | None = None,
+) -> list[FactSupport]:
+    """Return distinct-source support for confirmed/accepted SPO triples.
+
+    The grouping key canonicalizes the relation, like `single_valued_conflicts`,
+    so two sources that used different raw aliases for the same relation ("설립"
+    and "founded") still merge into one corroborated group now that facts are
+    stored with their raw labels (#252).
+    """
+    aliases = aliases or {}
     sources: dict[tuple[str, str, str], set[str]] = {}
     for row in facts:
         if not is_engine_input(_value(row, "status", "")):
@@ -252,7 +262,8 @@ def corroboration(facts: Iterable[Mapping[str, object]]) -> list[FactSupport]:
         source = _source_ref(row)
         if not source:
             continue
-        key = (str(row["subject"]), str(row["relation"]), str(row["object"]))
+        relation = _canonical_relation(str(row["relation"]), aliases)
+        key = (str(row["subject"]), relation, str(row["object"]))
         sources.setdefault(key, set()).add(source)
     return [
         FactSupport(subject=s, relation=r, object=o, sources=tuple(sorted(srcs)))
@@ -312,7 +323,7 @@ def single_valued_conflicts(
 
 
 def store_corroboration(store: Store) -> list[FactSupport]:
-    return corroboration(store.facts())
+    return corroboration(store.facts(), store_relation_aliases(store))
 
 
 def store_single_valued_conflicts(store: Store) -> list[SingleValuedConflict]:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -650,14 +650,14 @@ def _candidate_rows(
     role_bearers = _role_bearer_subjects(facts, aliases)
     try:
         for f in facts:
-            f = _canonical_fact(f, aliases)
+            f = _canonical_fact(f)
             if f is None:
                 continue
-            if _is_normalization_bridge(f):
+            if _is_normalization_bridge(f, aliases):
                 continue
             if _is_reversed_role_designation(f, role_bearers, aliases):
                 continue
-            if _has_unbacked_han_translation(f, source_text):
+            if _has_unbacked_han_translation(f, source_text, aliases):
                 continue
             if _has_unbacked_ascii_relation(f, source_text, aliases):
                 continue
@@ -676,18 +676,22 @@ def _candidate_rows(
     return rows
 
 
-def _canonical_fact(
-    f: ExtractedFact, relation_aliases: dict[str, str]
-) -> ExtractedFact | None:
-    """Normalize shallow fact shapes and drop malformed S-P-O fragments."""
+def _canonical_fact(f: ExtractedFact) -> ExtractedFact | None:
+    """Normalize shallow fact shapes and drop malformed S-P-O fragments.
+
+    Relation aliases are applied at read time only (`engine_input`), never here:
+    overwriting the source's own label at write time destroys it irrecoverably
+    and defeats the `relation_raw` preservation, UI alias badge, and alias-file
+    re-decisions that read-time normalization exists to provide (#252). Each
+    later legitimacy filter canonicalizes the relation for its own decision, so
+    dropping the write-time merge keeps their behavior identical while storage
+    keeps the raw label. The `값`->`value` rewrite below is a separate, hardcoded
+    shape normalization with no read-time handler, so it stays.
+    """
     if _is_bad_spo_shape(f):
         return None
     if f.relation_kind == "string" and f.relation.strip() in _KEY_VALUE_RELATIONS:
         return replace(f, relation="value")
-    if f.relation_kind == "string":
-        relation = canonical_relation(f.relation.strip(), relation_aliases)
-        if relation != f.relation:
-            return replace(f, relation=relation)
     return f
 
 
@@ -715,10 +719,15 @@ def _slot_is_typed_literal(value: str, _kind: str) -> bool:
     return isinstance(term, Compound) and term.functor in _TYPED_LITERAL_FUNCTORS
 
 
-def _is_normalization_bridge(f: ExtractedFact) -> bool:
-    relation = f.relation.strip().lower()
-    relation_kind = f.relation_kind
-    if relation_kind != "string" or relation not in _NORMALIZATION_BRIDGE_RELATIONS:
+def _is_normalization_bridge(
+    f: ExtractedFact, relation_aliases: dict[str, str]
+) -> bool:
+    if f.relation_kind != "string":
+        return False
+    # Canonicalize first so an alias key still matches the bridge set (#252): the
+    # relation is now stored raw, so this filter no longer receives it canonical.
+    relation = canonical_relation(f.relation.strip(), relation_aliases).lower()
+    if relation not in _NORMALIZATION_BRIDGE_RELATIONS:
         return False
     return f.subject_kind == "term" or f.object_kind == "term"
 
@@ -774,13 +783,20 @@ def _is_reversed_role_designation(
     return f.object_kind == "string" and _norm_entity(f.object) in role_bearers
 
 
-def _has_unbacked_han_translation(f: ExtractedFact, source_text: str) -> bool:
-    """Drop likely Chinese/Hanja translations hallucinated from Korean sources."""
+def _has_unbacked_han_translation(
+    f: ExtractedFact, source_text: str, relation_aliases: dict[str, str]
+) -> bool:
+    """Drop likely Chinese/Hanja translations hallucinated from Korean sources.
+
+    Only the relation is canonicalized before the check (#252): subject and
+    object are never aliased, so they must be tested on their raw source labels.
+    """
     if _HANGUL_RE.search(source_text) is None:
         return False
+    relation = canonical_relation(f.relation.strip(), relation_aliases)
     return any(
         _has_han_run_not_in_source(value, source_text)
-        for value in (f.subject, f.relation, f.object)
+        for value in (f.subject, relation, f.object)
     )
 
 
@@ -790,7 +806,10 @@ def _has_unbacked_ascii_relation(
     """Drop English/snake_case relation labels hallucinated from Korean sources."""
     if _HANGUL_RE.search(source_text) is None:
         return False
-    relation = f.relation.strip()
+    # Canonicalize first so an aliased ASCII key (e.g. `founded`) is checked as
+    # its policy-backed canonical, not dropped as unbacked (#252): the relation is
+    # now stored raw, so this filter no longer receives it already canonical.
+    relation = canonical_relation(f.relation.strip(), relation_aliases)
     allowed_ascii = _policy_backed_ascii_relations(relation_aliases)
     if relation.casefold() in allowed_ascii:
         return False


### PR DESCRIPTION
## Summary

Relation aliasing was applied twice — at write time (`pipeline/extract.py`'s `_canonical_fact`) and read time (`engine_input.py`, PR #250). The write-time application irreversibly overwrote and destroyed the original relation label a source actually used before storage — so a source saying "설립"/"founded" was persisted as "established_on", and the original wording was structurally unrecoverable. This defeated the entire read-time preservation architecture #250 already built: `relation_raw` always equalled the canonical for an aliased relation, so the UI's alias badge never fired and finding annotations never showed a source's own words on the real extraction path — both only worked in tests that bypassed extraction via direct `add_fact` injection (a known mock-gap class, #241). It was also forward-only data loss: a misconfigured alias merging two distinct relations could never be undone by fixing the alias file afterward.

This removes the write-time merge so storage keeps the raw label; aliasing stays read-time only. Three legitimacy filters that previously received an already-canonical relation (`_has_unbacked_ascii_relation`, `_has_unbacked_han_translation`, `_is_normalization_bridge`) now canonicalize their own decision internally — without this, a real fact using an aliased ASCII or Hanja relation key would be silently dropped as a hallucination, since the filters' policy-backed allow-sets are built from canonical values, not alias keys. Two other filters were deliberately left untouched (one already self-canonicalizes; the other is more correct on raw input, since it locates evidence in source text which contains the raw label). `corroboration()`'s dashboard grouping had an independent, smaller gap — it wasn't canonicalizing at all, unlike its sibling `single_valued_conflicts` — now fixed to match.

**⚠️ Migration exposure for existing KBs (documented per design review, tracked as #343):** a fact stored under its canonical relation before this fix, when its source is re-synced after this fix, will get a different internal fact identity (raw vs. canonical relation), so it won't be recognized as the same fact as before. For most facts this just means a redundant candidate appears in the review queue. But if you have **human-rejected (`superseded`) facts under an aliased relation**, re-syncing that source after this fix can cause the rejected fact to resurface as a new, un-rejected candidate — and if a second source independently corroborates the same value, it could theoretically auto-accept without any human review, since the rejection history doesn't carry over to the new fact identity. This is a **pre-existing latent gap** in reject-suppression (it's sensitive to *any* relation relabeling, not just this fix — e.g. editing your alias file already triggers it today) that this change happens to mass-trigger across an entire KB on its first post-fix re-sync. It does not corrupt data or worsen the steady state, but operators with existing rejections of aliased facts should be aware before re-syncing. Tracked for a proper fix as #343.

## Test plan
- [x] Full suite: 1492 passed, 7 skipped
- [x] `ruff check` clean
- [x] Tests drive the real extraction path (not a direct `add_fact` bypass) to close the #241 mock-gap that let this bug ship undetected
- [x] Aliased ASCII relation (e.g. "founded") is kept and stored raw; a genuinely unaliased/hallucinated ASCII relation is still correctly dropped (both cases tested, proving the fix doesn't just disable the filter)
- [x] Same guard for the Hanja/CJK alias case
- [x] Two sources using different raw aliases for the same fact still merge into one corroboration group on the dashboard
- [x] Functional-conflict detection (#238) still correctly flags exactly one conflict for contradictory facts stored under different raw aliases
- [x] Accepted tradeoff documented and tested: within one source, an extraction yielding both an alias and its canonical for the same claim now produces two candidate rows instead of merging (no false conflict, no false auto-accept — just a redundant review item)
