### PR TITLE
fix(#169): let the CLI and web UI share the DuckDB fact-term sidecar

### DIFF
--- a/tests/test_duckdb_fact_terms_concurrency.py
+++ b/tests/test_duckdb_fact_terms_concurrency.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Cross-process concurrency tests for the DuckDB fact-term sidecar (#169).
+
+DuckDB takes a single-process write lock, so the interesting failure only shows
+up across a real OS process boundary: two connections to the same file from
+*within one process* share DuckDB's per-process instance cache and never
+conflict, which would make a same-process test a false green. Every test here
+that exercises lock contention therefore spawns a genuine child process.
+"""
+
+import select
+import subprocess
+import sys
+import time
+
+import pytest
+
+from verinote import cli
+from verinote.config import local_root
+from verinote.engine.terms import StringLit
+from verinote.store import duckdb_fact_terms
+from verinote.store.duckdb_fact_terms import (
+    DuckDBFactTermStore,
+    DuckDBFactTermStoreError,
+    DuckDBFactTermStoreLockedError,
+    FACT_TERMS_FILENAME,
+)
+
+# The subprocess tests read child output through `select`, which does not work on
+# Windows pipes; Windows also has different file-locking semantics. The fix is
+# cross-platform, but reliably *exercising* the lock across processes is a POSIX
+# affair here. The two unit tests below (in-memory regression, non-lock
+# classification) carry no such dependency and run everywhere.
+_posix_only = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="cross-process file-lock contention needs POSIX select/lock semantics",
+)
+
+
+def _duckdb():
+    return pytest.importorskip("duckdb")
+
+
+# A raw DuckDB connection held open in another process -- exactly what an external
+# process (or, before this fix, a `verinote ui` fact-page render) does to the
+# sidecar. Post-fix the store holds no connection between calls, so to *hold* the
+# lock a test needs a genuine adversary like this, not a `DuckDBFactTermStore`.
+_HOLDER = """
+import sys, time, duckdb
+path, max_hold = sys.argv[1], float(sys.argv[2])
+con = duckdb.connect(path)
+con.execute(
+    "CREATE TABLE IF NOT EXISTS fact_terms ("
+    "fact_id BIGINT PRIMARY KEY, subject VARCHAR NOT NULL, "
+    "rel VARCHAR NOT NULL, object VARCHAR NOT NULL, term_token VARCHAR)"
+)
+sys.stdout.write("READY\\n")
+sys.stdout.flush()
+time.sleep(max_hold)
+con.close()
+"""
+
+# The post-fix web UI: opens the sidecar per operation, reads, and lets go --
+# repeatedly, mimicking a user paging through fact views while a sync runs.
+_UI_LOOP = """
+import sys, time
+from verinote.store.duckdb_fact_terms import (
+    DuckDBFactTermStore,
+    DuckDBFactTermStoreLockedError,
+)
+root, duration = sys.argv[1], float(sys.argv[2])
+store = DuckDBFactTermStore.for_root(root)
+deadline = time.monotonic() + duration
+reads = 0
+announced = False
+try:
+    while time.monotonic() < deadline:
+        store.get_many_fact_terms([1, 2, 3, 4, 5])
+        reads += 1
+        if not announced:
+            sys.stdout.write("READY\\n")
+            sys.stdout.flush()
+            announced = True
+    sys.stdout.write("OK reads=%d\\n" % reads)
+    sys.stdout.flush()
+except DuckDBFactTermStoreLockedError as exc:
+    sys.stdout.write("LOCKED reads=%d %s\\n" % (reads, exc))
+    sys.stdout.flush()
+    sys.exit(3)
+"""
+
+# A second verinote process opening the sidecar with NO patience of its own: a
+# near-zero retry budget. It succeeds only if the lock is free the instant it
+# tries -- so it cannot be carried by retry-wait masking a still-held connection.
+_OPEN_PROBE = """
+import sys
+from verinote.store import duckdb_fact_terms
+from verinote.store.duckdb_fact_terms import (
+    DuckDBFactTermStore,
+    DuckDBFactTermStoreLockedError,
+)
+root, budget = sys.argv[1], float(sys.argv[2])
+duckdb_fact_terms._LOCK_TIMEOUT_SECONDS = budget
+store = DuckDBFactTermStore.for_root(root)
+try:
+    store.get_fact_terms(1)
+    sys.stdout.write("OK\\n")
+    sys.stdout.flush()
+except DuckDBFactTermStoreLockedError as exc:
+    sys.stdout.write("LOCKED %s\\n" % exc)
+    sys.stdout.flush()
+    sys.exit(4)
+"""
+
+
+def _spawn(tmp_path, source, *args):
+    script = tmp_path / "child.py"
+    script.write_text(source)
+    return subprocess.Popen(
+        [sys.executable, str(script), *[str(a) for a in args]],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        # A neutral cwd: never the repo root, so the child imports the installed
+        # package rather than shadowing it via sys.path[0].
+        cwd=str(tmp_path),
+    )
+
+
+def _readline_until(proc, token, timeout):
+    """Return the first child stdout line containing `token`, or None on timeout/EOF."""
+    end = time.monotonic() + timeout
+    while True:
+        remaining = end - time.monotonic()
+        if remaining <= 0:
+            return None
+        ready, _, _ = select.select([proc.stdout], [], [], remaining)
+        if not ready:
+            return None
+        line = proc.stdout.readline()
+        if line == "":
+            return None
+        if token in line:
+            return line
+
+
+def _terminate(proc):
+    if proc.poll() is None:
+        proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+@_posix_only
+def test_open_raises_locked_error_when_another_process_holds_it(tmp_path, monkeypatch):
+    _duckdb()
+    monkeypatch.setattr(duckdb_fact_terms, "_LOCK_TIMEOUT_SECONDS", 0.0)
+    root = tmp_path / "kb"
+    root.mkdir()
+    sidecar = root / FACT_TERMS_FILENAME
+    holder = _spawn(tmp_path, _HOLDER, sidecar, 30)
+    try:
+        assert _readline_until(holder, "READY", 20) is not None, "holder never took the lock"
+        store = DuckDBFactTermStore.for_root(root)
+        with pytest.raises(DuckDBFactTermStoreLockedError):
+            store.get_fact_terms(1)
+    finally:
+        _terminate(holder)
+
+
+@_posix_only
+def test_retry_succeeds_when_holder_releases_within_budget(tmp_path):
+    _duckdb()
+    root = tmp_path / "kb"
+    root.mkdir()
+    sidecar = root / FACT_TERMS_FILENAME
+    # Holder auto-releases after 0.5s, well inside the default ~5s retry budget.
+    holder = _spawn(tmp_path, _HOLDER, sidecar, 0.5)
+    try:
+        assert _readline_until(holder, "READY", 20) is not None, "holder never took the lock"
+        store = DuckDBFactTermStore.for_root(root)
+        # Starts while the lock is held; the retry loop waits it out and then the
+        # read finds an empty table -- no lock error escapes.
+        assert store.get_fact_terms(1) is None
+    finally:
+        _terminate(holder)
+
+
+@_posix_only
+def test_cli_seed_floors_lock_conflict_without_traceback(tmp_path, monkeypatch, capsys):
+    _duckdb()
+    root = local_root(tmp_path / "kb")
+    assert cli.main(["init", str(root)]) == 0
+    capsys.readouterr()
+    sidecar = root / FACT_TERMS_FILENAME
+    holder = _spawn(tmp_path, _HOLDER, sidecar, 30)
+    try:
+        assert _readline_until(holder, "READY", 20) is not None, "holder never took the lock"
+        monkeypatch.setattr(duckdb_fact_terms, "_LOCK_TIMEOUT_SECONDS", 0.0)
+        rc = cli.main(["seed", str(root)])
+        captured = capsys.readouterr()
+    finally:
+        _terminate(holder)
+
+    combined = captured.out + captured.err
+    assert rc == 1
+    # Actionable, and points at the real cause and the way out.
+    assert "lock" in combined.lower()
+    assert "verinote ui" in combined
+    assert FACT_TERMS_FILENAME in combined
+    # No raw traceback or exception-class name leaks to the user.
+    assert "Traceback" not in combined
+    assert "DuckDBFactTermStoreLockedError" not in combined
+
+
+@_posix_only
+def test_ui_reads_and_cli_seed_run_concurrently_without_lock_failures(tmp_path, capsys):
+    _duckdb()
+    root = local_root(tmp_path / "kb")
+    assert cli.main(["init", str(root)]) == 0
+    capsys.readouterr()
+    # Establish the sidecar file + schema up front so the concurrent run exercises
+    # pure read/write lock contention, not a first-writer file-creation race.
+    DuckDBFactTermStore.for_root(root).get_many_fact_terms([1])
+
+    ui = _spawn(tmp_path, _UI_LOOP, root, 2.0)
+    try:
+        assert _readline_until(ui, "READY", 20) is not None, "UI read loop never started"
+        # A real CLI write command running while the UI reads the same sidecar.
+        assert cli.main(["seed", str(root)]) == 0
+        capsys.readouterr()
+        rest = ui.communicate(timeout=30)[0]
+    except subprocess.TimeoutExpired:
+        _terminate(ui)
+        raise
+    assert ui.returncode == 0, f"UI read loop failed: {rest!r}"
+    assert "LOCKED" not in rest
+    assert "OK reads=" in rest
+
+
+@_posix_only
+def test_operation_releases_the_lock_as_soon_as_it_returns(tmp_path):
+    _duckdb()
+    # Isolates the core #169 mechanism -- releasing the connection when an
+    # operation returns -- from the retry logic that can otherwise mask a still-held
+    # connection. A file-backed store does exactly ONE operation and returns; under
+    # the fix its `_operation()` finally-closed the connection and dropped the OS
+    # lock. A separate process then opens the same sidecar with a near-ZERO retry
+    # budget of its own, so it can only succeed if the lock is genuinely free right
+    # now -- retry cannot carry it. If the store instead held the connection open
+    # for its lifetime (the literal #169 bug), this probe would hit the lock and,
+    # with no budget to wait it out, fail. The store is kept alive across the probe
+    # so that a lifetime-held connection would still be holding here.
+    root = tmp_path / "kb"
+    root.mkdir()
+    store = DuckDBFactTermStore.for_root(root)
+    try:
+        store.put_fact_terms(1, "A", "r", "B")
+        probe = _spawn(tmp_path, _OPEN_PROBE, root, 0.0)
+        try:
+            out = probe.communicate(timeout=30)[0]
+        except subprocess.TimeoutExpired:
+            _terminate(probe)
+            raise
+        assert probe.returncode == 0, (
+            f"the sidecar lock was still held after the operation returned: {out!r}"
+        )
+        assert "OK" in out
+    finally:
+        store.close()
+
+
+def test_in_memory_store_is_unchanged_by_the_per_operation_fix(tmp_path):
+    _duckdb()
+    # The in-memory store still holds one connection for its whole life: a write
+    # and a later read are separate method calls, and the row must survive between
+    # them (a fresh :memory: connection would be an empty database).
+    store = DuckDBFactTermStore(None)
+    try:
+        store.put_fact_terms(1, "A", "r", "B")
+        assert store.get_fact_terms(1) == (StringLit("A"), StringLit("r"), StringLit("B"))
+    finally:
+        store.close()
+
+    # And operating on a closed in-memory store still raises, unchanged.
+    store.close()
+    with pytest.raises(DuckDBFactTermStoreError, match="closed"):
+        store.get_fact_terms(1)
+
+
+def test_non_lock_open_failure_stays_generic_not_locked(tmp_path):
+    _duckdb()
+    root = tmp_path / "kb"
+    root.mkdir()
+    # A file that is not a DuckDB database: opening it fails, but not with a lock
+    # conflict. The retry/timeout path must not misclassify it as locked.
+    (root / FACT_TERMS_FILENAME).write_bytes(b"not a duckdb database file" * 8)
+    store = DuckDBFactTermStore.for_root(root)
+    with pytest.raises(DuckDBFactTermStoreError) as excinfo:
+        store.get_fact_terms(1)
+    assert not isinstance(excinfo.value, DuckDBFactTermStoreLockedError)

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -14,6 +14,7 @@ from verinote import __version__
 from verinote.config import Config, local_root
 from verinote.pipeline.question_outcome import format_question_outcome
 from verinote.store import Store, engine_statuses
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreLockedError
 
 # Local commands own their KB location: they never inherit the KB the web UI
 # last selected, so `verinote init` cannot scribble into somebody else's data.
@@ -1373,7 +1374,16 @@ def main(argv: list[str] | None = None) -> int:
         refusal = _refuse_on_halted_kb(cfg)
         if refusal is not None:
             return refusal
-    return args.func(cfg, args)
+    try:
+        return args.func(cfg, args)
+    except DuckDBFactTermStoreLockedError as exc:
+        # Centralized for the same reason as the halt guard above: every command
+        # that touches the DuckDB fact-term sidecar reaches it through this one
+        # line, so a single floor here spares `sync`, `seed`, and the rest from
+        # leaking a raw "Conflicting lock" traceback when another verinote
+        # process (typically `verinote ui`) is holding the store.
+        print(str(exc), file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -7,10 +7,12 @@ only the structural term payloads for fact triples, keyed by SQLite `facts.id`.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 import hashlib
 from pathlib import Path
-from typing import Iterable
+import time
+from typing import Iterable, Iterator
 
 from verinote.engine.duckdb_terms import (
     DuckDBTermError,
@@ -23,9 +25,30 @@ FACT_TERMS_FILENAME = "facts.duckdb"
 
 _TERM_COLUMNS = ("subject", "rel", "object")
 
+# DuckDB takes a single-process write lock on a database file and raises
+# immediately on a conflict -- it has no built-in wait -- so a `verinote sync`
+# launched while `verinote ui` holds the fact store would fail outright. A
+# file-backed store therefore holds no connection between calls (see below) and
+# waits out a transient holder up to this budget when it does open, mirroring the
+# SQLite `busy_timeout = 5000` convention in store/db.py. These are module-level
+# so a test can shrink the budget in-process; nothing on the production path
+# passes them, so the constructor signature stays as it was.
+_LOCK_TIMEOUT_SECONDS = 5.0
+_LOCK_POLL_SECONDS = 0.05
+_LOCK_MESSAGE_MARKERS = ("conflicting lock", "could not set lock")
+
 
 class DuckDBFactTermStoreError(ValueError):
     """Raised when the DuckDB fact-term store cannot complete an operation."""
+
+
+class DuckDBFactTermStoreLockedError(DuckDBFactTermStoreError):
+    """Raised when the fact-term file stays locked by another process past the retry budget.
+
+    A subclass of `DuckDBFactTermStoreError` so existing catch sites (the web
+    app's 409 handler) keep working, while the CLI can floor this one specific
+    cause with an actionable message instead of a raw traceback.
+    """
 
 
 @dataclass(frozen=True)
@@ -42,11 +65,22 @@ class DuckDBFactTermStore:
 
     def __init__(self, path: str | Path | None) -> None:
         self.path = Path(path).expanduser() if path is not None else None
+        self._schema_ready = False
         if self.path is not None:
             _reject_unsupported_path(self.path)
             self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._con = _connect(self.path)
-        self.init_schema()
+            # File-backed: hold no connection between calls. A long-lived Store
+            # (the web app's app.state.store lives for the whole server process)
+            # would otherwise keep the OS file lock forever and lock out a
+            # concurrent `verinote sync`. Each operation opens per-call instead.
+            self._con = None
+        else:
+            # In-memory: a fresh :memory: connection is a brand-new empty
+            # database, so the single connection must be held for the object's
+            # life. Only one process ever touches it, so there is no lock to hold.
+            self._con = _connect(self.path)
+            self.init_schema()
+            self._schema_ready = True
 
     @classmethod
     def for_root(cls, root: str | Path) -> "DuckDBFactTermStore":
@@ -55,7 +89,12 @@ class DuckDBFactTermStore:
 
     def init_schema(self) -> None:
         """Create the fact term table if it does not already exist."""
-        self._execute(
+        with self._operation() as con:
+            self._init_schema_on(con)
+
+    def _init_schema_on(self, con) -> None:
+        self._run(
+            con,
             """
             CREATE TABLE IF NOT EXISTS fact_terms (
                 fact_id BIGINT PRIMARY KEY,
@@ -64,20 +103,74 @@ class DuckDBFactTermStore:
                 object VARCHAR NOT NULL,
                 term_token VARCHAR
             )
-            """
+            """,
         )
         columns = {
             row[1]
-            for row in self._execute("PRAGMA table_info('fact_terms')").fetchall()
+            for row in self._run(con, "PRAGMA table_info('fact_terms')").fetchall()
         }
         if "term_token" not in columns:
-            self._execute("ALTER TABLE fact_terms ADD COLUMN term_token VARCHAR")
+            self._run(con, "ALTER TABLE fact_terms ADD COLUMN term_token VARCHAR")
 
     def close(self) -> None:
-        """Close the owned DuckDB connection. Safe to call more than once."""
+        """Release the store.
+
+        In-memory owns a persistent connection, so closing it is what "closed"
+        means for that mode. File-backed holds no connection between calls, so
+        this is a no-op there. Idempotent either way.
+        """
         if self._con is not None:
             self._con.close()
             self._con = None
+
+    @contextmanager
+    def _operation(self) -> Iterator[object]:
+        """Yield a connection for one store operation.
+
+        In-memory yields the persistent connection and never closes it. A
+        file-backed store opens a fresh connection (waiting out a transient lock
+        holder), initialises the schema once per object, and always closes the
+        connection when the operation finishes so nothing else is starved.
+        """
+        if self.path is None:
+            if self._con is None:
+                raise DuckDBFactTermStoreError("DuckDB fact-term store is closed")
+            yield self._con
+            return
+        con = self._open_with_retry()
+        try:
+            if not self._schema_ready:
+                self._init_schema_on(con)
+                self._schema_ready = True
+            yield con
+        finally:
+            con.close()
+
+    def _open_with_retry(self):
+        """Open the file-backed store, waiting out a transient lock holder.
+
+        DuckDB raises the lock conflict immediately with no wait of its own, so
+        we poll up to the retry budget. Only a genuine lock conflict is retried;
+        any other failure (a corrupt file, a missing driver) is re-raised at once
+        as the generic error so it is never mistaken for a busy peer.
+        """
+        deadline = time.monotonic() + max(0.0, _LOCK_TIMEOUT_SECONDS)
+        poll = _LOCK_POLL_SECONDS
+        while True:
+            try:
+                return _connect(self.path)
+            except DuckDBFactTermStoreError as exc:
+                if not _is_lock_conflict(exc):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise DuckDBFactTermStoreLockedError(
+                        f"the DuckDB fact-term store at {str(self.path)!r} is locked "
+                        f"by another process. Another verinote process -- most likely "
+                        f"`verinote ui` serving this KB -- is holding it. Stop that "
+                        f"process (or wait for it to finish) and retry."
+                    ) from exc
+                time.sleep(min(poll, max(0.0, deadline - time.monotonic())))
+                poll = min(poll * 1.5, 0.25)
 
     def put_fact_terms(
         self,
@@ -94,25 +187,30 @@ class DuckDBFactTermStore:
         token = term_token or fact_term_token_from_values(values)
         if token != fact_term_token_from_values(values):
             raise DuckDBFactTermStoreError("fact term token does not match term payload")
-        self._execute(
-            """
-            INSERT INTO fact_terms (fact_id, subject, rel, object, term_token)
-            VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(fact_id) DO UPDATE SET
-                subject = excluded.subject,
-                rel = excluded.rel,
-                object = excluded.object,
-                term_token = excluded.term_token
-            """,
-            [fid, *values, token],
-        )
+        with self._operation() as con:
+            self._run(
+                con,
+                """
+                INSERT INTO fact_terms (fact_id, subject, rel, object, term_token)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(fact_id) DO UPDATE SET
+                    subject = excluded.subject,
+                    rel = excluded.rel,
+                    object = excluded.object,
+                    term_token = excluded.term_token
+                """,
+                [fid, *values, token],
+            )
 
     def get_fact_terms(self, fact_id: int) -> tuple[Term, Term, Term] | None:
         """Return one stored fact triple, or None when the fact id is absent."""
         fid = _validate_fact_id(fact_id)
-        row = self._execute(
-            "SELECT subject, rel, object FROM fact_terms WHERE fact_id = ?", [fid]
-        ).fetchone()
+        with self._operation() as con:
+            row = self._run(
+                con,
+                "SELECT subject, rel, object FROM fact_terms WHERE fact_id = ?",
+                [fid],
+            ).fetchone()
         if row is None:
             return None
         return _decode_row(fid, row)
@@ -120,10 +218,12 @@ class DuckDBFactTermStore:
     def get_fact_term_record(self, fact_id: int) -> FactTermRecord | None:
         """Return one stored fact triple with its coherence token."""
         fid = _validate_fact_id(fact_id)
-        row = self._execute(
-            "SELECT subject, rel, object, term_token FROM fact_terms WHERE fact_id = ?",
-            [fid],
-        ).fetchone()
+        with self._operation() as con:
+            row = self._run(
+                con,
+                "SELECT subject, rel, object, term_token FROM fact_terms WHERE fact_id = ?",
+                [fid],
+            ).fetchone()
         if row is None:
             return None
         return _decode_record(fid, row)
@@ -136,11 +236,13 @@ class DuckDBFactTermStore:
         if not ids:
             return {}
         placeholders = ", ".join("?" for _ in ids)
-        rows = self._execute(
-            "SELECT fact_id, subject, rel, object "
-            f"FROM fact_terms WHERE fact_id IN ({placeholders}) ORDER BY fact_id",
-            ids,
-        ).fetchall()
+        with self._operation() as con:
+            rows = self._run(
+                con,
+                "SELECT fact_id, subject, rel, object "
+                f"FROM fact_terms WHERE fact_id IN ({placeholders}) ORDER BY fact_id",
+                ids,
+            ).fetchall()
         return {
             int(row[0]): _decode_row(int(row[0]), (row[1], row[2], row[3]))
             for row in rows
@@ -154,23 +256,36 @@ class DuckDBFactTermStore:
         if not ids:
             return {}
         placeholders = ", ".join("?" for _ in ids)
-        rows = self._execute(
-            "SELECT fact_id, subject, rel, object, term_token "
-            f"FROM fact_terms WHERE fact_id IN ({placeholders}) ORDER BY fact_id",
-            ids,
-        ).fetchall()
+        with self._operation() as con:
+            rows = self._run(
+                con,
+                "SELECT fact_id, subject, rel, object, term_token "
+                f"FROM fact_terms WHERE fact_id IN ({placeholders}) ORDER BY fact_id",
+                ids,
+            ).fetchall()
         return {int(row[0]): _decode_record(int(row[0]), row[1:]) for row in rows}
 
     def delete_fact_terms(self, fact_id: int) -> None:
         """Delete a fact term row. Missing ids are ignored."""
         fid = _validate_fact_id(fact_id)
-        self._execute("DELETE FROM fact_terms WHERE fact_id = ?", [fid])
+        with self._operation() as con:
+            self._run(con, "DELETE FROM fact_terms WHERE fact_id = ?", [fid])
 
     def _execute(self, sql: str, params: list[object] | None = None):
-        if self._con is None:
-            raise DuckDBFactTermStoreError("DuckDB fact-term store is closed")
+        """Run one statement in its own operation.
+
+        Retained for direct callers that issue a single autocommitting statement
+        and do not read from the returned cursor: for a file-backed store the
+        connection is already closed by the time this returns, so fetching from
+        the result afterwards would fail. The public read methods above open the
+        operation themselves and fetch while the connection is still live.
+        """
+        with self._operation() as con:
+            return self._run(con, sql, params)
+
+    def _run(self, con, sql: str, params: list[object] | None = None):
         try:
-            return self._con.execute(sql, params or [])
+            return con.execute(sql, params or [])
         except DuckDBFactTermStoreError:
             raise
         except Exception as exc:
@@ -226,6 +341,18 @@ def _connect(path: Path | None):
         return duckdb.connect(str(path) if path is not None else ":memory:")
     except Exception as exc:
         raise DuckDBFactTermStoreError(f"failed to open DuckDB fact-term store: {exc}") from exc
+
+
+def _is_lock_conflict(exc: Exception) -> bool:
+    """Report whether a failed open was a single-writer lock conflict.
+
+    `_connect` wraps DuckDB's `IOException` into `DuckDBFactTermStoreError` but
+    keeps its text, so we match on the message rather than the type. Anything
+    else (a corrupt file, a missing driver) is not a lock conflict and must not
+    be retried or reclassified.
+    """
+    message = str(exc).lower()
+    return any(marker in message for marker in _LOCK_MESSAGE_MARKERS)
 
 
 def _validate_fact_id(fact_id: int) -> int:


### PR DESCRIPTION
## Summary

- DuckDB takes a single-process write lock on the fact-term sidecar (`facts.duckdb`) and raises immediately on a conflict, with no wait of its own. `Store.fact_terms` opened this sidecar lazily and held the connection for the owning `Store`'s entire lifetime. The web app's `app.state.store` lives for the whole server process, so the very first fact-bearing page request locked the sidecar until the server exited — breaking the exact documented "sync, then review in the UI" workflow with a raw traceback on any concurrent `verinote sync`/`seed`.
- A file-backed `DuckDBFactTermStore` now holds no connection between calls: each public method opens fresh, waits out a transient holder with bounded retry-with-backoff (mirroring this codebase's existing SQLite `busy_timeout=5000` convention), and closes when the operation finishes. In-memory stores are unaffected — a second `:memory:` connection would be a fresh, empty database, so that path keeps its single persistent connection exactly as before.
- A new `DuckDBFactTermStoreLockedError` subclass lets the CLI floor a stale-lock timeout with an actionable message at the single top-level dispatch point in `main()` — the same place the existing halt guard lives — without disturbing the web app's existing exception handling for the broader class it subclasses.

## Why the fix is contained to one file

`Store.fact_terms` and its ~14 call sites in `db.py` are unchanged — it still returns the same `DuckDBFactTermStore` object for the `Store`'s life; only that object's internal connection handling changes. This was a deliberate design choice: an alternative (session-scoped lifecycle managed at the `Store` level) was considered and rejected after discovering it would require touching or breaking 12+ existing test call sites that depend on `.fact_terms` returning a stable, persistent object reference — including a test that monkeypatches a method directly on it.

## Verification

Every test that exercises lock contention crosses a real OS process boundary — two connections to the same file within one process share DuckDB's per-process instance cache and never conflict, so a same-process test would be a false green.

This went through one real revision cycle: the first review round found that the fix's core mechanism (releasing the connection between operations, not just retrying) wasn't actually pinned by any test — the headline concurrent test's hold time happened to fit inside the retry budget, so retry alone carried it, and a regression back to the original bug would have passed CI silently. A targeted isolation test was added (a store performs one operation and stays open; a real subprocess with its own near-zero retry budget must succeed instantly, which only happens if the lock was genuinely released) and mutation-tested independently by three separate people in this flow, each reproducing the exact same result.

Full suite: 1549 passed, 7 skipped. Ruff clean at CI-pinned 0.15.18.

Closes #169

## Scope note

No DuckDB storage-format change, no client/server DuckDB mode, no external lockfile. `read_only` mode was investigated and ruled out (conflicts persist across and within processes in ways that don't fit this codebase's actual usage). A handful of tight write/delete loops (`backfill_fact_terms`, `delete_source`'s per-fact cleanup) now pay a per-iteration connection-open cost instead of one open for the whole loop — an explicitly accepted tradeoff for rare, non-hot-path admin operations, not engineered around.
