### PR TITLE
fix(#326): route the API key through _pick like the other settings

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -200,6 +200,27 @@ def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):
     assert "supersecret" not in (tmp_path / "config.json").read_text(encoding="utf-8")
 
 
+def test_empty_api_key_env_reads_as_unset(tmp_path, monkeypatch):
+    # #326: the key now shares the blank-value normalisation the other settings
+    # get, so a blank VERINOTE_API_KEY is unset rather than an empty credential.
+    monkeypatch.setenv("VERINOTE_API_KEY", "")
+    assert Config.for_root(tmp_path).api_key is None
+
+
+def test_whitespace_only_api_key_env_reads_as_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_API_KEY", "   ")
+    assert Config.for_root(tmp_path).api_key is None
+
+
+def test_padded_api_key_env_is_trimmed(tmp_path, monkeypatch):
+    # Surrounding whitespace on a real key is always a copy-paste or .env-file
+    # artifact, never part of the credential. Trimming makes an otherwise-valid
+    # key authenticate instead of failing; this is a deliberate decision, not an
+    # accidental side effect of routing through _pick.
+    monkeypatch.setenv("VERINOTE_API_KEY", "  sk-secret  ")
+    assert Config.for_root(tmp_path).api_key == "sk-secret"
+
+
 def test_active_root_uses_env_first(tmp_path, monkeypatch):
     monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
     assert active_root() == tmp_path.resolve()

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -12,8 +12,10 @@ the default; if the selected value is blank or an invalid number, numeric
 parsers fall back to the default, while the boolean parser treats recognised
 truthy strings as true and everything else as false. The API key is **only**
 ever read from the environment — it is never persisted to or read from the
-settings file, and it skips this normalisation entirely, so a blank
-`VERINOTE_API_KEY` reaches the provider as-is for it to reject.
+settings file — but it shares the same blank-value handling: a blank (empty or
+whitespace-only) `VERINOTE_API_KEY` normalises to unset (`None`) and a used
+value is trimmed. With no saved or default source to fall back to, a blank key
+simply becomes `None` rather than falling through a chain.
 
 The active KB root is stored in a platform-native app config file when the web
 UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
@@ -377,7 +379,7 @@ class Config:
             db_path=root / "kb.sqlite",
             provider=provider,
             model=model,
-            api_key=os.environ.get("VERINOTE_API_KEY"),  # secrets only from env
+            api_key=_pick("VERINOTE_API_KEY", None, None),  # no saved/default source — secrets only from env
             base_url=base_url,
             llm_timeout_seconds=_llm_timeout_seconds(),
             extraction_chunk_chars=chunk_chars,


### PR DESCRIPTION
## Summary

- `VERINOTE_API_KEY` was read directly via `os.environ.get`, bypassing the shared `_pick` helper that `PROVIDER`/`MODEL`/`BASE_URL` already use for blank-value normalization (unified by #293). A blank or whitespace-only key reached the provider as-is instead of normalizing to unset like the other three string settings.
- Routes the API key through `_pick("VERINOTE_API_KEY", None, None)` — `saved=None`/`default=None` because API keys are genuinely env-only in this codebase (never persisted to or read from `config.json`, verified against `save_settings`'s actual behavior). A blank value now becomes `None`; a used value is trimmed, matching every other setting — deliberate, since surrounding whitespace on a real key is always a copy-paste artifact, never significant, and trimming makes an otherwise-valid padded key authenticate instead of failing.
- The module docstring is updated in the same commit. It previously (and accurately, at the time) described the API key as skipping this normalization entirely — that sentence becomes stale the moment the code changes, so it's rewritten here to describe the new behavior. Framed carefully as a consistency fix, not as "correcting an overclaim" — the old docstring wasn't wrong when it was written.

## Side benefit

`web/app.py`'s settings status line (`bool(c.api_key)`) previously reported a whitespace-only key as `has_key: True` — a false "set" state. It now correctly reports `False`. No code change needed there; automatic from the normalization.

## Verification

Confirmed independently by three separate reviewers in this flow, each reproducing the mutation test themselves (reverting only the production line and confirming the new tests fail, then restoring) rather than trusting prior reports. Full suite: 1542 passed, 7 skipped. Ruff clean at CI-pinned 0.15.18.

Closes #326
Related: #293

## Scope note

Does not touch `_pick`/`_pick_int`/`_pick_bool`, `save_settings`/`read_settings`/the config.json schema (API keys must never be persisted, and still aren't), or the LLM provider adapters.
