### PR TITLE
fix(#359): flag a policy with zero review rules instead of passing it silently

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -889,6 +889,61 @@ def test_coverage_strict_gates_on_gap(tmp_path, monkeypatch, capsys):
     assert "GAP" in capsys.readouterr().out
 
 
+_BARE_RELATION_POLICY = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+
+
+def _kb_covered_fact_with_policy(tmp_path, policy_text):
+    """A KB with one fully-covered source (no gap, no orphan) and `policy_text`.
+
+    The confirmed fact carries a `source_id` and becomes engine input, so the
+    source has no coverage gap — this isolates the zero-review-rule gate from the
+    pre-existing gap gate. The source file is created so it is not an orphan
+    either. `policy_text` is written to the KB's policy file (a PRESENT policy).
+    """
+    (tmp_path / "sources").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "sources" / "a.txt").write_text("sample", encoding="utf-8")
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    sid = s.add_source("sources/a.txt")
+    s.add_fact("A", "is_a", "B", status="confirmed", source_id=sid)
+    policy = tmp_path / "policy" / "logic-policy.dl"
+    policy.parent.mkdir(parents=True, exist_ok=True)
+    policy.write_text(policy_text, encoding="utf-8")
+    s.close()
+
+
+def test_coverage_strict_gates_on_zero_review_rules(tmp_path, monkeypatch, capsys):
+    # A present policy that declares relation/3 and no error_*/warn_* rule reviews
+    # nothing, so --strict must not green-light it. No gap exists, so this fails
+    # for the zero-rule reason alone.
+    _env(monkeypatch, tmp_path)
+    _kb_covered_fact_with_policy(tmp_path, _BARE_RELATION_POLICY)
+
+    assert cli.main(["coverage"]) == 0  # plain coverage is a recovery path, never gates
+    assert cli.main(["coverage", "--strict"]) == 1
+    assert "no review rules" in capsys.readouterr().err
+
+
+def test_coverage_strict_passes_when_policy_has_a_review_rule(tmp_path, monkeypatch, capsys):
+    # False-positive guard: a present policy that reviews something is gate-ready.
+    _env(monkeypatch, tmp_path)
+    _kb_covered_fact_with_policy(tmp_path, DEFAULT_POLICY)
+
+    assert cli.main(["coverage", "--strict"]) == 0
+
+
+def test_coverage_strict_does_not_mislabel_a_malformed_policy(tmp_path, monkeypatch, capsys):
+    # A malformed policy is a different fault — the web report surfaces it as an
+    # engine error. coverage must not call it "no review rules" (it may define
+    # rules that simply do not parse), so this gate stays quiet: out of #359's
+    # scope, rc is left unchanged from the pre-existing malformed-policy behaviour.
+    _env(monkeypatch, tmp_path)
+    _kb_covered_fact_with_policy(tmp_path, "this is not valid datalog !!!")
+
+    assert cli.main(["coverage", "--strict"]) == 0
+    assert "no review rules" not in capsys.readouterr().err
+
+
 def test_coverage_counts_structural_engine_fact_metadata(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     s = Store(tmp_path / "kb.sqlite")

--- a/tests/test_no_review_rules.py
+++ b/tests/test_no_review_rules.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Zero-review-rule detection: a policy that checks nothing is not a clean bill.
+
+A policy file that declares `relation/3` (the engine's only loud gate) but no
+`error_*`/`warn_*` rule runs clean and derives nothing, so both the web report
+and `coverage --strict` would otherwise green-light a KB nothing reviews. The
+pure `review_rule_count` tests below run in CI without DuckDB; the `verify()` and
+query-eval tests need the DuckDB backend.
+
+The last test is the load-bearing anti-regression guard: the check must live in
+the KB-review callers (`verify()`, `coverage --strict`), never in the shared
+engine, because the query-evaluation paths run a deliberately rule-less
+`relation/3` policy and are correct to report `ok=True` with no warning.
+"""
+
+import pytest
+
+from verinote.engine import DEFAULT_POLICY
+from verinote.engine.wirelog import review_rule_count
+from verinote.pipeline.query_candidate_eval import RELATION_DECL
+from verinote.pipeline.verify import (
+    NO_REVIEW_RULES_FINDING,
+    policy_path,
+    verify,
+)
+from verinote.store import Store
+
+BARE_RELATION_POLICY = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+
+
+# --- Pure helper (no DuckDB needed) ------------------------------------------
+
+
+def test_default_policy_has_a_review_rule():
+    # DEFAULT_POLICY ships `error_functional_conflict`, so it reviews something.
+    assert review_rule_count(DEFAULT_POLICY) >= 1
+
+
+def test_bare_relation_decl_has_no_review_rules():
+    assert review_rule_count(BARE_RELATION_POLICY) == 0
+
+
+def test_malformed_policy_counts_zero_review_rules():
+    # Matches `dead_rule_warnings`: the parse failure is an engine error, so this
+    # helper must not invent a second verdict — it just reports nothing to count.
+    assert review_rule_count("this is not valid datalog !!!") == 0
+
+
+def test_answer_only_policy_has_no_review_rules():
+    # An `answer_q*` head answers a query; it does not review the KB.
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O).\n'
+    )
+    assert review_rule_count(policy) == 0
+
+
+def test_single_warn_rule_is_counted():
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl warn_x(subject: symbol)\n"
+        'warn_x(S) :- relation(S, "is_a", "thing").\n'
+    )
+    assert review_rule_count(policy) >= 1
+
+
+def test_bare_declaration_without_a_rule_is_not_counted():
+    # A `.decl` for an `error_*` predicate declares it but runs no check: the
+    # count is over rule *heads*, not declarations.
+    policy = (
+        ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+        ".decl error_x(subject: symbol)\n"
+    )
+    assert review_rule_count(policy) == 0
+
+
+# --- Production path: verify() (needs DuckDB) --------------------------------
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _write_policy(store: Store, text: str) -> None:
+    path = policy_path(store)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_verify_warns_when_present_policy_has_no_review_rules(tmp_path):
+    """The issue's headline: a recorded rule-less policy must not read as clean.
+
+    `ok`/`errors` stay put — nothing inconsistent was derived — but a warning is
+    added and the engine's clean-bill sentence is replaced, so the report can no
+    longer be mistaken for a real all-clear.
+    """
+    pytest.importorskip("duckdb")
+    from verinote.engine import NO_FINDINGS_TEXT
+
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    _write_policy(s, BARE_RELATION_POLICY)
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert rep.errors == 0
+    assert rep.warnings == 1
+    assert NO_REVIEW_RULES_FINDING in rep.findings
+    assert any("no review rules" in f for f in rep.findings)
+    # The false "no findings — knowledge base is consistent." claim is gone.
+    assert NO_FINDINGS_TEXT not in rep.text
+    s.close()
+
+
+def test_verify_stays_silent_when_present_policy_reviews_something(tmp_path):
+    """False-positive guard: a policy with a real rule gets no zero-rule finding."""
+    pytest.importorskip("duckdb")
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    _write_policy(s, DEFAULT_POLICY)
+
+    rep = verify(s)
+
+    assert rep.ok is True
+    assert NO_REVIEW_RULES_FINDING not in rep.findings
+    assert not any("no review rules" in f for f in rep.findings)
+    s.close()
+
+
+# --- Anti-regression: the check must NOT reach the engine layer --------------
+
+
+def test_query_eval_path_is_unaffected_by_the_zero_rule_check():
+    """The central design constraint, pinned as a permanent regression guard.
+
+    `ask` and `query_candidate_eval` drive the DuckDB engine with a rule-less
+    `RELATION_DECL` policy plus a query rule, and correctly expect `ok=True` with
+    no warning. If anyone ever "simplifies" this fix by moving the zero-review
+    check into the shared engine (`duckdb_backend._collect_report` / wirelog
+    `run_check`), this test fails — which is exactly its job.
+    """
+    pytest.importorskip("duckdb")
+    from verinote.engine.duckdb_backend import run_check_duckdb
+
+    query = (
+        ".decl answer_q1(value: symbol)\n"
+        'answer_q1(O) :- relation("Ada", "born_in", O).\n'
+    )
+    rep = run_check_duckdb(
+        [{"subject": "Ada", "relation": "born_in", "object": "London"}],
+        policy_dl=RELATION_DECL,
+        query_dl=query,
+    )
+
+    assert rep.ok is True
+    assert rep.warnings == 0
+    assert not any("no review rules" in f for f in rep.findings)
+    assert rep.answers == ["q1: London"]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
 from verinote.pipeline.query import query_path
-from verinote.pipeline.verify import load_policy, policy_path, verify
+from verinote.pipeline.verify import (
+    NO_REVIEW_RULES_FINDING,
+    load_policy,
+    policy_path,
+    verify,
+)
 from verinote.store import Store
 from verinote.store.duckdb_fact_terms import fact_terms_path
 from verinote.store.fact_input import structural_term
@@ -548,4 +553,9 @@ def test_verify_cached_engine_does_not_leak_changed_policy_findings(tmp_path):
         encoding="utf-8",
     )
 
-    assert verify(s).findings == []
+    # The rewritten policy reviews nothing, so it now surfaces the zero-review-rule
+    # warning. The anti-leak property this test guards still holds: the stale
+    # `WARN has_isa: Ada` from the cached engine must be gone.
+    findings = verify(s).findings
+    assert findings == [NO_REVIEW_RULES_FINDING]
+    assert not any("has_isa" in f for f in findings)

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1028,6 +1028,30 @@ def _print_policy_state_ro(conn: sqlite3.Connection, cfg: Config) -> bool:
     return False
 
 
+def _zero_review_rules_ro(conn: sqlite3.Connection, cfg: Config) -> bool:
+    """True when this KB has a *present* policy file that reviews nothing.
+
+    The read-only sibling of `verify()`'s zero-review-rule check. Only a policy a
+    human wrote (`PRESENT`) can trip it: `UNRECORDED_DEFAULT` runs the shipped
+    default (which has a real rule), and `MISSING_RECORDED` is already the halt
+    gate's. A policy this parser cannot read is *not* reported here — that is a
+    different fault, surfaced as an engine error by the web report, and calling a
+    broken policy "rule-less" would misreport it. So, mirroring `verify()`'s
+    `errors == 0` guard, an unreadable policy is left to that path; `_read_policy`
+    (the one authority on "unreadable") is the read-only proxy for it, since
+    `coverage` runs no engine.
+    """
+    from verinote.engine.wirelog import _read_policy, review_rule_count
+    from verinote.pipeline.policy_state import PolicyStatus
+
+    state = _policy_state_ro(conn, cfg)
+    if state.status is not PolicyStatus.PRESENT:
+        return False
+    if _read_policy(state.text) is None:
+        return False
+    return review_rule_count(state.text) == 0
+
+
 def _unusable_kb(cfg: Config, exc: Exception) -> int:
     """Turn a SQLite error escaping a read-only command into a diagnosis.
 
@@ -1089,6 +1113,9 @@ def _coverage(cfg: Config, args: argparse.Namespace) -> int:
             )
         cov = Coverage(sources=sources)
         halted = _print_policy_state_ro(conn, cfg)
+        # Compute before `conn.close()`: `_zero_review_rules_ro` reads the KB's
+        # policy marker over this same read-only connection.
+        zero_review_rules = _zero_review_rules_ro(conn, cfg)
     finally:
         conn.close()
     for s in cov.sources:
@@ -1109,6 +1136,13 @@ def _coverage(cfg: Config, args: argparse.Namespace) -> int:
     # stays rc=0: it is a recovery path, and a halt you cannot inspect is a brick.
     if args.strict and halted:
         print("strict: this KB's logic policy file is missing", file=sys.stderr)
+        return 1
+    if args.strict and zero_review_rules:
+        print(
+            "strict: this KB's policy defines no review rules (error_*/warn_*); "
+            "nothing is being checked",
+            file=sys.stderr,
+        )
         return 1
     if args.strict and cov.gaps:
         print("strict: uncovered text source(s) present", file=sys.stderr)
@@ -1275,7 +1309,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     coverage = sub.add_parser("coverage", help="report per-source engine-fact coverage")
     coverage.add_argument(
-        "--strict", action="store_true", help="exit non-zero if any text source has no engine facts"
+        "--strict",
+        action="store_true",
+        help=(
+            "exit non-zero if the KB is not review-ready: a missing/halted policy, "
+            "a policy that defines no review rules (error_*/warn_*), or a text "
+            "source with no engine facts"
+        ),
     )
     coverage.set_defaults(func=cmd_coverage, halt_safe=True)
 

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -268,6 +268,39 @@ def dead_rule_warnings(policy_dl: str, present_relations: Iterable[str]) -> list
     )
 
 
