### PR TITLE
fix(#339): keep human-decided facts when a source is reanalyzed

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -284,6 +284,56 @@ def test_clear_source_analysis_removes_fact_evidence(tmp_path):
     assert list(s._conn.execute("SELECT * FROM fact_evidence")) == []
 
 
+def test_clear_source_analysis_preserves_human_decided_facts_and_their_terms(tmp_path):
+    # #339: reanalyze clears only the review tier. A human's engine-tier decision
+    # (confirmed/accepted) and terminal rejection (superseded) must survive, and a
+    # preserved fact's DuckDB terms must survive with it -- the SELECT is filtered
+    # too, so the term-deletion loop never reaches a preserved fact.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    candidate = s.add_fact("Cand", "r", "X", status="candidate", source_id=sid)
+    needs_review = s.add_fact("Need", "r", "X", status="needs_review", source_id=sid)
+    confirmed = s.add_fact("Conf", "r", "X", status="confirmed", source_id=sid)
+    accepted = s.add_fact("Acc", "r", "X", status="accepted", source_id=sid)
+    superseded = s.add_fact("Sup", "r", "X", status="superseded", source_id=sid)
+
+    removed = s.clear_source_analysis(sid)
+
+    assert removed == 2
+    assert s.get_fact(candidate) is None
+    assert s.get_fact(needs_review) is None
+    # The preserved rows keep not just their presence but their exact status.
+    assert s.get_fact(confirmed)["status"] == "confirmed"
+    assert s.get_fact(accepted)["status"] == "accepted"
+    assert s.get_fact(superseded)["status"] == "superseded"
+    # The DuckDB-term half of the trap: a preserved fact keeps its terms, a
+    # removed one loses them. This is what proves the SELECT was filtered too --
+    # had it not been, the loop would have dropped these three facts' terms while
+    # leaving their SQLite rows intact, corrupting the engine's view invisibly.
+    assert s.get_fact_terms(confirmed) is not None
+    assert s.get_fact_terms(accepted) is not None
+    assert s.get_fact_terms(superseded) is not None
+    assert s.get_fact_terms(candidate) is None
+    assert s.get_fact_terms(needs_review) is None
+
+
+def test_clear_source_analysis_never_deletes_a_superseded_fact(tmp_path):
+    # #339 via the real human-rejection path: reject_fact, not a direct
+    # add_fact(status="superseded"), so this pins the fix for how rejection
+    # actually happens in production.
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    s.add_source_artifact(source_id=sid, kind="original_text", path="sources/a.txt")
+    rejected = s.add_fact("Ada", "died_in", "Rome", status="candidate", source_id=sid)
+    s.reject_fact(rejected)
+    assert s.get_fact(rejected)["status"] == "superseded"
+
+    s.clear_source_analysis(sid)
+
+    assert s.get_fact(rejected) is not None
+    assert s.get_fact(rejected)["status"] == "superseded"
+
+
 def test_fact_evidence_persists_chunk_and_span_references(tmp_path):
     s = _store(tmp_path)
     sid = s.add_source("sources/sample.txt")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -989,6 +989,118 @@ def test_reanalyze_source_reuses_artifact_and_replaces_extracted_facts(
     assert store.get_extraction_job_detail(fact["job_id"])["artifact_id"] == artifact_id
 
 
+def test_reanalyze_preserves_human_decisions_and_suppresses_resurrection(
+    tmp_path, monkeypatch, fake_client
+):
+    # #339 through the real route: reanalyze must not delete a human's confirmed
+    # fact nor resurrect a superseded one. The fake run re-emits the superseded
+    # triple, so reconcile_fact finds the preserved row and suppresses the
+    # re-insert (#160). The confirmed/superseded facts carry NO artifact-anchored
+    # evidence, isolating this from the #329 staleness sweep (see the next test).
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(
+            [
+                ExtractedFact("New", "is_a", "Fact", 0.9),
+                ExtractedFact("Ghost", "is_a", "Spirit", 0.9),
+            ]
+        ),
+    )
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/a.txt", kind="text")
+    artifact_path = tmp_path / "sources" / "a.txt"
+    artifact_path.parent.mkdir()
+    artifact_path.write_text("source body", encoding="utf-8")
+    store.add_source_artifact(source_id=sid, kind="original_text", path="sources/a.txt")
+    store.add_fact("Old", "is_a", "Thing", status="candidate", source_id=sid)
+    confirmed = store.add_fact(
+        "Kept", "is_a", "Confirmed", status="confirmed", source_id=sid
+    )
+    superseded = store.add_fact(
+        "Ghost", "is_a", "Spirit", status="candidate", source_id=sid
+    )
+    store.reject_fact(superseded)
+    assert store.get_fact(superseded)["status"] == "superseded"
+
+    r = c.post(f"/sources/{sid}/reanalyze", follow_redirects=False)
+    assert r.status_code == 303
+
+    def reanalyzed():
+        assert any(row["subject"] == "New" for row in store.review_queue())
+        assert "Analysis complete: 1/1 chunk(s)" in c.get("/sources").text
+
+    _wait_for(reanalyzed)
+
+    # The review-tier candidate is gone; both human decisions are untouched.
+    assert not any(row["subject"] == "Old" for row in store.review_queue())
+    assert store.get_fact(confirmed)["status"] == "confirmed"
+    assert store.get_fact(superseded)["status"] == "superseded"
+    # Exactly one row for the superseded triple: the preserved rejection, never a
+    # fresh candidate resurrected from the re-emitted triple.
+    ghost_rows = [
+        f
+        for f in store.facts()
+        if (f["subject"], f["relation"], f["object"]) == ("Ghost", "is_a", "Spirit")
+    ]
+    assert len(ghost_rows) == 1
+    assert ghost_rows[0]["id"] == superseded
+    assert ghost_rows[0]["status"] == "superseded"
+
+
+def test_reanalyze_demotes_a_now_unsupported_confirmed_fact_via_the_sweep(
+    tmp_path, monkeypatch, fake_client
+):
+    # #339 composition proof: preserving the confirmed row is all it takes for the
+    # #329 post-extraction sweep to demote it when the current artifact no longer
+    # supports it -- NO demotion logic lives in clear_source_analysis or the route.
+    # The confirmed fact is anchored at an OLDER artifact; reanalyze runs over the
+    # newer one and re-extracts a different triple, so the sweep finds no evidence
+    # for the confirmed fact at the current artifact and returns it to review,
+    # stale=1 (never deleted, never silently left confirmed).
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("Fresh", "is_a", "Fact", 0.9)]),
+    )
+    c = _client(tmp_path)
+    store = c.app.state.store
+    sid = store.add_source("sources/a.txt", kind="text")
+    artifact_path = tmp_path / "sources" / "a.txt"
+    artifact_path.parent.mkdir()
+    artifact_path.write_text("current body", encoding="utf-8")
+    old_artifact = store.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a-v1.txt", checksum="v1"
+    )
+    new_artifact = store.add_source_artifact(
+        source_id=sid, kind="original_text", path="sources/a.txt", checksum="v2"
+    )
+    assert new_artifact != old_artifact
+    confirmed = store.add_fact(
+        "Ada", "is_a", "Analyst", status="confirmed", source_id=sid
+    )
+    store.add_fact_evidence(
+        fact_id=confirmed, source_id=sid, artifact_id=old_artifact, snippet="Ada"
+    )
+
+    r = c.post(f"/sources/{sid}/reanalyze", follow_redirects=False)
+    assert r.status_code == 303
+
+    # The sweep runs AFTER the job is marked done, so wait on the demotion itself
+    # rather than the "Analysis complete" message.
+    def swept():
+        assert any(row["subject"] == "Fresh" for row in store.review_queue())
+        assert store.get_fact(confirmed)["status"] == "needs_review"
+
+    _wait_for(swept)
+
+    row = store.get_fact(confirmed)
+    assert row is not None
+    assert row["status"] == "needs_review"
+    assert row["stale"] == 1
+
+
 def test_upload_docx_converts_and_extracts(tmp_path, monkeypatch, fake_client):
     import io
 

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -569,17 +569,32 @@ class Store:
                 raise
 
     def clear_source_analysis(self, source_id: int) -> int:
-        """Remove extracted facts and extraction jobs while keeping source files.
+        """Clear the review tier (candidate/needs_review facts + their terms) and
+        the extraction jobs for a source, keeping the source files.
 
-        Returns the number of facts removed. DuckDB term rows are deleted in the
-        same logical operation so re-analysis starts from a clean source state.
+        `confirmed`/`accepted` facts (a human's engine-tier decision) and
+        `superseded` facts (a human's terminal rejection) are preserved: a
+        reanalyze must never silently destroy a human decision (#339). Whether a
+        preserved engine-tier fact is still supported by the re-extracted source
+        is judged afterwards by the post-extraction `surface_stale_engine_facts`
+        sweep (#329), not here; a preserved superseded fact stays matchable so
+        `reconcile_fact` keeps suppressing its resurrection (#160).
+
+        The status filter is applied to BOTH the id-selecting SELECT and the
+        facts DELETE: the DuckDB `fact_terms` deletion loop is driven by the
+        SELECT's id list, so filtering only the DELETE would leave a preserved
+        fact's SQLite row intact while silently dropping its DuckDB terms.
+
+        Returns the number of review-tier facts removed.
         """
         with self._lock:
+            placeholders, statuses = _status_filter(REVIEW_STATUSES)
             fact_ids = [
                 int(row["id"])
                 for row in self._conn.execute(
-                    "SELECT id FROM facts WHERE source_id = ? ORDER BY id",
-                    (source_id,),
+                    f"SELECT id FROM facts WHERE source_id = ? "
+                    f"AND status IN ({placeholders}) ORDER BY id",
+                    (source_id, *statuses),
                 )
             ]
             deleted_terms: list[int] = []
@@ -588,7 +603,10 @@ class Store:
                 for fact_id in fact_ids:
                     self.fact_terms.delete_fact_terms(fact_id)
                     deleted_terms.append(fact_id)
-                self._conn.execute("DELETE FROM facts WHERE source_id = ?", (source_id,))
+                self._conn.execute(
+                    f"DELETE FROM facts WHERE source_id = ? AND status IN ({placeholders})",
+                    (source_id, *statuses),
+                )
                 self._conn.execute(
                     "DELETE FROM extraction_jobs WHERE source_id = ?", (source_id,)
                 )


### PR DESCRIPTION
## Summary

- `POST /sources/{id}/reanalyze` → `Store.clear_source_analysis` deleted **every** fact for a source with no status filter — including `confirmed`/`accepted` (a human's engine-tier decision) and `superseded` (a human's terminal rejection). One click permanently destroyed human decisions with no recovery path: worse than #329, which demotes a stale confirmed fact to `needs_review` (recoverable) rather than deleting the row outright.
- `clear_source_analysis` now narrows both the id-selecting SELECT (which drives a DuckDB `fact_terms` deletion loop) and the facts DELETE to the existing `REVIEW_STATUSES` tier (`candidate`/`needs_review`) via the existing `_status_filter` helper — both queries share one predicate computed once, so they can't drift apart. The `extraction_jobs` DELETE is untouched. The docstring is rewritten; the old one falsely claimed a full wipe.
- Allow-list (`status IN REVIEW_STATUSES`), not the deny-list form the issue itself proposed — fails safe if a future status is ever added to the schema: preserved by default instead of destroyed by default, which is the actual class of bug this issue is about.

## Why the minimal fix is also the complete fix

The issue frames "narrow the DELETE" and "add #329-style demotion" as two different directions needing a choice. They're not. Reanalyze's re-extraction already flows through machinery that handles both:

- **#160 resurrection suppression** (`reconcile_fact`) already matches an existing `(source, triple)` row in *any* status, including `superseded`, and suppresses re-insertion. It only ever failed here because `clear_source_analysis` deleted the superseded row *before* reconcile could see it. Preserving the row is the fix.
- **#329 stale demotion** (`surface_stale_engine_facts`) already runs after every clean job completion in the same worker reanalyze uses. A preserved confirmed fact the re-extracted source no longer supports gets demoted to `needs_review, stale=1` automatically — no new code needed.

So this ships as a single, narrowly-scoped storage-layer change with no route, schema, or #329/#310 changes.

## Tests

- `test_clear_source_analysis_preserves_human_decided_facts_and_their_terms` — one fact per status; confirms only the review tier is removed, survivors keep their status *and* their DuckDB terms (the one real trap: an unfiltered term-deletion loop would silently strip a survivor's engine-visible terms while its SQL row looked intact).
- `test_clear_source_analysis_never_deletes_a_superseded_fact` — exercises the real `reject_fact` path.
- `test_reanalyze_preserves_human_decisions_and_suppresses_resurrection` — end-to-end through the actual route; the fake extraction client re-emits the exact superseded triple, proving `reconcile_fact`'s suppression fires (not just that the row wasn't deleted).
- `test_reanalyze_demotes_a_now_unsupported_confirmed_fact_via_the_sweep` — proves the #329 sweep supplies demotion for free when the reanalyzed source no longer supports a previously-confirmed fact (asserts `needs_review` + `stale=1`, the sweep's unique signature).

Mutation-tested: reverting only the `db.py` change makes all four new tests fail; restoring makes them pass. Verified independently by three separate reviewers in this flow (implementer, reviewer, and both audit voices), not just asserted.

Closes #339
Related: #329, #160, #292, #310 (#310's planned terminal-superseded DB trigger is not yet merged; this fix removes the one caller that would otherwise violate it)

## Scope note

`Store.delete_source`'s own unconditional fact delete is deliberately untouched — deleting a source is a fundamentally different, explicit whole-entity removal where nothing needs preserving. This issue is specifically about the reanalyze button, which implies "redo the analysis," not "erase my history with this source."
