### PR TITLE
refactor(#324): give the answer qid format one definition all four readers share

### DIFF
--- a/tests/test_answer_qid_contract.py
+++ b/tests/test_answer_qid_contract.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: MPL-2.0
+"""One definition of the `answer_q*` qid format, shared by every reader.
+
+The engine collectors take any `answer_q<something>` relation, because a policy
+and a query file are both user-authored and nothing gates them. When a reader
+downstream re-decided that format for itself, the two definitions drifted: the
+report's Traceability section matched `answer_q[0-9]+` and so dropped answers
+the "Query answers" line above it had just printed, and Ask's prefix strip
+matched `^q\\d+:` and so left `qfoo: ` in front of a user's answer.
+
+Each guard here pins a *result* on both sides of one of those seams, so a reader
+that goes back to deciding the format locally fails rather than diverges quietly.
+"""
+
+import pytest
+
+from verinote.engine.wirelog import (
+    answer_line,
+    answer_qid,
+    strip_answer_line_prefix,
+    validate_query,
+)
+from verinote.pipeline.ask import _render_engine_answer_body
+from verinote.pipeline.query import query_path
+from verinote.pipeline.report_trace import report_trace
+from verinote.pipeline.verify import verify
+from verinote.store import Store
+
+
+def _store_with_born_in(tmp_path, query_dl: str) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    source_id = store.add_source("sources/ada.txt")
+    store.add_fact(
+        "Ada", "born_in", "London", status="confirmed", source_id=source_id
+    )
+    query_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    query_path(tmp_path).write_text(query_dl, encoding="utf-8")
+    return store
+
+
+def _answer_rule(qid: str) -> str:
+    return (
+        f".decl answer_q{qid}(value: symbol)\n"
+        f'answer_q{qid}(O) :- relation("Ada", "born_in", O).\n'
+    )
+
+
+# --- the helper's own contract -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("predicate", "expected"),
+    [
+        ("answer_q1", "1"),
+        ("answer_q0", "0"),
+        # Non-numeric qids are the whole point: the collectors have always
+        # accepted them, so the shared reader has to hand them back, not filter.
+        ("answer_qfoo", "foo"),
+        # Starts numeric, is not a number — the shape that an unanchored
+        # `[0-9]+` match would still call numeric.
+        ("answer_q12abc", "12abc"),
+        # A bare `answer_q` relation has an empty qid, and an empty qid is still
+        # a qid. Callers must test `is None`, never truthiness.
+        ("answer_q", ""),
+        # The prefix test is `startswith`, exactly as both collectors have always
+        # done it. Narrowing it here would silently drop a relation the engine
+        # still counts as an answer and still prints.
+        ("answer_query", "uery"),
+        # Not answers at all.
+        ("answer_x", None),
+        ("answer", None),
+        ("error_q1", None),
+        ("warn_q1", None),
+        ("relation", None),
+        # The prefix is a prefix, not a substring.
+        ("my_answer_q1", None),
+    ],
+)
+def test_answer_qid_reads_the_qid_out_of_a_predicate_name(predicate, expected):
+    assert answer_qid(predicate) == expected
+
+
+@pytest.mark.parametrize("qid", ["0", "7", "foo", "12abc", ""])
+def test_stripping_the_answer_prefix_undoes_rendering_it(qid):
+    """The strip is the formatter's inverse, which is why it takes the qid."""
+    assert strip_answer_line_prefix(answer_line(qid, ["London"]), qid) == "London"
+
+
+def test_answer_line_joins_a_bucket_the_way_report_reads_it():
+    assert answer_line("3", ["London", "Paris"]) == "q3: London, Paris"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Another question's prefix is not this question's to remove.
+        "q3: London",
+        # A value may legitimately open with something prefix-shaped; a pattern
+        # loose enough to cover non-numeric qids would eat both of these.
+        "qty: 5",
+        "queue: London",
+        "London",
+        # A prefix is only a prefix at the front of the line.
+        "born in q0: London",
+    ],
+)
+def test_stripping_leaves_a_line_that_is_not_this_qids_answer_alone(line):
+    assert strip_answer_line_prefix(line, 0) == line
+
+
+def test_stripping_removes_only_the_one_prefix_it_added():
+    assert strip_answer_line_prefix("q0: q0: London", 0) == "q0: London"
+
+
+# --- the query contract stayed strict ------------------------------------
+#
+# Sharing the prefix constant with the collectors must not loosen the snippet
+# contract: an LLM-authored query still has to declare a numbered question.
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "answer_qfoo",  # not numeric at all
+        "answer_q12abc",  # starts numeric, is not a number
+        "answer_q",  # no qid
+        "answer_q1x",  # one stray character past the digits
+    ],
+)
+def test_validate_query_still_requires_a_numbered_answer_predicate(name):
+    pytest.importorskip("duckdb")
+    ok, reason = validate_query(
+        f".decl {name}(value: symbol)\n"
+        f'{name}(O) :- relation("Ada", "born_in", O).'
+    )
+
+    assert ok is False
+    assert "answer" in reason
+
+
+def test_validate_query_accepts_a_numbered_answer_predicate():
+    pytest.importorskip("duckdb")
+    ok, reason = validate_query(_answer_rule("1"))
+
+    assert (ok, reason) == (True, "")
+
+
+# --- /report: the answer line and the trace below it agree ---------------
+
+
+def test_report_traces_a_non_numeric_qid_the_answer_line_shows(tmp_path):
+    """A qid the engine answered must not vanish from Traceability.
+
+    A query file is user-authored, so `answer_qfoo` reaches the engine and gets
+    printed under "Query answers". While the trace matched `answer_q[0-9]+` it
+    skipped that rule, and /report showed an answer with no facts behind it.
+    """
+    pytest.importorskip("duckdb")
+    store = _store_with_born_in(tmp_path, _answer_rule("foo"))
+
+    rep = verify(store)
+    trace = report_trace(store)
+
+    assert rep.answers == ["qfoo: London"]
+    assert [(a.qid, a.value) for a in trace.answers] == [("foo", "London")]
+    assert [fact.subject for fact in trace.answers[0].facts] == ["Ada"]
+
+
+def test_report_orders_traced_answers_the_way_the_answer_line_orders_them(tmp_path):
+    """Both sides sort on the same key, so both list the questions alike.
+
+    q2/q10 catch a string sort; `foo` catches a reader that drops or reorders
+    the non-numeric bucket instead of parking it after the numbered ones.
+    """
+    pytest.importorskip("duckdb")
+    store = _store_with_born_in(
+        tmp_path, "".join(_answer_rule(qid) for qid in ("10", "2", "foo"))
+    )
+
+    rep = verify(store)
+    trace = report_trace(store)
+
+    assert rep.answers == ["q2: London", "q10: London", "qfoo: London"]
+    assert [a.qid for a in trace.answers] == ["2", "10", "foo"]
+
+
+# --- Ask: the report prefix never reaches the user -----------------------
+
+
+def test_ask_strips_the_report_prefix_from_a_bare_engine_answer():
+    """`q<id>: ` is a /report artifact; Ask shows the answer, not the artifact.
+
+    This is the fallback rendering, used when the source trace came back empty.
+    """
+    assert _render_engine_answer_body(("q0: London",), ()) == "London"
+
+
+def test_ask_keeps_a_value_that_merely_looks_prefixed():
+    """Ask asks q0 and only q0, so nothing else on the line is a prefix.
+
+    A pattern wide enough to also strip a non-numeric qid would take `qty: ` off
+    the front of a real answer; keying on the known qid cannot.
+    """
+    assert _render_engine_answer_body(("q0: qty: 5",), ()) == "qty: 5"
+    assert _render_engine_answer_body(("qty: 5",), ()) == "qty: 5"