+def review_rule_count(policy_dl: str) -> int:
+    """Count the review rules — ``error_*``/``warn_*`` heads — a policy defines.
+
+    A KB earns its "consistent" verdict by *running rules*: every ``error_*``
+    head is a blocking check and every ``warn_*`` head a non-blocking one. A
+    policy that declares ``relation/3`` and nothing else parses, runs, and
+    derives nothing, so the engine reports it clean — a green light on a KB no
+    rule ever examined. This count is how a caller tells "checked and consistent"
+    apart from "checked nothing"; the engine cannot, because deriving zero
+    findings is the correct result either way — the query-evaluation paths run a
+    deliberately rule-less ``relation/3`` policy and rely on exactly that. So this
+    is a caller-side concern and must never move into the engine, or every query
+    evaluation would trip it.
+
+    Only rule *heads* count. A bare ``.decl`` declares a relation but runs no
+    check, and an ``answer_q*`` head answers a query rather than reviewing the KB,
+    so neither is a review rule. A policy this parser cannot read yields 0, the
+    same convention `dead_rule_warnings` uses: the parse failure is already an
+    engine error, so this must not invent a second verdict from it. This shares
+    only `_read_policy` with dead-rule detection; the two checks stay separate,
+    since a rule that is *absent* and a rule that *cannot fire* are different
+    faults.
+    """
+    program = _read_policy(policy_dl)
+    if program is None:
+        return 0
+    return sum(
+        1
+        for rule in program.rules
+        if rule.head.predicate.startswith((_ERROR_PREFIX, _WARN_PREFIX))
+    )
+
+
 # The engine's "clean bill of health" body. Exported because it is a claim about
 # the policy that ran, so callers that ran a *different* policy than the KB's own
 # (see pipeline.policy_state) must be able to recognise and replace it rather

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -11,6 +11,7 @@ at minimum a warning.
 from __future__ import annotations
 
 from verinote.engine import NO_FINDINGS_TEXT, CheckReport
