### PR TITLE
fix(#325): reject wrong-typed config.json values where they are read, not where they are used

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
+import json
 import sys
 
 import pytest
@@ -452,3 +453,327 @@ def test_config_corrupt_error_is_not_an_llm_error():
     # the dedicated halt handler.
     assert not issubclass(ConfigCorruptError, LLMError)
     assert not isinstance(ConfigCorruptError("x"), LLMError)
+
+
+# --- #325: a wrong-typed value in config.json is as unusable as a corrupt file ---
+
+
+def _write_settings(root, payload):
+    _write_settings_raw(root, json.dumps(payload))
+
+
+# Wrong-typed values that are nonetheless truthy and plausible in a hand-edited
+# file: the interesting cases are the ones a silent `if value:` guard would let
+# through, not `null` and `0`.
+_WRONG_FOR_STRING = [123, 0, 12.5, True, False, ["http://x"], {"url": "http://x"}]
+_WRONG_FOR_INT = ["450", "", 4.5, True, False, [450], {"n": 450}]
+_WRONG_FOR_BOOL = ["true", "false", "", 1, 0, ["true"], {"on": True}]
+
+# The nullability split the policy turns on. `save_settings` writes
+# `"base_url": null` and omits the extraction settings entirely, so null is a
+# legitimate "unset" in those; it never writes a null provider or model, so one
+# there is a present-but-unusable value.
+_NULLABLE = [
+    "base_url",
+    "extraction_chunk_chars",
+    "extraction_chunk_overlap_chars",
+    "extraction_max_facts_per_chunk",
+    "auto_accept_recommendations",
+]
+_NON_NULLABLE = ["provider", "model"]
+# Settings that decide where a request goes: unusable here means halt, not
+# default. The rest only tune local extraction.
+_ROUTING = ["provider", "model", "base_url"]
+_TUNING = [
+    "extraction_chunk_chars",
+    "extraction_chunk_overlap_chars",
+    "extraction_max_facts_per_chunk",
+    "auto_accept_recommendations",
+]
+
+
+def _valid_settings(**overrides):
+    payload = {"provider": "ollama", "model": "llama3.1", "base_url": "http://x"}
+    payload.update(overrides)
+    return payload
+
+
+# --- routing settings: unusable means the KB refuses to run ---
+
+
+@pytest.mark.parametrize("value", _WRONG_FOR_STRING)
+@pytest.mark.parametrize("key", _ROUTING)
+def test_wrong_typed_routing_setting_halts_instead_of_defaulting(
+    tmp_path, capsys, key, value
+):
+    # The whole point of the rework: dropping the key is what *causes* the
+    # silent fallback, so dropping cannot be the remedy. `provider` resolving to
+    # "anthropic" below is the leak this halt is the only thing standing in
+    # front of.
+    _write_settings(tmp_path, _valid_settings(**{key: value}))
+    capsys.readouterr()
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.settings_error is not None
+    assert key in cfg.settings_error
+    assert str(tmp_path / "config.json") in cfg.settings_error
+    with pytest.raises(ConfigCorruptError):
+        assert_settings_intact(cfg)
+
+
+@pytest.mark.parametrize("key", _NON_NULLABLE)
+def test_null_routing_setting_halts_because_it_is_unusable_not_unset(
+    tmp_path, capsys, key
+):
+    # `"provider": null` is present-but-unusable, not absent. Reading it as
+    # "unset" is how a null lands on the anthropic cloud default.
+    _write_settings(tmp_path, _valid_settings(**{key: None}))
+    capsys.readouterr()
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.settings_error is not None
+    assert key in cfg.settings_error
+    assert "null" in cfg.settings_error
+    with pytest.raises(ConfigCorruptError):
+        assert_settings_intact(cfg)
+
+
+@pytest.mark.parametrize("key", _ROUTING)
+def test_wrong_typed_routing_setting_never_reaches_a_provider_client(
+    tmp_path, capsys, key
+):
+    # The halt asserted through its real consumer, not through the flag: a
+    # config that should refuse must not hand back a working cloud client.
+    from verinote.llm.factory import get_client
+
+    _write_settings(tmp_path, _valid_settings(**{key: 123}))
+    capsys.readouterr()
+
+    with pytest.raises(ConfigCorruptError):
+        get_client(Config.for_root(tmp_path))
+
+
+def test_wrong_typed_provider_would_otherwise_resolve_to_the_cloud_default(
+    tmp_path, capsys
+):
+    # Pins the danger the halt exists for. If this ever stops holding, the
+    # halt tests above could pass for the wrong reason.
+    _write_settings(tmp_path, _valid_settings(provider=123))
+    capsys.readouterr()
+
+    assert Config.for_root(tmp_path).provider == "anthropic"
+
+
+def test_env_override_does_not_excuse_an_unusable_saved_routing_setting(
+    tmp_path, monkeypatch, capsys
+):
+    # An env var that happens to shadow the bad key does not make the file
+    # usable — the same stance main already takes for a whole-file corruption.
+    _write_settings(tmp_path, _valid_settings(base_url=123))
+    monkeypatch.setenv("VERINOTE_BASE_URL", "https://llm.internal/v1")
+    capsys.readouterr()
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.base_url == "https://llm.internal/v1"
+    assert cfg.settings_error is not None
+
+
+def test_wrong_typed_base_url_does_not_reach_the_adapter(tmp_path, capsys):
+    # The issue's reproduction: a number here used to survive `read_settings`
+    # and blow up far away, in `OllamaAdapter.__init__`'s `rstrip`. The halt is
+    # the remedy; this is the containment behind it.
+    from verinote.llm.ollama_adapter import OllamaAdapter
+
+    _write_settings(tmp_path, _valid_settings(base_url=123))
+    capsys.readouterr()
+
+    cfg = Config.for_root(tmp_path)
+    assert cfg.base_url is None
+    assert OllamaAdapter(cfg).base_url == "http://localhost:11434"
+
+
+@pytest.mark.parametrize("key", _ROUTING)
+def test_unusable_routing_setting_warns_that_the_kb_is_unusable(tmp_path, capsys, key):
+    # The warning must not promise a harmless default, because there is none.
+    _write_settings(tmp_path, _valid_settings(**{key: 123}))
+
+    read_settings(tmp_path)
+
+    err = capsys.readouterr().err
+    assert key in err
+    assert "falls back to its default" not in err
+    assert "unusable" in err
+
+
+def test_only_the_first_routing_reason_is_reported_and_it_is_stable(tmp_path, capsys):
+    # Key order in the file must not change the diagnosis, or the same broken
+    # config would describe itself differently on two machines.
+    both = {"model": 1, "provider": 2, "base_url": 3}
+    _write_settings(tmp_path, both)
+    capsys.readouterr()
+    first = Config.for_root(tmp_path).settings_error
+
+    _write_settings(tmp_path, {"base_url": 3, "model": 1, "provider": 2})
+    capsys.readouterr()
+
+    assert Config.for_root(tmp_path).settings_error == first
+    assert "provider" in first
+
+
+# --- tuning settings: unusable means warn and use the default, not halt ---
+
+
+@pytest.mark.parametrize("value", _WRONG_FOR_INT)
+@pytest.mark.parametrize("key", _TUNING[:3])
+def test_wrong_typed_int_setting_warns_and_defaults_without_halting(
+    tmp_path, capsys, key, value
+):
+    # The discriminator that keeps the policy a *split* rather than "everything
+    # halts": a bad chunk size changes how much local text a step reads, not
+    # where the text goes, so it must not brick the KB.
+    _write_settings(tmp_path, _valid_settings(**{key: value}))
+
+    cfg = Config.for_root(tmp_path)
+
+    assert key not in read_settings(tmp_path)
+    assert cfg.settings_error is None
+    assert_settings_intact(cfg)  # must not raise
+    assert getattr(cfg, key) == {
+        "extraction_chunk_chars": 300,
+        "extraction_chunk_overlap_chars": 40,
+        "extraction_max_facts_per_chunk": 8,
+    }[key]
+    assert key in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("value", _WRONG_FOR_BOOL)
+def test_wrong_typed_bool_setting_warns_and_defaults_without_halting(
+    tmp_path, capsys, value
+):
+    _write_settings(tmp_path, _valid_settings(auto_accept_recommendations=value))
+
+    cfg = Config.for_root(tmp_path)
+
+    assert "auto_accept_recommendations" not in read_settings(tmp_path)
+    assert cfg.settings_error is None
+    assert cfg.auto_accept_recommendations is False
+    assert "auto_accept_recommendations" in capsys.readouterr().err
+
+
+def test_json_true_is_not_a_chunk_size_and_json_one_is_not_a_flag(tmp_path, capsys):
+    # `bool` is an `int` subclass in Python but a distinct JSON type. A plain
+    # isinstance check would let each of these through as the other.
+    _write_settings(
+        tmp_path,
+        _valid_settings(extraction_chunk_chars=True, auto_accept_recommendations=1),
+    )
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.extraction_chunk_chars == 300
+    assert cfg.auto_accept_recommendations is False
+
+
+# --- what a valid file must keep doing ---
+
+
+def test_correctly_typed_settings_survive_untouched(tmp_path, capsys):
+    payload = _valid_settings(
+        extraction_chunk_chars=450,
+        extraction_chunk_overlap_chars=0,
+        extraction_max_facts_per_chunk=6,
+        auto_accept_recommendations=True,
+    )
+    _write_settings(tmp_path, payload)
+
+    cfg = Config.for_root(tmp_path)
+
+    assert read_settings(tmp_path) == payload
+    assert cfg.settings_error is None
+    assert (cfg.provider, cfg.model, cfg.base_url) == ("ollama", "llama3.1", "http://x")
+    assert cfg.extraction_chunk_chars == 450
+    assert cfg.extraction_chunk_overlap_chars == 0
+    assert cfg.extraction_max_facts_per_chunk == 6
+    assert cfg.auto_accept_recommendations is True
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("key", _NULLABLE)
+def test_null_in_a_nullable_setting_is_unset_and_stays_silent(tmp_path, capsys, key):
+    _write_settings(tmp_path, _valid_settings(**{key: None}))
+
+    cfg = Config.for_root(tmp_path)
+
+    assert read_settings(tmp_path)[key] is None
+    assert cfg.settings_error is None
+    assert_settings_intact(cfg)  # must not raise
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("provider", sorted(PROVIDERS))
+def test_nothing_save_settings_writes_can_halt_its_own_kb(tmp_path, capsys, provider):
+    # The self-inflicted-halt guard: every shape the Settings UI can produce
+    # must read back clean, including the `"base_url": null` it writes for a KB
+    # with no custom endpoint and the extraction keys it omits entirely.
+    save_settings(tmp_path, provider=provider, model="")
+    bare = Config.for_root(tmp_path)
+
+    save_settings(
+        tmp_path,
+        provider=provider,
+        model="m",
+        base_url="http://x",
+        extraction_chunk_chars=450,
+        extraction_chunk_overlap_chars=0,
+        extraction_max_facts_per_chunk=6,
+        auto_accept_recommendations=False,
+    )
+    full = Config.for_root(tmp_path)
+
+    assert bare.settings_error is None
+    assert full.settings_error is None
+    assert_settings_intact(bare)
+    assert_settings_intact(full)
+    assert capsys.readouterr().err == ""
+
+
+def test_unknown_setting_passes_through_and_never_halts(tmp_path, capsys):
+    # A config written by a newer verinote must not be eaten or condemned by an
+    # older one that has no opinion about its keys.
+    _write_settings(tmp_path, _valid_settings(future_setting=7))
+
+    cfg = Config.for_root(tmp_path)
+
+    assert read_settings(tmp_path)["future_setting"] == 7
+    assert cfg.settings_error is None
+    assert capsys.readouterr().err == ""
+
+
+def test_one_bad_tuning_setting_does_not_discard_the_good_ones(tmp_path, capsys):
+    _write_settings(tmp_path, _valid_settings(extraction_chunk_chars="450"))
+
+    saved = read_settings(tmp_path)
+
+    assert saved["provider"] == "ollama"
+    assert saved["base_url"] == "http://x"
+    assert "extraction_chunk_chars" not in saved
+
+
+@pytest.mark.parametrize(
+    ("key", "attr", "expected"),
+    [("provider", "provider", "ollama"), ("model", "model", "llama3.1")],
+)
+def test_saved_routing_values_still_go_through_the_trim_normalisation(
+    tmp_path, monkeypatch, key, attr, expected
+):
+    # Type-checking the saved side must not become a bypass around `_pick`: a
+    # padded saved value is a valid string, so it survives the type check and
+    # must still be trimmed on the way out.
+    monkeypatch.delenv("VERINOTE_PROVIDER", raising=False)
+    monkeypatch.delenv("VERINOTE_MODEL", raising=False)
+    _write_settings(tmp_path, _valid_settings(**{key: f"  {expected}  "}))
+
+    assert getattr(Config.for_root(tmp_path), attr) == expected

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -17,6 +17,17 @@ whitespace-only) `VERINOTE_API_KEY` normalises to unset (`None`) and a used
 value is trimmed. With no saved or default source to fall back to, a blank key
 simply becomes `None` rather than falling through a chain.
 
