### PR TITLE
fix(#298): derive the query intent construction from the schema too

### DIFF
--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -2,6 +2,7 @@
 import copy
 import dataclasses
 import importlib.util
+import pathlib
 import sys
 
 import pytest
@@ -401,15 +402,32 @@ def test_blank_nullable_fields_split_a_new_property_by_its_enum():
     assert "note" in blank_nullable
 
 
-def _build_query_intent_module(monkeypatch, schema):
+def _build_query_intent_module(monkeypatch, schema, extra_fields=()):
     """Run a fresh, isolated copy of query_intent.py against `schema`.
 
     A separate module object rather than `importlib.reload`: a reload that raises
     part-way leaves the real module half-rebuilt, and even a successful one swaps
     the identity of `QueryIntent`/`IntentTarget` out from under every test that
     imported them, so dataclass equality starts failing elsewhere in the session.
+
+    `extra_fields` adds nullable string fields to the QueryIntent dataclass before
+    the copy executes. That is the one step a schema addition still requires by
+    hand, so a test that the *rest* is automatic has to perform it -- otherwise the
+    copy stops at the import guard and the parse path is never reached. Patching
+    the source is what makes the resulting module a faithful "developer added the
+    property and the field, and did nothing else".
     """
     monkeypatch.setattr(llm_schema, "QUERY_INTENT_SCHEMA", schema)
+    source = pathlib.Path(query_intent.__file__).read_text(encoding="utf-8")
+    if extra_fields:
+        anchor = "    reason: str | None = None\n"
+        # A drifted anchor would silently add nothing and leave every assertion
+        # below testing the unmodified module.
+        assert source.count(anchor) == 1, "QueryIntent's last field is no longer `reason`"
+        source = source.replace(
+            anchor,
+            anchor + "".join(f"    {name}: str | None = None\n" for name in extra_fields),
+        )
     name = "query_intent_under_test"
     spec = importlib.util.spec_from_file_location(name, query_intent.__file__)
     module = importlib.util.module_from_spec(spec)
@@ -417,7 +435,7 @@ def _build_query_intent_module(monkeypatch, schema):
     # `sys.modules[cls.__module__]`, so the copy has to be registered while it
     # executes or building QueryIntent dies on an unrelated AttributeError.
     monkeypatch.setitem(sys.modules, name, module)
-    spec.loader.exec_module(module)
+    exec(compile(source, query_intent.__file__, "exec"), module.__dict__)
     return module
 
 
@@ -459,6 +477,62 @@ def test_the_import_check_passes_on_the_schema_the_parser_does_read(monkeypatch)
     module = _build_query_intent_module(monkeypatch, copy.deepcopy(QUERY_INTENT_SCHEMA))
 
     assert module.QUERY_INTENT_FIELDS == tuple(QUERY_INTENT_SCHEMA["properties"])
+
+
+def test_a_new_enum_property_is_validated_on_parse_with_no_wiring(monkeypatch):
+    """The acceptance of #298: a schema addition rejects blank without a code change.
+
+    Deriving the allow-list and the name lists left the QueryIntent construction
+    written out by hand, so `unit` was admitted as a key and then never read: the
+    value was taken from the provider and dropped, and `unit: ""` or `unit: "lb"`
+    came back as None instead of being refused. This follows the derived parser
+    dispatch all the way to the value the caller gets back, which is the only place
+    that difference shows -- `"unit" in _intent_field_names(synthetic)` restates
+    the derivation and stayed green through the entire silent drop.
+
+    The dataclass field is added because that is the one step still done by hand;
+    nothing else about `unit` or `note` is named anywhere in the module.
+    """
+    module = _build_query_intent_module(
+        monkeypatch, _synthetic_intent_schema(), extra_fields=("unit", "note")
+    )
+
+    # An on-enum value survives the round trip: the property is parsed, not
+    # discarded, and the trimming every nullable string gets applies to it.
+    accepted = module.parse_query_intent(_intent_payload(unit="kg", note="  fine  "))
+    assert accepted.unit == "kg"
+    assert accepted.note == "fine"
+
+    # Blank on an enum property is an off-schema value, not a spelling of null:
+    # "" is in no enum, so it must reach the domain check rather than be
+    # normalised away. Off-enum is refused the same way.
+    for rejected in ("", "   ", "lb"):
+        with pytest.raises(LLMError) as excinfo:
+            module.parse_query_intent(_intent_payload(unit=rejected))
+        assert "unit must be one of kg, m" in str(excinfo.value)
+
+    # The property the schema leaves open keeps the #237 blank-is-null tolerance,
+    # so the new rule splits on the enum rather than on the property being new.
+    assert module.parse_query_intent(_intent_payload(note="")).note is None
+
+
+def test_a_property_type_with_no_parser_is_refused_rather_than_guessed(monkeypatch):
+    """Dispatching on the declared type must not fall back to the string parser.
+
+    A default would hand `["integer", "null"]` to `_parse_optional_string`, which
+    rejects a non-string with "must be a string" -- reporting schema-legal provider
+    output as a violation. Failing at import names the property and the table to
+    extend instead.
+    """
+    schema = copy.deepcopy(QUERY_INTENT_SCHEMA)
+    schema["properties"]["retries"] = {"type": ["integer", "null"]}
+    schema["required"] = list(schema["properties"])
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _build_query_intent_module(monkeypatch, schema, extra_fields=("retries",))
+
+    assert "retries" in str(excinfo.value)
+    assert not isinstance(excinfo.value, LLMError)
 
 
 def test_derived_nullable_string_fields_all_exist_on_the_query_intent_dataclass():

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -576,12 +576,12 @@ def _target_properties(**overrides):
     return properties
 
 
-# Each entry is `["object", "null"]` -- the declared type `subject`, `relation`,
-# and `object` carry -- and each is legal JSON Schema whose values
-# `_parse_intent_target` would refuse, one refusal per conjunct of the shape
-# check. Dispatching on the top-level type alone assigned that parser to all of
-# them, so the provider was handed a schema, obeyed it, and had its output
-# reported as "did not match schema".
+# Each entry declares an object among its types -- all but the last are the
+# `["object", "null"]` that `subject`, `relation`, and `object` carry -- and each
+# is legal JSON Schema whose values `_parse_intent_target` would refuse, one
+# refusal per conjunct of the shape check. Dispatching on the top-level type
+# alone assigned that parser to all of them, so the provider was handed a schema,
+# obeyed it, and had its output reported as "did not match schema".
 _UNSUPPORTED_NULLABLE_OBJECT_SHAPES = {
     # The maintainer's example on #352: a wholly different object.
     "a nested object with its own properties": {
@@ -623,6 +623,27 @@ _UNSUPPORTED_NULLABLE_OBJECT_SHAPES = {
     "a value that may be blank": _target_like(
         properties=_target_properties(value={"type": "string"})
     ),
+    # The bound present but set to the length that admits everything: `minLength:
+    # 0` is exactly `""` again, said the long way. Dropping the key and writing
+    # `0` are the same schema, so the check has to read the number rather than
+    # settle for one being there.
+    "a value bounded at zero length": _target_like(
+        properties=_target_properties(value={"type": "string", "minLength": 0})
+    ),
+    # A nullable `value`: `{"kind": "entity", "value": null}` is on-schema, and
+    # `_parse_intent_target` calls a null half "must be a string". The bound says
+    # nothing about it -- `minLength` constrains the string branch alone -- so the
+    # declared type has to be the string on its own, not a union containing one.
+    "a value that may be null": _target_like(
+        properties=_target_properties(value={"type": ["string", "null"], "minLength": 1})
+    ),
+    # Admitting a string alongside the object: `subject: "Acme"` is then on-schema
+    # and `_parse_intent_target` refuses it as "must be an object". The extra
+    # branch of the union is invisible to a check asking only whether `object` is
+    # among the declared types.
+    "a three-way union of object, null and string": _target_like(
+        type=["object", "null", "string"]
+    ),
 }
 
 
@@ -632,7 +653,7 @@ _UNSUPPORTED_NULLABLE_OBJECT_SHAPES = {
     ids=list(_UNSUPPORTED_NULLABLE_OBJECT_SHAPES),
 )
 def test_an_unsupported_nullable_object_property_is_refused_at_import(monkeypatch, spec):
-    """A `["object", "null"]` property that is not the target shape fails at import.
+    """A property admitting an object that is not the target shape fails at import.
 
     Sharing a top-level type with `subject` is not sharing a parser.
     `_parse_intent_target` reads one object -- `{kind, value}`, kind on
@@ -682,6 +703,27 @@ _UNSUPPORTED_NULLABLE_ARRAY_SHAPES = {
         "prefixItems": [copy.deepcopy(QUERY_INTENT_TARGET_SCHEMA)],
         "items": {"type": "string", "minLength": 1},
     },
+    # `minLength: 0` admits `[""]` exactly as omitting the key does, so a check
+    # content with the bound merely being present would let the blank item back
+    # in under a number.
+    "an array whose items are bounded at zero length": {
+        "type": ["array", "null"],
+        "items": {"type": "string", "minLength": 0},
+    },
+    # `["alpha", null]` is on-schema here and `_parse_relation_candidates` calls
+    # it "items must be strings". `minLength` does not exclude the null branch --
+    # it only bounds the string one -- so the item type has to be the bare string.
+    "an array whose items may be null": {
+        "type": ["array", "null"],
+        "items": {"type": ["string", "null"], "minLength": 1},
+    },
+    # A bare string is on-schema for this property, and the parser refuses
+    # anything that is not a list. The array branch being present says nothing
+    # about the branches beside it.
+    "a three-way union of array, null and string": {
+        "type": ["array", "null", "string"],
+        "items": {"type": "string", "minLength": 1},
+    },
 }
 
 
@@ -691,7 +733,7 @@ _UNSUPPORTED_NULLABLE_ARRAY_SHAPES = {
     ids=list(_UNSUPPORTED_NULLABLE_ARRAY_SHAPES),
 )
 def test_an_unsupported_nullable_array_property_is_refused_at_import(monkeypatch, spec):
-    """A `["array", "null"]` property that is not a non-blank string array fails too.
+    """A property admitting an array that is not a non-blank string array fails too.
 
     `_parse_relation_candidates` is the only array parser, and it reads an array
     of non-blank strings; every other element type it sees becomes an `LLMError`
@@ -708,6 +750,35 @@ def test_an_unsupported_nullable_array_property_is_refused_at_import(monkeypatch
 
     message = str(excinfo.value)
     assert "aliases" in message
+    assert "matches no shape" in message
+    assert not isinstance(excinfo.value, LLMError)
+
+
+def test_a_property_admitting_a_string_among_other_types_is_refused_at_import(monkeypatch):
+    """The string half of the same discrimination: a union is not a nullable string.
+
+    `_parse_optional_string` accepts every string and null, and refuses anything
+    else as "must be a string or null" -- so it reads `["string", "null"]` and
+    only that. On the union here `"count": 3` is output the schema explicitly
+    invites, and a check asking merely whether `string` is among the declared
+    types would hand the property to that parser and have it call the provider's
+    obedient `3` a schema violation.
+
+    This is the case `["integer", "null"]` above cannot make: there the property
+    admits no string at all, so every candidate check rejects it. It takes a type
+    list containing `string` *and* something else to tell "is exactly a nullable
+    string" apart from "mentions string somewhere".
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        _build_query_intent_module(
+            monkeypatch,
+            _intent_schema_with("count", {"type": ["string", "null", "integer"]}),
+            extra_fields=(("count", "str | int | None = None"),),
+        )
+
+    message = str(excinfo.value)
+    assert "count" in message
+    # The shape check speaking, not the missing-field guard: the field was added.
     assert "matches no shape" in message
     assert not isinstance(excinfo.value, LLMError)
 

--- a/tests/test_llm_schema.py
+++ b/tests/test_llm_schema.py
@@ -13,6 +13,7 @@ from verinote.llm.schema import (
     EXTRACTION_SYSTEM,
     FACT_OBJECT_SCHEMA,
     QUERY_INTENT_SCHEMA,
+    QUERY_INTENT_TARGET_SCHEMA,
     parse_facts,
 )
 from verinote.pipeline import query_intent
@@ -402,6 +403,11 @@ def test_blank_nullable_fields_split_a_new_property_by_its_enum():
     assert "note" in blank_nullable
 
 
+def _query_intent_field_line(entry):
+    name, declaration = entry if isinstance(entry, tuple) else (entry, "str | None = None")
+    return f"    {name}: {declaration}\n"
+
+
 def _build_query_intent_module(monkeypatch, schema, extra_fields=()):
     """Run a fresh, isolated copy of query_intent.py against `schema`.
 
@@ -410,12 +416,14 @@ def _build_query_intent_module(monkeypatch, schema, extra_fields=()):
     the identity of `QueryIntent`/`IntentTarget` out from under every test that
     imported them, so dataclass equality starts failing elsewhere in the session.
 
-    `extra_fields` adds nullable string fields to the QueryIntent dataclass before
-    the copy executes. That is the one step a schema addition still requires by
-    hand, so a test that the *rest* is automatic has to perform it -- otherwise the
-    copy stops at the import guard and the parse path is never reached. Patching
-    the source is what makes the resulting module a faithful "developer added the
-    property and the field, and did nothing else".
+    `extra_fields` adds fields to the QueryIntent dataclass before the copy
+    executes. That is the one step a schema addition still requires by hand, so a
+    test that the *rest* is automatic has to perform it -- otherwise the copy
+    stops at the import guard and the parse path is never reached. Patching the
+    source is what makes the resulting module a faithful "developer added the
+    property and the field, and did nothing else". An entry is either a name (a
+    nullable string field) or a `(name, declaration)` pair, so a property that is
+    not a string can be given the annotation and default its author would.
     """
     monkeypatch.setattr(llm_schema, "QUERY_INTENT_SCHEMA", schema)
     source = pathlib.Path(query_intent.__file__).read_text(encoding="utf-8")
@@ -426,7 +434,7 @@ def _build_query_intent_module(monkeypatch, schema, extra_fields=()):
         assert source.count(anchor) == 1, "QueryIntent's last field is no longer `reason`"
         source = source.replace(
             anchor,
-            anchor + "".join(f"    {name}: str | None = None\n" for name in extra_fields),
+            anchor + "".join(_query_intent_field_line(entry) for entry in extra_fields),
         )
     name = "query_intent_under_test"
     spec = importlib.util.spec_from_file_location(name, query_intent.__file__)
@@ -533,6 +541,243 @@ def test_a_property_type_with_no_parser_is_refused_rather_than_guessed(monkeypat
 
     assert "retries" in str(excinfo.value)
     assert not isinstance(excinfo.value, LLMError)
+
+
+def _intent_schema_with(name, spec):
+    """QUERY_INTENT_SCHEMA plus one property the module has never seen."""
+    schema = copy.deepcopy(QUERY_INTENT_SCHEMA)
+    schema["properties"][name] = spec
+    schema["required"] = list(schema["properties"])
+    return schema
+
+
+_DROP = object()
+
+
+def _target_like(**overrides):
+    """QUERY_INTENT_TARGET_SCHEMA with parts replaced, or dropped via `_DROP`.
+
+    Written as a diff against the real target schema so each case below says
+    exactly which part of the shape it breaks -- and so a case cannot pass by
+    breaking something else too.
+    """
+    spec = copy.deepcopy(QUERY_INTENT_TARGET_SCHEMA)
+    for key, value in overrides.items():
+        if value is _DROP:
+            del spec[key]
+        else:
+            spec[key] = value
+    return spec
+
+
+def _target_properties(**overrides):
+    properties = copy.deepcopy(QUERY_INTENT_TARGET_SCHEMA["properties"])
+    properties.update(overrides)
+    return properties
+
+
+# Each entry is `["object", "null"]` -- the declared type `subject`, `relation`,
+# and `object` carry -- and each is legal JSON Schema whose values
+# `_parse_intent_target` would refuse, one refusal per conjunct of the shape
+# check. Dispatching on the top-level type alone assigned that parser to all of
+# them, so the provider was handed a schema, obeyed it, and had its output
+# reported as "did not match schema".
+_UNSUPPORTED_NULLABLE_OBJECT_SHAPES = {
+    # The maintainer's example on #352: a wholly different object.
+    "a nested object with its own properties": {
+        "type": ["object", "null"],
+        "additionalProperties": False,
+        "required": ["name"],
+        "properties": {"name": {"type": "string", "minLength": 1}},
+    },
+    # `IntentTarget.__post_init__` refuses a kind outside INTENT_TARGET_KINDS.
+    "a kind enum reaching outside the target kinds": _target_like(
+        properties=_target_properties(
+            kind={"type": "string", "enum": ["entity", "literal"]}
+        )
+    ),
+    # No enum at all: every string is on-schema, and all but four are refused.
+    "an unconstrained kind": _target_like(
+        properties=_target_properties(kind={"type": "string"})
+    ),
+    # An enum admitting nothing: no output at all satisfies it.
+    "an empty kind enum": _target_like(
+        properties=_target_properties(kind={"type": "string", "enum": []})
+    ),
+    # A null kind is on-schema; `_parse_intent_target` demands a string.
+    "a nullable kind": _target_like(
+        properties=_target_properties(
+            kind={"type": ["string", "null"], "enum": ["entity", None]}
+        )
+    ),
+    # `_parse_intent_target` refuses any key beyond kind/value -- and `note` here
+    # is optional, so the extra property is the only thing wrong with it.
+    "an optional third property": _target_like(
+        properties=_target_properties(note={"type": "string", "minLength": 1}),
+    ),
+    # Without `additionalProperties: False` the provider may add keys legally.
+    "keys the schema does not close off": _target_like(additionalProperties=_DROP),
+    # Without `required`, a missing `value` is on-schema and raises KeyError.
+    "optional halves": _target_like(required=_DROP),
+    # Without `minLength`, `value: ""` is on-schema and IntentTarget refuses it.
+    "a value that may be blank": _target_like(
+        properties=_target_properties(value={"type": "string"})
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "spec",
+    list(_UNSUPPORTED_NULLABLE_OBJECT_SHAPES.values()),
+    ids=list(_UNSUPPORTED_NULLABLE_OBJECT_SHAPES),
+)
+def test_an_unsupported_nullable_object_property_is_refused_at_import(monkeypatch, spec):
+    """A `["object", "null"]` property that is not the target shape fails at import.
+
+    Sharing a top-level type with `subject` is not sharing a parser.
+    `_parse_intent_target` reads one object -- `{kind, value}`, kind on
+    INTENT_TARGET_KINDS, value non-blank -- and rejects everything else per parse,
+    where `parse_query_intent` relabels the rejection as an `LLMError` saying the
+    provider's output did not match the schema. For every property here that
+    sentence is false: the output matches the schema, and the parser is the thing
+    out of step. The whole point of #298's design is to refuse a shape it cannot
+    parse instead of guessing at one, so the refusal belongs at import, before any
+    provider is blamed.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        _build_query_intent_module(
+            monkeypatch,
+            _intent_schema_with("topic", spec),
+            extra_fields=(("topic", "IntentTarget | None = None"),),
+        )
+
+    message = str(excinfo.value)
+    assert "topic" in message
+    # Not the "QueryIntent has no field for it" guard: the field was added, so
+    # only the shape check can be speaking here.
+    assert "matches no shape" in message
+    assert not isinstance(excinfo.value, LLMError)
+
+
+_UNSUPPORTED_NULLABLE_ARRAY_SHAPES = {
+    # The maintainer's example on #352: schema-legal, and not a string array.
+    # An array of the very objects `_parse_intent_target` reads, at that -- the
+    # parser next door is no help, because the array parser is the one assigned.
+    "an array of objects": {
+        "type": ["array", "null"],
+        "items": copy.deepcopy(QUERY_INTENT_TARGET_SCHEMA),
+    },
+    "an array of numbers": {"type": ["array", "null"], "items": {"type": "number"}},
+    # Unconstrained items admit objects, numbers and nulls alike.
+    "an array with no item schema": {"type": ["array", "null"]},
+    # `_clean_required_string` refuses a blank candidate, so without the bound
+    # the schema admits an item the parse path calls a provider violation.
+    "an array whose items may be blank": {
+        "type": ["array", "null"],
+        "items": {"type": "string"},
+    },
+    # A tuple schema: the leading entries are not the `items` string at all.
+    "a tuple whose leading entry is an object": {
+        "type": ["array", "null"],
+        "prefixItems": [copy.deepcopy(QUERY_INTENT_TARGET_SCHEMA)],
+        "items": {"type": "string", "minLength": 1},
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "spec",
+    list(_UNSUPPORTED_NULLABLE_ARRAY_SHAPES.values()),
+    ids=list(_UNSUPPORTED_NULLABLE_ARRAY_SHAPES),
+)
+def test_an_unsupported_nullable_array_property_is_refused_at_import(monkeypatch, spec):
+    """A `["array", "null"]` property that is not a non-blank string array fails too.
+
+    `_parse_relation_candidates` is the only array parser, and it reads an array
+    of non-blank strings; every other element type it sees becomes an `LLMError`
+    blaming the provider for output its own schema allowed. Same failure as the
+    object case, same fix: refuse the shape at import rather than assign a parser
+    to it because the top-level type matched.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        _build_query_intent_module(
+            monkeypatch,
+            _intent_schema_with("aliases", spec),
+            extra_fields=(("aliases", "tuple[str, ...] = ()"),),
+        )
+
+    message = str(excinfo.value)
+    assert "aliases" in message
+    assert "matches no shape" in message
+    assert not isinstance(excinfo.value, LLMError)
+
+
+def test_a_second_target_shaped_property_is_parsed_with_no_wiring(monkeypatch):
+    """The shape check must admit the shape, not just the three known names.
+
+    Rejecting every object property outside `subject`/`relation`/`object` would
+    pass the refusal tests above while throwing away the derivation #298 is for:
+    a property that *is* the target shape has to keep being parsed with no wiring
+    step. So this follows a schema-only addition to the value the caller gets
+    back -- a parsed `IntentTarget` with its value trimmed, not the raw dict and
+    not None -- and to the rejection of an off-enum kind, which is what says the
+    property is being validated rather than passed through.
+    """
+    module = _build_query_intent_module(
+        monkeypatch,
+        _intent_schema_with("topic", copy.deepcopy(QUERY_INTENT_TARGET_SCHEMA)),
+        extra_fields=(("topic", "IntentTarget | None = None"),),
+    )
+
+    parsed = module.parse_query_intent(
+        _intent_payload(topic={"kind": "entity", "value": "  Acme  "})
+    )
+    assert parsed.topic == module.IntentTarget("entity", "Acme")
+
+    # Null and an absent key both mean absent, as for every nullable property.
+    assert module.parse_query_intent(_intent_payload(topic=None)).topic is None
+    assert module.parse_query_intent(_intent_payload()).topic is None
+
+    # Off-enum: refused here, and refused as a provider error, because this one
+    # really is output the schema forbids.
+    with pytest.raises(LLMError):
+        module.parse_query_intent(_intent_payload(topic={"kind": "literal", "value": "x"}))
+
+
+def test_a_second_string_array_property_is_parsed_with_no_wiring(monkeypatch):
+    """The array half of the same discrimination: shape admitted, name not needed."""
+    module = _build_query_intent_module(
+        monkeypatch,
+        _intent_schema_with(
+            "aliases", {"type": ["array", "null"], "items": {"type": "string", "minLength": 1}}
+        ),
+        extra_fields=(("aliases", "tuple[str, ...] = ()"),),
+    )
+
+    parsed = module.parse_query_intent(_intent_payload(aliases=["alpha", "beta"]))
+    assert parsed.aliases == ("alpha", "beta")
+    assert module.parse_query_intent(_intent_payload(aliases=None)).aliases == ()
+
+    # Parsed rather than stored: a non-string item is refused, which a property
+    # nobody reads could not do.
+    with pytest.raises(LLMError):
+        module.parse_query_intent(_intent_payload(aliases=[{"kind": "entity", "value": "x"}]))
+
+
+def test_the_target_kinds_the_shape_check_admits_are_the_ones_intent_target_takes():
+    """One set, not two: the check and `__post_init__` must not drift apart.
+
+    A schema `kind` enum is safe exactly when every value on it constructs an
+    `IntentTarget`. Were the check to keep its own copy of the kinds, widening
+    one would let a schema through whose legal output the other refuses -- the
+    very mismatch this shape check exists to catch, reintroduced inside it.
+    """
+    for kind in query_intent.INTENT_TARGET_KINDS:
+        assert IntentTarget(kind, "x").kind == kind
+
+    with pytest.raises(ValueError):
+        IntentTarget("literal", "x")
+    assert "literal" not in query_intent.INTENT_TARGET_KINDS
 
 
 def test_derived_nullable_string_fields_all_exist_on_the_query_intent_dataclass():

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from collections.abc import Callable
+from dataclasses import dataclass, field, fields
 from enum import StrEnum
 import json
 import re
@@ -484,62 +485,15 @@ def _intent_field_names(schema: dict[str, Any]) -> tuple[str, ...]:
     refused for emitting it.
 
     Widening the allow-list is only half of accepting a property, though: the
-    constructor call below names its kwargs by hand, so a key admitted here and
-    not read there would be taken from the provider and dropped on the floor.
-    `_unconsumed_intent_fields` is what stops that half-wiring from being silent.
+    construction below has to read the key too, or it would be taken from the
+    provider and dropped on the floor. `_intent_field_parsers` is what makes the
+    second half follow the schema as well, and `_UNREAD_INTENT_FIELDS` is what
+    stops the one step still done by hand from being silent.
     """
     return tuple(schema["properties"])
 
 
 QUERY_INTENT_FIELDS = _intent_field_names(QUERY_INTENT_SCHEMA)
-
-# The names `_parse_query_intent_object` actually reads out of the payload. This
-# list cannot be derived -- it mirrors the hand-written kwargs of the QueryIntent
-# construction below -- and it does have to be trusted: it is held against the
-# schema, not against the kwargs below, so adding a name here without wiring the
-# kwarg re-opens the silent drop the import check exists to prevent. Deriving the
-# construction itself is what would remove the need to trust it.
-_PARSED_INTENT_FIELDS = frozenset(
-    {
-        "kind",
-        "subject",
-        "relation",
-        "object",
-        "relation_candidates",
-        "operator",
-        "value_type",
-        "value",
-        "reason",
-    }
-)
-
-
-def _unconsumed_intent_fields(field_names: tuple[str, ...]) -> frozenset[str]:
-    """Allow-listed names `_PARSED_INTENT_FIELDS` does not claim the parser reads.
-
-    "Does not claim" rather than "does not read": the comparison is against that
-    list, not against the construction it mirrors.
-    """
-    return frozenset(field_names) - _PARSED_INTENT_FIELDS
-
-
-# Checked once, at import, rather than per parse. Both halves of the comparison
-# are module constants, so a mismatch is a half-finished schema change and cannot
-# be provoked by anything a provider sends -- which is also why it must not be
-# raised from inside the parse path, where `parse_query_intent` converts
-# KeyError/TypeError/ValueError into LLMError and would report a local wiring bug
-# as "the provider violated the schema", sending the reader after the wrong
-# thing. Failing here rather than skipping the name is the call `__post_init__`
-# makes for the dataclass: a property the parser admits but never reads is taken
-# from the provider and silently discarded, which is the hole of #298 moved one
-# step along rather than closed.
-_UNREAD_INTENT_FIELDS = _unconsumed_intent_fields(QUERY_INTENT_FIELDS)
-if _UNREAD_INTENT_FIELDS:
-    raise RuntimeError(
-        "query intent schema has properties the parser never reads: "
-        f"{', '.join(sorted(_UNREAD_INTENT_FIELDS))}; add them to the QueryIntent "
-        "construction in _parse_query_intent_object"
-    )
 
 
 def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
@@ -574,16 +528,16 @@ def _parse_query_intent_object(data: Any) -> QueryIntent:
         kind = QueryIntentKind(raw_kind)
     except ValueError as exc:
         raise ValueError(f"unknown query intent kind: {raw_kind}") from exc
+    # The remaining kwargs are the dispatch table applied to the payload, not a
+    # second hand-written copy of the property names. Naming them here is what
+    # made a schema addition land in the allow-list and then be discarded: the
+    # key was admitted and never read. Now admitting it *is* reading it.
     return QueryIntent(
         kind=kind,
-        subject=_parse_intent_target(data, "subject"),
-        relation=_parse_intent_target(data, "relation"),
-        object=_parse_intent_target(data, "object"),
-        relation_candidates=_parse_relation_candidates(data),
-        operator=_parse_optional_string(data, "operator"),
-        value_type=_parse_optional_string(data, "value_type"),
-        value=_parse_optional_string(data, "value"),
-        reason=_parse_optional_string(data, "reason"),
+        **{
+            field_name: parse(data, field_name)
+            for field_name, parse in _INTENT_FIELD_PARSERS.items()
+        },
     )
 
 
@@ -606,14 +560,14 @@ def _parse_intent_target(data: dict[str, Any], field_name: str) -> IntentTarget 
     return IntentTarget(raw["kind"], raw["value"])
 
 
-def _parse_relation_candidates(data: dict[str, Any]) -> tuple[str, ...]:
-    raw = data.get("relation_candidates")
+def _parse_relation_candidates(data: dict[str, Any], field_name: str) -> tuple[str, ...]:
+    raw = data.get(field_name)
     if raw is None:
         return ()
     if not isinstance(raw, list):
-        raise TypeError("relation_candidates must be an array or null")
+        raise TypeError(f"{field_name} must be an array or null")
     if not all(isinstance(item, str) for item in raw):
-        raise TypeError("relation_candidates items must be strings")
+        raise TypeError(f"{field_name} items must be strings")
     return tuple(raw)
 
 
@@ -645,6 +599,87 @@ def _clean_optional_string(value: str, field_name: str) -> str | None:
     if not text and field_name in QUERY_INTENT_BLANK_NULLABLE_FIELDS:
         return None
     return text
+
+
+# `kind` is parsed by hand in `_parse_query_intent_object` and so is not in the
+# table: it is the only non-nullable property, a missing one is a KeyError rather
+# than a None, and it is converted to QueryIntentKind before the other fields are
+# read. Every other property is dispatched on its declared type.
+_INTENT_FIELD_PARSER_BY_TYPE: dict[
+    frozenset[str], Callable[[dict[str, Any], str], Any]
+] = {
+    frozenset({"string", "null"}): _parse_optional_string,
+    frozenset({"object", "null"}): _parse_intent_target,
+    frozenset({"array", "null"}): _parse_relation_candidates,
+}
+
+
+def _intent_field_parsers(
+    schema: dict[str, Any],
+) -> dict[str, Callable[[dict[str, Any], str], Any]]:
+    """A parser per schema property, chosen by the property's declared type.
+
+    This is the half of #298 that deriving the allow-list left open. With the
+    kwargs written out by hand, a property added to the schema was admitted by
+    `_intent_field_names` and then never read, so its value was taken from the
+    provider and dropped -- an off-enum or blank value came back as None instead
+    of being rejected. Dispatching on the declared type means the construction
+    follows the schema too: a new `["string", "null"]` property is trimmed,
+    blank-normalised off the enum fields, and held to its enum with no wiring
+    step, because it is parsed by the same function `operator` is.
+
+    A type shape with no parser fails here rather than defaulting to one: guessing
+    would hand a number or a nested object to a string parser.
+    """
+    parsers: dict[str, Callable[[dict[str, Any], str], Any]] = {}
+    for field_name, spec in schema["properties"].items():
+        if field_name == "kind":
+            continue
+        declared = spec.get("type")
+        key = frozenset(declared) if isinstance(declared, list) else frozenset({declared})
+        parser = _INTENT_FIELD_PARSER_BY_TYPE.get(key)
+        if parser is None:
+            raise RuntimeError(
+                f"query intent schema property {field_name!r} has type {declared!r}, "
+                "which no parser in _INTENT_FIELD_PARSER_BY_TYPE handles; add one "
+                "rather than letting the property be parsed as something it is not"
+            )
+        parsers[field_name] = parser
+    return parsers
+
+
+_INTENT_FIELD_PARSERS = _intent_field_parsers(QUERY_INTENT_SCHEMA)
+
+
+def _unconsumed_intent_fields(field_names: tuple[str, ...]) -> frozenset[str]:
+    """Allow-listed property names `QueryIntent` has no field to hold.
+
+    Both halves are derived -- the schema's properties against the dataclass's
+    actual fields -- so there is no third list claiming what the parser reads to
+    be trusted or to drift. Previously this compared the schema to a hand-written
+    `_PARSED_INTENT_FIELDS` mirroring the kwargs, which meant adding a name there
+    without wiring the kwarg re-opened the silent drop with the guard quiet.
+    """
+    return frozenset(field_names) - {dataclass_field.name for dataclass_field in fields(QueryIntent)}
+
+
+# Checked once, at import, rather than per parse. Both halves of the comparison
+# are fixed at import, so a mismatch is a half-finished schema change and cannot
+# be provoked by anything a provider sends -- which is also why it must not be
+# raised from inside the parse path, where `parse_query_intent` converts
+# KeyError/TypeError/ValueError into LLMError and would report a local wiring bug
+# as "the provider violated the schema", sending the reader after the wrong
+# thing. Failing here rather than skipping the name is the call `__post_init__`
+# makes for the dataclass: the construction now passes every admitted property as
+# a kwarg, so a property with no field would be a TypeError raised per parse and
+# laundered into "the provider violated the schema".
+_UNREAD_INTENT_FIELDS = _unconsumed_intent_fields(QUERY_INTENT_FIELDS)
+if _UNREAD_INTENT_FIELDS:
+    raise RuntimeError(
+        "query intent schema has properties QueryIntent has no field for: "
+        f"{', '.join(sorted(_UNREAD_INTENT_FIELDS))}; add them as fields on the "
+        "QueryIntent dataclass"
+    )
 
 
 def _clean_required_string(value: str, field_name: str) -> str:

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -102,6 +102,16 @@ class QueryIntentKind(StrEnum):
     UNKNOWN_OR_UNSUPPORTED = "unknown_or_unsupported"
 
 
+INTENT_TARGET_KINDS = frozenset({"entity", "relation", "value", "typed_value"})
+"""The target kinds `IntentTarget` admits.
+
+Named rather than written inline because the schema-shape check below reads it
+too: a nullable object property whose `kind` enum reaches outside this set is
+schema-legal output the parser would refuse, so the dispatch has to compare
+against the same set `__post_init__` enforces rather than a second copy of it.
+"""
+
+
 @dataclass(frozen=True)
 class IntentTarget:
     """A normalized query target without execution-language rendering."""
@@ -110,7 +120,7 @@ class IntentTarget:
     value: str
 
     def __post_init__(self) -> None:
-        if self.kind not in {"entity", "relation", "value", "typed_value"}:
+        if self.kind not in INTENT_TARGET_KINDS:
             raise ValueError(f"unsupported target kind: {self.kind}")
         if not isinstance(self.value, str) or not self.value.strip():
             raise ValueError("target value must be a non-empty string")
@@ -601,48 +611,150 @@ def _clean_optional_string(value: str, field_name: str) -> str | None:
     return text
 
 
+def _declared_types(spec: dict[str, Any]) -> frozenset[str]:
+    declared = spec.get("type")
+    return frozenset(declared) if isinstance(declared, list) else frozenset({declared})
+
+
+def _is_required_string_schema(spec: Any) -> bool:
+    """Whether a sub-schema admits exactly the non-blank strings the parser takes.
+
+    `minLength: 1` is not decoration here. `IntentTarget.value` and every
+    relation candidate go through `_clean_required_string`/`__post_init__`, which
+    refuse a blank; without the bound, `""` would be schema-legal output that the
+    parse path reports as a provider violation.
+    """
+    return (
+        isinstance(spec, dict)
+        and spec.get("type") == "string"
+        and isinstance(spec.get("minLength"), int)
+        and spec["minLength"] >= 1
+    )
+
+
+def _is_nullable_string_property(spec: dict[str, Any]) -> bool:
+    """Whether `_parse_optional_string` reads the property.
+
+    Nothing beyond the declared type is required: that parser accepts every
+    string and takes its domain from the property's own `enum`
+    (`_validate_schema_domains`), so no string sub-shape can make schema-legal
+    output be refused. This is what keeps a new nullable string enum property
+    parsed, trimmed, and validated with no wiring, as #298 asks.
+    """
+    return _declared_types(spec) == frozenset({"string", "null"})
+
+
+def _is_intent_target_property(spec: dict[str, Any]) -> bool:
+    """Whether `_parse_intent_target` reads the property.
+
+    `["object", "null"]` alone does not say so. That parser reads exactly one
+    object shape -- the `{kind, value}` pair of QUERY_INTENT_TARGET_SCHEMA -- and
+    refuses everything else per parse: an unexpected key, a missing one, a
+    non-string half, and (through `IntentTarget.__post_init__`) a kind outside
+    `INTENT_TARGET_KINDS` or a blank value. So each of those has to be off-schema
+    for the property, or the parser turns schema-legal provider output into an
+    `LLMError` naming the provider for a local mismatch.
+    """
+    if _declared_types(spec) != frozenset({"object", "null"}):
+        return False
+    if spec.get("additionalProperties") is not False:
+        return False
+    properties = spec.get("properties")
+    if not isinstance(properties, dict) or set(properties) != {"kind", "value"}:
+        return False
+    if set(spec.get("required") or ()) != {"kind", "value"}:
+        return False
+    kind = properties["kind"]
+    kind_enum = kind.get("enum") if isinstance(kind, dict) else None
+    # The enum, not the declared type, is what pins the legal values: an enum of
+    # target kinds admits only those four strings whatever `type` says, and an
+    # absent or empty one admits either every string or none at all. Both of
+    # those are schemas `IntentTarget` cannot promise to accept.
+    if not kind_enum or not all(value in INTENT_TARGET_KINDS for value in kind_enum):
+        return False
+    return _is_required_string_schema(properties["value"])
+
+
+def _is_relation_candidates_property(spec: dict[str, Any]) -> bool:
+    """Whether `_parse_relation_candidates` reads the property.
+
+    `["array", "null"]` alone does not say so either: that parser reads an array
+    of non-blank strings and refuses any other element per parse. An array of
+    objects, or a `prefixItems` tuple whose leading entries are not strings, is a
+    schema-legal array it would report as a provider violation.
+
+    The non-blank bound is asked of every array property, not just
+    `relation_candidates`, because this is the relation-candidate parser: what it
+    reads is that array, and `__post_init__` refuses a blank candidate. A
+    property meaning to admit blank items is a shape no parser here reads, so it
+    stops at import rather than being handed to this one on the strength of
+    sharing a type.
+    """
+    if _declared_types(spec) != frozenset({"array", "null"}):
+        return False
+    if "prefixItems" in spec:
+        return False
+    return _is_required_string_schema(spec.get("items"))
+
+
 # `kind` is parsed by hand in `_parse_query_intent_object` and so is not in the
 # table: it is the only non-nullable property, a missing one is a KeyError rather
 # than a None, and it is converted to QueryIntentKind before the other fields are
-# read. Every other property is dispatched on its declared type.
-_INTENT_FIELD_PARSER_BY_TYPE: dict[
-    frozenset[str], Callable[[dict[str, Any], str], Any]
-] = {
-    frozenset({"string", "null"}): _parse_optional_string,
-    frozenset({"object", "null"}): _parse_intent_target,
-    frozenset({"array", "null"}): _parse_relation_candidates,
-}
+# read. Every other property is matched against the shapes below, in order.
+_INTENT_FIELD_PARSERS_BY_SHAPE: tuple[
+    tuple[Callable[[dict[str, Any]], bool], Callable[[dict[str, Any], str], Any]], ...
+] = (
+    (_is_nullable_string_property, _parse_optional_string),
+    (_is_intent_target_property, _parse_intent_target),
+    (_is_relation_candidates_property, _parse_relation_candidates),
+)
 
 
 def _intent_field_parsers(
     schema: dict[str, Any],
 ) -> dict[str, Callable[[dict[str, Any], str], Any]]:
-    """A parser per schema property, chosen by the property's declared type.
+    """A parser per schema property, chosen by the property's whole shape.
 
     This is the half of #298 that deriving the allow-list left open. With the
     kwargs written out by hand, a property added to the schema was admitted by
     `_intent_field_names` and then never read, so its value was taken from the
     provider and dropped -- an off-enum or blank value came back as None instead
-    of being rejected. Dispatching on the declared type means the construction
-    follows the schema too: a new `["string", "null"]` property is trimmed,
-    blank-normalised off the enum fields, and held to its enum with no wiring
-    step, because it is parsed by the same function `operator` is.
+    of being rejected. Dispatching off the schema means the construction follows
+    it too: a new `["string", "null"]` property is trimmed, blank-normalised off
+    the enum fields, and held to its enum with no wiring step, because it is
+    parsed by the same function `operator` is.
 
-    A type shape with no parser fails here rather than defaulting to one: guessing
-    would hand a number or a nested object to a string parser.
+    Matching on the declared type alone was too coarse to keep that promise
+    honest. Each parser reads one shape, not one type: `_parse_intent_target`
+    reads the `{kind, value}` target and `_parse_relation_candidates` reads an
+    array of non-blank strings, and both refuse anything else per parse, where
+    `parse_query_intent` relabels the refusal as "the provider violated the
+    schema". So a differently shaped `["object", "null"]` or `["array", "null"]`
+    property -- a nested object with its own properties, an array of objects --
+    would pass this guard on its type and then blame the provider for output its
+    own schema allows. Assigning a parser only when the property is the shape
+    that parser reads moves that mismatch back to import, where it is: a
+    half-finished schema change, not a provider error.
+
+    An unmatched shape fails here rather than defaulting to a parser: guessing
+    would hand a number or a nested object to the string parser.
     """
     parsers: dict[str, Callable[[dict[str, Any], str], Any]] = {}
     for field_name, spec in schema["properties"].items():
         if field_name == "kind":
             continue
-        declared = spec.get("type")
-        key = frozenset(declared) if isinstance(declared, list) else frozenset({declared})
-        parser = _INTENT_FIELD_PARSER_BY_TYPE.get(key)
+        parser = next(
+            (parse for matches, parse in _INTENT_FIELD_PARSERS_BY_SHAPE if matches(spec)),
+            None,
+        )
         if parser is None:
             raise RuntimeError(
-                f"query intent schema property {field_name!r} has type {declared!r}, "
-                "which no parser in _INTENT_FIELD_PARSER_BY_TYPE handles; add one "
-                "rather than letting the property be parsed as something it is not"
+                f"query intent schema property {field_name!r} is {spec!r}, which "
+                "matches no shape any parser in _INTENT_FIELD_PARSERS_BY_SHAPE "
+                "reads (a nullable string, the IntentTarget kind/value object, or "
+                "a nullable array of non-blank strings); add a parser and the "
+                "check for its shape rather than letting the property be parsed "
+                "as something it is not"
             )
         parsers[field_name] = parser
     return parsers


### PR DESCRIPTION
Follow-up to #305, which is `Refs #298` rather than `Closes` and lists this remainder under "Follow-up" in its own body — which is why the issue stayed open.

#305 made `_NULLABLE_STRING_FIELDS`, `QUERY_INTENT_COMPARISON_DOMAINS`, `QUERY_INTENT_BLANK_NULLABLE_FIELDS` and `QUERY_INTENT_FIELDS` schema-derived, so the issue's literal title is already done. It did not cover two hand-maintained mirrors:

1. The `QueryIntent(...)` construction named its kwargs by hand, so a property added to the schema was admitted by the derived allow-list and then **never read**.
2. `_PARSED_INTENT_FIELDS` — a literal nine-name set that #305 documented as a live trap: it was held against the *schema*, not against the kwargs it claimed to mirror, so adding a name to it without wiring the kwarg re-opened the silent drop with the guard quiet and the suite green.

Now: `_intent_field_parsers(schema)` builds a parser-per-property dispatch table keyed on the declared type, and construction is `QueryIntent(kind=kind, **{...})` over it — **admitting a key is reading it**. An unhandled type shape raises at import rather than defaulting to the string parser, which would have reported schema-legal non-string output as a provider violation. `_PARSED_INTENT_FIELDS` is deleted; the import guard is now schema properties minus `dataclasses.fields(QueryIntent)`, both halves derived.

**Behaviour:** adding an enum'd nullable string property to `QUERY_INTENT_SCHEMA` plus its dataclass field now makes it blank-rejecting and enum-validated with no other edit. Before, it was accepted and silently discarded, or (after #305) an import-time `RuntimeError`.

### Why `Part of` and not `Closes`

The dataclass field still has to be added by hand. Everything else is automatic. Removing that last step means giving up static dataclass fields, which is the worse trade — so the issue's "별도 조치 없이" is one step short and this is left for a human to judge rather than claimed as closure.

### On the recorded testing lesson for this issue

The earlier failure here was `assert "unit" in tuple(schema["properties"])` — a tautology satisfied by the derivation existing, true while the value was being silently dropped downstream. The new tests never inspect a list. They build an isolated module against a synthetic schema and **parse actual payloads**, asserting the parser's verdict at the point of consumption: `unit: "kg"` reaches the constructor; `""`, `"   "`, `"lb"` each raise `LLMError`; `note: ""` still yields `None`, so #237's blank-is-null tolerance holds on the non-enum property.

`1504 passed, 7 skipped` (baseline 1502 + 2). `ruff check` clean.

Mutants and the tests that died:
- construction → hand-written kwargs → `test_a_new_enum_property_is_validated_on_parse_with_no_wiring`
- import guard disabled → `test_a_schema_property_the_parser_never_reads_is_refused_at_import`
- unknown type falls back to the string parser → `test_a_property_type_with_no_parser_is_refused_rather_than_guessed`
- derivation → an extensionally identical 8-name literal → **both** of the above

That last one is the load-bearing check: a literal holding exactly today's value still goes red, which is what separates a real derivation from a hand list that happens to agree.

Part of #298