### PR TITLE
fix(#173): halt consistently and non-silently when a fact's terms are unreadable

### DIFF
--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -13,7 +13,11 @@ from verinote.engine.terms import (
 )
 from verinote.store import Store
 from verinote.store.db import FACT_TERMS_MARKER_KEY
-from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError, fact_terms_path
+from verinote.store.duckdb_fact_terms import (
+    DuckDBFactTermStoreError,
+    fact_term_token,
+    fact_terms_path,
+)
 from verinote.store.fact_input import structural_term
 
 
@@ -264,6 +268,31 @@ def test_engine_fact_terms_rejects_missing_modern_sidecar_terms(tmp_path):
     assert s.get_fact_terms(fid) is None
 
 
+def test_amend_fact_refuses_and_writes_nothing_when_sidecar_is_corrupt(tmp_path):
+    # Guard the write at the store, not only the web route, so every caller (CLI,
+    # any future writer) is protected. The pre-write read of the structural terms
+    # forces the sidecar open, so genuine corruption aborts the amend before any
+    # SQLite write -- both stores are left untouched.
+    seed = _store(tmp_path)
+    fid = seed.add_fact(
+        Compound("person", (StringLit("Ada"),)),
+        Atom("born_in"),
+        StringLit("London"),
+        status="needs_review",
+    )
+    token = seed.get_fact(fid)["term_token"]
+    seed.close()
+    fact_terms_path(tmp_path).write_bytes(b"not a duckdb database file" * 500)
+
+    store = _store(tmp_path)
+    with pytest.raises(DuckDBFactTermStoreError):
+        store.amend_fact(fid, subject="Ada", relation="born_in", obj="Paris", note="")
+
+    # get_fact reads SQLite only, so it stays legible through the corruption; an
+    # unchanged token proves the amend wrote nothing to either store.
+    assert store.get_fact(fid)["term_token"] == token
+
+
 def test_engine_fact_terms_rejects_stale_modern_sidecar_terms(tmp_path):
     s = _store(tmp_path)
     fid = s.add_fact("Ada", "born_in", "Paris", status="confirmed")
@@ -376,9 +405,13 @@ def test_add_fact_duckdb_failure_rolls_back_sqlite_insert(tmp_path, monkeypatch)
     assert s.facts() == []
 
 
-def test_amend_fact_duckdb_failure_commits_sqlite_but_blocks_engine(
+def test_amend_fact_duckdb_failure_rolls_back_sqlite_leaving_no_divergence(
     tmp_path, monkeypatch
 ):
+    # The DuckDB write runs inside the amend's SQLite transaction, so a write-time
+    # sidecar failure rolls the SQLite update back too: the stores move together
+    # instead of leaving SQLite ahead of a stale DuckDB (the divergence that used
+    # to surface later as a confusing "stale DuckDB fact terms" engine error).
     s = _store(tmp_path)
     fid = s.add_fact("A", "r", "B", status="confirmed", note="orig")
     before_terms = s.get_fact_terms(fid)
@@ -393,15 +426,55 @@ def test_amend_fact_duckdb_failure_commits_sqlite_but_blocks_engine(
 
     row = s.get_fact(fid)
     assert (row["subject"], row["relation"], row["object"], row["note"]) == (
-        "A2",
-        "r2",
-        "B2",
-        "changed",
+        "A",
+        "r",
+        "B",
+        "orig",
     )
-    assert [event["action"] for event in s.fact_log(fid)] == ["amended"]
+    assert s.fact_log(fid) == []
     assert s.get_fact_terms(fid) == before_terms
-    with pytest.raises(DuckDBFactTermStoreError, match="stale DuckDB fact terms"):
-        s.engine_fact_terms()
+    # The stores still agree, so the engine reads cleanly -- no stale divergence.
+    assert len(s.engine_fact_terms()) == 1
+
+
+def test_amend_retry_self_heals_when_duckdb_is_ahead_of_stale_sqlite(tmp_path):
+    # Simulate the residual divergence the reordered write cannot fully close: a
+    # prior amend wrote DuckDB but its SQLite COMMIT failed, leaving DuckDB ahead
+    # of a stale SQLite row. A retry of the same edit must PROCEED and correct
+    # SQLite -- not early-return "unchanged" on the strength of DuckDB alone,
+    # which would mask the stale row forever. The no-op guard also compares
+    # SQLite's own term_token, so the retry self-heals.
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "r", "B", status="needs_review")
+
+    new_subject = structural_term('person("Ada")')
+    new_relation = structural_term("born_in")
+    new_object = "London"
+    # DuckDB ahead of the request; SQLite still holds the stale "A"/"r"/"B" row.
+    s.fact_terms.put_fact_terms(
+        fid,
+        new_subject,
+        new_relation,
+        new_object,
+        term_token=fact_term_token(new_subject, new_relation, new_object),
+    )
+
+    decision = s.amend_fact(
+        fid, subject=new_subject, relation=new_relation, obj=new_object, note=""
+    )
+
+    assert decision.changed is True
+    row = s.get_fact(fid)
+    assert (row["subject"], row["relation"], row["object"]) == (
+        'person("Ada")',
+        "born_in",
+        "London",
+    )
+    assert s.get_fact_terms(fid) == (
+        Compound("person", (StringLit("Ada"),)),
+        Atom("born_in"),
+        StringLit("London"),
+    )
 
 
 def test_amend_fact_rejects_direct_nonground_terms_and_restores_state(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -25,6 +25,7 @@ from verinote.pipeline.query import query_path  # noqa: E402
 from verinote.pipeline.query_intent import parse_query_intent  # noqa: E402
 from verinote.store import Store  # noqa: E402
 from verinote.store import db as store_db  # noqa: E402
+from verinote.store.duckdb_fact_terms import fact_terms_path  # noqa: E402
 from verinote.store.fact_input import structural_term  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
@@ -1876,6 +1877,166 @@ def test_amend_endpoint_saves_term_looking_text_as_stringlit_in_string_mode(tmp_
         StringLit('role(person("Ada"), "PI")'),
     )
     assert 'class="subj term-string">"person(\\"Ada\\")"' in unescape(r.text)
+
+
+def _corrupt_sidecar_kb(tmp_path, *, status="needs_review", with_query=False):
+    """Build a KB whose facts.duckdb is genuine garbage and hand back a FRESH
+    client, so its store lazily opens the corrupt file on first use.
+
+    Seeding through one app then serving through another matters: a store that
+    already holds an open DuckDB handle would keep reading the pre-corruption
+    file from cache and give a false pass. The fact carries a compound term, so
+    the corruption destroys real structural data (not an empty row). Returns
+    (client, fact_id, sqlite_term_token).
+    """
+    cfg = Config(
+        root=tmp_path, db_path=tmp_path / "kb.sqlite",
+        provider="anthropic", model="m", api_key=None, base_url=None,
+    )
+    seed = create_app(cfg).state.store
+    source_id = seed.add_source("sources/a.txt")
+    fact_id = seed.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("born_in"),
+        "London",
+        status=status,
+        source_id=source_id,
+        confidence=0.9,
+    )
+    token = seed.get_fact(fact_id)["term_token"]
+    if with_query:
+        qp = query_path(tmp_path)
+        qp.parent.mkdir(parents=True, exist_ok=True)
+        qp.write_text(
+            ".decl answer_q1(value: symbol)\n"
+            'answer_q1(O) :- relation("Ada", "born_in", O).\n',
+            encoding="utf-8",
+        )
+    seed.close()
+    fact_terms_path(tmp_path).write_bytes(b"not a duckdb database file" * 500)
+    return TestClient(create_app(cfg)), fact_id, token
+
+
+def test_review_halts_loudly_when_the_sidecar_is_unreadable(tmp_path):
+    # The dangerous former behavior: `_fact_view`'s `except ValueError` swallowed
+    # the corruption and rendered every field as kind="string" with a 200 -- a
+    # structural fact made indistinguishable from a genuine string fact. /review
+    # is a full-page GET, so the handler renders the halt page inline.
+    client, _fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.get("/review")
+
+    assert r.status_code == 409
+    assert "Fact terms unavailable" in r.text
+    assert "born_in" not in r.text  # the fact is never rendered as a plain string
+
+
+def test_provenance_halts_loudly_when_the_sidecar_is_unreadable(tmp_path):
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.get(f"/facts/{fid}/provenance")
+
+    assert r.status_code == 409
+    assert "Fact terms unavailable" in r.text
+
+
+def test_report_halts_loudly_when_the_sidecar_is_unreadable(tmp_path):
+    # `report_trace` used to raise an uncaught 500 here while `verify()` degraded
+    # gracefully in the same route -- the two now converge on the halt page.
+    client, _fid, _token = _corrupt_sidecar_kb(
+        tmp_path, status="confirmed", with_query=True
+    )
+
+    r = client.get("/report")
+
+    assert r.status_code == 409
+    assert "Fact terms unavailable" in r.text
+
+
+def test_edit_form_over_htmx_redirects_instead_of_silently_swallowing(tmp_path):
+    # The edit form is an htmx partial swap, and htmx will not swap a 4xx/5xx body
+    # into the DOM -- an inline halt page would be a *silent* no-op on exactly the
+    # path #173 is about. The handler must send HX-Redirect so htmx does a
+    # full-page navigation to the halt page instead.
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.get(f"/facts/{fid}/edit", headers={"HX-Request": "true"})
+
+    assert r.status_code == 409
+    assert r.headers.get("HX-Redirect") == webapp.FACT_TERMS_UNAVAILABLE_PATH
+
+
+def test_amend_over_htmx_is_refused_via_redirect_and_writes_nothing(tmp_path):
+    # The anti-data-loss guarantee on the real (htmx) save path: without
+    # HX-Redirect the swallowed 4xx would leave the user with no halt and no
+    # feedback at all. The redirect forces the halt page; nothing is written.
+    client, fid, token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.post(
+        f"/facts/{fid}/amend",
+        headers={"HX-Request": "true"},
+        data={
+            "subject": 'person("Ada")',
+            "subject_kind": "string",
+            "relation": "born_in",
+            "relation_kind": "string",
+            "object": "London",
+            "object_kind": "string",
+            "note": "",
+        },
+    )
+
+    assert r.headers.get("HX-Redirect") == webapp.FACT_TERMS_UNAVAILABLE_PATH
+    # get_fact reads SQLite only, so the token is legible through the corruption:
+    # an unchanged token proves the amend wrote nothing to either store.
+    assert client.app.state.store.get_fact(fid)["term_token"] == token
+
+
+def test_amend_without_htmx_is_refused_inline_and_writes_nothing(tmp_path):
+    # A non-browser client (script/API) sends no HX-Request header, so it gets the
+    # inline halt page. The store guard still refuses the write regardless.
+    client, fid, token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": "A",
+            "subject_kind": "string",
+            "relation": "r",
+            "relation_kind": "string",
+            "object": "B",
+            "object_kind": "string",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 409
+    assert "Fact terms unavailable" in r.text
+    assert client.app.state.store.get_fact(fid)["term_token"] == token
+
+
+def test_fact_terms_unavailable_page_renders_without_touching_terms(tmp_path):
+    # The HX-Redirect target must render even while the term store cannot be read,
+    # so the route reads no fact terms of its own.
+    client, _fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.get(webapp.FACT_TERMS_UNAVAILABLE_PATH)
+
+    assert r.status_code == 409
+    assert "Fact terms unavailable" in r.text
+
+
+def test_review_renders_normally_for_a_string_fact_on_a_healthy_sidecar(tmp_path):
+    # False-positive guard: a legitimately string-typed fact must keep rendering
+    # as kind="string" with a 200 -- only a genuine raise halts, never the
+    # absent/None-terms path.
+    c = _client(tmp_path)
+
+    r = c.get("/review")
+
+    assert r.status_code == 200
+    assert "Fact terms unavailable" not in r.text
+    assert "is_a" in r.text
 
 
 def test_amend_endpoint_rejects_invalid_structural_terms_without_writing(tmp_path):

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1934,11 +1934,30 @@ class Store:
             before = self.get_fact(fact_id)
             if before is None:
                 return FactDecision.unchanged(None)
+            # Pre-write corruption guard: reading the structural terms forces the
+            # DuckDB sidecar open, so a corrupt/unreadable sidecar raises here and
+            # aborts the amend before BEGIN -- nothing is written. This is
+            # deliberate, not just change-detection: without it a corruption-driven
+            # read failure could let the SQLite mirror be rewritten (downgrading a
+            # structural term to text) while DuckDB is left behind. The guard fires
+            # only on genuine corruption, never on a healthy sidecar, so an
+            # intentional kind="string" downgrade stays allowed.
             previous_terms = self.fact_terms.get_fact_terms(fact_id)
             requested_terms = _stored_fact_terms(subject, relation, obj)
-            if previous_terms == requested_terms and before["note"] == note:
-                return FactDecision.unchanged(before)
             token = fact_term_token(subject, relation, obj)
+            # Treat the amend as a no-op only when BOTH stores already hold the
+            # request. Comparing SQLite's own term_token here (not just the DuckDB
+            # terms + note) is what lets a retry recover the residual divergence
+            # noted at the DuckDB write below: if a prior amend wrote DuckDB but
+            # its SQLite COMMIT then failed, DuckDB would already match the request
+            # while SQLite stayed stale, and a DuckDB-only check would early-return
+            # "unchanged" and mask the stale SQLite row forever.
+            if (
+                previous_terms == requested_terms
+                and before["term_token"] == token
+                and before["note"] == note
+            ):
+                return FactDecision.unchanged(before)
             self._conn.execute("BEGIN")
             try:
                 self._conn.execute(
@@ -1956,13 +1975,22 @@ class Store:
                 after = self.get_fact(fact_id)
                 self._log(fact_id, "amended", before, after)
                 self._record_fact_terms_marker_unlocked(origin="write")
+                # Write DuckDB inside the SQLite transaction, before COMMIT. The
+                # two stores share no transaction, so this is not true atomicity;
+                # it closes the common failure -- an unwritable sidecar raises here
+                # and the except below ROLLs BACK SQLite, so neither store changes
+                # and the amend is refused honestly. A residual window remains if
+                # put_fact_terms succeeds and the SQLite COMMIT then fails, leaving
+                # DuckDB ahead of a stale SQLite; that is rare, engine-detectable
+                # (the stale-token check), and self-healed on retry by the no-op
+                # guard above, which compares SQLite's own term_token.
+                self.fact_terms.put_fact_terms(
+                    fact_id, subject, relation, obj, term_token=token
+                )
                 self._conn.execute("COMMIT")
             except BaseException:
                 self._conn.execute("ROLLBACK")
                 raise
-            self.fact_terms.put_fact_terms(
-                fact_id, subject, relation, obj, term_token=token
-            )
             return FactDecision(fact=after, changed=True)
 
     # --- questions -------------------------------------------------------

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -14,7 +14,7 @@ import threading
 import unicodedata
 from urllib.parse import urlencode
 
-from fastapi import FastAPI, File, Form, Request, UploadFile
+from fastapi import FastAPI, File, Form, Request, Response, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -94,6 +94,7 @@ from verinote.store import (
 # Imported as a module, not `from ... import ENGINE_STATUSES`: the tier must be
 # read at call time so the web layer cannot pin a stale copy of the constant.
 from verinote.store import db as store_db
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
 from verinote.store.fact_input import structural_term, term_input_kind
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,11 @@ _STATIC = resources.files("verinote.web").joinpath("static")
 # a change made while this KB's rules are not being applied.
 _POLICY_GUARD_READ_PATHS = ("/report", "/settings", "/static")
 _POLICY_GUARD_WRITE_PATHS = ("/kb/select", "/settings/root")
+
+# Full-page halt shown when a fact's logical terms cannot be read. htmx partial
+# swaps are redirected here (HX-Redirect) because htmx will not swap an error
+# response into the DOM -- see `_fact_terms_unreadable_handler`.
+FACT_TERMS_UNAVAILABLE_PATH = "/fact-terms-unavailable"
 
 
 def _matches(path: str, allowed: tuple[str, ...]) -> bool:
@@ -176,6 +182,57 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return _policy_halted(request, str(exc))
 
     app.add_exception_handler(PolicyMissingError, _policy_missing_handler)
+
+    def _fact_terms_unavailable_page(request: Request):
+        # Deliberately generic: DuckDBFactTermStoreError covers a corrupt/unopenable
+        # sidecar but also stale/missing-term and malformed-input conditions, so the
+        # copy must not diagnose one specific cause it cannot be sure of.
+        return templates.TemplateResponse(
+            request,
+            "sidecar_unreadable.html",
+            {},
+            status_code=409,
+        )
+
+    @app.get(FACT_TERMS_UNAVAILABLE_PATH, response_class=HTMLResponse)
+    def fact_terms_unavailable(request: Request):
+        # The full-page halt and the HX-Redirect target below. It reads no fact
+        # terms, so it still renders while the term store cannot be read.
+        return _fact_terms_unavailable_page(request)
+
+    def _fact_terms_unreadable_handler(request: Request, exc: Exception):
+        """One loud, non-lying halt for every surface that cannot read a fact's
+        logical terms.
+
+        Read routes (`/review`, `/provenance`, `GET /facts/{id}/edit`, `/report`'s
+        trace) let `DuckDBFactTermStoreError` propagate here rather than degrading
+        a structural fact to a silent `kind="string"`. What reaching this handler
+        means on a POST is route-dependent: `amend_fact` refuses in the store
+        *before* it commits, so nothing was written; but `accept`/`reject`/`toggle`
+        do a bare SQLite status UPDATE that autocommits immediately and only reach
+        this handler on the follow-on row re-render, so for those the decision
+        already succeeded and merely could not be displayed. This page therefore
+        never claims the action was rejected -- only that the terms could not be
+        read.
+
+        htmx will NOT swap a 4xx/5xx response into the DOM -- it fires
+        `htmx:responseError` and swaps nothing -- so answering an htmx partial
+        swap (the edit form, the amend save) with an inline page would be a
+        *silent* no-op, the exact failure #173 forbids. For htmx requests we send
+        HX-Redirect to force a full-page navigation to the halt page; htmx 2.x
+        acts on HX-Redirect regardless of status, so the 409 stays honest.
+        Full-page (non-htmx) requests render the halt page inline.
+        """
+        if request.headers.get("HX-Request") == "true":
+            return Response(
+                status_code=409,
+                headers={"HX-Redirect": FACT_TERMS_UNAVAILABLE_PATH},
+            )
+        return _fact_terms_unavailable_page(request)
+
+    app.add_exception_handler(
+        DuckDBFactTermStoreError, _fact_terms_unreadable_handler
+    )
 
     def _active_store() -> Store:
         store = app.state.store
@@ -308,10 +365,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return None
         store = _active_store()
         view = dict(fact)
-        try:
-            terms = store.get_fact_terms(fact["id"])
-        except ValueError:
-            terms = None
+        # A raise here (corrupt/unreadable sidecar) must propagate to the shared
+        # DuckDBFactTermStoreError handler, not be swallowed: silently treating it
+        # as `terms is None` would render a structural fact as a plain string,
+        # making genuine corruption indistinguishable from a real string fact.
+        terms = store.get_fact_terms(fact["id"])
         if terms is None:
             for field in ("subject", "relation", "object"):
                 view[f"{field}_display"] = fact[field]

--- a/verinote/web/templates/sidecar_unreadable.html
+++ b/verinote/web/templates/sidecar_unreadable.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fact terms unavailable — verinote</title>
+  <link rel="stylesheet" href="/static/app.css?v=4">
+</head>
+<body>
+  <main class="chooser">
+    <h1>Fact terms unavailable</h1>
+
+    {# Generic on purpose: the underlying error may be a corrupt/unopenable
+       structural term store, a stale or missing term row, or malformed input.
+       verinote stops rather than render or change a fact whose logical terms it
+       cannot read, because falling back to the plain-text mirror would show a
+       structural fact as an ordinary string and invite a save that destroys it. #}
+    <p class="error" role="alert">The knowledge base could not read this fact's
+      logical terms, so it stopped instead of showing or changing the fact in a
+      way that might misrepresent it.</p>
+
+    <p class="muted">If the structural term store (<code>facts.duckdb</code>) was
+      moved, replaced or damaged, restore it from a backup or version control. The
+      knowledge base recovers on its own once the terms can be read again.</p>
+
+    <p><a href="/">Dashboard</a> · <a href="/settings">Settings</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes #173. A corrupt or unopenable DuckDB sidecar (`facts.duckdb`) previously produced ~5 divergent behaviors across web routes — the worst being `/review` and `/provenance` silently rendering a structural (compound) fact as a plain string with no indication anything was wrong, making genuine corruption indistinguishable from a real string fact. This converges every surface onto one loud, non-lying behavior.

Read paths (`_fact_view`) no longer swallow the read failure into a fake `kind="string"` — the legitimate "no term data yet" case (`None`) still renders as a string exactly as before; only genuine corruption now propagates. A shared exception handler covers `/review`, `/provenance`, the fact-edit form, and `/report`'s trace path with one consistent halt. Because several of these routes are htmx partial swaps — and htmx does not swap 4xx/5xx responses into the DOM by default — the handler detects `HX-Request` and answers with `HX-Redirect` to force a full-page navigation to a real halt page, rather than risking a silent no-op on the exact interactive edit/save path this issue is about.

On the write side, `amend_fact`'s pre-write term read is now a documented, deliberate corruption guard (it aborts before any write on a corrupt sidecar), the DuckDB write moved inside the SQLite transaction so a write-time failure rolls both back instead of leaving them diverged, and the no-op/change-detection guard was hardened to also check SQLite's own stored state — closing a narrow window where a retry after a rare write failure could otherwise mask a stale row instead of self-healing it.

Two adjacent issues were discovered during design/review and filed separately rather than folded in:
- **#345** — `POST /facts/{id}/amend`'s `*_kind` form fields default to `"string"` when omitted, which can silently downgrade a term on a perfectly *healthy* sidecar. Independent root cause (unrelated to corruption-handling), different fix surface — not addressed here.
- **#346** — two minor, non-blocking notes: a decision (accept/reject/toggle) that hits the new halt page on its follow-on display has actually already succeeded (not been rejected) — low risk since accept/reject are idempotent, though `toggle` is not, so a confused retry could theoretically double-flip; and the hardened write-path guard causes an ordinary re-save of a legacy pre-DuckDB fact to register as a real `amend` event (a beneficial self-heal, but a possibly-surprising one).

## Test plan
- [x] Full suite: 1502 passed, 7 skipped
- [x] `ruff check` clean
- [x] Corrupt sidecar → `/review`, `/provenance`, `/report` all show the same halt page (not divergent behaviors)
- [x] Corrupt sidecar → the edit form and save (htmx partial-swap routes) redirect to the halt page via `HX-Redirect` rather than silently failing to update
- [x] Corrupt sidecar → `POST /facts/{id}/amend` is refused and verifiably writes nothing
- [x] A healthy sidecar with a genuinely string-only fact renders completely normally — no false-positive halt
- [x] Store-level test: `amend_fact` refuses and writes nothing when the sidecar is corrupt (protects every caller, not just the web route)
- [x] A write-time DuckDB failure now rolls SQLite back too, instead of leaving the two stores diverged
- [x] A retry during the narrow residual divergence window self-heals instead of masking the stale row (dedicated regression test)
- [x] Existing explicit kind-mode toggle tests (deliberate healthy-sidecar string-mode downgrade) unaffected