+The saved file is also type-checked per key, since it is hand-editable JSON.
+A setting whose value has the wrong JSON type is never handed on to the code
+that expects the right one. What happens next depends on the setting: a bad
+`provider`, `model`, or `base_url` makes the whole KB refuse to run
+(`settings_error`), because ignoring it would resolve to the built-in cloud
+default the user never chose; a bad extraction setting only warns and falls back
+to its default, which is what the numeric parsers already do for an unparsable
+value. `null` means "unset" only where `save_settings` can write it —
+`base_url` and the optional extraction settings — and counts as unusable in
+`provider` and `model`.
+
 The active KB root is stored in a platform-native app config file when the web
 UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
 Support`, and Unix uses `${XDG_CONFIG_HOME:-~/.config}`. `VERINOTE_ROOT` still
@@ -129,6 +140,15 @@ def _bad_config_reason(path: Path, error: Exception | None) -> str:
     return f"{path} is not a JSON object"
 
 
+def _warn_config(reason: str, consequence: str) -> None:
+    """Emit one config warning in the single shape every config warning has.
+
+    Whole-file and per-key problems differ in how they are classified, not in
+    how they are announced, so both go through here.
+    """
+    print(f"warning: {reason}; {consequence}", file=sys.stderr)
+
+
 def _warn_bad_config(path: Path, error: Exception | None, consequence: str) -> None:
     """Warn on stderr that a config file is unreadable and is being ignored.
 
@@ -137,7 +157,7 @@ def _warn_bad_config(path: Path, error: Exception | None, consequence: str) -> N
     real corruption from the user. `error` is the raised exception, or None for
     a well-formed JSON value that simply is not an object.
     """
-    print(f"warning: {_bad_config_reason(path, error)}; {consequence}", file=sys.stderr)
+    _warn_config(_bad_config_reason(path, error), consequence)
 
 
 def read_app_config() -> dict:
@@ -224,8 +244,143 @@ def _settings_path(root: Path) -> Path:
     return root / SETTINGS_FILENAME
 
 
+# Every setting this reader knows how to type-check: the JSON type its value
+# must have, and whether `null` is a legitimate way to write "unset".
+#
+# The nullability column is not decoration. `save_settings` writes
+# `"base_url": null` itself for a KB with no custom endpoint, so null there is
+# this app's own output and must stay a silent "unset". `provider` and `model`
+# are always written as strings, so a null in either is a value that is present
+# but unusable — reading it as "unset" would let it fall through to the
+# built-in `anthropic` default, which is exactly the silent cloud fallback the
+# halt below exists to prevent.
+_SETTING_SPECS: dict[str, tuple[type, bool]] = {  # key -> (JSON type, null means unset)
+    "provider": (str, False),
+    "model": (str, False),
+    "base_url": (str, True),
+    "extraction_chunk_chars": (int, True),
+    "extraction_chunk_overlap_chars": (int, True),
+    "extraction_max_facts_per_chunk": (int, True),
+    "auto_accept_recommendations": (bool, True),
+}
+
+# The settings that decide *where* a request goes and *what* answers it. An
+# unusable value in one of these cannot be warned about and defaulted away: the
+# default is the `anthropic` cloud, so "ignore it and carry on" would ship the
+# user's notes to a provider they never chose (#269). These become a
+# `settings_error`, i.e. the same halt a corrupt file already triggers. The
+# remaining settings only tune local extraction, where falling back to the
+# built-in default is the documented and harmless answer to a bad value.
+# Ordered, so the same broken file always reports the same reason.
+_ROUTING_SETTINGS = ("provider", "model", "base_url")
+
+_EXPECTED_NAMES = {str: "a string", int: "a whole number", bool: "true or false"}
+
+
+def _json_type_name(value: object) -> str:
+    """Name the JSON type a Python value came from, for the warning text."""
+    if isinstance(value, bool):
+        return "a boolean"
+    if isinstance(value, (int, float)):
+        return "a number"
+    if isinstance(value, str):
+        return "a string"
+    if isinstance(value, list):
+        return "an array"
+    if isinstance(value, dict):
+        return "an object"
+    return "null"
+
+
+def _has_type(value: object, expected: type) -> bool:
+    """Check a value against the JSON type a setting is declared to hold.
+
+    `bool` is a subclass of `int` in Python but a distinct type in JSON, so a
+    plain `isinstance` would let `true` pass as a chunk size and `1` pass as a
+    flag. Both directions are rejected here.
+    """
+    if expected is bool:
+        return isinstance(value, bool)
+    if expected is int:
+        return isinstance(value, int) and not isinstance(value, bool)
+    return isinstance(value, expected)
+
+
+def _bad_setting_reason(path: Path, key: str, value: object) -> str | None:
+    """Why one saved setting's value is unusable, or None when it is fine.
+
+    The single per-key verdict: the stderr warning and the `settings_error`
+    halt both ask *this*, so a value can never be dropped by one and accepted by
+    the other. Unknown keys are never judged — a `config.json` written by a
+    newer verinote may hold settings this version has no opinion about, and
+    guessing about them is worse than passing them through.
+    """
+    spec = _SETTING_SPECS.get(key)
+    if spec is None:
+        return None
+    expected, null_is_unset = spec
+    if value is None:
+        if null_is_unset:
+            return None
+        return f"{path} has {key} set to null, expected {_EXPECTED_NAMES[expected]}"
+    if _has_type(value, expected):
+        return None
+    return (
+        f"{path} has {key} as {_json_type_name(value)}, "
+        f"expected {_EXPECTED_NAMES[expected]}"
+    )
+
+
+def _bad_routing_setting_reason(path: Path, data: dict) -> str | None:
+    """The first unusable provider-routing setting in an otherwise valid file.
+
+    Separate from `_checked_settings` because the two do different jobs with the
+    same verdict: that one decides what a caller *sees*, this one decides
+    whether the KB may be used at all. Only `_ROUTING_SETTINGS` are consulted —
+    a bad chunk size is a warning, not a reason to refuse the KB.
+    """
+    for key in _ROUTING_SETTINGS:
+        if key not in data:
+            continue
+        reason = _bad_setting_reason(path, key, data[key])
+        if reason is not None:
+            return reason
+    return None
+
+
+def _checked_settings(path: Path, data: dict) -> dict:
+    """Drop settings whose value is unusable, warning about each.
+
+    This file is the boundary where untrusted JSON enters: a hand-edited (or
+    older-version-written) `config.json` can hold `"base_url": 123`, and without
+    this the failure surfaces far from its cause, as an `AttributeError` inside
+    whichever adapter finally calls a string method on it. Dropping is *not* the
+    whole answer for a routing setting — being dropped is what makes it fall
+    back to the cloud default — so those also raise a `settings_error` that
+    halts the KB, and the warning says so rather than promising a harmless
+    default. Unknown keys pass through untouched.
+    """
+    checked = {}
+    for key, value in data.items():
+        reason = _bad_setting_reason(path, key, value)
+        if reason is None:
+            checked[key] = value
+        elif key in _ROUTING_SETTINGS:
+            _warn_config(reason, f"this KB is unusable until {key} is fixed")
+        else:
+            _warn_config(reason, f"ignoring it, so {key} falls back to its default")
+    return checked
+
+
 def read_settings(root: Path) -> dict:
-    """Read saved non-secret runtime settings, or {} if absent/bad."""
+    """Read saved non-secret runtime settings, or {} if absent/bad.
+
+    Individual settings whose value is unusable are warned about and dropped, so
+    the caller sees them as unset rather than passing a number on to code that
+    expects a string. For a provider-routing setting that drop is a containment
+    measure, not the remedy: `_settings_error` turns the same verdict into a
+    halt. See `_checked_settings`.
+    """
     path = _settings_path(root)
     if not path.is_file():
         return {}
@@ -244,7 +399,7 @@ def read_settings(root: Path) -> dict:
     if not isinstance(data, dict):
         _warn_bad_config(path, None, consequence)
         return {}
-    return data
+    return _checked_settings(path, data)
 
 
 def _settings_error(root: Path) -> str | None:
@@ -252,14 +407,22 @@ def _settings_error(root: Path) -> str | None:
 
     A *missing* file is never an error — a fresh KB legitimately has none, and
     reporting one would spuriously halt it. Only a file that is PRESENT but
-    unreadable/corrupt yields a reason. Shares `_bad_config_reason` with the CLI
-    stderr warning so the web/GUI halt and the warning describe the same file the
-    same way.
+    unusable yields a reason. Shares `_bad_config_reason` with the CLI stderr
+    warning so the web/GUI halt and the warning describe the same file the same
+    way.
+
+    "Unusable" is not only whole-file corruption. A file that parses perfectly
+    but holds `"provider": 123` or `"model": null` is just as unusable, and
+    ignoring the key would resolve the provider to the `anthropic` cloud default
+    the user never chose — the identical leak, arrived at through a narrower
+    door (#325). So the per-key verdict on `_ROUTING_SETTINGS` halts here too,
+    while a bad chunk size stays a warning: it changes how much text a local
+    step reads, not where the text goes.
 
     Deliberately re-reads the file rather than inferring from `read_settings`'s
-    `{}` return: an empty `{}` is ambiguous (a valid empty object returns it too),
-    and `read_settings`'s return contract is left untouched — per-key validation
-    of its body is a separate concern (#325).
+    return: what that returns is ambiguous about *why* a key is absent (a valid
+    file simply omitting it looks the same as a dropped bad one), and an empty
+    `{}` is ambiguous about the file as a whole.
     """
     path = _settings_path(root)
     if not path.is_file():
@@ -270,7 +433,7 @@ def _settings_error(root: Path) -> str | None:
         return _bad_config_reason(path, err)
     if not isinstance(data, dict):
         return _bad_config_reason(path, None)
-    return None
+    return _bad_routing_setting_reason(path, data)
 
 
 def save_settings(
@@ -315,9 +478,10 @@ def _pick(env: str, saved: str | None, default: str | None) -> str | None:
     a URL that no endpoint answers.
     """
     for candidate in (os.environ.get(env), saved):
-        # A hand-edited config.json can hold a non-string here. Passing those
-        # through untouched is what this function has always done; normalising
-        # them is a separate question from the blank-value one.
+        # `read_settings` now type-checks the saved side, so a non-string should
+        # no longer arrive from there; this guard stays because it is what makes
+        # the blank-value rule apply to the string sources only, and because a
+        # caller may pass a saved value this function never chose.
         if isinstance(candidate, str):
             candidate = candidate.strip()
         if candidate:
@@ -373,11 +537,14 @@ class Config:
     extraction_chunk_overlap_chars: int = 40
     extraction_max_facts_per_chunk: int = 8
     auto_accept_recommendations: bool = False
-    # Set only when the settings file is PRESENT but unreadable/corrupt (never on
-    # a missing file — absence is legitimate). A trailing, defaulted field so no
-    # existing `Config(...)` construction site has to change. `assert_settings_intact`
-    # turns it into the halt that keeps a corrupt config from silently defaulting
-    # to a cloud provider the user never chose (#269).
+    # Set only when the settings file is PRESENT but unusable — either as a whole
+    # (unreadable/not a JSON object) or in one of the provider-routing keys, whose
+    # wrong-typed value would otherwise be dropped and resolve to the cloud
+    # default (#325). Never set for a missing file: absence is legitimate. A
+    # trailing, defaulted field so no existing `Config(...)` construction site has
+    # to change. `assert_settings_intact` turns it into the halt that keeps a
+    # corrupt config from silently defaulting to a provider the user never chose
+    # (#269).
     settings_error: str | None = None
 
     def extraction_schema_hint(self) -> str:


### PR DESCRIPTION
`read_settings` returned whatever JSON object it found, so `"base_url": 123` surfaced far from its cause — as an `AttributeError` inside whichever adapter finally called a string method on it. This validates per key at the boundary where untrusted JSON enters, with the same warn-and-ignore policy the whole-file checks already use, just finer grained.

A wrong-typed value is warned about on stderr and dropped, so the caller sees it as unset and the normal default applies.

Two details worth naming:

- **`bool` vs `int`** — `bool` is a subclass of `int` in Python but a distinct type in JSON, so a plain `isinstance` would let `true` pass as a chunk size and `1` pass as a flag. `_has_type` rejects both directions.
- **`null` is not a type error.** It means *unset*, and `save_settings` itself writes `"base_url": null` on every save without a base URL — rejecting it would make the reader warn about its own writer's output on an ordinary round trip. Covered as accepted-not-rejected by `test_null_setting_is_unset_not_a_type_error`.

Unknown keys pass through untouched, so this reader does not silently eat a key a newer version wrote.

## ⚠️ BREAKING

The issue names only `provider` and `base_url`. This also validates the `int`/`bool` keys: `extraction_chunk_chars`, `extraction_chunk_overlap_chars`, `extraction_max_facts_per_chunk`, `auto_accept_recommendations`.

**Consequence for existing users:** a hand-edited `"extraction_chunk_chars": "450"` or `"auto_accept_recommendations": "true"` used to work silently, because `_pick_int`/`_pick_bool` accept strings. It now warns and falls back to the default. Anyone who hand-edited `config.json` with JSON-string values for these keys will see their setting stop taking effect — loudly, but it is a real behaviour change.

This was a deliberate call: `config.json` is JSON, the types should be JSON types, and warning beats silently ignoring. Flagging it here so the breakage is a decision on the record rather than a surprise.

`1559 passed, 7 skipped` (`test_config.py` 47 → 96). `ruff check` clean.

Mutation self-check, with the tests that died:
- delete the call (`return data`) → 53 failed
- `_has_type` → plain `isinstance` (drops the bool/int split) → 7 failed
- `value is None` → `not value` → 14 failed
- warn but still keep the value → 53 failed
- validate `provider` only → 16 failed

Wrong-type-but-plausible inputs covered per key: `123`, `0`, `12.5`, `true`, `false`, `["…"]`, `{...}` where a string is expected; `"450"`, `""`, `4.5`, `true`, `false`, `[450]`, `{...}` where an int is expected; `"true"`, `"false"`, `""`, `1`, `0`, `["true"]`, `{...}` where a bool is expected. Assertions are on results (`Config.for_root(...).provider`, `OllamaAdapter(cfg).base_url`), never on source text.

Closes #325