### PR TITLE
fix(#337): stop an owned extraction job from self-demoting mid-run, and restore CLI recovery

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,6 +289,192 @@ def test_sync_empty_source_is_success(tmp_path, monkeypatch, capsys, fake_client
     assert "sync failed" not in capsys.readouterr().err
 
 
+def _register_two_chunk_source(tmp_path, monkeypatch) -> Path:
+    """Ingest a registered source whose text splits into two chunks."""
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "40")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+    src = tmp_path / "note.txt"
+    src.write_text(
+        "alpha beta gamma delta epsilon\n\nzeta eta theta iota kappa",
+        encoding="utf-8",
+    )
+    assert cli.main(["ingest", str(src)]) == 0
+    return src
+
+
+def _stuck_running_job(tmp_path) -> int:
+    """Leave the registered source's newest job `running` with a chunk in flight.
+
+    Built the way `cmd_sync` would build it (same artifact, provider, model and
+    chunk config), so once `--recover` rewinds it to `pending` the ordinary claim
+    path resumes it instead of rebuilding a fresh job.
+    """
+    from verinote.pipeline import create_chunked_extraction_job
+
+    cfg = config.Config.load()
+    s = Store(tmp_path / "kb.sqlite")
+    row = s.source_text_inputs()[0]
+    text = (cfg.root / row["artifact_path"]).read_text(encoding="utf-8")
+    job_id = create_chunked_extraction_job(
+        s,
+        source_id=int(row["source_id"]),
+        artifact_id=int(row["artifact_id"]),
+        source_text=text,
+        provider=cfg.provider,
+        model=cfg.model,
+        chunk_chars=cfg.extraction_chunk_chars,
+        chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
+    )
+    assert s.claim_pending_extraction_job(job_id) is True  # pending -> running
+    s.mark_chunk_running(int(s.source_chunks(job_id)[0]["id"]))  # a crash mid-run
+    s.close()
+    return job_id
+
+
+def _rolled_back_events(store, job_id: int | None = None) -> int:
+    sql = "SELECT COUNT(*) AS n FROM fact_events WHERE event_type = 'extraction_job_rolled_back'"
+    params: tuple = ()
+    if job_id is not None:
+        sql += " AND job_id = ?"
+        params = (job_id,)
+    return store._conn.execute(sql, params).fetchone()["n"]
+
+
+def test_sync_running_job_points_at_the_recovery_path(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    # A plain sync must not touch a `running` job, and its skip line must name
+    # BOTH possibilities (live worker vs. crashed mid-run) and the recovery path,
+    # since the two are indistinguishable from DB state (#337).
+    _env(monkeypatch, tmp_path)
+    _register_two_chunk_source(tmp_path, monkeypatch)
+    job_id = _stuck_running_job(tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+
+    rc = cli.main(["sync"])
+
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert f"#{job_id} is already running, or was interrupted mid-run" in err
+    assert "verinote sync --recover" in err
+    s = Store(tmp_path / "kb.sqlite")
+    assert s.get_extraction_job(job_id)["status"] == "running"
+    assert _rolled_back_events(s) == 0
+
+
+def test_sync_recover_resumes_a_stuck_running_job(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    # The happy path: `--recover` rolls the stuck job back and the SAME invocation
+    # resumes it to completion.
+    _env(monkeypatch, tmp_path)
+    _register_two_chunk_source(tmp_path, monkeypatch)
+    job_id = _stuck_running_job(tmp_path)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+
+    rc = cli.main(["sync", "--recover"])
+
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert f"rolled back stuck extraction job #{job_id}" in err
+    s = Store(tmp_path / "kb.sqlite")
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "done"
+    assert int(job["completed_chunks"]) == int(job["total_chunks"]) == 2
+    assert _rolled_back_events(s, job_id) == 1
+
+
+def test_sync_recover_is_a_noop_on_a_done_job(tmp_path, monkeypatch, fake_client):
+    # The most important guard: `rollback_extraction_job` does NOT self-guard a
+    # `done` job, so a missing `status == 'running'` gate would rewind a finished
+    # job and churn an empty run. `--recover` must leave it strictly alone.
+    _env(monkeypatch, tmp_path)
+    _register_two_chunk_source(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+    assert cli.main(["sync"]) == 0
+    s = Store(tmp_path / "kb.sqlite")
+    done_id = int(s.source_extraction_jobs()[0]["id"])
+    assert s.get_extraction_job(done_id)["status"] == "done"
+    s.close()
+
+    assert cli.main(["sync", "--recover"]) == 0
+
+    s2 = Store(tmp_path / "kb.sqlite")
+    assert _rolled_back_events(s2) == 0
+    assert s2.get_extraction_job(done_id)["status"] == "done"
+
+
+def test_sync_recover_is_a_noop_on_a_failed_job(tmp_path, monkeypatch, fake_client):
+    # `rollback_extraction_job` does not self-guard a `failed` job either. Rewinding
+    # one would resume it via the plain claim path, bypassing #323's retry/exhausted
+    # machinery, so `--recover` must not touch it — it stays exactly where a plain,
+    # non-`--recover` sync would leave it.
+    _env(monkeypatch, tmp_path)
+    _register_two_chunk_source(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(error=LLMError("provider down")),
+    )
+    assert cli.main(["sync"]) == 1  # every chunk fails -> job terminalises 'failed'
+    s = Store(tmp_path / "kb.sqlite")
+    failed_id = int(s.source_extraction_jobs()[0]["id"])
+    assert s.get_extraction_job(failed_id)["status"] == "failed"
+    s.close()
+
+    assert cli.main(["sync", "--recover"]) == 1
+
+    s2 = Store(tmp_path / "kb.sqlite")
+    # never rolled back: a plain-claim resume of a failed job requires a prior
+    # rollback to `pending`, which would have logged this event.
+    assert _rolled_back_events(s2, failed_id) == 0
+    assert s2.get_extraction_job(failed_id)["status"] == "failed"
+
+
+def test_sync_recover_is_a_noop_on_a_canceled_job(tmp_path, monkeypatch, fake_client):
+    # Consistent with `rollback_extraction_job`'s own `canceled` guard: a human
+    # took it out of the queue, and `--recover` must not revive it.
+    _env(monkeypatch, tmp_path)
+    _register_two_chunk_source(tmp_path, monkeypatch)
+    job_id = _stuck_running_job(tmp_path)
+    s = Store(tmp_path / "kb.sqlite")
+    s._conn.execute(
+        "UPDATE extraction_jobs SET status = 'canceled' WHERE id = ?", (job_id,)
+    )
+    s.close()
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)]),
+    )
+
+    assert cli.main(["sync", "--recover"]) == 0
+
+    s2 = Store(tmp_path / "kb.sqlite")
+    assert _rolled_back_events(s2, job_id) == 0
+    assert s2.get_extraction_job(job_id)["status"] == "canceled"
+
+
+def test_sync_recover_with_a_path_is_rejected(tmp_path, monkeypatch, capsys):
+    # A path routes to the legacy non-chunked sync, which has no extraction job to
+    # recover. Reject it rather than silently recovering nothing.
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "note.txt"
+    src.write_text("hello", encoding="utf-8")
+
+    rc = cli.main(["sync", str(src), "--recover"])
+
+    assert rc == 2
+    assert "--recover applies to registered sources" in capsys.readouterr().err
+
+
 def test_query_adds_and_translates(tmp_path, monkeypatch, capsys, fake_client, intent_payload):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -243,9 +243,10 @@ def test_sync_reports_a_resumed_run_that_fails_everything_as_failed_not_incomple
 def test_sync_retries_a_chunk_that_failed_before_the_halt(tmp_path, monkeypatch):
     """A `failed` chunk must not be stranded by resuming (regression, review).
 
-    `reset_running_chunks` rewinds only `running`; `next_pending_chunk` claims
-    only `pending`. A chunk left `failed` by a transient provider error is
-    NEITHER, so a resumed job walks straight past it and calls the source done.
+    `claim_pending_extraction_job`'s reclaim rewinds only `running`;
+    `next_pending_chunk` claims only `pending`. A chunk left `failed` by a
+    transient provider error is NEITHER, so a resumed job walks straight past it
+    and calls the source done.
     Its text never reaches the LLM again and the facts it would have produced are
     lost silently — `sync` exits 0 and the job reads `done`.
 
@@ -501,8 +502,8 @@ def test_sync_leaves_a_running_job_alone(tmp_path, monkeypatch, capsys):
     assert [int(job["id"]) for job in jobs] == [job_id]  # no replacement job
     store = _store(tmp_path)
     chunks = store.source_chunks(job_id)
-    # Not one chunk was claimed: resuming would have `reset_running_chunks` pull
-    # the other process's in-flight chunk back and send it to the LLM twice.
+    # Not one chunk was claimed: resuming would have `claim_pending_extraction_job`
+    # pull the other process's in-flight chunk back and send it to the LLM twice.
     assert {chunk["status"] for chunk in chunks} == {"pending"}
     assert {int(chunk["attempts"]) for chunk in chunks} == {0}
     store.close()
@@ -639,10 +640,14 @@ def _failed_retryable_job(tmp_path, *, source_text="alpha beta gamma", attempts=
     chunk_id = int(store.source_chunks(job_id)[0]["id"])
     store.mark_extraction_job_running(job_id)
     store.mark_chunk_running(chunk_id)
-    store.mark_chunk_failed(chunk_id, "provider down")  # job + chunk -> failed
+    store.mark_chunk_failed(chunk_id, "provider down")  # chunk -> failed
     store._conn.execute(
         "UPDATE source_chunks SET attempts = ? WHERE id = ?", (attempts, chunk_id)
     )
+    # A job is only `failed` once terminalised; mid-run it stays `running` (#337),
+    # so finish it to reach the genuine `failed` state the planner treats as a
+    # retry/give-up candidate.
+    store.finish_extraction_job(job_id)
     return store, source_id, job_id
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -835,6 +835,7 @@ def test_sources_with_counts_includes_latest_analysis_summary(tmp_path):
     s.mark_chunk_done(chunks[0], candidates=3)
     s.mark_chunk_running(chunks[1])
     s.mark_chunk_failed(chunks[1], "provider down")
+    s.finish_extraction_job(job_id)  # terminalise to `failed` (#337)
 
     row = s.sources_with_counts()[0]
 
@@ -1028,31 +1029,21 @@ def test_extraction_job_tracks_chunk_progress_and_retry(tmp_path):
     s.mark_chunk_running(chunk_ids[1])
     s.mark_chunk_failed(chunk_ids[1], "provider down")
 
+    # The job is still owned and mid-run, so it stays `running` even with a failed
+    # chunk (#337); the counters and candidate tally track progress underneath.
     job = s.get_extraction_job(job_id)
-    assert job["status"] == "failed"
+    assert job["status"] == "running"
     assert job["completed_chunks"] == 1
     assert job["failed_chunks"] == 1
     assert job["candidate_count"] == 2
-    assert "1 chunk(s) failed" in job["message"]
+    assert "1/2 chunk(s) complete" in job["message"]
 
+    # Only an explicit finish terminalises the job to `failed`; that is the state
+    # the retry claim can then take.
+    s.finish_extraction_job(job_id)
+    assert s.get_extraction_job(job_id)["status"] == "failed"
     assert s.claim_extraction_job_for_retry(job_id, max_attempts=None) is True
     assert s.source_chunks(job_id)[1]["status"] == "pending"
-
-
-def test_reset_running_chunks_makes_job_resumable(tmp_path):
-    s = _store(tmp_path)
-    sid = s.add_source("sources/a.txt")
-    job_id = s.create_extraction_job(
-        source_id=sid, provider="fake", model="m", total_chunks=1
-    )
-    chunk_id = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])[0]
-
-    s.mark_extraction_job_running(job_id)
-    s.mark_chunk_running(chunk_id)
-
-    assert s.reset_running_chunks(job_id) == 1
-    assert s.next_pending_chunk(job_id)["id"] == chunk_id
-    assert s.get_extraction_job(job_id)["status"] == "pending"
 
 
 def test_claim_pending_extraction_job_is_exclusive_across_connections(tmp_path):
@@ -1125,7 +1116,8 @@ def test_claim_pending_extraction_job_rejects_non_pending(tmp_path):
 
 def test_claim_pending_extraction_job_reclaims_a_stray_running_chunk(tmp_path):
     """A claim reclaims a stray `running` chunk WITHOUT flipping the job back out of
-    `running` — the reason the claim uses a raw update, not `reset_running_chunks` (#240)."""
+    `running` — the reason the reclaim is a raw update, not a helper that recomputes
+    job status from the chunks (#240)."""
     s = _store(tmp_path)
     sid = s.add_source("sources/a.txt")
     job_id = s.create_extraction_job(
@@ -1141,8 +1133,9 @@ def test_claim_pending_extraction_job_reclaims_a_stray_running_chunk(tmp_path):
 
     assert s.claim_pending_extraction_job(job_id) is True
 
-    # `reset_running_chunks` would have `_refresh_extraction_job` recompute the job
-    # from its (now zero) running chunks and flip it straight back to `pending`.
+    # The CAS set the job `running` and the reclaim is a raw update, so the job
+    # stays `running`: the reclaim never routes through `_refresh_extraction_job`,
+    # which since #337 would keep an owned job `running` anyway.
     assert s.get_extraction_job(job_id)["status"] == "running"
     assert s.source_chunks(job_id)[0]["status"] == "pending"  # stray chunk reclaimed
     assert s.next_pending_chunk(job_id)["id"] == chunk_ids[0]
@@ -1161,7 +1154,8 @@ def test_claim_extraction_job_for_retry_is_exclusive_across_connections(tmp_path
     chunk_id = store_a.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])[0]
     store_a.mark_extraction_job_running(job_id)
     store_a.mark_chunk_running(chunk_id)
-    store_a.mark_chunk_failed(chunk_id, "provider down")  # job + chunk now 'failed'
+    store_a.mark_chunk_failed(chunk_id, "provider down")  # chunk 'failed'
+    store_a.finish_extraction_job(job_id)  # terminalise: job now genuinely 'failed'
     store_b = Store(db_path)  # a second process's connection to the same KB file
 
     assert store_a.claim_extraction_job_for_retry(job_id, max_attempts=None) is True
@@ -1195,6 +1189,7 @@ def test_claim_extraction_job_for_retry_respects_the_attempts_cap(tmp_path):
     s.mark_chunk_failed(chunk_id, "boom")
     # Force the chunk to the cap without disturbing its `failed` status.
     s._conn.execute("UPDATE source_chunks SET attempts = 2 WHERE id = ?", (chunk_id,))
+    s.finish_extraction_job(job_id)  # terminalise the job to `failed` first (#337)
 
     # attempts (2) is NOT < cap (2): the claim still takes ownership but resets nothing.
     assert s.claim_extraction_job_for_retry(job_id, max_attempts=2) is True
@@ -1247,7 +1242,7 @@ def test_claim_extraction_job_for_retry_refuses_a_canceled_job(tmp_path):
     chunk_id = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a"])[0]
     s.mark_extraction_job_running(job_id)
     s.mark_chunk_running(chunk_id)
-    s.mark_chunk_failed(chunk_id, "provider down")  # job + chunk 'failed'
+    s.mark_chunk_failed(chunk_id, "provider down")  # chunk 'failed'; job 'running'
     s._conn.execute(
         "UPDATE extraction_jobs SET status = 'canceled' WHERE id = ?", (job_id,)
     )
@@ -1283,6 +1278,7 @@ def test_claim_extraction_job_for_retry_resets_only_under_cap_chunks_in_a_mixed_
     s._conn.execute(
         "UPDATE source_chunks SET attempts = 3 WHERE id = ?", (chunk_ids[1],)
     )  # at the cap
+    s.finish_extraction_job(job_id)  # terminalise the job to `failed` first (#337)
 
     assert s.claim_extraction_job_for_retry(job_id, max_attempts=3) is True
 
@@ -1321,6 +1317,114 @@ def test_claim_extraction_job_for_retry_reclaims_a_stray_running_chunk_on_a_fail
 
     assert s.get_extraction_job(job_id)["status"] == "running"  # claimed
     assert s.get_source_chunk(chunk_id)["status"] == "pending"  # stray reclaimed
+
+
+def test_mark_chunk_done_keeps_an_owned_job_running_against_a_second_claim(tmp_path):
+    """W1 (#337): a chunk finishing mid-run must not drop an owned job to `pending`
+    where a second connection's pending-claim could steal it.
+
+    Between one chunk finishing and the next being claimed, zero chunks are
+    `running` in the DB. Recomputing job status from that aggregate used to flip
+    the owner's job to `pending`, and a concurrent `claim_pending_extraction_job`
+    (CAS on `status='pending'`) then matched a job already being processed.
+    """
+    db_path = tmp_path / "kb.sqlite"
+    store_a = Store(db_path)
+    store_a.init_schema()
+    sid = store_a.add_source("sources/a.txt")
+    job_id = store_a.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    chunk_ids = store_a.add_source_chunks(
+        job_id=job_id, source_id=sid, chunks=["a", "b"]
+    )
+    store_b = Store(db_path)  # a second process's connection to the same KB file
+
+    assert store_a.claim_pending_extraction_job(job_id) is True
+    store_a.mark_chunk_running(chunk_ids[0])
+    store_a.mark_chunk_done(chunk_ids[0], candidates=1)
+
+    # Zero chunks `running` now, but the job is still owned: it stays `running`.
+    assert store_a.get_extraction_job(job_id)["status"] == "running"
+    # So the second connection cannot claim it out from under the live owner...
+    assert store_b.claim_pending_extraction_job(job_id) is False
+    # ...and the owner keeps processing its remaining chunk unobstructed.
+    assert store_a.mark_chunk_running(chunk_ids[1]) is not None
+    store_a.close()
+    store_b.close()
+
+
+def test_mark_chunk_failed_keeps_an_owned_job_running_against_a_retry_claim(tmp_path):
+    """W2 (#337): a chunk failing mid-run must not drop an owned job to `failed`
+    where a second connection's retry-claim could steal it — and reset the owner's
+    in-flight chunk out from under it.
+
+    `claim_extraction_job_for_retry` CASes `status IN ('pending','failed')` and, on
+    a match, reclaims stray `running` chunks. A mid-run failed chunk used to
+    terminalise the owned job to `failed`, so the retry claim matched it and its
+    stray-running reclaim rewound the owner's next chunk to `pending` — the same
+    chunk then sent to the LLM a second time.
+    """
+    db_path = tmp_path / "kb.sqlite"
+    store_a = Store(db_path)
+    store_a.init_schema()
+    sid = store_a.add_source("sources/a.txt")
+    job_id = store_a.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    chunk_ids = store_a.add_source_chunks(
+        job_id=job_id, source_id=sid, chunks=["a", "b"]
+    )
+    store_b = Store(db_path)  # a second process's connection to the same KB file
+
+    assert store_a.claim_pending_extraction_job(job_id) is True
+    store_a.mark_chunk_running(chunk_ids[0])
+    store_a.mark_chunk_failed(chunk_ids[0], "provider down")
+
+    # A failed chunk mid-run does NOT terminalise the still-owned job.
+    assert store_a.get_extraction_job(job_id)["status"] == "running"
+    # The owner moves on and claims its next chunk as `running`.
+    assert store_a.mark_chunk_running(chunk_ids[1]) is not None
+
+    # The retry claim cannot match a `running` job, so it neither takes ownership
+    # nor resets the owner's in-flight chunk.
+    assert store_b.claim_extraction_job_for_retry(job_id, max_attempts=3) is False
+    assert store_a.get_source_chunk(chunk_ids[1])["status"] == "running"
+    store_a.close()
+    store_b.close()
+
+
+def test_finish_extraction_job_terminalises_a_running_job(tmp_path):
+    """finish still terminalises correctly despite the running-guard (#337): a job
+    carrying a failed chunk stays `running` right up until finish, then `failed`;
+    a job whose chunks all finish cleanly ends `done`."""
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+
+    mixed = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    mixed_chunks = s.add_source_chunks(job_id=mixed, source_id=sid, chunks=["a", "b"])
+    s.mark_extraction_job_running(mixed)
+    s.mark_chunk_running(mixed_chunks[0])
+    s.mark_chunk_done(mixed_chunks[0], candidates=1)
+    s.mark_chunk_running(mixed_chunks[1])
+    s.mark_chunk_failed(mixed_chunks[1], "provider down")
+    # owned and mid-run, so still `running` even though a chunk has failed
+    assert s.get_extraction_job(mixed)["status"] == "running"
+    s.finish_extraction_job(mixed)
+    assert s.get_extraction_job(mixed)["status"] == "failed"
+
+    clean = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    clean_chunks = s.add_source_chunks(job_id=clean, source_id=sid, chunks=["a", "b"])
+    s.mark_extraction_job_running(clean)
+    for cid in clean_chunks:
+        s.mark_chunk_running(cid)
+        s.mark_chunk_done(cid, candidates=1)
+    s.finish_extraction_job(clean)
+    assert s.get_extraction_job(clean)["status"] == "done"
 
 
 def _job_with_mixed_chunks(s, sid):
@@ -1401,8 +1505,9 @@ def test_rollback_extraction_job_records_a_fact_event(tmp_path):
     assert event["actor"] == "system"
     assert event["job_id"] == job_id
     assert event["source_id"] == sid
-    # the job carried a failed chunk, so it stood at 'failed' before the rewind
-    assert json.loads(event["before_json"])["status"] == "failed"
+    # the job was halted mid-run, so it genuinely stood at 'running' before the
+    # rewind (a failed chunk no longer terminalises an owned job, #337)
+    assert json.loads(event["before_json"])["status"] == "running"
     assert json.loads(event["after_json"])["status"] == "pending"
 
 
@@ -1584,6 +1689,9 @@ def test_extraction_job_records_lifecycle_events(tmp_path):
     s.mark_extraction_job_running(failed_job)
     s.mark_chunk_running(failed_chunk)
     s.mark_chunk_failed(failed_chunk, "provider down")
+    # A failed chunk leaves the owned job `running`; only finish terminalises it to
+    # `failed` (a completed event) so the retry claim can then take it (#337).
+    s.finish_extraction_job(failed_job)
     s.claim_extraction_job_for_retry(failed_job, max_attempts=None)
     s.fail_extraction_job(failed_job, "analysis failed")
 
@@ -1613,6 +1721,7 @@ def test_extraction_job_records_lifecycle_events(tmp_path):
     assert event_types == [
         "extraction_job_started",  # mark_extraction_job_running(failed_job)
         "chunk_failed",  # mark_chunk_failed
+        "extraction_job_completed",  # finish_extraction_job terminalises it (#337)
         "chunk_retried",  # claim_extraction_job_for_retry resets the failed chunk
         "extraction_job_started",  # ...and takes ownership in the same locked step
         "extraction_job_failed",  # fail_extraction_job

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -513,6 +513,7 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.pipeline import (
         create_chunked_extraction_job,
         ExtractionJobBusyError,
+        latest_source_job_ids,
         MAX_CHUNK_ATTEMPTS,
         plan_source_extraction,
         process_extraction_job,
@@ -526,6 +527,20 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
             return cfg.extraction_schema_hint()
         except PromptError as exc:
             raise LLMError(str(exc)) from exc
+
+    # `--recover` rewinds a stuck `running` extraction job so this run can resume
+    # it, and those jobs exist only for registered sources: the path branch of
+    # `_resolve_sources` builds an unregistered legacy source with no chunked job
+    # to recover. Reject `--recover <path>` rather than silently running an
+    # ordinary path sync that recovers nothing and leaves the user thinking they
+    # scoped a recovery that never happened.
+    if args.recover and args.path:
+        print(
+            "error: --recover applies to registered sources; run "
+            "`verinote sync --recover` without a path",
+            file=sys.stderr,
+        )
+        return 2
 
     # No path, no KB, and no source files: there is nothing to sync, so refuse
     # before `_store()` — `Store()` mkdirs the parent and connects in its
@@ -564,6 +579,34 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
         client = get_client(cfg)
         registered = [source for source in sources if source.source_id is not None]
         if registered:
+            if args.recover:
+                # User-asserted crash recovery: before planning, rewind each
+                # source's newest job that is stuck `running` so the ordinary
+                # claim path below resumes it. The `status == 'running'` gate is
+                # mandatory and belongs HERE, not in the reused
+                # `rollback_extraction_job` (which only self-guards `canceled`):
+                # on a `done` job a rollback would churn an empty run, and on a
+                # `failed` job it would resume via the plain claim path,
+                # bypassing #323's retry/exhausted machinery. There is no
+                # liveness check — see the flag's help text.
+                recover_jobs = store.source_extraction_jobs()
+                recover_latest = latest_source_job_ids(recover_jobs)
+                for source in registered:
+                    latest_id = recover_latest.get(source.source_id)
+                    if latest_id is None:
+                        continue
+                    job = store.get_extraction_job(latest_id)
+                    if job is None or job["status"] != "running":
+                        continue
+                    store.rollback_extraction_job(
+                        latest_id,
+                        "Recovering an extraction job interrupted mid-run.",
+                    )
+                    print(
+                        f"recovering {source.source_path}: rolled back stuck "
+                        f"extraction job #{latest_id}; resuming it below",
+                        file=sys.stderr,
+                    )
             per_source = []
             blocked: list[_BlockedSource] = []
             total = 0
@@ -580,10 +623,17 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     chunk_overlap_chars=cfg.extraction_chunk_overlap_chars,
                 )
                 if plan.busy_job_id is not None:
+                    # A `running` job is either genuinely owned by a live worker
+                    # or was left `running` by a crash mid-run — the two are
+                    # indistinguishable from DB state alone (#337/#242), so this
+                    # names both and points at the recovery paths rather than
+                    # asserting an owner that may not exist.
                     print(
                         f"skipping {source.source_path}: extraction job "
-                        f"#{plan.busy_job_id} is already running (another process "
-                        f"owns its chunks)",
+                        f"#{plan.busy_job_id} is already running, or was "
+                        f"interrupted mid-run — if no analysis is in progress, "
+                        f"run `verinote ui` once to resume it, or "
+                        f"`verinote sync --recover` to resume it directly",
                         file=sys.stderr,
                     )
                     continue
@@ -1197,6 +1247,18 @@ def build_parser() -> argparse.ArgumentParser:
         "path",
         nargs="?",
         help="a source file; omit to sync every .txt/.md under <root>/sources/",
+    )
+    sync.add_argument(
+        "--recover",
+        action="store_true",
+        help=(
+            "before syncing, roll back each registered source's stuck 'running' "
+            "extraction job so this run resumes it (for a job left running by a "
+            "crash). Has NO liveness check: use only when you are certain no "
+            "analysis is in progress for this KB, including a running `verinote "
+            "ui` server, or it will reset a live worker's in-flight chunk. Cannot "
+            "be combined with a path"
+        ),
     )
     sync.set_defaults(func=cmd_sync, halt_safe=False)
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -242,8 +242,9 @@ def plan_source_extraction(
 
     A job rolled back to `pending` (see `_halt_extraction_job`) still holds every
     chunk it finished, and the machinery to carry on already works —
-    `next_pending_chunk` skips `done` chunks, `reset_running_chunks` reclaims
-    in-flight ones, `candidate_count` accumulates. What was missing was anyone
+    `next_pending_chunk` skips `done` chunks, `claim_pending_extraction_job`
+    reclaims any in-flight one as it takes ownership, `candidate_count`
+    accumulates. What was missing was anyone
     asking for it, so every sync started from chunk zero and paid for the same
     LLM calls twice.
 
@@ -270,8 +271,9 @@ def plan_source_extraction(
     fresh, which is why the gates run before the failed-chunk handling below.
 
     A `failed` job that is NOT stale is decided by its failed chunks. A failed
-    chunk is invisible to resume (`reset_running_chunks` rewinds only `running`,
-    `next_pending_chunk` claims only `pending`), so the job is re-run through the
+    chunk is invisible to resume (`claim_pending_extraction_job`'s reclaim
+    rewinds only `running`, `next_pending_chunk` claims only `pending`), so the
+    job is re-run through the
     atomic retry claim, which resets the failed chunks under the same lock that
     takes ownership. But the moment ANY failed chunk has spent its whole attempt
     budget (`attempts >= max_chunk_attempts`) the job has given up: it is surfaced
@@ -282,8 +284,9 @@ def plan_source_extraction(
     resets every failed chunk regardless of attempt count.
 
     A `running` job is neither resumed nor replaced. It may belong to a live UI
-    worker, and resuming would have `reset_running_chunks` yank that worker's
-    in-flight chunk back into the queue — the same chunk sent to the LLM twice.
+    worker, and resuming would have `claim_pending_extraction_job`'s reclaim yank
+    that worker's in-flight chunk back into the queue — the same chunk sent to the
+    LLM twice.
     """
     jobs = store.source_extraction_jobs()
     latest_job_ids = latest_source_job_ids(jobs)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -658,18 +658,6 @@ class Store:
             )
         )
 
-    def reset_running_chunks(self, job_id: int) -> int:
-        """Return stale running chunks for a job to pending before resume."""
-        with self._lock:
-            cur = self._conn.execute(
-                "UPDATE source_chunks SET status = 'pending', error = '', "
-                "updated_at = datetime('now') "
-                "WHERE job_id = ? AND status = 'running'",
-                (job_id,),
-            )
-            self._refresh_extraction_job(job_id)
-            return int(cur.rowcount)
-
     def next_pending_chunk(self, job_id: int) -> sqlite3.Row | None:
         return self._conn.execute(
             "SELECT * FROM source_chunks "
@@ -728,11 +716,11 @@ class Store:
             if cur.rowcount == 0:
                 return False
             # Now that we exclusively own it, reclaim any chunk a prior crashed run
-            # left `running`. RAW update, NOT `reset_running_chunks`: that helper ends
-            # in `_refresh_extraction_job`, which would recompute the job from its
-            # chunks and flip our just-set `running` back to `pending`. A claimed
-            # `pending` job has no `running` chunk in any real path, so this is a
-            # defensive no-op that preserves the invariant without disturbing status.
+            # left `running`. Raw update, no event, no `_refresh_extraction_job`: the
+            # status is ours by the CAS above and, since #337, stays `running` for the
+            # whole owned pass regardless. A claimed `pending` job has no `running`
+            # chunk in any real path, so this is a defensive no-op that preserves the
+            # invariant without disturbing status.
             self._conn.execute(
                 "UPDATE source_chunks SET status = 'pending', error = '', "
                 "updated_at = datetime('now') WHERE job_id = ? AND status = 'running'",
@@ -816,8 +804,8 @@ class Store:
         button — nothing stays stranded); an int resets only chunks still under the
         cap (`attempts < max_attempts`), leaving exhausted chunks failed so planning
         can surface the job as given up. Raw SQL, never `_refresh_extraction_job`:
-        that helper recomputes the job from its chunks and would flip our just-set
-        `running` straight back out.
+        the status is ours by the CAS above and stays `running` for the whole owned
+        pass (#337), so re-deriving it from the chunks here would only be redundant.
         """
         with self._lock:
             before = self.get_extraction_job(job_id)
@@ -2395,10 +2383,23 @@ class Store:
         failed = int(counts["failed"])
         running = int(counts["running"])
         total = int(counts["total"])
+        current = self.get_extraction_job(job_id)
+        current_status = current["status"] if current is not None else None
         if final and failed:
             status = "failed"
         elif final or (total and done == total):
             status = "done"
+        elif current_status == "running":
+            # An owned job stays 'running' for its whole processing pass. `status`
+            # is #240's ownership handshake -- the claim_pending_extraction_job /
+            # claim_extraction_job_for_retry CAS keys on it -- NOT a chunk
+            # aggregate: between chunks running == 0, and recomputing from that
+            # dropped an actively-owned job to 'pending' (after a done chunk) or
+            # 'failed' (after a failed one) mid-run, so a second worker's claim
+            # matched a job already being processed (#337). Only an explicit
+            # transition -- finish (final, handled above) or rollback (a direct
+            # UPDATE that never routes through here) -- leaves 'running'.
+            status = "running"
         elif running:
             status = "running"
         elif failed:


### PR DESCRIPTION
## Summary

Closes #337. `Store._refresh_extraction_job` unconditionally recomputed a job's status from its chunks' aggregate counts on every `mark_chunk_done`/`mark_chunk_failed` call — even while the job was actively `running` (owned by a worker mid-processing). Since the processing loop only ever holds one chunk `running` at a time, there's a real window between one chunk finishing and the next being claimed where zero chunks are `running`; the aggregate recompute fell through to `pending` (after a done chunk) or `failed` (after a failed one), and the job stayed there for its *entire remaining processing duration*, not a moment. That opened two double-ownership windows: a concurrent `claim_pending_extraction_job` could steal a job that fell to `pending`, and — worse — a concurrent `claim_extraction_job_for_retry` could steal a job that fell to `failed`, whose stray-running-chunk reclaim would reset the live worker's own in-flight chunk and send it to the LLM a second time. This bug grew since it was first discovered as a side effect of #323's design: the retry-claim window didn't exist until #323's own merge created `claim_extraction_job_for_retry`.

**Unit 1** adds a guard: a job that's already `running` stays `running` through any non-final refresh — its status is the ownership handshake #240's claim CAS keys on, not a chunk aggregate, and only an explicit transition (finish, or rollback) should move it. Placement in the status-decision chain is safety-critical (must gate before the failed-chunk fallthrough, not just the pending one, or only half the bug closes) and was empirically verified with real two-connection Store tests for both windows. `reset_running_chunks` — the one function that legitimately wanted the old behavior — had zero production callers and is deleted.

**Unit 2** completes the fix's real-world consequence: the core fix removes an *accidental* side effect where a CLI-only user (cron/automation, never launching `verinote ui`) got free recovery from a crashed multi-chunk job, because the bug made a crashed job indistinguishable from a live one. This restores native CLI recovery deliberately rather than leaving it to chance: an honest skip message (the old "another process owns its chunks" line is a lie once a crashed job looks identical to a live one from DB state alone), and a new `verinote sync --recover` flag that rewinds a source's *stuck* job — gated strictly on the job's status being `running` at the moment of recovery, since the reused `rollback_extraction_job` does not self-guard against `done`/`failed` jobs and calling it on either would either churn a spurious empty run or silently bypass #323's retry/exhausted machinery. `--recover` is explicit, user-asserted, and documented as having no liveness check.

## Test plan
- [x] Full suite: 1510 passed, 7 skipped (was 1502 before this fix)
- [x] `ruff check` clean
- [x] Two real-connection regression tests proving both double-ownership windows are closed (not just one — the second, retry-path window is easy to miss since the original issue text didn't describe it)
- [x] `finish_extraction_job` still correctly terminalizes both a clean job and one carrying a failed chunk
- [x] `verinote sync --recover` resumes a genuinely stuck job to completion in one invocation
- [x] `--recover` is a verified no-op on `done`, `failed`, and `canceled` jobs — including confirming it does not bypass the existing chunk-retry/give-up logic on a failed job
- [x] The plan-time skip message is honest about ambiguity; the separate genuine-live-race message elsewhere is correctly left unchanged
- [x] `--recover` combined with an explicit path is rejected with a clear error, rather than silently scoping nothing