--- a/tests/test_report_trace.py
+++ b/tests/test_report_trace.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 from verinote.engine.terms import Atom, Compound, StringLit
+from verinote.engine.wirelog import answer_bucket_sort_key
 from verinote.pipeline.query import query_path
-from verinote.pipeline.report_trace import AnswerTrace, _qid_sort_key, report_trace
+from verinote.pipeline.report_trace import AnswerTrace, report_trace
 from verinote.pipeline.verify import verify
 from verinote.store import Store, db as store_db
 
@@ -365,15 +366,15 @@ def test_report_trace_dedupes_render_alike_heads_by_engine_identity(tmp_path):
 def test_report_trace_sorts_an_overlong_qid_last_without_crashing():
     """A user-authored `answer_q<thousands of digits>` rule must not 500 /report.
 
-    `trace.qid` is the `[0-9]+` capture of `_ANSWER_RE`, so a policy can make it
-    longer than `int()` accepts (`sys.get_int_max_str_digits()`, 4300 by default).
-    The answer sort has to survive that, parking the answer after the numbered
-    ones the way the query-answer line's `answer_bucket_sort_key` already does.
+    `trace.qid` is whatever follows `answer_q`, so a policy can make it longer
+    than `int()` accepts (`sys.get_int_max_str_digits()`, 4300 by default). The
+    answer sort has to survive that, parking the answer after the numbered ones
+    the way the query-answer line does — it is the same key on both sides.
     """
     overlong = "1" * 5000
 
     # The guard itself: no raise, and a trailing bucket that outranks any number.
