### PR TITLE
fix(#164): correct the report's false promotion/query gate claim

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -429,9 +429,33 @@ def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
     report = client.get("/report")
     assert report.status_code == 200
     assert "policy_missing" in report.text
-    # ("inconsistent — promotion stays gated" is the errors banner, not a claim
+    # (the "has unresolved errors under its policy" errors banner is not a claim
     # that the KB checked out clean)
     assert "knowledge base is consistent" not in report.text
+
+
+def test_report_banner_makes_no_fact_causal_claim_on_a_lost_policy(tmp_path, monkeypatch):
+    """The errors banner must be accurate for every `errors > 0` cause (#164).
+
+    A policy_missing KB short-circuits in `verify()` before the engine reads any
+    fact (errors=1), so a banner that said the errors were "derived from the
+    facts currently promoted" or advised "reject, correct, or demote the facts
+    involved" would assert a cause the check never produced — the same false-claim
+    class #164 exists to close, one layer down. Recovery here is restoring the
+    policy file, not touching facts.
+    """
+    client = _halted_client(tmp_path, monkeypatch)
+
+    report = client.get("/report")
+
+    assert report.status_code == 200
+    assert "policy_missing" in report.text
+    # The banner renders (errors > 0) and states the two load-bearing true things,
+    assert "Promotion is not blocked" in report.text
+    assert "has unresolved errors under its policy" in report.text
+    # but makes no fact-specific causal claim or fact-only recovery advice.
+    assert "from the facts currently promoted to it" not in report.text
+    assert "reject, correct, or demote the facts involved" not in report.text
 
 
 def test_report_survives_a_lost_policy_when_the_kb_has_a_query(tmp_path, monkeypatch):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1591,7 +1591,7 @@ def test_report_traceability_renders_one_status_then_none(tmp_path):
     assert "awaiting review" not in body
 
 
-def test_report_gates_on_contradiction(tmp_path):
+def test_report_flags_contradiction(tmp_path):
     c = _client(tmp_path)
     store = c.app.state.store
     store.add_fact("Org", "established_on", "2020", status="confirmed")
@@ -1600,6 +1600,122 @@ def test_report_gates_on_contradiction(tmp_path):
     assert r.status_code == 200
     assert "ERRORS" in r.text
     assert "functional_conflict" in r.text
+
+
+def test_report_does_not_claim_a_promotion_gate(tmp_path):
+    """The errors banner must not resurrect the false "promotion/query gated" claim.
+
+    No gate exists (see #164): promotion writes never consult the report, and this
+    page renders its own answers unconditionally. The banner may say the KB is
+    inconsistent, but not that anything is blocked.
+    """
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Org", "established_on", "2021", status="confirmed")
+
+    r = c.get("/report")
+
+    assert r.status_code == 200
+    assert "ERRORS" in r.text
+    # The old banner falsely claimed promotion and this page's own answers were
+    # gated; both are untrue.
+    assert "stay gated" not in r.text
+    assert "promotion/query" not in r.text
+    # The honest banner is present and says promotion is not blocked.
+    assert "Promotion is not blocked" in r.text
+
+
+def test_promotion_succeeds_while_errors_exist(tmp_path):
+    """The issue's own repro, pinned as intended behavior (#164).
+
+    A human's accept is a review-tier decision that writes unconditionally with
+    respect to the consistency report — an unrelated error must never block it,
+    and the promoted fact must reach engine input.
+    """
+    c = _client(tmp_path)
+    store = c.app.state.store
+    # A functional conflict on `established_on` (both confirmed): errors > 0.
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Org", "established_on", "2021", status="confirmed")
+    assert "ERRORS" in c.get("/report").text
+    unrelated = store.add_fact("Widget", "is_a", "Gadget", status="needs_review")
+
+    r = c.post(f"/facts/{unrelated}/accept")
+
+    assert r.status_code == 200
+    assert store.get_fact(unrelated)["status"] == "confirmed"
+    assert unrelated in {int(row["id"]) for row in store.engine_fact_terms()}
+    # The error is unchanged — promotion neither cleared nor worsened it.
+    assert "ERRORS" in c.get("/report").text
+
+
+def test_report_shows_answers_even_while_errors_exist(tmp_path):
+    """The "query gated" half of the old claim was false: answers still render.
+
+    `verify()` returns findings and answers together and the template renders
+    `rep.answers` with no error guard, so an answer and an error coexist on the
+    page — the banner must not say otherwise.
+    """
+    c = _client(tmp_path)
+    store = c.app.state.store
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("Ada", "born_in", "London", status="confirmed", source_id=source_id)
+    path = query_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O).\n',
+        encoding="utf-8",
+    )
+    # An unrelated functional conflict drives errors > 0 on the same page.
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Org", "established_on", "2021", status="confirmed")
+
+    body = unescape(c.get("/report").text)
+
+    assert "ERRORS" in body
+    assert "London" in body
+
+
+def test_ask_still_verifies_a_clean_answer_while_errors_exist(tmp_path, monkeypatch):
+    """Ask does not gate its VERIFIED label on the KB consistency report (#164).
+
+    Ask certifies from the answer query's own run (policy is the base relation
+    decl), not from `/report`'s error count, so an unrelated functional_conflict
+    never downgrades a clean deterministic answer. This pins that the report
+    banner must NOT claim Ask withholds VERIFIED while errors stand — it does not.
+    If Ask ever starts gating on report errors, this fails and the banner copy
+    must be revisited in lockstep.
+    """
+    class DeterministicOnly:
+        name = "deterministic-only"
+
+        def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+            raise AssertionError("deterministic question must bypass LLM")
+
+        def translate_query(self, *, question: str, qid: int, schema_hint: str = ""):
+            raise AssertionError("Ask must not call direct Datalog fallback")
+
+        def answer_question(self, *, question: str, context: str):
+            raise AssertionError("verified engine answer must not call fallback")
+
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: DeterministicOnly())
+    c = _client(tmp_path)
+    store = c.app.state.store
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플인물", "역할", "검토자", status="confirmed", source_id=source_id)
+    # An unrelated functional conflict makes /report show errors > 0.
+    store.add_fact("Org", "established_on", "2020", status="confirmed")
+    store.add_fact("Org", "established_on", "2021", status="confirmed")
+    assert "ERRORS" in c.get("/report").text
+
+    r = c.post("/ask", data={"question": "샘플인물의 역할은 무엇인가?"})
+
+    assert r.status_code == 200
+    body = unescape(r.text)
+    assert "VERIFIED — engine" in body
+    assert "검토자" in body
 
 
 def test_report_shows_missing_duckdb_message(tmp_path, monkeypatch):

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -68,9 +68,10 @@ DEFAULT_POLICY = f"""\
 //
 // verinote compiles confirmed/accepted facts to
 //   relation(subject, rel, object)
-// and runs this policy over them. A derived `error_*` relation FAILS the review
-// gate; a `warn_*` relation is a non-blocking note. Edit freely — the engine
-// re-checks every fact, so the policy is the one place review rules live.
+// and runs this policy over them. A derived `error_*` relation makes the check
+// report a failure; a `warn_*` relation is a non-blocking note. Edit freely —
+// the engine re-checks every fact, so the policy is the one place review rules
+// live.
 
 .decl relation(subject: symbol, rel: symbol, object: symbol)
 
@@ -481,8 +482,9 @@ def run_check(
     `dl_text` is `compile_dl` output (the verbatim engine input). `policy_dl`
     defaults to `DEFAULT_POLICY`. `query_dl` holds `answer_q<id>(...)` query rules
     (see pipeline.query). Derived `error_*`/`warn_*` tuples become findings
-    (`errors > 0` is the review gate); `answer_q<id>` tuples become answers. If
-    pyrewire is absent we still return a legacy compatibility report flagged
+    (`errors > 0` marks the report not-ok; it does not block promotion or query);
+    `answer_q<id>` tuples become answers. If pyrewire is absent we still return a
+    legacy compatibility report flagged
     `engine_available=False`.
     """
     policy = policy_dl if policy_dl is not None else DEFAULT_POLICY

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -16,8 +16,9 @@
 </p>
 {% if rep.errors > 0 %}
 <p class="error" role="alert">