+from verinote.engine.wirelog import review_rule_count
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.engine_input import annotate_source_labels, engine_relation_rows
 from verinote.pipeline.policy_state import (
@@ -37,6 +38,22 @@ __all__ = [
     "resolve_policy",
     "verify",
 ]
+
+
+# A present policy that declares `relation/3` and no `error_*`/`warn_*` rule runs
+# clean and derives nothing, so the engine's clean-bill sentence becomes a green
+# light on a KB no rule ever checked. `verify()` prepends this finding and
+# replaces that sentence; `ok`/`errors` stay put — nothing inconsistent was
+# derived (see `_with_no_review_rules_warning`).
+NO_REVIEW_RULES_FINDING = (
+    "WARNING policy_no_review_rules: this KB's policy file declares no review "
+    "rules (error_*/warn_*), so verification checked nothing"
+)
+NO_REVIEW_RULES_NO_FINDINGS_TEXT = (
+    "no findings, but this KB's policy file declares no review rules "
+    "(error_*/warn_*): nothing was actually checked, so this says nothing about "
+    "the KB's consistency."
+)
 
 
 def load_policy(store: Store) -> str | None:
@@ -107,6 +124,16 @@ def verify(store: Store) -> CheckReport:
     )
     if state.status is PolicyStatus.UNRECORDED_DEFAULT:
         return _with_unrecorded_policy_warning(report)
