### PR TITLE
fix(#171): diagnose an empty policy file instead of bricking the logic check

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -11,11 +11,15 @@ from verinote.pipeline.corroboration import store_functional_relations
 from verinote.pipeline.policy_state import (
     POLICY_CLI_LINE_MISSING_RECORDED,
     POLICY_CLI_LINE_PRESENT,
+    POLICY_CLI_LINE_PRESENT_EMPTY,
     POLICY_CLI_LINE_UNRECORDED_DEFAULT,
     POLICY_RELPATH,
+    PolicyEmptyError,
     PolicyMissingError,
     PolicyState,
     PolicyStatus,
+    assert_writable,
+    ensure_policy_marker,
     policy_cli_line,
     policy_sha256,
     resolve_policy,
@@ -831,8 +835,12 @@ def test_policy_cli_line_covers_every_policy_status():
     assert len(set(lines.values())) == len(PolicyStatus)  # states are distinguishable
     assert lines[PolicyStatus.MISSING_RECORDED] == POLICY_CLI_LINE_MISSING_RECORDED
     assert lines[PolicyStatus.PRESENT] == POLICY_CLI_LINE_PRESENT
+    assert lines[PolicyStatus.PRESENT_EMPTY] == POLICY_CLI_LINE_PRESENT_EMPTY
     assert lines[PolicyStatus.UNRECORDED_DEFAULT] == POLICY_CLI_LINE_UNRECORDED_DEFAULT
     assert "HALTED" in POLICY_CLI_LINE_MISSING_RECORDED
+    # #171: an empty policy file is a halt, so its line reads HALTED like the
+    # missing-recorded one — the two halted states share the loud word, distinct text.
+    assert "HALTED" in POLICY_CLI_LINE_PRESENT_EMPTY
     # #288: PRESENT is the one state that cannot see rule content, so its line
     # claims only the file's presence — never that the KB's rules exist.
     assert POLICY_CLI_LINE_PRESENT == "policy: ok (policy file present)"
@@ -903,22 +911,226 @@ def test_status_of_unrecorded_kb_prints_the_default_line(tmp_path, monkeypatch, 
     assert captured.err == ""  # the benign state is not an error
 
 
-def test_present_line_is_honest_on_an_empty_policy_file(tmp_path, monkeypatch, capsys):
-    """A 0-byte policy file still resolves to PRESENT (`is_file()` is True); the
-    line must not claim rules exist — the #288 lie. This asserts phrasing only:
-    *detecting* an empty policy is a separate issue (#359), deliberately not done
-    here.
+def test_status_halts_on_an_empty_policy_file(tmp_path, monkeypatch, capsys):
+    """#171 (was #288's placeholder): an empty policy file is HALTED, not "ok".
+
+    #288 could only make the PRESENT line honest ("policy file present", never
+    "rules present") because *detecting* emptiness was out of scope then. #171
+    detects it: an empty file resolves to PRESENT_EMPTY, so `status` prints the
+    HALTED-empty line on stdout and the actionable recovery text on stderr — no
+    longer the "ok" line. The original spirit survives: the output still makes no
+    false claim that rules are present.
     """
     _env(monkeypatch, tmp_path)
     assert cli.main(["init"]) == 0
     (tmp_path / POLICY_RELPATH).write_text("", encoding="utf-8")
     capsys.readouterr()  # drop init's output
 
-    assert cli.main(["status"]) == 0
+    assert cli.main(["status"]) == 0  # diagnosis must still work *on* a halted KB
 
-    out = capsys.readouterr().out
-    assert POLICY_CLI_LINE_PRESENT in out
-    assert "rules are present" not in out  # the specific false claim #288 removed
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_PRESENT_EMPTY in captured.out
+    assert POLICY_CLI_LINE_PRESENT not in captured.out  # not the old "ok" line
+    assert "rules are present" not in captured.out  # the #288 lie stays gone
+    assert "empty" in captured.err and "policy reset --force" in captured.err
+
+
+# --- #171: an empty/whitespace-only policy file is its own halted state -------
+#
+# `is_file()` is True for a 0-byte or whitespace-only policy, so the pre-#171 code
+# resolved both to PRESENT and let the engine reject them with a cryptic "program
+# must declare relation/3". These pin the dedicated PRESENT_EMPTY state instead:
+# halt loudly, name the file as empty, and (the resolved fork) never overwrite a
+# real recorded marker with `sha256("")` just because the file was truncated.
+
+_EMPTY_POLICY_TEXTS = [
+    pytest.param("", id="zero_byte"),
+    pytest.param("   \n\t  \n", id="whitespace_only"),
+]
+
+
+def _empty_policy_cli_kb(tmp_path, monkeypatch, *, text=""):
+    """A CLI-visible KB whose scaffolded policy file has been truncated to empty."""
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    policy = tmp_path / POLICY_RELPATH
+    policy.write_text(text, encoding="utf-8")
+    return policy
+
+
+@pytest.mark.parametrize("text", _EMPTY_POLICY_TEXTS)
+@pytest.mark.parametrize("with_marker", [False, True], ids=["no_marker", "with_marker"])
+def test_empty_policy_file_resolves_to_present_empty(tmp_path, text, with_marker):
+    """A 0-byte AND a whitespace-only file both resolve to PRESENT_EMPTY — marker
+    or not. Emptiness is a property of the file's content, decided the same way
+    whether or not the KB ever recorded a policy."""
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path, text)
+    if with_marker:
+        store.record_policy_marker(policy_sha256(FUNCTIONAL_POLICY), origin="scaffold")
+
+    state = resolve_policy(store)
+
+    assert state.status is PolicyStatus.PRESENT_EMPTY
+    assert state.path == path
+    store.close()
+
+
+@pytest.mark.parametrize("text", _EMPTY_POLICY_TEXTS)
+def test_emptying_a_policy_file_preserves_the_existing_marker(tmp_path, text):
+    """The resolved design fork, pinned. Opening a KB whose real policy file was
+    truncated must NOT overwrite the recorded marker with `sha256("")`: that would
+    erase the evidence a real policy ever existed, turning a recoverable truncation
+    into silent, permanent loss the next time the KB is opened (as the web UI does
+    on launch). The marker is returned exactly as it was read, unrefreshed.
+    """
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)  # a real, non-empty policy
+    real_sha = policy_sha256(path.read_text(encoding="utf-8"))
+    store.record_policy_marker(real_sha, origin="scaffold")
+    marker_before = dict(store.policy_marker())
+
+    path.write_text(text, encoding="utf-8")  # the file is truncated under the KB
+    state = ensure_policy_marker(store, tmp_path)  # merely opening the KB again
+
+    assert state.status is PolicyStatus.PRESENT_EMPTY
+    marker_after = dict(store.policy_marker())
+    assert marker_after == marker_before  # the whole marker is untouched
+    assert marker_after["sha256"] == real_sha  # specifically NOT overwritten
+    assert marker_after["sha256"] != policy_sha256(text)  # ...with sha256("")
+    store.close()
+
+
+@pytest.mark.parametrize("text", _EMPTY_POLICY_TEXTS)
+def test_assert_writable_raises_policy_empty_error(tmp_path, text):
+    """assert_writable halts an empty-policy KB with PolicyEmptyError — and that
+    error IS a PolicyMissingError, so every existing `except PolicyMissingError`
+    write gate catches it with no new catch clause."""
+    store = _store(tmp_path)
+    _write_policy(tmp_path, text)
+
+    with pytest.raises(PolicyEmptyError) as exc_info:
+        assert_writable(store)
+
+    assert isinstance(exc_info.value, PolicyMissingError)  # the subclass is load-bearing
+    message = str(exc_info.value)
+    assert "empty" in message and "policy reset --force" in message
+    store.close()
+
+
+def test_coverage_halts_on_an_empty_policy_file(tmp_path, monkeypatch, capsys):
+    """Plain `coverage` is a recovery path: it reports the empty halt but stays rc=0
+    so the KB can still be inspected."""
+    _empty_policy_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["coverage"]) == 0
+
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_PRESENT_EMPTY in captured.out
+    assert "coverage:" in captured.out
+    assert "empty" in captured.err and "policy reset --force" in captured.err
+
+
+def test_coverage_strict_reports_empty_not_missing_or_ruleless(tmp_path, monkeypatch, capsys):
+    """`--strict` fails an empty-policy KB and names it precisely: "empty", not
+    "missing" (the file is right there), and not #359's "no review rules" (a
+    rule-less relation-only policy is a different, still-valid state that must keep
+    its own message)."""
+    _empty_policy_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["coverage", "--strict"]) == 1
+
+    captured = capsys.readouterr()
+    assert POLICY_CLI_LINE_PRESENT_EMPTY in captured.out
+    assert "logic policy file is empty" in captured.err
+    assert "is missing" not in captured.err
+    assert "no review rules" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["seed"], id="seed"),
+        pytest.param(["ingest", "<src>"], id="ingest"),
+        pytest.param(["query", "who is Ada?"], id="query"),
+        pytest.param(["sync", "<src>"], id="sync"),
+    ],
+)
+def test_cli_write_commands_refuse_on_empty_policy_kb(tmp_path, monkeypatch, capsys, argv):
+    """Every write command is refused at the pre-dispatch guard on an empty-policy
+    KB — with the empty-specific message, exit code 2, and nothing written."""
+    policy = _empty_policy_cli_kb(tmp_path, monkeypatch)
+    src = tmp_path / "input.txt"
+    src.write_text("Ada is_a engineer\n", encoding="utf-8")
+
+    rc = cli.main([a.replace("<src>", str(src)) for a in argv])
+
+    assert rc == 2  # the same code the missing-policy refusal uses
+    err = capsys.readouterr().err
+    assert "empty" in err and "policy reset --force" in err
+    # nothing was written: no registered source file, no rows, no query file
+    assert not (tmp_path / "sources" / "input.txt").exists()
+    assert not (tmp_path / "facts" / "query.dl").exists()
+    assert _kb_rows(tmp_path) == (0, 0, 0)
+    assert policy.read_text(encoding="utf-8") == ""  # the empty file is left as-is
+
+
+def test_init_refuses_on_an_empty_policy_kb_without_overwriting_it(
+    tmp_path, monkeypatch, capsys
+):
+    """`init` on a present-but-empty KB is refused and must NOT silently rewrite the
+    empty file with the default — recovery is the explicit `policy reset --force`,
+    exactly as for a recorded-but-missing policy. `--seed` must not slip rows in on
+    the way to the refusal either."""
+    policy = _empty_policy_cli_kb(tmp_path, monkeypatch)
+
+    assert cli.main(["init", "--seed"]) == 2
+
+    assert "empty" in capsys.readouterr().err
+    assert policy.read_text(encoding="utf-8") == ""  # untouched, not re-scaffolded
+    assert _kb_rows(tmp_path) == (0, 0, 0)
+
+
+def test_init_refuses_an_empty_policy_file_when_no_db_exists_yet(tmp_path, monkeypatch, capsys):
+    """The reachable `_scaffold_policy` PRESENT_EMPTY branch — a DIFFERENT path from
+    the test above. When an empty policy file exists but `kb.sqlite` does not yet,
+    the pre-dispatch halt guard cannot fire (it gates on `db_path.is_file()`, still
+    false here), so `init` proceeds into `cmd_init`, creates the KB, and reaches
+    `_scaffold_policy` — which must refuse rather than silently overwrite the empty
+    file with the default policy. (The test above hits the pre-dispatch guard, whose
+    db already exists; this one is the only path that reaches the scaffold branch.)
+    """
+    _env(monkeypatch, tmp_path)
+    policy = tmp_path / POLICY_RELPATH
+    policy.parent.mkdir(parents=True, exist_ok=True)
+    policy.write_text("", encoding="utf-8")
+    assert not (tmp_path / "kb.sqlite").is_file()  # no DB: the pre-dispatch guard is inert
+
+    assert cli.main(["init"]) == 2
+
+    assert "empty" in capsys.readouterr().err
+    assert policy.read_text(encoding="utf-8") == ""  # NOT overwritten with the default
+    # the KB was created (init ran past the inert guard into cmd_init), so the
+    # refusal is `_scaffold_policy`'s — not a pre-dispatch halt that never got here
+    assert (tmp_path / "kb.sqlite").is_file()
+
+
+def test_policy_reset_force_recovers_an_empty_policy_kb(tmp_path, monkeypatch, capsys):
+    """`policy reset --force` overwrites the empty file with the shipped default and
+    un-halts the KB. This needs no code change, but a recovery path that does not
+    actually recover is no recovery — so it is pinned with a real run."""
+    policy = _empty_policy_cli_kb(tmp_path, monkeypatch)
+    src = tmp_path / "input.txt"
+    src.write_text("Ada is_a engineer\n", encoding="utf-8")
+    assert cli.main(["ingest", str(src)]) == 2  # halted before recovery
+    capsys.readouterr()
+
+    assert cli.main(["policy", "reset", "--force"]) == 0
+
+    assert policy.read_text(encoding="utf-8") == DEFAULT_POLICY
+    # and the KB accepts writes again — recovery that leaves it halted is no recovery
+    assert cli.main(["ingest", str(src)]) == 0
+    assert (tmp_path / "sources" / "input.txt").is_file()
 
 
 # --- (b) the worker: a mid-job halt must rewind the job, not strand it ------

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2,11 +2,15 @@
 import builtins
 from pathlib import Path
 
+import pytest
+
 import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import (
     NO_REVIEW_RULES_FINDING,
+    PolicyEmptyError,
+    PolicyMissingError,
     load_policy,
     policy_path,
     verify,
@@ -83,6 +87,51 @@ def test_verify_loads_kb_policy_file(tmp_path):
     rep = verify(s)
     assert rep.errors == 1
     assert "has_isa: Org company" in "\n".join(rep.findings)
+
+
+def _write_empty_policy(store: Store, text: str) -> None:
+    p = policy_path(store)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+@pytest.mark.parametrize("text", ["", "   \n\t  \n"], ids=["zero_byte", "whitespace"])
+def test_verify_halts_on_an_empty_policy_file(tmp_path, text):
+    """#171: an empty policy file is diagnosed as empty and halted BEFORE the engine
+    runs — so the cryptic "program must declare relation/3" is never produced. The
+    finding names it `policy_empty`, and the report text says both what is wrong
+    ("empty") and how to fix it (`policy reset --force`)."""
+    s = _store(tmp_path)
+    s.add_fact("Org", "is_a", "company", status="confirmed")
+    _write_empty_policy(s, text)
+
+    rep = verify(s)
+
+    assert rep.ok is False
+    assert rep.errors == 1
+    assert rep.warnings == 0
+    assert any("policy_empty" in f for f in rep.findings), rep.findings
+    assert "empty" in rep.text
+    assert "policy reset --force" in rep.text
+    # the whole point: the pre-#171 cryptic engine error must never surface here
+    assert "must declare relation/3" not in rep.text
+    s.close()
+
+
+@pytest.mark.parametrize("text", ["", "   \n\t  \n"], ids=["zero_byte", "whitespace"])
+def test_load_policy_raises_policy_empty_error(tmp_path, text):
+    """load_policy raises PolicyEmptyError on an empty file — returning None there
+    would silently substitute the shipped default for rules a human wrote. The
+    error is a PolicyMissingError, so every existing catch site handles it."""
+    s = _store(tmp_path)
+    _write_empty_policy(s, text)
+
+    with pytest.raises(PolicyEmptyError) as exc_info:
+        load_policy(s)
+
+    assert isinstance(exc_info.value, PolicyMissingError)  # caught by the base handler
+    assert "empty" in str(exc_info.value)
+    s.close()
 
 
 def test_verify_loads_hand_written_fixture_policy(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1306,6 +1306,57 @@ def _job_event_types(cfg, job_id):
         ]
 
 
+def _empty_policy_web_kb(tmp_path, *, text=""):
+    """A KB that recorded a real policy whose file has since been truncated to
+    empty. Returns (cfg, fact_id): the fact is reviewable, so a POST acting on it
+    is a genuine write the halt guard must refuse (#171)."""
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    policy = tmp_path / POLICY_RELPATH
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        fact_id = store.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+    policy.write_text(text, encoding="utf-8")  # truncated to empty under the KB
+    return cfg, fact_id
+
+
+def test_web_mutating_route_returns_409_on_an_empty_policy_kb(tmp_path):
+    """#171: an empty-policy KB is halted for writes on the web too. A mutating
+    route (accepting a fact) is refused by the existing middleware guard with the
+    existing 409 halted page — no new template — because PolicyEmptyError is a
+    PolicyMissingError that guard already catches."""
+    cfg, fact_id = _empty_policy_web_kb(tmp_path)
+    c = TestClient(create_app(cfg))
+
+    r = c.post(f"/facts/{fact_id}/accept")
+
+    assert r.status_code == 409
+    assert "empty" in r.text
+    assert "policy reset --force" in r.text
+
+
+def test_web_report_renders_the_empty_policy_diagnosis(tmp_path):
+    """/report is exempt from the write guard and calls verify() directly, so it
+    renders the new empty-policy diagnosis instead of the cryptic engine error."""
+    cfg, _ = _empty_policy_web_kb(tmp_path)
+    c = TestClient(create_app(cfg))
+
+    r = c.get("/report")
+
+    assert r.status_code == 200
+    assert "empty" in r.text
+    assert "must declare relation/3" not in r.text
+
+
 def test_launching_the_ui_on_a_halted_kb_resumes_nothing(tmp_path, monkeypatch, fake_client):
     """Zero HTTP requests, and still the launcher used to write to a halted KB (#194).
 

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -117,8 +117,10 @@ def _scaffold_policy(cfg: Config, store: Store) -> Path | None:
     --force`).
     """
     from verinote.pipeline.policy_state import (
+        PolicyEmptyError,
         PolicyMissingError,
         PolicyStatus,
+        policy_empty_message,
         policy_missing_message,
         resolve_policy,
         write_default_policy,
@@ -129,6 +131,12 @@ def _scaffold_policy(cfg: Config, store: Store) -> Path | None:
         return None
     if state.status is PolicyStatus.MISSING_RECORDED:
         raise PolicyMissingError(policy_missing_message(state))
+    # An empty file is present, so it must not be overwritten with the default
+    # here: recovery is the explicit `policy reset --force`, never a silent
+    # re-scaffold. The pre-dispatch halt guard normally catches this first; this
+    # branch is the backstop so a direct call cannot misbehave (#171).
+    if state.status is PolicyStatus.PRESENT_EMPTY:
+        raise PolicyEmptyError(policy_empty_message(state))
     return write_default_policy(store, cfg.root, origin="scaffold")
 
 
@@ -424,17 +432,24 @@ def _policy_marker_ro(conn: sqlite3.Connection) -> dict[str, object] | None:
 
 
 def _policy_state_ro(conn: sqlite3.Connection, cfg: Config):
-    from verinote.pipeline.policy_state import POLICY_RELPATH, PolicyState, PolicyStatus
+    from verinote.pipeline.policy_state import (
+        POLICY_RELPATH,
+        PolicyState,
+        PolicyStatus,
+        _policy_text_is_empty,
+    )
 
     path = cfg.root / POLICY_RELPATH
     marker = _policy_marker_ro(conn)
     if path.is_file():
-        return PolicyState(
-            status=PolicyStatus.PRESENT,
-            path=path,
-            text=path.read_text(encoding="utf-8"),
-            marker=marker,
+        # Shares `_policy_text_is_empty` with `resolve_policy` so this read-only
+        # reimplementation (used by `status`/`coverage`) cannot drift from it and
+        # keep reporting "ok" on an empty-policy KB the write path already halts.
+        text = path.read_text(encoding="utf-8")
+        status = (
+            PolicyStatus.PRESENT_EMPTY if _policy_text_is_empty(text) else PolicyStatus.PRESENT
         )
+        return PolicyState(status=status, path=path, text=text, marker=marker)
     if marker is not None:
         return PolicyState(status=PolicyStatus.MISSING_RECORDED, path=path, marker=marker)
     return PolicyState(status=PolicyStatus.UNRECORDED_DEFAULT, path=path)
@@ -1002,6 +1017,7 @@ def _print_policy_state(store: Store) -> bool:
     from verinote.pipeline.policy_state import (
         PolicyStatus,
         policy_cli_line,
+        policy_empty_message,
         policy_missing_message,
         resolve_policy,
     )
@@ -1011,6 +1027,9 @@ def _print_policy_state(store: Store) -> bool:
     if state.status is PolicyStatus.MISSING_RECORDED:
         print(f"error: {policy_missing_message(state)}", file=sys.stderr)
         return True
+    if state.status is PolicyStatus.PRESENT_EMPTY:
+        print(f"error: {policy_empty_message(state)}", file=sys.stderr)
+        return True
     return False
 
 
@@ -1018,6 +1037,7 @@ def _print_policy_state_ro(conn: sqlite3.Connection, cfg: Config) -> bool:
     from verinote.pipeline.policy_state import (
         PolicyStatus,
         policy_cli_line,
+        policy_empty_message,
         policy_missing_message,
     )
 
@@ -1025,6 +1045,9 @@ def _print_policy_state_ro(conn: sqlite3.Connection, cfg: Config) -> bool:
     print(policy_cli_line(state))
     if state.status is PolicyStatus.MISSING_RECORDED:
         print(f"error: {policy_missing_message(state)}", file=sys.stderr)
+        return True
+    if state.status is PolicyStatus.PRESENT_EMPTY:
+        print(f"error: {policy_empty_message(state)}", file=sys.stderr)
         return True
     return False
 
@@ -1114,6 +1137,11 @@ def _coverage(cfg: Config, args: argparse.Namespace) -> int:
             )
         cov = Coverage(sources=sources)
         halted = _print_policy_state_ro(conn, cfg)
+        # Capture the halt reason while the connection is open so the --strict
+        # message can name it precisely: an empty policy file is not a *missing*
+        # one, and reporting it as missing would send the user hunting for a file
+        # that is right there (#171).
+        halted_status = _policy_state_ro(conn, cfg).status if halted else None
         # Compute before `conn.close()`: `_zero_review_rules_ro` reads the KB's
         # policy marker over this same read-only connection.
         zero_review_rules = _zero_review_rules_ro(conn, cfg)
@@ -1136,7 +1164,10 @@ def _coverage(cfg: Config, args: argparse.Namespace) -> int:
     # does — otherwise automation greenlights a KB with no rules. Plain `coverage`
     # stays rc=0: it is a recovery path, and a halt you cannot inspect is a brick.
     if args.strict and halted:
-        print("strict: this KB's logic policy file is missing", file=sys.stderr)
+        from verinote.pipeline.policy_state import PolicyStatus
+
+        detail = "empty" if halted_status is PolicyStatus.PRESENT_EMPTY else "missing"
+        print(f"strict: this KB's logic policy file is {detail}", file=sys.stderr)
         return 1
     if args.strict and zero_review_rules:
         print(

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -18,16 +18,22 @@ not as a verdict: editing a policy is normal and a hash mismatch is never an
 error. The `.dl` file remains the owner of the policy text; the DB never stores
 its body.
 
-Three states, one resolution point:
+Four states, one resolution point:
 
-| file    | marker  | status               | behaviour                        |
-|---------|---------|----------------------|----------------------------------|
-| present | either  | `PRESENT`            | use the file                     |
-| absent  | present | `MISSING_RECORDED`   | loud error, no engine run        |
-| absent  | absent  | `UNRECORDED_DEFAULT` | shipped default + loud warning   |
+| file            | marker  | status               | behaviour                      |
+|-----------------|---------|----------------------|--------------------------------|
+| present (rules) | either  | `PRESENT`            | use the file                   |
+| present (empty) | either  | `PRESENT_EMPTY`      | loud error, no engine run      |
+| absent          | present | `MISSING_RECORDED`   | loud error, no engine run      |
+| absent          | absent  | `UNRECORDED_DEFAULT` | shipped default + loud warning |
 
-Future states (e.g. an empty-policy state, #171) belong in `PolicyStatus` and in
-`resolve_policy`; they must not reintroduce a silent fallback to DEFAULT_POLICY.
+An empty or whitespace-only file (`PRESENT_EMPTY`, #171) is halted, not run: it
+declares no `relation/3`, so the engine would otherwise reject it with a cryptic
+"program must declare relation/3" that never names the real cause. Like the other
+halted states it must not reintroduce a silent fallback to DEFAULT_POLICY, and —
+unlike a non-empty present file — opening the KB records no marker for it, since
+`sha256("")` would overwrite the evidence of a policy that once existed. Recovery
+is `verinote policy reset --force`.
 """
 
 from __future__ import annotations
@@ -80,18 +86,37 @@ POLICY_UNRECORDED_BANNER = (
 # The loud, actionable text for a real halt is `policy_missing_message`, which the
 # CLI prints to stderr *in addition* to the stdout marker.
 POLICY_CLI_LINE_PRESENT = "policy: ok (policy file present)"
+POLICY_CLI_LINE_PRESENT_EMPTY = "policy: HALTED (policy file empty)"
 POLICY_CLI_LINE_MISSING_RECORDED = "policy: HALTED (rules missing)"
 POLICY_CLI_LINE_UNRECORDED_DEFAULT = "policy: default (this KB records no rules of its own)"
 
 
 class PolicyMissingError(RuntimeError):
-    """Raised when a KB recorded a logic policy but the policy file is gone."""
+    """Raised when a KB's recorded logic policy cannot be run.
+
+    Covers both halted-present states: the file is *gone* (a KB recorded one and
+    it is missing), and the file *exists but is empty* (`PolicyEmptyError`). Both
+    halt for the same reason — the KB's rules are not being applied — so every
+    `except PolicyMissingError` write gate catches both without change.
+    """
+
+
+class PolicyEmptyError(PolicyMissingError):
+    """Raised when a KB's policy file exists but is empty or whitespace-only.
+
+    A subclass of `PolicyMissingError` on purpose: an empty file declares no
+    rules, so it must halt writes exactly as a missing one does, and subclassing
+    means every existing `except PolicyMissingError` site (CLI dispatch, the web
+    write guard and its exception handler, the acceptance/corroboration gates)
+    catches it with no new catch clause (#171).
+    """
 
 
 class PolicyStatus(str, Enum):
     """How the KB's policy file relates to what the KB declared about it."""
 
     PRESENT = "present"
+    PRESENT_EMPTY = "present_empty"
     MISSING_RECORDED = "missing_recorded"
     UNRECORDED_DEFAULT = "unrecorded_default"
 
@@ -115,25 +140,37 @@ def policy_sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
+def _policy_text_is_empty(text: str) -> bool:
+    """Whether a present policy file declares nothing at all (#171).
+
+    A 0-byte file and a whitespace-only one are byte-different but behave
+    identically: both parse to an empty program and fail the engine's later
+    `relation/3` check. `text.strip() == ""` is the whole definition on purpose —
+    a comment-only file or one that declares `functional` but not literally
+    `relation` is *not* empty and is left to the engine, not caught here. The CLI's
+    read-only resolver shares this helper so the two cannot drift apart.
+    """
+    return text.strip() == ""
+
+
 def policy_path(store: "Store") -> Path:
     return store.db_path.parent / POLICY_RELPATH
 
 
 def resolve_policy(store: "Store") -> PolicyState:
-    """Resolve the KB's policy into exactly one of the three states.
+    """Resolve the KB's policy into exactly one of the four states.
 
-    The only judgement inputs are: does the file exist, and did the KB record a
-    marker. Nothing else is inferred.
+    The only judgement inputs are: does the file exist, is it empty, and did the
+    KB record a marker. Nothing else is inferred.
     """
     path = policy_path(store)
     marker = store.policy_marker()
     if path.is_file():
-        return PolicyState(
-            status=PolicyStatus.PRESENT,
-            path=path,
-            text=path.read_text(encoding="utf-8"),
-            marker=marker,
+        text = path.read_text(encoding="utf-8")
+        status = (
+            PolicyStatus.PRESENT_EMPTY if _policy_text_is_empty(text) else PolicyStatus.PRESENT
         )
+        return PolicyState(status=status, path=path, text=text, marker=marker)
     if marker is not None:
         return PolicyState(status=PolicyStatus.MISSING_RECORDED, path=path, marker=marker)
     return PolicyState(status=PolicyStatus.UNRECORDED_DEFAULT, path=path)
@@ -156,6 +193,24 @@ def policy_missing_message(state: PolicyState) -> str:
     )
 
 
+def policy_empty_message(state: PolicyState) -> str:
+    """The loud, actionable message for a present-but-empty policy file.
+
+    Deliberately cites no marker hash: the marker is preserved as-is (#171), but a
+    hash in a "your file is empty" message only adds confusion. The point is the
+    file, not the evidence of what used to be in it.
+    """
+    return (
+        f"policy file {state.path} exists but is empty or whitespace-only: "
+        "it declares no rules at all — not even the `relation/3` declaration the "
+        "engine requires. Verification is halted instead of running an empty policy "
+        "or silently falling back to the shipped default policy. Recover by either "
+        "(1) restoring the policy file from a backup or version control, or (2) "
+        "running `verinote policy reset --force` to re-create the default policy "
+        "for this KB."
+    )
+
+
 def policy_cli_line(state: PolicyState) -> str:
     """The one-line stdout marker for a resolved policy state.
 
@@ -168,6 +223,7 @@ def policy_cli_line(state: PolicyState) -> str:
 
 _POLICY_CLI_LINES = {
     PolicyStatus.PRESENT: POLICY_CLI_LINE_PRESENT,
+    PolicyStatus.PRESENT_EMPTY: POLICY_CLI_LINE_PRESENT_EMPTY,
     PolicyStatus.MISSING_RECORDED: POLICY_CLI_LINE_MISSING_RECORDED,
     PolicyStatus.UNRECORDED_DEFAULT: POLICY_CLI_LINE_UNRECORDED_DEFAULT,
 }
@@ -189,6 +245,8 @@ def assert_writable(store: "Store") -> PolicyState:
     state = resolve_policy(store)
     if state.status is PolicyStatus.MISSING_RECORDED:
         raise PolicyMissingError(policy_missing_message(state))
+    if state.status is PolicyStatus.PRESENT_EMPTY:
+        raise PolicyEmptyError(policy_empty_message(state))
     return state
 
 
@@ -198,6 +256,11 @@ def ensure_policy_marker(store: "Store", root: Path | None = None) -> PolicyStat
     * file present, no marker  -> adopt it (`origin="adopted"`); pre-marker KBs
       keep working, and any *later* loss of the file is loud.
     * file present, marker     -> refresh the evidence hash (never an error).
+    * file present but empty    -> record NOTHING and return `PRESENT_EMPTY` with
+      the marker as read: recording `sha256("")` here would silently overwrite a
+      real policy's marker, so merely opening a KB whose file was truncated — which
+      the web UI does on launch and on a KB switch, without any write — would
+      destroy the evidence a policy ever existed (#171).
     * file absent              -> do nothing; the two absent states are already
       distinguishable and must stay that way.
     """
@@ -209,6 +272,10 @@ def ensure_policy_marker(store: "Store", root: Path | None = None) -> PolicyStat
         )
         return PolicyState(status=status, path=path, marker=marker)
     text = path.read_text(encoding="utf-8")
+    if _policy_text_is_empty(text):
+        return PolicyState(
+            status=PolicyStatus.PRESENT_EMPTY, path=path, text=text, marker=marker
+        )
     origin = str(marker.get("origin")) if marker else "adopted"
     if origin not in POLICY_ORIGINS:
         origin = "adopted"

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -19,9 +19,11 @@ from verinote.pipeline.policy_state import (
     POLICY_UNRECORDED_BANNER,
     POLICY_UNRECORDED_FINDING,
     POLICY_UNRECORDED_NO_FINDINGS_TEXT,
+    PolicyEmptyError,
     PolicyMissingError,
     PolicyState,
     PolicyStatus,
+    policy_empty_message,
     policy_missing_message,
     policy_path,
     resolve_policy,
@@ -30,6 +32,7 @@ from verinote.store import Store
 
 __all__ = [
     "POLICY_RELPATH",
+    "PolicyEmptyError",
     "PolicyMissingError",
     "PolicyState",
     "PolicyStatus",
@@ -60,14 +63,17 @@ def load_policy(store: Store) -> str | None:
     """The KB's policy text, or None to use the shipped default.
 
     Raises `PolicyMissingError` when the KB recorded a policy file that is now
-    gone: returning None there would silently substitute the shipped default for
-    rules a human wrote. Every policy consumer (verification and the
+    gone, and `PolicyEmptyError` (its subclass) when the file exists but is empty:
+    returning None in either case would silently substitute the shipped default
+    for rules a human wrote. Every policy consumer (verification and the
     corroboration/acceptance gates alike) goes through here, so none of them can
     quietly disagree about what this KB's rules are.
     """
     state = resolve_policy(store)
     if state.status is PolicyStatus.MISSING_RECORDED:
         raise PolicyMissingError(policy_missing_message(state))
+    if state.status is PolicyStatus.PRESENT_EMPTY:
+        raise PolicyEmptyError(policy_empty_message(state))
     if state.status is PolicyStatus.PRESENT:
         return state.text
     return None
@@ -87,6 +93,19 @@ def verify(store: Store) -> CheckReport:
             warnings=0,
             text=f"backend: DuckDB\n\npolicy error: {message}",
             findings=[f"ERROR policy_missing: {message}"],
+        )
+    # BEFORE the engine runs: an empty policy declares no `relation/3`, so letting
+    # it reach the backend produces the cryptic "program must declare relation/3"
+    # that names "policy/engine" but never the real cause. Halt here with the
+    # honest diagnosis instead (#171). Mirrors the MISSING_RECORDED branch above.
+    if state.status is PolicyStatus.PRESENT_EMPTY:
+        message = policy_empty_message(state)
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"backend: DuckDB\n\npolicy error: {message}",
+            findings=[f"ERROR policy_empty: {message}"],
         )
 
     try:


### PR DESCRIPTION
## Summary

Closes #171.

An empty or whitespace-only `policy/logic-policy.dl` used to resolve to `PolicyStatus.PRESENT` (`resolve_policy` only checked `path.is_file()`), reach the engine, and surface a cryptic `program must declare relation/3` error — never saying the file is empty, never pointing at the recovery command. Worse, the same empty KB was diagnosed four *inconsistent* ways depending on which command you ran: `status`/`coverage` claimed `ok (policy file present)` at rc 0, `coverage --strict` misfired the unrelated #359 "no review rules" message, and `verify()`/the web `/report` showed the raw engine error.

This gives an empty file its own honestly-diagnosed halted state, `PolicyStatus.PRESENT_EMPTY`, threaded through the single resolution point (`resolve_policy`) so every consuming surface (CLI `status`/`coverage`/`init`, `verify()`, the web write-guard and `/report`) inherits the fix automatically.

## Design

- **New `PolicyStatus.PRESENT_EMPTY`**, not folded into `MISSING_RECORDED`: that state is marker-gated, so folding empty in would misroute an empty-and-never-recorded file into `UNRECORDED_DEFAULT`'s silent-default-running behavior — the exact anti-pattern #180 exists to fight. "Empty" is precisely `text.strip() == ""` (0-byte and whitespace-only are byte-identical downstream).
- **New `PolicyEmptyError(PolicyMissingError)`**, a subclass rather than a new hierarchy — mirrors #169's `DuckDBFactTermStoreLockedError(DuckDBFactTermStoreError)` earlier this cycle. Every existing `except PolicyMissingError` site (CLI dispatch, the web write-guard middleware and its registered exception handler, the acceptance/corroboration gates via `assert_writable`) catches it automatically via MRO — zero catch-site churn.
- **`ensure_policy_marker` preserves the marker on an empty file** instead of refreshing it. This was the one real design fork in this unit: recording `sha256("")` for an empty file would silently overwrite a real policy's marker, destroying the evidence a policy ever existed — reachable just by opening the KB, which the web UI does on launch and on every KB switch (not by `status`, which uses a read-only connection and never calls this function). This one marker-write change is scoped to the empty-file case only; general `recorded_at` immutability is #181's separate, broader question and stays out of scope here.
- `verify()`/`load_policy` halt on `PRESENT_EMPTY` before the engine runs, so the cryptic `relation/3` text is never produced. `_scaffold_policy` refuses rather than silently overwriting an empty file. `web/app.py` needed no code change — the subclass flows through the existing guard and `/report` rendering.
- `#180`/`#181`: independent of both. #171 intercepts empty text upstream of #180's engine-signature concern (reduces its surface, doesn't fight it); it touches `ensure_policy_marker` only for the narrow empty-detection case, not #181's general immutability redesign.

## Consensus record (`/implementation-flow`)

- **reviewer-171**: APPROVE (0 blocker, 0 major, 0 minor, 4 nit). Independently reproduced the marker-preservation mutation test in an isolated worktree; confirmed the #359 distinction and the single-resolution-point claim empirically end-to-end (CLI + web).
- **architect-171**: CONCUR. Verified per-boundary test falsifiability across all five guards; traced the single-resolution-point fix; flagged one non-blocking docstring inaccuracy (fixed in this branch, see below).
- **critic-171**: CONCUR. Independently reproduced the marker-preservation mutation via a *different* vector (predicate-blinding vs. branch-body patching) and traced all `record_policy_marker` call sites repo-wide (exactly 2) to confirm no residual marker-corruption path exists. Found a new low-severity gap (BOM-only files, see below), explicitly not blocking.

## Post-audit polish (folded into the same commit)

Three cheap, reviewer-suggested items were amended in before opening this PR (no behavior change, no new scope):
1. Corrected a docstring example that architect-171 caught was empirically false (claimed `status` could clobber the marker; verified the real path is a web UI open).
2. Fixed a doubled "empty" in the halted-KB user-facing message.
3. Added a regression test for a reachable-but-previously-untested `_scaffold_policy` path that critic-171 found: `init` when the policy file exists-and-is-empty but `kb.sqlite` doesn't exist yet, so the pre-dispatch halt guard is inert and `_scaffold_policy` itself must refuse. Mutation-proven non-vacuous (neutralizing the raise makes the test fail as predicted).

## Follow-ups filed (out of scope here, not blocking)

- #367 — a BOM-only policy file (`"﻿"`) bypasses the `text.strip() == ""` emptiness check (Python doesn't treat U+FEFF as whitespace), so it still hits the old cryptic error. Found by critic-171 during audit; explicitly assessed as low-severity and not a repro case from the original issue.
- Two sub-nit items were left as acknowledged-but-unfiled since they're pre-existing/trivial: `_print_policy_state` (the non-`_ro` sibling) is confirmed dead code with zero callers repo-wide; `_coverage` does one redundant state re-resolution on the `--strict` diagnostic path.

## Test plan

- [x] Full suite: 1572 passed, 7 skipped (verified independently, not just trusted).
- [x] `ruff check` (0.15.18): all checks passed.
- [x] 0-byte and whitespace-only parametrized across `resolve_policy`, `ensure_policy_marker`, `assert_writable`, `verify()`, CLI `status`/`coverage`/`coverage --strict`, `init` (both refusal paths), web 409 + `/report`.
- [x] Anti-regression: marker preservation on an emptied file, mutation-tested independently three times (implementer, reviewer, architect via a second vector) — all confirm the test fails when the guard is reverted.
- [x] Confirm-green: all existing `MISSING_RECORDED`/`UNRECORDED_DEFAULT` tests and all of #359's `test_no_review_rules` tests unaffected.
- [x] `policy reset --force` still recovers an empty-policy KB unchanged.
