### PR TITLE
fix(#340): keep a done extraction job done when auto-accept raises

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+import logging
 import re
 import threading
 import time
@@ -1632,6 +1633,84 @@ def test_worker_still_auto_accepts_on_a_healthy_kb(tmp_path, monkeypatch, fake_c
         assert _fact_statuses(cfg) == ["accepted", "accepted"]
 
     _wait_for(auto_accepted)
+
+
+def test_worker_leaves_a_done_job_done_when_auto_accept_raises(
+    tmp_path, monkeypatch, fake_client
+):
+    # #340 exception-safety, the sibling of the #329 sweep guard directly above it:
+    # auto-accept is a call inside the worker's try/except, so WITHOUT the local
+    # guard an auto-accept error would reach the outer `except Exception ->
+    # fail_extraction_job` and retroactively flip an already-`done` extraction to
+    # `failed` — the KB lying about its own run state (#194/#239). The extraction
+    # genuinely succeeded and its facts are already committed, so the guard must
+    # keep the job `done`.
+    cfg, job_id, _ = _auto_accept_kb(tmp_path)  # auto-accept on, policy present
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("auto-accept exploded")
+
+    # Patch the module-level function as bound in app.py's namespace (auto-accept is
+    # a module-level function reference here, not a Store method like the sweep).
+    monkeypatch.setattr(webapp, "apply_auto_accept_recommendations", boom)
+
+    create_app(cfg)  # resumes the pending job -> _start_source_extraction
+
+    def job_finished():
+        assert _job_row(cfg, job_id)["status"] == "done"
+
+    _wait_for(job_finished)
+    time.sleep(0.2)  # let a late fail_extraction_job land, if the guard regressed
+    row = _job_row(cfg, job_id)
+    assert row["status"] == "done"  # the auto-accept error did NOT flip it to failed
+    assert row["failed_chunks"] == 0
+    assert "analysis failed" not in (row["message"] or "")  # never marked failed
+    # extraction genuinely completed; only the (now contained) auto-accept failed.
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        assert any(f["subject"] == "X" for f in store.facts())
+
+
+def test_worker_lets_a_policy_missing_halt_from_auto_accept_reach_the_halt_handler(
+    tmp_path, monkeypatch, fake_client, caplog
+):
+    # A DIFFERENT test from the one above: a `PolicyMissingError` out of auto-accept
+    # is a #194 halt, not an ordinary failure. It must reach the worker's outer
+    # `except PolicyMissingError` handler (which writes NOTHING), NOT be swallowed by
+    # the local `except Exception` guard. Job status alone can't tell the two apart
+    # (`done` either way — this test passes on today's unguarded code too), so it
+    # pins the distinction on the LOG: the halt handler's line must appear and the
+    # local guard's must not. That is what catches a guard missing the
+    # `except PolicyMissingError: raise` clause, or ordering it below `except
+    # Exception`.
+    cfg, job_id, _ = _auto_accept_kb(tmp_path)  # auto-accept on, policy present
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    def halt(*args, **kwargs):
+        raise PolicyMissingError("policy vanished after the job finished")
+
+    monkeypatch.setattr(webapp, "apply_auto_accept_recommendations", halt)
+
+    with caplog.at_level(logging.WARNING, logger="verinote.web.app"):
+        create_app(cfg)  # resumes the pending job -> _start_source_extraction
+
+        def halt_logged():
+            assert "halted (KB policy missing)" in caplog.text
+
+        _wait_for(halt_logged)  # the halt reached the outer PolicyMissingError handler
+        # ...and the local `except Exception` guard did NOT swallow it as a failure.
+        assert "auto-accept failed" not in caplog.text
+    # the outer handler wrote nothing: the completed job is left exactly `done`.
+    assert _job_row(cfg, job_id)["status"] == "done"
 
 
 def test_report_ok_for_consistent_kb(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -863,9 +863,31 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         # pass can't demote-then-immediately-re-promote them. Part
                         # C's `stale` flag is what blocks re-promotion on later
                         # syncs; this only ever covered the same-pass case.
-                        apply_auto_accept_recommendations(
-                            worker_store, exclude_fact_ids=demoted_ids
-                        )
+                        try:
+                            apply_auto_accept_recommendations(
+                                worker_store, exclude_fact_ids=demoted_ids
+                            )
+                        except PolicyMissingError:
+                            # ORDER IS LOAD-BEARING — this must stay ABOVE `except
+                            # Exception`. Auto-accept runs `assert_writable` as its
+                            # own first act (acceptance.py); a policy lost
+                            # post-completion is a #194 halt that must reach the
+                            # outer PolicyMissingError handler (which writes
+                            # NOTHING), never be contained here as if it were an
+                            # ordinary failure.
+                            raise
+                        except Exception:  # noqa: BLE001 - an auto-accept error must not fail a done job
+                            # Auto-accept does no LLM/network I/O, so a raise here is
+                            # a rare sqlite/WAL-lock-class error. The extraction
+                            # genuinely succeeded and its facts are already
+                            # committed; leave the job `done` rather than letting the
+                            # outer handler bury a completed run as `failed` (#340;
+                            # sibling of the #329 sweep guard directly above).
+                            logger.warning(
+                                "auto-accept failed for job %s; leaving it done",
+                                job_id,
+                                exc_info=True,
+                            )
             except PolicyMissingError as e:
                 # ORDER IS LOAD-BEARING — this must stay ABOVE `except Exception`.
                 # The worker runs outside the request middleware, so a halt surfaces


### PR DESCRIPTION
## Summary

- `apply_auto_accept_recommendations` sat inside the same `try` block as `process_extraction_job` in the source sync worker, guarded only by the worker's outer `except Exception -> fail_extraction_job`. Extraction could fully succeed — job `'done'`, facts already committed — and then have that success retroactively overwritten to `'failed'` by an unrelated auto-accept error (a rare sqlite/WAL-lock-class exception; auto-accept does no LLM/network I/O). The KB would falsely report a failed run that actually succeeded.
- This is the sibling of #329's stale-sweep guard, but deliberately **not a copy of its shape**. `surface_stale_engine_facts` doesn't self-check writability — its caller checks externally — so #329's guard was a bare `except Exception`. `apply_auto_accept_recommendations` calls `assert_writable` as the first line of its own body, so a bare `except Exception` here would *also* swallow a genuine `PolicyMissingError` halt, mislabeling "the KB just went halted" as "auto-accept failed" and defeating the outer handler that exists specifically to leave a halt unwritten (#194).
- The new guard re-raises `PolicyMissingError` above a broader `except Exception` that only logs and leaves the job `done`. Order is load-bearing and commented as such.

## Verification

Two tests, verified non-vacuous in both directions by three separate people in this flow (implementer, reviewer, and both audit voices), each reproducing the mutations independently rather than trusting prior reports:
- Reverting only the production guard: the "stays done" test fails with the bug's exact signature (`'failed' == 'done'`).
- Implementing a naive/wrong guard (bare `except Exception`, no `PolicyMissingError` special-case — the mistake a literal #329 copy would make): the halt-routing test fails, showing the wrong log line captured and the halt's traceback silently swallowed.
- Both mutations confirm the two tests catch genuinely different mistakes, and neither is individually sufficient.

Full suite: 1527 passed, 7 skipped. Ruff clean at CI-pinned 0.15.18.

Closes #340
Related: #329, #194, #239, #323

## Scope note

Does not touch `apply_auto_accept_recommendations` itself (its internal `assert_writable` is correct and deliberate), `_maybe_apply_auto_accept` (the unrelated HTTP-request-path auto-accept call site), or the #329 sweep guard directly above this one.