-  The knowledge base is inconsistent — promotion/query stay gated until the
-  errors below are resolved.
+  The knowledge base has unresolved errors under its policy (listed below).
+  Promotion is not blocked and this page still lists any answers, so resolve
+  these before trusting results.
 </p>
 {% endif %}
 {% if rep.findings %}


### PR DESCRIPTION
## Summary

Closes #164. The web report's error banner claimed "The knowledge base is inconsistent — promotion/query stay gated until the errors below are resolved," but no such gate exists anywhere in the code: every human status-transition route (accept/toggle/reject/amend/accept-all) writes unconditionally with respect to `verify()`'s findings, and `/report` renders its own query answers with no error guard — so the page printed the false claim directly above the answers that disprove it. This is the same "system asserts a safety property it doesn't provide" class as two issues already fixed this session (#329, #286).

This is a **copy-only fix** — the actual promotion/query behavior was already correct; only the text describing it was false. Building an actual gate was considered and rejected: a global block would deadlock conflict resolution itself (clearing a `functional_conflict` requires promotion-tier writes — reject or demote one of the conflicting facts), and a per-fact scoped gate is infeasible by the codebase's own deliberate design (finding-to-fact attribution only works for the one built-in `functional_conflict` rule, not user-authored policy rules — a scoped gate would itself become a mechanism silently over/under-blocking for custom policies, the exact bug class this issue exists to close).

The reworded banner states only what's true for every `errors > 0` cause (promotion isn't blocked; this page still lists any answers; resolve before trusting results) — deliberately making no claim about *why* the errors arose, since `verify()` also short-circuits to `errors=1` for policy-missing/engine/parse failures before ever reading a fact, where a "derived from promoted facts" framing would itself be false. Two related code comments in `wirelog.py` that made the same false gate-equation (one of which is scaffolded verbatim into every new KB's policy file) were corrected too.

Notably, an earlier draft of this fix's banner credited `/ask`'s VERIFIED-label gating as the "honest" replacement for the false query-gating claim — this was empirically disproven mid-implementation (`/ask`'s consistency check runs against a bare relation declaration with no functional-policy rules loaded, so a KB-wide conflict never reaches it) and independently re-confirmed false by re-verification, so the shipped banner makes no claim about Ask at all. Caught and corrected before shipping, rather than replacing one false claim with a different one.

## Test plan
- [x] Full suite: 1515 passed, 7 skipped
- [x] `ruff check` clean
- [x] The issue's own repro is now pinned as explicitly intended behavior: promotion succeeds while the report shows errors
- [x] Query answers render on `/report` alongside errors (the other false half of the original claim)
- [x] `/ask` still correctly labels a clean, unrelated answer VERIFIED while unrelated errors exist (pins the decoupling that corrected the design mid-flight)
- [x] The banner makes no fact-specific causal claim on a policy-missing KB (accurate across every `errors > 0` cause, not just fact contradictions)
- [x] No other correct use of "review gate" elsewhere in the codebase was touched — only the two specific comments that falsely equated an error finding with failing that gate