+    # A present policy that declares `relation/3` and no review rule reviews
+    # nothing. The `errors == 0` guard is load-bearing: a malformed policy also
+    # counts zero review rules, but the engine already returned an error report
+    # for it, and stacking this note on that would double-report one fault.
+    if (
+        state.status is PolicyStatus.PRESENT
+        and report.errors == 0
+        and review_rule_count(state.text) == 0
+    ):
+        return _with_no_review_rules_warning(report)
     return report
 
 
@@ -123,4 +150,22 @@ def _with_unrecorded_policy_warning(report: CheckReport) -> CheckReport:
     report.findings = [POLICY_UNRECORDED_FINDING, *report.findings]
     report.text = report.text.replace(NO_FINDINGS_TEXT, POLICY_UNRECORDED_NO_FINDINGS_TEXT)
     report.text = f"{POLICY_UNRECORDED_BANNER}\n\n{report.text}"
+    return report
+
+
+def _with_no_review_rules_warning(report: CheckReport) -> CheckReport:
+    """Stop a policy that reviews nothing from reading as a clean bill of health.
+
+    A present policy that declares `relation/3` and no `error_*`/`warn_*` rule
+    runs cleanly and derives nothing, so the engine's "no findings — knowledge
+    base is consistent." sentence is true and badly misleading: no rule examined
+    the KB. As in `_with_unrecorded_policy_warning`, the sentence is replaced (not
+    just prefixed) and `ok`/`errors` are left alone — a rule-less policy derived
+    no inconsistency, and inventing an error would be inference. Only a KB-review
+    caller may add this; the engine must not, since the query-evaluation paths run
+    the same rule-less `relation/3` policy shape on purpose and are correct to.
+    """
+    report.warnings += 1
+    report.findings = [NO_REVIEW_RULES_FINDING, *report.findings]
+    report.text = report.text.replace(NO_FINDINGS_TEXT, NO_REVIEW_RULES_NO_FINDINGS_TEXT)
     return report


