### PR TITLE
refactor(#310, #311): encode the superseded terminal invariant in the schema

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1748,11 +1748,18 @@ def test_existing_fact_for_source_is_scoped_to_the_source(tmp_path):
 def test_reconcile_fact_never_resurrects_a_legacy_superseded_row(tmp_path):
     # A rejected fact whose row predates the term_token column (NULL token) must
     # still be recognised on the fallback and left superseded -- never reinserted.
+    #
+    # The token is cleared *before* the reject, not after: a legacy row has a NULL
+    # token from creation and is rejected later, so this is the order the scenario
+    # actually occurs in. The reverse order also trips the #311 content freeze,
+    # which is correct of it -- no production path rewrites a superseded row's
+    # term_token (backfill_fact_terms writes DuckDB, not facts.term_token), so
+    # only this fixture was doing it.
     s = _store(tmp_path)
     sid = s.add_source("sources/sample.txt")
     fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)
-    s.reject_fact(fact_id)
     s._conn.execute("UPDATE facts SET term_token = NULL WHERE id = ?", (fact_id,))
+    s.reject_fact(fact_id)
     before = len(s.facts())
 
     result = s.reconcile_fact("A", "count", NumberLit(36), source_id=sid)

--- a/tests/test_superseded_terminal.py
+++ b/tests/test_superseded_terminal.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: MPL-2.0
+"""`superseded` is terminal, enforced by the schema (#310, #311).
+
+Every guard before these lived in Python and read a *syntactic* property of the
+source — an allowlist of method names (#292 first pass), then a regex over each
+method body (#292 second pass). Both were walked past: the first by adding a
+name, the second by reordering a SET clause. #309 records the hole neither can
+close, because it is the shape of the technique rather than a bug in it: a write
+factored into a private helper is invisible to a scan that reads one public
+method at a time.
+
+So these tests do not assert anything about how the source is written. They
+attempt the forbidden write through channels that no Python guard sits on — raw
+SQL on the store's own connection, spelled several ways — and assert the
+database refuses. The claim under test is "the transition cannot happen", not
+"the code does not appear to contain it".
+
+Two axes, both terminal, enforced by two triggers:
+
+  status  (#310) — a superseded fact cannot be moved to another status.
+  content (#311) — a superseded fact's subject/relation/object/note cannot be
+                   rewritten. A reject is a judgment about a *specific claim*,
+                   so the claim is frozen with the judgment; otherwise the audit
+                   log's "rejected" ends up naming text nobody rejected.
+
+Deliberately NOT frozen: `stale` and `updated_at`. `add_fact_evidence()` clears
+`stale=1` on every re-observation without regard to status (#329), and that path
+is load-bearing. `test_re_observing_a_superseded_fact_still_clears_stale` is the
+regression guard for that carve-out — freezing the whole row would break it.
+
+Finally, terminality is a different axis from tiering, and this must stay true:
+see `test_superseded_belongs_to_neither_status_tier`.
+"""
+
+import sqlite3
+
+import pytest
+
+from verinote.store import Store, TerminalFactError
+from verinote.store.db import ENGINE_STATUSES, REVIEW_STATUSES
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from verinote.config import Config  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+NON_TERMINAL = ("candidate", "needs_review", "confirmed", "accepted")
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _rejected_fact(store: Store) -> int:
+    fact_id = store.add_fact("Ledger", "owner", "Park", status="needs_review")
+    store.reject_fact(fact_id)
+    assert store.get_fact(fact_id)["status"] == "superseded"
+    return fact_id
+
+
+def _row(store: Store, fact_id: int) -> dict:
+    fact = store.get_fact(fact_id)
+    return {k: fact[k] for k in fact.keys()}
+
+
+def _actions(store: Store, fact_id: int) -> list[str]:
+    return [event["action"] for event in store.fact_log(fact_id)]
+
+
+# --- #310: the status axis is terminal at the write boundary ---------------
+
+
+@pytest.mark.parametrize("target", NON_TERMINAL)
+def test_raw_sql_cannot_move_a_superseded_fact_to_any_other_status(tmp_path, target):
+    # The headline. This bypasses every Python guard there is — no method name to
+    # add to an allowlist, no method body for a scan to read — and goes straight
+    # at the connection. Parameterised across the whole non-terminal vocabulary
+    # rather than one representative, so a trigger narrowed to a single status
+    # (`NEW.status = 'confirmed'`, say) is red instead of green-on-the-one-case.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute(
+            "UPDATE facts SET status = ? WHERE id = ?", (target, fact_id)
+        )
+
+    assert store.get_fact(fact_id)["status"] == "superseded"
+
+
+def test_the_refusal_does_not_depend_on_how_the_update_is_spelled(tmp_path):
+    # Column order is exactly what walked past the #292 regex, so the guard that
+    # replaced it must be indifferent to it. Each spelling below defeated some
+    # earlier version of a source-reading guard; none of them defeat a trigger,
+    # because the trigger reads the row, not the statement.
+    store = _store(tmp_path)
+    spellings = (
+        "UPDATE facts SET status = 'confirmed' WHERE id = ?",
+        # status last, with a function call and its apostrophes in front of it
+        "UPDATE facts SET updated_at = datetime('now'), status = 'confirmed' "
+        "WHERE id = ?",
+        # lowercase keywords
+        "update facts set status = 'confirmed' where id = ?",
+        # no WHERE clause at all: a scan keyed on `SET ... WHERE` sees nothing
+        "UPDATE facts SET status = 'confirmed'",
+        # reached via a subquery rather than a literal id
+        "UPDATE facts SET status = 'confirmed' "
+        "WHERE id IN (SELECT id FROM facts WHERE status = 'superseded') AND id = ?",
+    )
+
+    for sql in spellings:
+        fact_id = _rejected_fact(store)
+        params = () if "?" not in sql else (fact_id,)
+        with pytest.raises(sqlite3.IntegrityError), store._conn:
+            store._conn.execute(sql, params)
+        assert store.get_fact(fact_id)["status"] == "superseded", sql
+
+
+def test_a_write_from_a_private_helper_is_refused_too(tmp_path):
+    # #309: a status write factored out of a public method into a helper is the
+    # one hole the source scan concedes it cannot see, because it reads a single
+    # public method's body at a time. The trigger has no notion of where a
+    # statement was called from, so the hole simply is not there. This is the
+    # test that says #310 subsumes #309 rather than sitting beside it.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    def _helper_the_scan_never_reads(conn, target_id):
+        conn.execute(
+            "UPDATE facts SET status = 'accepted' WHERE id = ?", (target_id,)
+        )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        _helper_the_scan_never_reads(store._conn, fact_id)
+
+    assert store.get_fact(fact_id)["status"] == "superseded"
+
+
+def test_rejecting_a_fact_still_works(tmp_path):
+    # Over-fix guard: only the way *out* is closed. reject_fact writes
+    # candidate -> superseded and must stay unobstructed, or the trigger would
+    # have made rejection itself impossible.
+    store = _store(tmp_path)
+    fact_id = store.add_fact("Ledger", "owner", "Park", status="needs_review")
+
+    decision = store.reject_fact(fact_id)
+
+    assert decision.changed is True
+    assert store.get_fact(fact_id)["status"] == "superseded"
+
+
+def test_a_same_status_rewrite_of_a_superseded_fact_is_allowed(tmp_path):
+    # Over-fix guard on the WHEN clause: `OLD.status = 'superseded'` alone would
+    # abort a write that sets status to the value it already holds. That is not a
+    # transition and must not raise — reject_fact's own early-return relies on
+    # nothing pathological happening on the replay path.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    store._conn.execute(
+        "UPDATE facts SET status = 'superseded' WHERE id = ?", (fact_id,)
+    )
+
+    assert store.get_fact(fact_id)["status"] == "superseded"
+
+
+@pytest.mark.parametrize("start", NON_TERMINAL)
+def test_transitions_between_non_terminal_statuses_are_untouched(tmp_path, start):
+    # The trigger keys on OLD.status, so every transition that does not *leave*
+    # superseded must be unaffected. Without this, a trigger written as
+    # `NEW.status <> 'superseded'` (dropping the OLD test) would freeze the whole
+    # lifecycle and this file would still be green on everything above.
+    store = _store(tmp_path)
+    fact_id = store.add_fact("Ledger", "owner", "Park", status=start)
+
+    store._conn.execute(
+        "UPDATE facts SET status = 'confirmed' WHERE id = ?", (fact_id,)
+    )
+
+    assert store.get_fact(fact_id)["status"] == "confirmed"
+
+
+# --- #311: the content axis is terminal too --------------------------------
+
+
+def test_amend_fact_refuses_a_superseded_fact(tmp_path):
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+    before = _row(store, fact_id)
+    log_before = _actions(store, fact_id)
+
+    with pytest.raises(TerminalFactError):
+        store.amend_fact(
+            fact_id, subject="Ledger", relation="owner", obj="Choi", note="typo"
+        )
+
+    # Result, not just the exception: the row is untouched and the audit log did
+    # not gain an `amended` event next to the `rejected` one.
+    assert _row(store, fact_id) == before
+    assert _actions(store, fact_id) == log_before
+
+
+def test_raw_sql_cannot_rewrite_a_superseded_fact_s_content(tmp_path):
+    # The Python guard in amend_fact is diagnosis; this is the invariant. Same
+    # reasoning as the status axis — a caller that reaches the connection
+    # directly must still be refused.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute(
+            "UPDATE facts SET subject = 'Rewritten' WHERE id = ?", (fact_id,)
+        )
+
+    assert store.get_fact(fact_id)["subject"] == "Ledger"
+
+
+@pytest.mark.parametrize("column", ("subject", "relation", "object", "note"))
+def test_every_content_column_is_frozen(tmp_path, column):
+    # Parameterised so a trigger that lists only some of the amend columns in its
+    # UPDATE OF clause is red. `note` matters as much as the triple: a rejected
+    # claim annotated after the fact reads as though the annotation was there
+    # when the judgment was made.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute(
+            f"UPDATE facts SET {column} = 'rewritten' WHERE id = ?", (fact_id,)
+        )
+
+
+def test_term_token_alone_is_frozen_on_a_superseded_fact(tmp_path):
+    # term_token is derived from the *typed* terms, so a kind-only amend (same
+    # display text, different term kind) moves the token while leaving
+    # subject/relation/object byte-identical. A trigger that omitted term_token
+    # from its comparison would wave exactly that amend through, and every other
+    # test in this file would stay green.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute(
+            "UPDATE facts SET term_token = 'rewritten-token' WHERE id = ?",
+            (fact_id,),
+        )
+
+
+def test_a_replayed_amend_on_a_superseded_fact_is_a_quiet_no_op(tmp_path):
+    # The two layers must refuse the *same* calls. An amend asking for content
+    # already stored writes nothing, so the trigger (which compares values) lets
+    # it pass — and the Python guard, which sits after the replay check, must let
+    # it pass too. If the guard moved above that check this would raise, and the
+    # layers would disagree about what "amending a superseded fact" means.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+    before = _row(store, fact_id)
+
+    decision = store.amend_fact(
+        fact_id, subject="Ledger", relation="owner", obj="Park", note=""
+    )
+
+    assert decision.changed is False
+    assert _row(store, fact_id) == before
+
+
+def test_amending_a_live_fact_is_untouched(tmp_path):
+    # Over-fix guard: the freeze keys on OLD.status, so amending anything that is
+    # not superseded must behave exactly as before.
+    store = _store(tmp_path)
+    fact_id = store.add_fact("A", "is_a", "B", status="needs_review", note="orig")
+
+    decision = store.amend_fact(
+        fact_id, subject="A2", relation="became", obj="C", note="fixed"
+    )
+
+    assert decision.changed is True
+    assert decision.fact["subject"] == "A2"
+    assert "amended" in _actions(store, fact_id)
+
+
+# --- the carve-out: stale/updated_at stay writable (#329) ------------------
+
+
+def test_re_observing_a_superseded_fact_still_clears_stale(tmp_path):
+    # The reason the content freeze is scoped to the amend axis instead of
+    # freezing the row. note_fact_reobserved() clears stale=1 on EVERY
+    # re-observation without consulting status (#329, load-bearing per its
+    # docstring). A row-wide freeze would turn that into an IntegrityError the
+    # moment a rejected fact's text reappeared in its source.
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/a.txt")
+    artifact_id = store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path="artifacts/a.txt"
+    )
+    fact_id = _rejected_fact(store)
+    store._conn.execute("UPDATE facts SET stale = 1 WHERE id = ?", (fact_id,))
+
+    store.note_fact_reobserved(
+        fact_id=fact_id, source_id=source_id, artifact_id=artifact_id
+    )
+
+    assert store.get_fact(fact_id)["stale"] == 0
+    assert store.get_fact(fact_id)["status"] == "superseded"
+
+
+def test_updated_at_stays_writable_on_a_superseded_fact(tmp_path):
+    # Same carve-out, second column: bookkeeping is not content.
+    store = _store(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    store._conn.execute(
+        "UPDATE facts SET updated_at = '2030-01-01 00:00:00' WHERE id = ?",
+        (fact_id,),
+    )
+
+    assert store.get_fact(fact_id)["updated_at"] == "2030-01-01 00:00:00"
+
+
+# --- terminality is not tiering (justinjoy, #310/#311) ---------------------
+
+
+def test_superseded_belongs_to_neither_status_tier(tmp_path):
+    # Hard dependency flagged on both issues. The #287 resolution path — reject a
+    # rival, it supersedes, the survivor auto-promotes on the next cascade —
+    # works only because superseded sits outside both tiers. Reclassifying it
+    # into either one would leave a rejected rival blocking the survivor forever
+    # and starve auto-accept.
+    #
+    # These triggers encode *terminality*, a different axis, and must never be
+    # read as licence to move superseded into a tier. This assertion is here so
+    # that a change which does gets caught in the same file that might tempt it;
+    # the behavioural pin is
+    # tests/test_acceptance.py::test_rejecting_one_rival_unblocks_auto_accept_of_the_other.
+    assert "superseded" not in ENGINE_STATUSES
+    assert "superseded" not in REVIEW_STATUSES
+
+
+# --- the web routes agree with the store (#311) ----------------------------
+
+
+def _client(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+    return client, client.app.state.store
+
+
+def test_edit_route_hands_back_a_read_only_row_for_a_superseded_fact(tmp_path):
+    # fact_row.html has always hidden the edit control on a superseded row, but
+    # the control being absent from one render is not the same as the route
+    # refusing. Anyone holding the URL — or a page opened before the reject
+    # landed — could still pull the form. The route now answers with the row.
+    client, store = _client(tmp_path)
+    fact_id = _rejected_fact(store)
+
+    resp = client.get(f"/facts/{fact_id}/edit")
+
+    assert resp.status_code == 200
+    # The distinguishing mark of the edit partial is the amend form; the row
+    # says why there is nothing to do instead.
+    assert f'hx-post="/facts/{fact_id}/amend"' not in resp.text
+    assert "rejected" in resp.text
+
+
+def test_edit_route_still_serves_a_form_for_a_live_fact(tmp_path):
+    # Over-fix guard for the route above.
+    client, store = _client(tmp_path)
+    fact_id = store.add_fact("Ledger", "owner", "Park", status="needs_review")
+
+    resp = client.get(f"/facts/{fact_id}/edit")
+
+    assert resp.status_code == 200
+    assert f'hx-post="/facts/{fact_id}/amend"' in resp.text
+
+
+def test_amend_route_on_a_superseded_fact_answers_without_a_server_error(tmp_path):
+    # The store raises TerminalFactError, which is a ValueError; unhandled it
+    # would be a 500. Reachable from a form that was already open when someone
+    # else rejected the fact, so it has to answer cleanly.
+    #
+    # 200 rather than 4xx on purpose: htmx's default responseHandling does not
+    # swap 4xx, so an error status would leave the stale form on screen still
+    # offering a save that cannot succeed. Asserting the swapped-in row is what
+    # makes this a guard on the user-visible result and not just on the status
+    # code.
+    client, store = _client(tmp_path)
+    fact_id = _rejected_fact(store)
+    before = _row(store, fact_id)
+
+    resp = client.post(
+        f"/facts/{fact_id}/amend",
+        data={"subject": "Ledger", "relation": "owner", "object": "Choi"},
+    )
+
+    assert resp.status_code == 200
+    assert "rejected" in resp.text
+    assert _row(store, fact_id) == before
+
+
+# --- legacy databases ------------------------------------------------------
+
+
+def test_a_legacy_db_without_term_token_gets_both_triggers(tmp_path):
+    # SQLite resolves a trigger's column references when it fires, not when it is
+    # created. So a content trigger naming term_token, if it were defined in
+    # schema.sql (which runs before the ALTER that adds the column), would create
+    # cleanly on a legacy DB and then abort every later UPDATE with a bare
+    # "no such column: NEW.term_token" — including writes to unrelated columns.
+    # This builds that DB shape and checks both triggers work rather than
+    # misfire.
+    db_path = tmp_path / "legacy.sqlite"
+    legacy = sqlite3.connect(db_path)
+    legacy.executescript(
+        """
+        CREATE TABLE facts (
+            id         INTEGER PRIMARY KEY,
+            subject    TEXT NOT NULL,
+            relation   TEXT NOT NULL,
+            object     TEXT NOT NULL,
+            status     TEXT NOT NULL DEFAULT 'candidate',
+            confidence REAL NOT NULL DEFAULT 0.0,
+            source_id  INTEGER,
+            run_id     INTEGER,
+            note       TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO facts (id, subject, relation, object, status)
+        VALUES (1, 'Ledger', 'owner', 'Park', 'superseded');
+        """
+    )
+    legacy.commit()
+    legacy.close()
+
+    store = Store(db_path)
+    store.init_schema()
+
+    # The bookkeeping carve-out still works — i.e. the content trigger is not
+    # aborting every write with a missing-column error.
+    store._conn.execute("UPDATE facts SET stale = 1 WHERE id = 1")
+    assert store.get_fact(1)["stale"] == 1
+
+    # And both invariants hold on the migrated row.
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute("UPDATE facts SET status = 'confirmed' WHERE id = 1")
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute("UPDATE facts SET subject = 'Rewritten' WHERE id = 1")
+    assert store.get_fact(1)["status"] == "superseded"

--- a/tests/test_superseded_terminal.py
+++ b/tests/test_superseded_terminal.py
@@ -249,6 +249,39 @@ def test_term_token_alone_is_frozen_on_a_superseded_fact(tmp_path):
         )
 
 
+@pytest.mark.parametrize(
+    "stored,written",
+    [(None, "'backfilled'"), ("'a-token'", "NULL")],
+)
+def test_a_null_term_token_is_frozen_in_both_directions(tmp_path, stored, written):
+    # The test that makes `IS NOT` load-bearing. term_token is nullable, and in
+    # SQL `NULL <> 'x'` evaluates to NULL, which a WHEN clause reads as false --
+    # so a comparison-based guard would wave through exactly the legacy rows
+    # (token never backfilled) it most needs to catch, and abort only on rows
+    # that already have one.
+    #
+    # Every other content test uses a fact built by add_fact, whose token is
+    # non-NULL, so `<>` fires on those and they stay green while the invariant
+    # is dead for legacy rows. Both directions are parameterised because each
+    # puts the NULL on a different side of the comparison.
+    store = _store(tmp_path)
+    fact_id = store.add_fact("Ledger", "owner", "Park", status="needs_review")
+    store._conn.execute(
+        f"UPDATE facts SET term_token = {'NULL' if stored is None else stored} "
+        "WHERE id = ?",
+        (fact_id,),
+    )
+    store.reject_fact(fact_id)
+    before = store.get_fact(fact_id)["term_token"]
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store._conn.execute(
+            f"UPDATE facts SET term_token = {written} WHERE id = ?", (fact_id,)
+        )
+
+    assert store.get_fact(fact_id)["term_token"] == before
+
+
 def test_a_replayed_amend_on_a_superseded_fact_is_a_quiet_no_op(tmp_path):
     # The two layers must refuse the *same* calls. An amend asking for content
     # already stored writes nothing, so the trigger (which compares values) lets

--- a/verinote/store/__init__.py
+++ b/verinote/store/__init__.py
@@ -8,6 +8,7 @@ from verinote.store.db import (
     REVIEW_PAGE_SIZES,
     ReviewQueuePage,
     Store,
+    TerminalFactError,
 )
 from verinote.store.tiers import (
     engine_statuses,
@@ -23,6 +24,7 @@ from verinote.store.tiers import (
 __all__ = [
     "Store",
     "FactDecision",
+    "TerminalFactError",
     "POLICY_MARKER_KEY",
     "engine_statuses",
     "review_statuses",

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -2315,14 +2315,26 @@ class Store:
         #
         # Deliberately scoped to the amend axis rather than freezing the row:
         # `stale` and `updated_at` must stay writable, because
-        # add_fact_evidence() clears stale=1 on every re-observation without
+        # note_fact_reobserved() clears stale=1 on every re-observation without
         # regard to status (#329) and that path is load-bearing.
         #
-        # Here rather than in schema.sql for the same reason as the index above:
-        # this body names term_token, and SQLite resolves a trigger's columns
-        # when it fires, not when it is created -- so on a legacy DB defining it
-        # there would create cleanly and then fail every subsequent UPDATE with
-        # a bare "no such column: NEW.term_token". By this point it exists.
+        # `confidence`, `source_id`, `run_id` and `job_id` are also left
+        # writable, and that is a decision rather than an oversight: no path in
+        # the codebase updates any of them on an existing row today (checked
+        # against every `UPDATE facts` in this file). If one is ever added --
+        # re-pointing a fact at a different source is the plausible one -- this
+        # list must be revisited, because "which source's claim was rejected" is
+        # part of the same audit story the content freeze exists to protect.
+        #
+        # On placement: unlike the index above, this does NOT have to live here.
+        # SQLite resolves a trigger's column references when it fires rather
+        # than when it is created, so naming term_token in schema.sql would
+        # create cleanly and still work -- init_schema() runs the ALTER that adds
+        # the column immediately after executescript(), in the same call, so the
+        # column always exists before any UPDATE can reach the trigger. It is
+        # here so that dependency is local and visible: the trigger sits below
+        # the ALTER it needs instead of relying on a caller's ordering that a
+        # later refactor could silently change.
         #
         # `IS NOT` rather than `<>` throughout: term_token is nullable, and
         # NULL <> 'x' is NULL, which a WHEN clause reads as false -- so a

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -28,6 +28,20 @@ ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
 
 
+class TerminalFactError(ValueError):
+    """A write was refused because the fact has reached a terminal status.
+
+    The invariant itself lives in the schema (the `facts_superseded_*` triggers),
+    which is what makes it unroutable-around. This exception is the *diagnosis*
+    layered over it: a caller that trips the trigger would otherwise get a bare
+    `sqlite3.IntegrityError` naming a trigger, which says what stopped the write
+    but not what the caller should do instead.
+
+    Subclasses ValueError so the web layer's existing "bad request" handling
+    treats it as the caller error it is, rather than a 500.
+    """
+
+
 @dataclass(frozen=True)
 class FactDecision:
     """The outcome of a review decision: the fact's row, and whether it moved.
@@ -1927,6 +1941,11 @@ class Store:
         target or an exact replay writes nothing, logs nothing, and returns
         `changed=False` so callers do not run follow-on effects for a request
         that made no decision.
+
+        Raises `TerminalFactError` when the target is `superseded` (#311): a
+        reject is a judgment about a specific claim, so the claim it names is
+        frozen with it. The schema enforces this too; the check here exists to
+        name the refusal rather than surface a trigger's IntegrityError.
         """
         with self._lock:
             from verinote.store.duckdb_fact_terms import fact_term_token
@@ -1958,6 +1977,22 @@ class Store:
                 and before["note"] == note
             ):
                 return FactDecision.unchanged(before)
+            # After the replay check, not before, so this layer refuses exactly
+            # the calls the trigger refuses: an amend asking for content already
+            # stored writes nothing, and the trigger (which compares old and new
+            # values) lets it pass too. Guarding earlier would turn a harmless
+            # replay into an error on this path only, and the two layers would
+            # disagree about what "amending a superseded fact" even means.
+            #
+            # Note this sits below the sidecar-corruption guard above as well, so
+            # a corrupt sidecar is still reported as corruption rather than being
+            # masked by a terminal-status refusal.
+            if before["status"] == "superseded":
+                raise TerminalFactError(
+                    f"fact {fact_id} is superseded: a rejected fact's content "
+                    "cannot be amended. Add the correction as a new fact so the "
+                    "rejection keeps naming what was actually rejected."
+                )
             self._conn.execute("BEGIN")
             try:
                 self._conn.execute(
@@ -2269,6 +2304,41 @@ class Store:
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_facts_source_term_token "
             "ON facts(source_id, term_token)"
+        )
+        # #311: superseded is terminal on the content axis too, and for the same
+        # reason it is terminal on the status axis. A reject is a judgment about
+        # a *specific claim*; rewriting the body afterwards leaves the audit
+        # log's "rejected" event pointing at text nobody ever rejected. The UI
+        # has always said as much -- a superseded row renders "rejected -- no
+        # further action" and offers no edit control -- so this closes the same
+        # door behind the route, which until now only the template guarded.
+        #
+        # Deliberately scoped to the amend axis rather than freezing the row:
+        # `stale` and `updated_at` must stay writable, because
+        # add_fact_evidence() clears stale=1 on every re-observation without
+        # regard to status (#329) and that path is load-bearing.
+        #
+        # Here rather than in schema.sql for the same reason as the index above:
+        # this body names term_token, and SQLite resolves a trigger's columns
+        # when it fires, not when it is created -- so on a legacy DB defining it
+        # there would create cleanly and then fail every subsequent UPDATE with
+        # a bare "no such column: NEW.term_token". By this point it exists.
+        #
+        # `IS NOT` rather than `<>` throughout: term_token is nullable, and
+        # NULL <> 'x' is NULL, which a WHEN clause reads as false -- so a
+        # comparison-based guard would wave through exactly the legacy rows
+        # (token still unbackfilled) it most needs to catch.
+        self._conn.execute(
+            "CREATE TRIGGER IF NOT EXISTS facts_superseded_content_is_frozen "
+            "BEFORE UPDATE OF subject, relation, object, note, term_token ON facts "
+            "FOR EACH ROW WHEN OLD.status = 'superseded' AND ("
+            "NEW.subject IS NOT OLD.subject "
+            "OR NEW.relation IS NOT OLD.relation "
+            "OR NEW.object IS NOT OLD.object "
+            "OR NEW.note IS NOT OLD.note "
+            "OR NEW.term_token IS NOT OLD.term_token) "
+            "BEGIN SELECT RAISE(ABORT, 'superseded is terminal: a rejected "
+            "fact''s content cannot be amended'); END"
         )
         self._conn.executescript(
             """

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -151,10 +151,12 @@ BEGIN
     );
 END;
 -- The companion trigger freezing a superseded fact's *content* (#311) is created
--- in Store._ensure_schema_migrations for the same reason as the index above: its
--- body names term_token, and SQLite resolves a trigger's columns when it fires
--- rather than when it is created, so defining it here would succeed on a legacy
--- DB and then break every later UPDATE with a bare "no such column".
+-- in Store._ensure_schema_migrations, next to the ALTER that adds the term_token
+-- column its body names. That placement is for locality, not necessity: unlike an
+-- index, a trigger resolves its column references when it fires rather than when
+-- it is created, so defining it here would work too (init_schema runs that ALTER
+-- immediately after this script, in the same call). Keeping it beside the ALTER
+-- means the dependency is visible instead of resting on that call ordering.
 
 -- Source-backed evidence anchors for extracted facts. Chunk-level anchors are
 -- available for every chunked extraction; exact spans/table cells can be added

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -120,6 +120,42 @@ CREATE INDEX IF NOT EXISTS idx_facts_triple ON facts(subject, relation, object);
 -- not here: on a legacy DB this script runs before term_token is added, so an
 -- index over that column here would fail on the very DBs that most need it.
 
+-- #310: the lifecycle comment above is documentation; this trigger is the
+-- invariant. Every guard before it read a *syntactic* property of the source --
+-- "is the method name on the allowlist", "does this function body contain SQL
+-- of this shape" -- and each was walked past in turn, first by adding a name,
+-- then by reordering a SET clause. A BEFORE UPDATE trigger asks the only
+-- question that matters, at the only place it cannot be routed around: is this
+-- write leaving 'superseded'. However the SQL is spelled and wherever it lives,
+-- including a helper no source scan would think to read, it aborts.
+--
+-- Note what this does NOT do: it says nothing about tier membership. The
+-- resolution path #287 depends on -- reject a rival, it supersedes, the
+-- survivor auto-promotes on the next cascade -- works precisely because
+-- 'superseded' sits outside both ENGINE_STATUSES and REVIEW_STATUSES, and
+-- terminality is a separate axis from tiering. Reclassifying superseded into
+-- either tier would starve auto-accept; this trigger does not, and must not, be
+-- read as licence to. Pinned by
+-- tests/test_acceptance.py::test_rejecting_one_rival_unblocks_auto_accept_of_the_other.
+--
+-- The write into superseded stays open (reject_fact does exactly that), as does
+-- a same-status rewrite; only the way back out is closed.
+CREATE TRIGGER IF NOT EXISTS facts_superseded_status_is_terminal
+BEFORE UPDATE OF status ON facts
+FOR EACH ROW
+WHEN OLD.status = 'superseded' AND NEW.status <> 'superseded'
+BEGIN
+    SELECT RAISE(
+        ABORT,
+        'superseded is terminal: a rejected fact cannot be moved to another status'
+    );
+END;
+-- The companion trigger freezing a superseded fact's *content* (#311) is created
+-- in Store._ensure_schema_migrations for the same reason as the index above: its
+-- body names term_token, and SQLite resolves a trigger's columns when it fires
+-- rather than when it is created, so defining it here would succeed on a legacy
+-- DB and then break every later UPDATE with a bare "no such column".
+
 -- Source-backed evidence anchors for extracted facts. Chunk-level anchors are
 -- available for every chunked extraction; exact spans/table cells can be added
 -- later without changing the fact contract.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -89,6 +89,7 @@ from verinote.store import (
     REVIEW_PAGE_SIZES,
     ReviewQueuePage,
     Store,
+    TerminalFactError,
     review_statuses,
 )
 # Imported as a module, not `from ... import ENGINE_STATUSES`: the tier must be
@@ -1194,10 +1195,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):
+        fact = _active_store().get_fact(fact_id)
+        # #311: a superseded fact's content is frozen, so do not hand back a form
+        # that invites an edit the store will refuse. The row template already
+        # hides the edit control for these, so reaching here means a page that
+        # went stale (the fact was rejected while it was open) or a direct GET;
+        # re-rendering the read-only row answers both -- it swaps the stale
+        # controls for the current "rejected -- no further action" state.
+        if fact is not None and fact["status"] == "superseded":
+            return _row(request, fact)
         return templates.TemplateResponse(
             request,
             "partials/fact_edit.html",
-            _fact_edit_context(_active_store().get_fact(fact_id)),
+            _fact_edit_context(fact),
         )
 
     @app.get("/facts/{fact_id}/row", response_class=HTMLResponse)
@@ -1228,13 +1238,23 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 _fact_edit_context(_active_store().get_fact(fact_id), error=str(e)),
                 status_code=400,
             )
-        amended = _active_store().amend_fact(
-            fact_id,
-            subject=subject_value,
-            relation=relation_value,
-            obj=object_value,
-            note=note,
-        )
+        try:
+            amended = _active_store().amend_fact(
+                fact_id,
+                subject=subject_value,
+                relation=relation_value,
+                obj=object_value,
+                note=note,
+            )
+        except TerminalFactError:
+            # #311: the fact was rejected, so its content is frozen. Reachable
+            # from a form that was already open when someone else rejected it.
+            # Re-render the read-only row at 200 rather than an error at 4xx:
+            # htmx's default responseHandling does not swap 4xx, so an error
+            # status would leave the stale edit form on screen still offering a
+            # save that cannot succeed. The row it swaps in says "rejected -- no
+            # further action", which is both the state and the explanation.
+            return _row(request, _active_store().get_fact(fact_id))
         # The rule may act on the amended fact itself, unlike a toggle demotion.
         # An amend decides the fact's content, not its tier: correcting a term so
         # it finally matches a second source's wording *is* corroboration

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -207,7 +207,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         Read routes (`/review`, `/provenance`, `GET /facts/{id}/edit`, `/report`'s
         trace) let `DuckDBFactTermStoreError` propagate here rather than degrading
-        a structural fact to a silent `kind="string"`. What reaching this handler
+        a structural fact to a silent `kind="string"`. One narrow exception since
+        #311: `GET /facts/{id}/edit` on a *superseded* fact returns the read-only
+        row without building the edit context, so it does not read that fact's
+        terms — the row render can still raise for its own reasons, but the edit
+        form's read is skipped. What reaching this handler
         means on a POST is route-dependent: `amend_fact` refuses in the store
         *before* it commits, so nothing was written; but `accept`/`reject`/`toggle`
         do a bare SQLite status UPDATE that autocommits immediately and only reach
@@ -1254,6 +1258,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # status would leave the stale edit form on screen still offering a
             # save that cannot succeed. The row it swaps in says "rejected -- no
             # further action", which is both the state and the explanation.
+            #
+            # By the same reasoning the validation-error path above, which
+            # re-renders the edit form at 400, does not swap either and so shows
+            # the user nothing. That predates this change and is left alone here
+            # rather than fixed in passing, but it is the same bug.
             return _row(request, _active_store().get_fact(fact_id))
         # The rule may act on the amended fact itself, unlike a toggle demotion.
         # An amend decides the fact's content, not its tier: correcting a term so


### PR DESCRIPTION
Every guard on this invariant so far read a **syntactic property of the source** — an allowlist of method names, then a regex over each method body — and each was walked past in turn, first by adding a name, then by reordering a SET clause. #309 records the hole neither technique can close, because it is the shape of the technique rather than a bug in it: a write factored into a private helper is invisible to a scan that reads one public method at a time.

Two `BEFORE UPDATE` triggers move the question to the write boundary, where how the SQL is spelled and where it lives stop mattering:

- `facts_superseded_status_is_terminal` (#310) — a superseded fact cannot move to another status. The way *into* superseded stays open (`reject_fact` is unaffected) and a same-status rewrite is not a transition.
- `facts_superseded_content_is_frozen` (#311) — a superseded fact's `subject`/`relation`/`object`/`note`/`term_token` cannot be rewritten.

### #311 was a policy question — the decision and its reason

A reject is a judgment about a **specific claim**, so the claim is frozen with the judgment. Otherwise the audit log's "rejected" ends up naming text nobody rejected. This is also what the UI has always told people: a superseded row renders "rejected — no further action" and offers no edit control. The store now agrees with the promise the template was making alone. A correction to a rejected fact goes in as a new fact and takes its own trip through review.

### The hard dependency flagged on both issues is intact

@justinjoy recorded on #310 and #311 that the #287 reject-to-unblock resolution path depends on `superseded ∉ (review_statuses ∪ engine_statuses)`, pinned by `tests/test_acceptance.py::test_rejecting_one_rival_unblocks_auto_accept_of_the_other`.

**Terminality is a different axis from tiering, and this change does not touch tiering.** `tiers.py` is untouched and both tier constants are unchanged; superseded still sits outside both, so rejecting a rival still supersedes it and the survivor still auto-promotes. Review confirmed the pin passes and is non-vacuous, and that a mutant removing the `OLD.status` test kills 66 tests including that pin. `test_superseded_belongs_to_neither_status_tier` now states the constraint in the file most likely to tempt a change.

### Scope of the freeze

`stale` and `updated_at` stay writable: `note_fact_reobserved()` clears `stale=1` on every re-observation regardless of status (#329) and that path is load-bearing. `confidence`/`source_id`/`run_id`/`job_id` are also left writable — no path updates them on an existing row today, and the comment records the condition for revisiting that.

### Review follow-ups included here

Two guards were assertions in prose rather than in tests, both now fixed:

- **`IS NOT` vs `<>`** — substituting `<>` left the suite green. It should not have: `NULL <> 'x'` is NULL, which a `WHEN` clause reads as false, so a comparison-based guard waves through exactly the legacy rows whose token was never backfilled. Every existing content test used a fact from `add_fact` (non-NULL token), so `<>` fired on all of them. `test_a_null_term_token_is_frozen_in_both_directions` now kills that mutant.
- **The placement rationale was wrong**, in three places. It claimed a trigger naming `term_token` could not live in `schema.sql`. The resolution timing is right (a trigger resolves columns at fire time) but the conclusion does not follow: `init_schema()` runs the ALTER immediately after `executescript()`, in the same call. Moving the trigger to `schema.sql` leaves the suite green — the test said to be pinning this was pinning nothing. The comments now say what is true: placement is for locality.

### Compatibility

`init_schema()` runs on every open, so existing on-disk KBs pick up both triggers on next open. One existing fixture changed: `test_reconcile_fact_never_resurrects_a_legacy_superseded_row` nulled a `term_token` *after* rejecting. No production path does that (`backfill_fact_terms` writes DuckDB, not `facts.term_token`), and a legacy row has a NULL token from creation, so the fixture now builds the state in the order it actually occurs.

`1532 passed, 7 skipped`. `ruff check` clean.

Closes #310
Closes #311