-    assert _qid_sort_key(overlong) > _qid_sort_key("999999")
+    assert answer_bucket_sort_key(overlong) > answer_bucket_sort_key("999999")
 
     def _trace(qid: str, value: str) -> AnswerTrace:
         return AnswerTrace(
@@ -381,6 +382,6 @@ def test_report_trace_sorts_an_overlong_qid_last_without_crashing():
         )
 
     traces = [_trace(overlong, "z"), _trace("10", "b"), _trace("2", "a")]
-    ordered = sorted(traces, key=lambda t: (*_qid_sort_key(t.qid), t.value))
+    ordered = sorted(traces, key=lambda t: (*answer_bucket_sort_key(t.qid), t.value))
 
     assert [t.qid for t in ordered] == ["2", "10", overlong]

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -42,12 +42,13 @@ from verinote.engine.wirelog import (
     NO_FINDINGS_TEXT,
     FindingRow,
     answer_bucket_sort_key,
+    answer_line,
+    answer_qid,
     dead_rule_warnings,
 )
 
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
-_ANSWER_PREFIX = "answer_q"
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 _ZERO_ARITY_COLUMN = "__present"
 _RELATION_COLUMNS = ("subject", "rel", "object")
@@ -422,7 +423,7 @@ def _collect_report(
         if not (
             name.startswith(_ERROR_PREFIX)
             or name.startswith(_WARN_PREFIX)
-            or name.startswith(_ANSWER_PREFIX)
+            or answer_qid(name) is not None
         ):
             continue
         rows = con.execute(
@@ -452,15 +453,14 @@ def _collect_report(
                     name,
                     columns,
                 )
-        elif name.startswith(_ANSWER_PREFIX):
+        elif (qid := answer_qid(name)) is not None:
             if rows:
-                qid = name[len(_ANSWER_PREFIX) :]
                 answers_by_q.setdefault(qid, []).extend(
                     _render_answer_row(row) for row in rows
                 )
 
     answers = [
-        f"q{qid}: {', '.join(sorted(vals))}"
+        answer_line(qid, sorted(vals))
         for qid, vals in sorted(
             answers_by_q.items(), key=lambda item: answer_bucket_sort_key(item[0])
         )

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -39,13 +39,31 @@ from verinote.engine.terms import StringLit, escape_string_value
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
 _ANSWER_PREFIX = "answer_q"
+# The qid format has one definition, and it lives here. `_ANSWER_DECL` holds an
+# LLM-authored query snippet to numeric qids, but a *policy* is user-authored and
+# ungated, so an `answer_q<anything>` relation really does reach the collectors —
+# every reader below it (bucket ordering, /report traceability, Ask's prefix
+# strip) has to agree on what that name means instead of re-deciding locally.
+_NUMERIC_QID_PATTERN = r"[0-9]+"
 # A qid is the question's INTEGER primary key rendered as text, so it has to sort
 # by number: plain string order puts q10 ahead of q2. `[0-9]+` matches what
 # `_ANSWER_DECL` accepts — `str.isdigit()` would let through digits like "²" that
-# `int()` then rejects. A policy is user-authored, so a non-numeric
-# `answer_q*` relation does reach here; park those after the numbered ones
-# instead of raising.
-_NUMERIC_QID = re.compile(r"[0-9]+\Z")
+# `int()` then rejects.
+_NUMERIC_QID = re.compile(_NUMERIC_QID_PATTERN + r"\Z")
+
+
+def answer_qid(predicate: str) -> str | None:
+    """The question id an `answer_q*` relation answers, or None if it is not one.
+
+    Tolerant on purpose: whatever follows the prefix is the qid, non-numeric
+    included. That is what the engine collectors have always accepted, so a
+    reader that narrowed it locally would just drop those answers on the floor.
+    An empty qid (a bare `answer_q` relation) is a qid too — `is None` is the
+    only correct way to test this result.
+    """
+    if not predicate.startswith(_ANSWER_PREFIX):
+        return None
+    return predicate[len(_ANSWER_PREFIX) :]
 
 
 def answer_bucket_sort_key(qid: str) -> tuple[int, int, str]:
@@ -60,6 +78,22 @@ def answer_bucket_sort_key(qid: str) -> tuple[int, int, str]:
         except ValueError:
             pass
     return (1, 0, qid)
+
+
+def answer_line(qid: str, values: Iterable[str]) -> str:
+    """Render one answer bucket as the `q<id>: v, v` line /report shows."""
+    return f"q{qid}: " + ", ".join(values)
+
+
+def strip_answer_line_prefix(line: str, qid: str | int) -> str:
+    """Drop the `q<id>: ` prefix `answer_line` added, for a reader that has none.
+
+    Takes the qid rather than pattern-matching the line because the prefix is
+    only a prefix when it is *this* question's: an answer value of its own may
+    start `q3: `, and guessing would eat it.
+    """
+    prefix = answer_line(str(qid), ())
+    return line[len(prefix) :] if line.startswith(prefix) else line
 
 # Shipped default policy. `verinote init` scaffolds a copy to
 # `<root>/policy/logic-policy.dl`; edit that copy per-KB.
@@ -358,7 +392,7 @@ def _degraded_report(dl_text: str, warnings: list[str] | None = None) -> CheckRe
 
 
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
-_ANSWER_DECL = re.compile(r"answer_q[0-9]+\Z")
+_ANSWER_DECL = re.compile(re.escape(_ANSWER_PREFIX) + _NUMERIC_QID_PATTERN + r"\Z")
 
 
 def validate_query(query_dl: str) -> tuple[bool, str]:
@@ -538,14 +572,13 @@ def run_check(
                     columns_by_rule.get(name, ()),
                 )
             )
-        elif name.startswith(_ANSWER_PREFIX):
-            qid = name[len(_ANSWER_PREFIX) :]
+        elif (qid := answer_qid(name)) is not None:
             answers_by_q.setdefault(qid, []).append(_render_row(row))
 
     errors.sort()
     warnings.sort()
     answers = [
-        f"q{qid}: {', '.join(sorted(vals))}"
+        answer_line(qid, sorted(vals))
         for qid, vals in sorted(
             answers_by_q.items(), key=lambda item: answer_bucket_sort_key(item[0])
         )

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -10,6 +10,7 @@ import unicodedata
 
 from verinote.engine import CheckReport
 from verinote.engine.duckdb_backend import run_check_duckdb
+from verinote.engine.wirelog import strip_answer_line_prefix
 from verinote.llm.base import LLMClient, LLMError
 from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
 from verinote.pipeline.engine_input import engine_relation_rows
@@ -24,10 +25,6 @@ MAX_CONTEXT_CHARS = 12000
 MAX_EXCERPTS = 8
 MAX_GROUNDING_FACTS = 8
 _TOKEN = re.compile(r"[A-Za-z0-9_]{2,}|[가-힣一-龥ぁ-んァ-ン]{1,}")
-# The engine formats each answer as ``q<id>: value`` for the /report view. That
-# report prefix is never part of the answer itself, so strip it when it leaks
-# into an Ask answer body.
-_ANSWER_QID_PREFIX = re.compile(r"^q\d+:\s*")
 
 
 @dataclass(frozen=True)
@@ -243,7 +240,11 @@ def _render_engine_answer_body(
             lines.append(f"{subject}, {relation}, {obj}")
             lines.extend(f"    ← {source}" for source in sources)
         return "\n".join(lines)
-    return "\n".join(_ANSWER_QID_PREFIX.sub("", line) for line in answers)
+    # Ask asks exactly one question, `ASK_QID`, and `classify_query_draft`
+    # refuses a draft that answers any other one — so the prefix the engine put
+    # on these lines is this qid's, and undoing it by name beats re-guessing it
+    # with a pattern that would also eat an answer of the shape `q3: ...`.
+    return "\n".join(strip_answer_line_prefix(line, ASK_QID) for line in answers)
 
 
 def _fallback_answer(

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
 
 from verinote.engine.datalog import (
     AtomExpr,
@@ -22,6 +21,7 @@ from verinote.engine.terms import (
     term_compare_key,
     terms_equal,
 )
+from verinote.engine.wirelog import answer_bucket_sort_key, answer_qid
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.engine_input import engine_relation_rows
 from verinote.pipeline.query import load_query
@@ -29,7 +29,6 @@ from verinote.pipeline.trust import fact_trust_summary
 from verinote.store import Store, review_statuses
 
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
-_ANSWER_RE = re.compile(r"answer_q(?P<qid>[0-9]+)\Z")
 
 
 @dataclass(frozen=True)
@@ -121,7 +120,7 @@ def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
     traces = []
     seen: set[tuple[str, str, tuple[int, ...]]] = set()
     for rule in program.rules:
-        qid = _answer_qid(rule.head.predicate)
+        qid = answer_qid(rule.head.predicate)
         if qid is None:
             continue
         relation_atom = _direct_relation_atom(rule.body)
@@ -147,25 +146,14 @@ def trace_query_answers(store: Store, query: str) -> tuple[AnswerTrace, ...]:
                     conflicted=any(fact.conflicted for fact in trace_facts),
                 )
             )
+    # Same key the engine orders its "Query answers" line by, so the
+    # Traceability section below it lists the questions in the same order.
     return tuple(
-        sorted(traces, key=lambda trace: (*_qid_sort_key(trace.qid), trace.value))
+        sorted(
+            traces,
+            key=lambda trace: (*answer_bucket_sort_key(trace.qid), trace.value),
+        )
     )
-
-
-def _answer_qid(predicate: str) -> str | None:
-    match = _ANSWER_RE.fullmatch(predicate)
-    return match.group("qid") if match else None
-
-
-def _qid_sort_key(qid: str) -> tuple[int, int]:
-    # `_ANSWER_RE` guarantees all-digits but not that `int()` accepts them: past
-    # `sys.get_int_max_str_digits()` (4300 by default) it raises ValueError. Mirror
-    # `answer_bucket_sort_key`: park a pathologically long qid in a trailing bucket
-    # so it sorts after every parseable one instead of 500ing /report mid-sort.
-    try:
-        return (0, int(qid))
-    except ValueError:
-        return (1, 0)
 
 
 def _direct_relation_atom(body: tuple[AtomExpr | Comparison, ...]) -> AtomExpr | None:


### PR DESCRIPTION
The `answer_q*` qid format had drifted into four hand-maintained copies. This takes the issue's recommended direction (c): one helper in `verinote/engine/wirelog.py`, all readers reference it.

- `answer_qid()` — the tolerant `startswith` rule both collectors always used
- `answer_line()` — the `"q<id>: v, v"` rendering
- `strip_answer_line_prefix()` — its inverse, keyed on the qid

`_ANSWER_DECL` is rebuilt from the same prefix constant plus the numeric pattern, so the strict LLM-snippet contract no longer keeps a second copy of the string. `report_trace.py`'s `_ANSWER_RE` and duplicated `_qid_sort_key` are deleted, as is `ask.py`'s `^q\d+:\s*` regex.

### User-visible change

`/report` Traceability now lists a non-numeric qid's answer with its backing facts. Before, the "Query answers" line printed `qfoo: London` and the Traceability section below it silently showed nothing.

### Honest scope note — only one of the issue's three symptoms was live

Worth recording for anyone reading the issue later:

- **Symptom 1** (sort key) was already fixed by #317.
- **Symptom 3** (Ask leaking a `qfoo: ` prefix) is **not reachable in production**: `_foreign_answer_predicate` (`verinote/pipeline/query.py:112`) rejects any draft whose answer predicate is not exactly `answer_q{qid}`, and Ask always passes `ASK_QID=0`, so only `"q0: "` ever reaches `_render_engine_answer_body`. The drift was real but latent there.
- **Symptom 2** (`/report` traceability) is the only one a user could actually hit, and it is fixed.

`Closes` is used because that user-visible symptom is fixed and the shared-helper refactor the issue asked for is complete.

### Behaviour deliberately preserved

The collectors' existing tolerance is locked exactly as it was, including `answer_query` parsing as qid `"uery"` and a bare `answer_q` as qid `""`. Narrowing either would have been the issue's option (b), which it explicitly calls risky, so this pins current behaviour in tests rather than quietly altering it. `answer_qid` returns `""` for a bare `answer_q`, which is falsy, so callers must test `is None` — documented in the docstring and pinned by a test.

The LLM query-snippet contract (`answer_q[0-9]+`) is unchanged.

`1535 passed, 7 skipped` (baseline 1502 + 33 new cases). `ruff check` clean. 11 mutants run, 10 killed; the survivor is a provably equivalent mutant (`\Z` under `fullmatch`), kept for a future switch to `.match` and noted in the test comment.

Closes #324