### PR TITLE
fix(#288): word the PRESENT policy line to what it actually checks

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -833,6 +833,10 @@ def test_policy_cli_line_covers_every_policy_status():
     assert lines[PolicyStatus.PRESENT] == POLICY_CLI_LINE_PRESENT
     assert lines[PolicyStatus.UNRECORDED_DEFAULT] == POLICY_CLI_LINE_UNRECORDED_DEFAULT
     assert "HALTED" in POLICY_CLI_LINE_MISSING_RECORDED
+    # #288: PRESENT is the one state that cannot see rule content, so its line
+    # claims only the file's presence — never that the KB's rules exist.
+    assert POLICY_CLI_LINE_PRESENT == "policy: ok (policy file present)"
+    assert "rules" not in POLICY_CLI_LINE_PRESENT
 
 
 def test_status_says_the_kb_is_halted_on_stdout(tmp_path, monkeypatch, capsys):
@@ -897,6 +901,24 @@ def test_status_of_unrecorded_kb_prints_the_default_line(tmp_path, monkeypatch, 
     assert POLICY_CLI_LINE_UNRECORDED_DEFAULT in captured.out
     assert "HALTED" not in captured.out
     assert captured.err == ""  # the benign state is not an error
+
+
+def test_present_line_is_honest_on_an_empty_policy_file(tmp_path, monkeypatch, capsys):
+    """A 0-byte policy file still resolves to PRESENT (`is_file()` is True); the
+    line must not claim rules exist — the #288 lie. This asserts phrasing only:
+    *detecting* an empty policy is a separate issue (#359), deliberately not done
+    here.
+    """
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    (tmp_path / POLICY_RELPATH).write_text("", encoding="utf-8")
+    capsys.readouterr()  # drop init's output
+
+    assert cli.main(["status"]) == 0
+
+    out = capsys.readouterr().out
+    assert POLICY_CLI_LINE_PRESENT in out
+    assert "rules are present" not in out  # the specific false claim #288 removed
 
 
 # --- (b) the worker: a mid-job halt must rewind the job, not strand it ------

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -79,7 +79,7 @@ POLICY_UNRECORDED_BANNER = (
 # people to ignore the policy line, and then the HALTED line gets ignored with it.
 # The loud, actionable text for a real halt is `policy_missing_message`, which the
 # CLI prints to stderr *in addition* to the stdout marker.
-POLICY_CLI_LINE_PRESENT = "policy: ok (this KB's own rules are present)"
+POLICY_CLI_LINE_PRESENT = "policy: ok (policy file present)"
 POLICY_CLI_LINE_MISSING_RECORDED = "policy: HALTED (rules missing)"
 POLICY_CLI_LINE_UNRECORDED_DEFAULT = "policy: default (this KB records no rules of its own)"
 


### PR DESCRIPTION
## Summary

- `verinote status`'s `PRESENT` policy line claimed "this KB's own rules are present," but `resolve_policy` only ever checks file-existence + a KB marker — it never inspects rule content. On a 0-byte policy file, `status` printed a reassuring "policy: ok (this KB's own rules are present)" in the same breath that `verify()` correctly reported `ok=False` with an engine error. `status`/`coverage` are the only diagnostic surface for non-web users, and the wording pointed them the wrong way.
- Reworded the constant so it claims only what was actually checked: `policy: ok (policy file present)`. No change to `resolve_policy`, `PolicyStatus`, or the other two status lines (`MISSING_RECORDED`, `UNRECORDED_DEFAULT`) — their wording legitimately can speak to rules and is untouched.
- Added a regression test against a 0-byte policy file asserting the new wording appears and the old "rules are present" claim does not — non-vacuous, since the pre-fix literal would fail this assertion.

## Scope note

This fix makes `status`/`coverage` **honest-but-incomplete**, not complete. It does not touch the loud `verify()`/web-report path (already correct), and it does not add detection for a policy file that exists but declares zero rules — that remains a real silent-pass gap, tracked separately as #359. It's also distinct from #171 (a missing `relation` declaration bricking the engine), which is an engine-recovery fix, not a wording fix. Filing this now so the wording correction isn't mistaken for having closed the broader false-all-clear class.

Closes #288
Related: #171, #359

## Test plan

- [x] `test_present_line_is_honest_on_an_empty_policy_file` — new, exercises the 0-byte-file case directly
- [x] Existing `test_policy_state.py` / `test_cli.py:1605` wording-pinned tests pass unmodified
- [x] Full suite + ruff clean (see CI)