### PR DESCRIPTION
## Summary

- A policy file that declares `relation/3` (the engine's only loud gate) but contains zero actual `error_*`/`warn_*` rules ran clean and derived nothing, so `verify()` reported `ok=True`/"consistent" and `coverage --strict` also passed silently — a green all-clear on a KB nothing is actually reviewing.
- Adds a pure `review_rule_count(policy_dl)` helper (counts rule heads matching `error_`/`warn_` prefixes, not bare declarations) and wires it into exactly two KB-review surfaces:
  - `verify()` (the web `/report` page): prepends a warning finding and replaces the false "no findings — consistent" sentence. `ok`/`errors` are left untouched — a rule-less policy derived no inconsistency, so inventing an error would be inference. Mirrors the existing `_with_unrecorded_policy_warning` precedent exactly.
  - `coverage --strict`: hard-fails (rc=1). Plain `coverage` stays rc=0 (a recovery/inspection path). The `--strict` help text is corrected to describe everything it now gates on.
- Both surfaces are gated to a *present* policy only — a brand-new KB with no policy file yet runs the shipped default, which already has a real rule, so it can never trigger this.

## Why the check lives only in `verify()`/`coverage`, never the engine

Three production query-evaluation paths (`ask`, `query_candidate_eval`, and `wirelog`'s `validate_query`) deliberately drive the same shared engine entrypoint with a rule-less `relation/3`-only policy and correctly expect a clean `ok=True` result — that's the correct behavior for evaluating a query candidate, not a defect. Placing this check anywhere the engine's own report-building code could see it would raise a false-positive warning on every single query evaluation. This is pinned by a permanent regression test that calls the real engine entrypoint directly with a rule-less policy and asserts nothing changed.

## Verification

Confirmed by three independent reviewers, one of whom went further and actually implemented the "check in the engine" mistake to prove it's a genuine risk, not theoretical — it broke both the anti-regression test and an unrelated, pre-existing production test. Full suite: 1539 passed, 7 skipped. Ruff clean at CI-pinned 0.15.18.

Closes #359
Related: #288, #171, #245, #286

## Scope note

Does not touch `dead_rule_warnings` (a different, complementary check for rules that exist but can't fire — this issue is about rules being absent entirely). No new `PolicyStatus` value. No change to plain `coverage`'s return code or to `ok`'s codebase-wide meaning.
