### PR TITLE
fix(#269): halt on a corrupt config.json instead of silently defaulting to the cloud

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2112,3 +2112,62 @@ def test_sync_returns_a_stale_confirmed_fact_to_review(
     assert london_row["status"] == "needs_review"
     assert london_row["stale"] == 1
     assert london_row["id"] in [f["id"] for f in s2.review_queue()]
+
+
+# --- #269: a corrupt config.json refuses writes before dispatch; read-only and
+#     launcher subcommands (which never call a provider) stay exempt ---
+
+
+def test_sync_refuses_on_corrupt_config_before_constructing_a_client(
+    tmp_path, monkeypatch, capsys
+):
+    _env(monkeypatch, tmp_path)
+    (tmp_path / "config.json").write_text("{bad json", encoding="utf-8")
+    src = tmp_path / "note.txt"
+    src.write_text("hello", encoding="utf-8")
+    # The sole gateway to an adapter; a recording spy proves dispatch never reached
+    # it, so no bytes could have left the machine.
+    calls = []
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: calls.append(cfg))
+
+    rc = cli.main(["sync", str(src)])
+
+    assert rc == 2  # refused before dispatch, same code as the halted-KB refusal
+    assert calls == []  # no client constructed
+    err = capsys.readouterr().err
+    assert str(tmp_path / "config.json") in err
+    assert "not valid JSON" in err
+
+
+def test_status_is_exempt_from_corrupt_config(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0  # a real KB, config.json still absent here
+    (tmp_path / "config.json").write_text("{bad json", encoding="utf-8")
+    capsys.readouterr()
+
+    # `status` is halt_safe and calls no provider, so a corrupt config cannot leak
+    # through it — refusing would only strand the user's one diagnostic surface.
+    assert cli.main(["status"]) == 0
+
+
+def test_coverage_is_exempt_from_corrupt_config(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    (tmp_path / "config.json").write_text("{bad json", encoding="utf-8")
+    capsys.readouterr()
+
+    assert cli.main(["coverage"]) == 0
+
+
+def test_ui_is_exempt_from_corrupt_config(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    (tmp_path / "config.json").write_text("{bad json", encoding="utf-8")
+    capsys.readouterr()
+    # The web app renders its own proper config-corrupt halt page, so `ui` must
+    # still launch (halt_safe) rather than be refused at the CLI.
+    started = []
+    monkeypatch.setattr("uvicorn.run", lambda *a, **k: started.append(True))
+
+    assert cli.main(["ui", "--no-browser"]) == 0
+    assert started == [True]  # dispatch reached cmd_ui, not the refusal

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,15 +5,18 @@ import pytest
 
 from verinote.config import (
     Config,
+    ConfigCorruptError,
     PROVIDERS,
     TESTABLE_PROVIDERS,
     active_root,
     app_config_path,
+    assert_settings_intact,
     read_app_config,
     read_settings,
     save_active_root,
     save_settings,
 )
+from verinote.llm.base import LLMError
 
 
 def test_save_and_read_round_trip(tmp_path):
@@ -378,3 +381,74 @@ def test_read_app_config_oserror_warns(tmp_path, monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "could not read" in err
     assert str(path) in err
+
+
+# --- #269: a corrupt config.json must halt, not silently fall back to the cloud ---
+
+
+def test_absent_config_sets_no_settings_error(tmp_path):
+    # The critical discriminator: a fresh KB with no config.json is legitimate and
+    # must never be flagged — a naive "flag whenever the dict is empty"
+    # implementation would spuriously halt every brand-new KB.
+    cfg = Config.for_root(tmp_path)
+    assert cfg.settings_error is None
+    assert_settings_intact(cfg)  # must not raise
+
+
+def test_valid_config_sets_no_settings_error(tmp_path):
+    save_settings(tmp_path, provider="ollama", model="llama3.1")
+    cfg = Config.for_root(tmp_path)
+    assert cfg.settings_error is None
+    assert_settings_intact(cfg)  # must not raise
+
+
+def test_broken_json_config_sets_settings_error_but_still_resolves(tmp_path, capsys):
+    save_settings(tmp_path, provider="ollama", model="llama3.1")
+    (tmp_path / "config.json").write_text("{bad", encoding="utf-8")
+    capsys.readouterr()  # drop the loader's stderr warning
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.settings_error is not None
+    assert str(tmp_path / "config.json") in cfg.settings_error
+    assert "not valid JSON" in cfg.settings_error
+    # The provider still resolves (to the built-in default) — the point is that a
+    # halt guards that fallback, not that resolution itself fails.
+    assert cfg.provider == "anthropic"
+
+
+def test_invalid_utf8_config_sets_settings_error(tmp_path, capsys):
+    (tmp_path / "config.json").write_bytes(b"\xff\xfe\x00bad")
+    capsys.readouterr()
+    cfg = Config.for_root(tmp_path)
+    assert cfg.settings_error is not None
+    assert "could not decode" in cfg.settings_error
+
+
+def test_non_dict_config_sets_settings_error(tmp_path, capsys):
+    (tmp_path / "config.json").write_text("[]", encoding="utf-8")
+    capsys.readouterr()
+    cfg = Config.for_root(tmp_path)
+    assert cfg.settings_error is not None
+    assert "not a JSON object" in cfg.settings_error
+
+
+def test_assert_settings_intact_raises_only_when_error_set(tmp_path, capsys):
+    (tmp_path / "config.json").write_text("{bad", encoding="utf-8")
+    capsys.readouterr()
+    corrupt = Config.for_root(tmp_path)
+
+    with pytest.raises(ConfigCorruptError) as excinfo:
+        assert_settings_intact(corrupt)
+    # The raised message is the settings_error reason verbatim, so the CLI/web
+    # surfaces cannot describe the same file in different words.
+    assert str(excinfo.value) == corrupt.settings_error
+
+
+def test_config_corrupt_error_is_not_an_llm_error():
+    # Load-bearing: several `except LLMError` blocks wrap the very get_client()
+    # sites this guards. If ConfigCorruptError were an LLMError it would be
+    # swallowed there into a generic provider-failure message instead of reaching
+    # the dedicated halt handler.
+    assert not issubclass(ConfigCorruptError, LLMError)
+    assert not isinstance(ConfigCorruptError("x"), LLMError)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -12,7 +12,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 import verinote.web.app as webapp  # noqa: E402
-from verinote.config import Config  # noqa: E402
+from verinote.config import Config, ConfigCorruptError, save_settings  # noqa: E402
 from verinote.engine import DEFAULT_POLICY  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
@@ -3554,3 +3554,267 @@ def test_worker_leaves_a_done_job_done_when_the_stale_sweep_raises(
     with Store(cfg.db_path) as store:
         store.init_schema()
         assert any(f["subject"] == "A" for f in store.facts())
+
+
+# --- #269: a corrupt config.json halts the web app instead of silently
+#     defaulting extraction/ask/test to the cloud provider the user never chose ---
+
+
+def _config_web_kb(tmp_path, *, corrupt, with_job=False):
+    """A KB with a *recorded* policy (so the policy guard is inert) whose
+    config.json is corrupt when `corrupt`, else a valid ollama config. Returns
+    (cfg, fact_id, job_id); job_id is None unless `with_job`. cfg is resolved via
+    Config.for_root so it carries the real settings_error the app will see."""
+    policy = tmp_path / POLICY_RELPATH
+    job_id = None
+    with Store(tmp_path / "kb.sqlite") as store:
+        store.init_schema()
+        fact_id = store.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+        if with_job:
+            sid = store.add_source("sources/a.txt")
+            job_id = store.create_extraction_job(
+                source_id=sid, provider="ollama", model="m", total_chunks=1
+            )
+            store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["some text"])
+    if corrupt:
+        (tmp_path / "config.json").write_text("{bad json", encoding="utf-8")
+    else:
+        save_settings(tmp_path, provider="ollama", model="llama3.1")
+    return Config.for_root(tmp_path), fact_id, job_id
+
+
+def _spy_anthropic(monkeypatch):
+    """Record every construction of the concrete cloud adapter class.
+
+    The corrupt-config fallback provider is `anthropic`, so a non-empty list means
+    an adapter was built and bytes were about to leave the machine. A 409 alone
+    would not prove they didn't — only that the *response* was a halt."""
+    import verinote.llm.anthropic_adapter as aa
+
+    built = []
+    orig = aa.AnthropicAdapter.__init__
+
+    def spy(self, cfg):
+        built.append(cfg)
+        orig(self, cfg)
+
+    monkeypatch.setattr(aa.AnthropicAdapter, "__init__", spy)
+    return built
+
+
+def test_ask_on_corrupt_config_halts_and_never_builds_the_adapter(tmp_path, monkeypatch):
+    """A provider-calling POST (`/ask`) refuses with 409 AND the concrete adapter
+    is never constructed — the confidentiality guarantee, not just a halt page."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    built = _spy_anthropic(monkeypatch)
+    c = TestClient(create_app(cfg))
+
+    r = c.post("/ask", data={"question": "who is A?"})
+
+    assert r.status_code == 409
+    assert "did not choose" in r.text  # the config_corrupt page, not a stack trace
+    assert built == []  # no bytes left the machine
+
+
+def test_sources_upload_on_corrupt_config_halts_before_extraction(tmp_path, monkeypatch):
+    """`/sources` refuses on the triggering request itself (the synchronous hoist
+    in `_start_source_extraction`), so no adapter is built and no doomed worker
+    runs."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    built = _spy_anthropic(monkeypatch)
+    c = TestClient(create_app(cfg))
+
+    r = c.post("/sources", files={"file": ("note.txt", b"some text", "text/plain")})
+
+    assert r.status_code == 409
+    assert built == []
+
+
+def test_read_only_route_stays_reachable_under_corrupt_config(tmp_path):
+    """No over-blocking: `/review` reads no provider, so a deliberate absence of a
+    config middleware leaves it reachable at 200 while config is corrupt."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    c = TestClient(create_app(cfg))
+
+    r = c.get("/review")
+
+    assert r.status_code == 200
+    assert "is_a" in r.text  # the reviewable fact renders normally
+
+
+def test_settings_test_over_htmx_redirects_not_inline(tmp_path):
+    """htmx never swaps a 4xx into the DOM (#173), so the handler answers an htmx
+    request with HX-Redirect to the full-page halt, not an inline 409 body."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    c = TestClient(create_app(cfg))
+
+    r = c.post("/settings/test", headers={"HX-Request": "true"})
+
+    assert r.status_code == 409
+    assert r.headers.get("HX-Redirect") == webapp.CONFIG_UNAVAILABLE_PATH
+    # An htmx halt sends no inline body to be (silently) swallowed.
+    assert "did not choose" not in r.text
+
+
+def test_settings_page_reachable_and_warns_under_corrupt_config(tmp_path):
+    """`/settings` is the recovery page: it must stay reachable AND must not present
+    the fallback provider as if it were the user's saved choice."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    c = TestClient(create_app(cfg))
+
+    r = c.get("/settings")
+
+    assert r.status_code == 200
+    body = " ".join(unescape(r.text).split())  # collapse template line-breaks
+    assert "built-in defaults" in body  # the warning banner
+    assert "not your saved choice" in body
+
+
+def test_resaving_valid_settings_clears_the_config_halt(tmp_path, monkeypatch, fake_client):
+    """Re-saving a provider writes a fresh valid file; the app re-resolves and the
+    next provider call goes through instead of halting."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    app = create_app(cfg)
+    c = TestClient(app)
+
+    r = c.post("/settings", data={"provider": "ollama", "model": "llama3.1"})
+    assert r.status_code == 200  # followed the 303 redirect back to /settings
+    assert app.state.cfg.settings_error is None  # halt cleared on re-resolution
+
+    # And a provider call now reaches the client instead of 409-ing.
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: fake_client([ExtractedFact("A", "is_a", "B", 0.9)])
+    )
+    assert c.post("/settings/test").status_code == 200
+    assert "built-in defaults" not in c.get("/settings").text  # warning gone
+
+
+def test_mid_session_corruption_is_caught_at_the_next_resolution(tmp_path, monkeypatch):
+    """Healthy at create_app, corrupted on disk afterward: the next re-resolution
+    (re-opening the same root) must read DISK and catch it, not trust a cached
+    healthy dict from launch time.
+
+    The same action is the discriminator: re-opening the root succeeds (303) while
+    healthy, and is refused (400) once the file is corrupt.
+
+    This covers the explicit re-open path specifically. A passive on-disk corruption
+    with NO re-open keeps serving the cached (last-good) cfg, which is safe precisely
+    because `cfg.settings_error` is a one-time snapshot — the same frozen-snapshot
+    semantics that make the worker-thread ConfigCorruptError clause unreachable today
+    (see `test_worker_config_corrupt_does_not_mark_the_job_failed`) are what keep the
+    stale window from ever silently switching provider."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=False)  # valid ollama config
+    app = create_app(cfg)
+    c = TestClient(app)
+    assert app.state.cfg.settings_error is None
+
+    # Baseline: re-opening the (healthy) current root works.
+    r = c.post("/settings/root", data={"root": str(tmp_path)}, follow_redirects=False)
+    assert r.status_code == 303
+    assert app.state.cfg.provider == "ollama"
+
+    # Corrupt the current KB's config on disk, then re-open the same root.
+    (tmp_path / "config.json").write_text("{bad json", encoding="utf-8")
+    built = _spy_anthropic(monkeypatch)
+    r = c.post("/settings/root", data={"root": str(tmp_path)}, follow_redirects=False)
+
+    assert r.status_code == 400  # caught, not a stale/cached 303 false-negative
+    assert "config.json is corrupt" in unescape(r.text)
+    assert app.state.cfg.provider == "ollama"  # old healthy cfg still active
+    assert built == []
+
+
+def test_switching_root_to_a_corrupt_kb_is_refused_inline(tmp_path, monkeypatch):
+    """Switching from a healthy KB into a corrupt-config KB is refused inline (400)
+    with the OLD KB still active — never a transient swap into an untrusted cfg."""
+    healthy = tmp_path / "healthy"
+    corrupt = tmp_path / "corrupt"
+    healthy.mkdir()
+    corrupt.mkdir()
+    active_cfg, _, _ = _config_web_kb(healthy, corrupt=False)  # provider=ollama
+    _config_web_kb(corrupt, corrupt=True)
+
+    app = create_app(active_cfg)
+    c = TestClient(app)
+    built = _spy_anthropic(monkeypatch)
+
+    r = c.post("/settings/root", data={"root": str(corrupt)}, follow_redirects=False)
+
+    assert r.status_code == 400
+    assert "config.json is corrupt" in unescape(r.text)
+    # The old KB stays active: root unchanged, provider not swapped to the fallback.
+    assert app.state.cfg.root == healthy.resolve()
+    assert app.state.cfg.provider == "ollama"
+    assert built == []
+
+
+def test_launching_the_ui_on_a_corrupt_config_resumes_nothing(tmp_path, monkeypatch):
+    """A corrupt config discovered at launch resumes no jobs and touches nothing —
+    zero HTTP requests, and still the pending job must not be started or failed.
+    Mirrors `test_launching_the_ui_on_a_halted_kb_resumes_nothing` for #269."""
+    cfg, _, job_id = _config_web_kb(tmp_path, corrupt=True, with_job=True)
+    clients = []
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: clients.append(cfg))
+    before = _job_row(cfg, job_id)
+
+    create_app(cfg)
+
+    time.sleep(0.2)  # a worker, had one started, would have written by now
+    assert clients == []  # no worker was started at all
+    assert _job_row(cfg, job_id) == before  # job untouched: still pending
+    assert before["status"] == "pending"
+    assert _job_event_types(cfg, job_id) == []  # no started / failed / rolled_back
+
+
+def test_launching_the_ui_on_a_valid_config_still_resumes(tmp_path, monkeypatch, fake_client):
+    """The config gate above refuses a *corrupt* config, not every config: a valid
+    one with a pending job still resumes normally."""
+    cfg, _, job_id = _config_web_kb(tmp_path, corrupt=False, with_job=True)
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)])
+    )
+
+    create_app(cfg)  # the resume worker runs off a daemon thread started here
+
+    def resumed():
+        assert _job_row(cfg, job_id)["status"] == "done"
+
+    _wait_for(resumed)
+
+
+def test_worker_config_corrupt_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):
+    """`except ConfigCorruptError` must stay ABOVE `except Exception` in the worker.
+
+    This exercises an INJECTED scenario, not a naturally-occurring race: the worker's
+    get_client(cfg) reads the SAME frozen cfg that already passed the synchronous
+    hoist, and `cfg.settings_error` is a one-time `Config.for_root` snapshot, so today
+    the thread can never independently observe a fresher corruption. We monkeypatch
+    get_client to raise ConfigCorruptError to prove the clause is load-bearing IF such
+    an error were ever raised there (a future get_client that re-reads disk, or a
+    caller that passes a different cfg into the thread). A corrupt config is a
+    host/environment condition, not content-attributable, so the worker must write
+    NOTHING — not bury the job in `failed` (a misleading "analysis failed") and burn
+    this session's retry budget. Below `except Exception`, the generic handler would
+    call `fail_extraction_job`; this test pins that it does not."""
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)  # healthy cfg -> hoist passes
+    called = threading.Event()
+
+    def corrupt_at_get_client(cfg):
+        # Stand in for "config.json went corrupt after the hoist check": the worker
+        # reaches get_client and it raises the same error get_client would.
+        called.set()
+        raise ConfigCorruptError("config.json is not valid JSON")
+
+    monkeypatch.setattr(webapp, "get_client", corrupt_at_get_client)
+
+    create_app(cfg)  # resumes the pending job -> worker thread -> get_client raises
+
+    assert called.wait(timeout=2.0)
+    time.sleep(0.2)  # let a (wrong) fail_extraction_job land, if the order regressed
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "pending", "a corrupt-config race buried the job in `failed`"
+    assert "analysis failed" not in (job["message"] or "")
+    assert "extraction_job_failed" not in _job_event_types(cfg, job_id)

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1264,6 +1264,28 @@ def _refuse_on_halted_kb(cfg: Config | None) -> int | None:
     return None
 
 
+def _refuse_on_corrupt_config(cfg: Config | None) -> int | None:
+    """Exit code to return instead of running a write on a corrupt config, or None.
+
+    Asked once, in `main`, for every subcommand that did not declare itself
+    `halt_safe`. Simpler than `_refuse_on_halted_kb`: it opens no Store — the
+    corruption verdict is already resolved onto `cfg.settings_error`, so this only
+    turns it into the same rc=2 refusal. A corrupt `config.json` must not silently
+    resolve to the cloud default provider the user never chose (#269). A missing
+    file is never corrupt, so a fresh KB is unaffected.
+    """
+    from verinote.config import ConfigCorruptError, assert_settings_intact
+
+    if cfg is None:
+        return None
+    try:
+        assert_settings_intact(cfg)
+    except ConfigCorruptError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return None
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI.
 
@@ -1402,6 +1424,11 @@ def main(argv: list[str] | None = None) -> int:
     # dispatch, because every subcommand goes through this one line — a guard
     # sprinkled per-command is a guard the next command will forget.
     if not getattr(args, "halt_safe", False):
+        # Corrupt config first: it makes the resolved provider itself untrustworthy,
+        # and unlike the halt check it opens no Store. Then the halted-KB check.
+        refusal = _refuse_on_corrupt_config(cfg)
+        if refusal is not None:
+            return refusal
         refusal = _refuse_on_halted_kb(cfg)
         if refusal is not None:
             return refusal

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -111,6 +111,24 @@ def app_config_path() -> Path:
     return app_config_dir() / APP_CONFIG_FILENAME
 
 
+def _bad_config_reason(path: Path, error: Exception | None) -> str:
+    """Classify why a *present* config file cannot be used, as one plain line.
+
+    The single source of that classification: the CLI's stderr warning
+    (`_warn_bad_config`) and the web/GUI halt text (`Config.settings_error`) both
+    derive from it, so the two surfaces can never describe the same corrupt file
+    in different words. `error` is the raised exception, or None for a well-formed
+    JSON value that simply is not an object.
+    """
+    if isinstance(error, OSError):
+        return f"could not read {path}: {error}"
+    if isinstance(error, UnicodeDecodeError):
+        return f"could not decode {path} as UTF-8"
+    if isinstance(error, json.JSONDecodeError):
+        return f"{path} is not valid JSON"
+    return f"{path} is not a JSON object"
+
+
 def _warn_bad_config(path: Path, error: Exception | None, consequence: str) -> None:
     """Warn on stderr that a config file is unreadable and is being ignored.
 
@@ -119,15 +137,7 @@ def _warn_bad_config(path: Path, error: Exception | None, consequence: str) -> N
     real corruption from the user. `error` is the raised exception, or None for
     a well-formed JSON value that simply is not an object.
     """
-    if isinstance(error, OSError):
-        reason = f"could not read {path}: {error}"
-    elif isinstance(error, UnicodeDecodeError):
-        reason = f"could not decode {path} as UTF-8; ignoring it"
-    elif isinstance(error, json.JSONDecodeError):
-        reason = f"{path} is not valid JSON; ignoring it"
-    else:
-        reason = f"{path} is not a JSON object; ignoring it"
-    print(f"warning: {reason}; {consequence}", file=sys.stderr)
+    print(f"warning: {_bad_config_reason(path, error)}; {consequence}", file=sys.stderr)
 
 
 def read_app_config() -> dict:
@@ -237,6 +247,32 @@ def read_settings(root: Path) -> dict:
     return data
 
 
+def _settings_error(root: Path) -> str | None:
+    """Why the KB's saved settings file is unusable, or None if fine or absent.
+
+    A *missing* file is never an error — a fresh KB legitimately has none, and
+    reporting one would spuriously halt it. Only a file that is PRESENT but
+    unreadable/corrupt yields a reason. Shares `_bad_config_reason` with the CLI
+    stderr warning so the web/GUI halt and the warning describe the same file the
+    same way.
+
+    Deliberately re-reads the file rather than inferring from `read_settings`'s
+    `{}` return: an empty `{}` is ambiguous (a valid empty object returns it too),
+    and `read_settings`'s return contract is left untouched — per-key validation
+    of its body is a separate concern (#325).
+    """
+    path = _settings_path(root)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as err:
+        return _bad_config_reason(path, err)
+    if not isinstance(data, dict):
+        return _bad_config_reason(path, None)
+    return None
+
+
 def save_settings(
     root: Path,
     *,
@@ -337,6 +373,12 @@ class Config:
     extraction_chunk_overlap_chars: int = 40
     extraction_max_facts_per_chunk: int = 8
     auto_accept_recommendations: bool = False
+    # Set only when the settings file is PRESENT but unreadable/corrupt (never on
+    # a missing file — absence is legitimate). A trailing, defaulted field so no
+    # existing `Config(...)` construction site has to change. `assert_settings_intact`
+    # turns it into the halt that keeps a corrupt config from silently defaulting
+    # to a cloud provider the user never chose (#269).
+    settings_error: str | None = None
 
     def extraction_schema_hint(self) -> str:
         return render_prompt(
@@ -386,6 +428,7 @@ class Config:
             extraction_chunk_overlap_chars=chunk_overlap,
             extraction_max_facts_per_chunk=max_facts,
             auto_accept_recommendations=auto_accept,
+            settings_error=_settings_error(root),
         )
 
     @classmethod
@@ -396,3 +439,34 @@ class Config:
     def load_for_ui(cls) -> "Config | None":
         root = active_root()
         return cls.for_root(root) if root is not None else None
+
+
+class ConfigCorruptError(RuntimeError):
+    """Raised when a KB's `config.json` is present but unreadable/corrupt.
+
+    Deliberately NOT an `LLMError`: several `except LLMError` blocks wrap the very
+    `get_client()` call sites this guards (the web `/ask`, `/settings/test`, and
+    the CLI extraction path). Being an `LLMError` would let those blocks swallow
+    the halt into a generic "provider failed" message instead of reaching the
+    dedicated config-corrupt handler — and the whole point is that a corrupt
+    config must NOT silently fall back to the cloud default provider the user
+    never chose (#269).
+    """
+
+
+def assert_settings_intact(cfg: Config) -> None:
+    """Refuse to proceed when the KB's settings file is present but corrupt.
+
+    The single confidentiality predicate: `llm.factory.get_client` and every
+    explicit web/CLI checkpoint ask *this*, so none of them can disagree about
+    when a corrupt config halts. A corrupt `config.json` makes the resolved
+    provider untrustworthy — the user's saved `ollama` may have silently become
+    the `anthropic` cloud default — so any path that could reach a provider halts
+    instead of leaking to a cloud the user never consented to.
+
+    Mirrors `pipeline.policy_state.assert_writable`: a pure predicate over already
+    resolved state, raising the one dedicated error its callers catch. A missing
+    file is never corrupt, so a fresh KB with no `config.json` never halts here.
+    """
+    if cfg.settings_error is not None:
+        raise ConfigCorruptError(cfg.settings_error)

--- a/verinote/llm/factory.py
+++ b/verinote/llm/factory.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
-from verinote.config import Config
+from verinote.config import Config, assert_settings_intact
 from verinote.llm.base import LLMClient, LLMError
 
 
 def get_client(cfg: Config) -> LLMClient:
+    # First act, before any provider branch: a corrupt config.json must never
+    # resolve to a silent cloud fallback. Every current and future caller is
+    # protected here by construction, so no route enumeration is needed (#269).
+    assert_settings_intact(cfg)
     provider = cfg.provider
     if provider == "anthropic":
         from verinote.llm.anthropic_adapter import AnthropicAdapter

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -24,7 +24,9 @@ from verinote.config import (
     PROVIDERS,
     TESTABLE_PROVIDERS,
     Config,
+    ConfigCorruptError,
     app_config_path,
+    assert_settings_intact,
     save_active_root,
     save_settings,
 )
@@ -115,6 +117,11 @@ _POLICY_GUARD_WRITE_PATHS = ("/kb/select", "/settings/root")
 # swaps are redirected here (HX-Redirect) because htmx will not swap an error
 # response into the DOM -- see `_fact_terms_unreadable_handler`.
 FACT_TERMS_UNAVAILABLE_PATH = "/fact-terms-unavailable"
+
+# Full-page halt shown when this KB's config.json is present but corrupt. Same
+# HX-Redirect treatment as the fact-terms halt for the same htmx reason -- see
+# `_config_corrupt_handler`.
+CONFIG_UNAVAILABLE_PATH = "/config-unavailable"
 
 
 def _matches(path: str, allowed: tuple[str, ...]) -> bool:
@@ -234,6 +241,45 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         DuckDBFactTermStoreError, _fact_terms_unreadable_handler
     )
 
+    def _config_corrupt_page(request: Request, reason: str | None):
+        return templates.TemplateResponse(
+            request,
+            "config_corrupt.html",
+            {"reason": reason},
+            status_code=409,
+        )
+
+    @app.get(CONFIG_UNAVAILABLE_PATH, response_class=HTMLResponse)
+    def config_unavailable(request: Request):
+        # The full-page halt and the HX-Redirect target below. It reads no config
+        # file, so it still renders while config.json is corrupt; the already
+        # resolved `settings_error` field is shown for context when present.
+        cfg = app.state.cfg
+        return _config_corrupt_page(request, cfg.settings_error if cfg else None)
+
+    def _config_corrupt_handler(request: Request, exc: Exception):
+        """One loud, non-lying halt for every surface that would reach a provider
+        under a corrupt config.json.
+
+        Refusing here rather than silently resolving to the cloud default is the
+        whole point (#269): a user who chose `ollama` must not have a corrupt
+        config quietly ship their next extraction to `anthropic`.
+
+        htmx will NOT swap a 4xx/5xx response into the DOM -- it fires
+        `htmx:responseError` and swaps nothing -- so answering an htmx request
+        with an inline page would be a *silent* no-op, the failure #173 forbids.
+        For htmx requests we send HX-Redirect to force a full-page navigation to
+        the halt page; full-page requests render it inline at 409.
+        """
+        if request.headers.get("HX-Request") == "true":
+            return Response(
+                status_code=409,
+                headers={"HX-Redirect": CONFIG_UNAVAILABLE_PATH},
+            )
+        return _config_corrupt_page(request, str(exc))
+
+    app.add_exception_handler(ConfigCorruptError, _config_corrupt_handler)
+
     def _active_store() -> Store:
         store = app.state.store
         if store is None:
@@ -334,6 +380,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         root = root.expanduser().resolve()
         root.mkdir(parents=True, exist_ok=True)
         next_cfg = Config.for_root(root)
+        # Refuse BEFORE installing: transiently swapping in a corrupt cfg would let
+        # a provider call in the gap resolve to the silent cloud default. On a
+        # raise the old healthy cfg stays active and the caller renders the halt.
+        assert_settings_intact(next_cfg)
         next_store = Store(next_cfg.db_path)
         next_store.init_schema()
 
@@ -811,6 +861,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         retry: bool = False,
         retry_max_attempts: int | None = None,
     ) -> None:
+        # SYNCHRONOUS and OUTSIDE run(): raise on the triggering request itself so a
+        # corrupt config returns an immediate 409 instead of silently queuing a
+        # background job doomed to reach the cloud default. The worker's own
+        # get_client(cfg) below stays as a narrow backstop for the race window
+        # between this check and the thread actually running (#269).
+        assert_settings_intact(cfg)
+
         def run() -> None:
             try:
                 with Store(cfg.db_path) as worker_store:
@@ -916,6 +973,25 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     "extraction job %s already owned by another worker; not started here",
                     job_id,
                 )
+            except ConfigCorruptError as exc:
+                # ORDER IS LOAD-BEARING — above `except Exception`. Defense-in-depth,
+                # NOT a currently-reachable path: the worker's get_client(cfg) reads
+                # the SAME frozen cfg that already passed the synchronous hoist check
+                # above, and `cfg.settings_error` is a one-time snapshot taken in
+                # `Config.for_root`, so today the thread can never independently
+                # observe a fresher corruption than the hoist already cleared. This
+                # clause exists so that if that ever changes — a future get_client
+                # that re-reads disk, or a caller that passes a *different* cfg into
+                # the thread — a corrupt config (a host/environment condition, not
+                # content-attributable) still writes NOTHING here (mirror
+                # `except PolicyMissingError`) instead of falling through to
+                # `except Exception`, which would call `fail_extraction_job` —
+                # burying the job in `failed` with a misleading "analysis failed" and
+                # consuming this session's MAX_CHUNK_ATTEMPTS retry budget for a cause
+                # unrelated to the source content (#269).
+                logger.warning(
+                    "extraction job %s halted (config.json corrupt): %s", job_id, exc
+                )
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
@@ -973,6 +1049,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         `updated_at`) and is filed as a follow-up, not solved here.
         """
         if app.state.store is None or app.state.cfg is None:
+            return
+        try:
+            assert_settings_intact(app.state.cfg)
+        except ConfigCorruptError as exc:
+            # Same shape as the policy gate below: launching against a corrupt
+            # config must not resume a job that would reach the cloud default with
+            # zero HTTP requests made. Log and touch nothing (#269).
+            logger.warning("not resuming extraction jobs: %s", exc)
             return
         try:
             assert_writable(app.state.store)
@@ -1433,6 +1517,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "relation_aliases": _relation_aliases_text(),
                 "test_result": test_result,
                 "error": error,
+                # /settings is deliberately reachable during the halt (it is the
+                # recovery page). When config.json is corrupt the provider shown
+                # above is the built-in default, NOT the user's saved choice, so
+                # warn instead of silently presenting it as chosen (#269).
+                "settings_error": c.settings_error,
             },
             status_code=status_code,
         )
@@ -1526,6 +1615,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _settings(request, error="KB directory is required", status_code=400)
         try:
             _open_root(Path(path))
+        except ConfigCorruptError as e:
+            # The target KB's config.json is corrupt. Leave the current KB active
+            # rather than switch into one whose provider we cannot trust (#269).
+            return _settings(
+                request,
+                error=f"refused to open KB — its config.json is corrupt: {e}",
+                status_code=400,
+            )
         except OSError as e:
             return _settings(request, error=f"could not open KB directory: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)

--- a/verinote/web/templates/config_corrupt.html
+++ b/verinote/web/templates/config_corrupt.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Config unreadable — verinote</title>
+  <link rel="stylesheet" href="/static/app.css?v=4">
+</head>
+<body>
+  <main class="chooser">
+    <h1>Configuration halted: this KB's config.json is unreadable</h1>
+
+    {# There is deliberately no "proceed anyway" button: proceeding is exactly the
+       silent cloud fallback this halt exists to prevent. Recovery is restoring the
+       file or re-saving a provider, both human decisions. #}
+    <p class="error" role="alert">verinote could not read this KB's
+      <code>config.json</code>, so it refused to proceed rather than silently
+      defaulting to a cloud provider you did not choose.{% if reason %} ({{ reason }}){% endif %}</p>
+
+    <p class="muted">Your saved provider choice cannot be trusted while the file is
+      corrupt. Recover by either restoring <code>config.json</code> from a backup or
+      version control, or opening <a href="/settings">Settings</a> and re-saving your
+      provider. Re-saving writes a fresh, valid file and clears this immediately; if
+      you restored the file another way, restart verinote or re-open this KB.</p>
+
+    <p><a href="/settings">Settings</a> · <a href="/">Dashboard</a></p>
+  </main>
+</body>
+</html>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -6,6 +6,14 @@
   freely. Non-secret model settings are saved to that KB's <code>config.json</code>;
   the API key stays in the environment (<code>VERINOTE_API_KEY</code>).</p>
 
+{% if settings_error %}
+<p class="warn" role="alert">This KB's <code>config.json</code> is unreadable, so the
+  provider and model shown below are verinote's built-in defaults, <strong>not your
+  saved choice</strong>. Extraction and other provider calls are refused until it is
+  fixed. Re-save the provider below to write a fresh valid file, or restore
+  <code>config.json</code> from a backup. ({{ settings_error }})</p>
+{% endif %}
+
 <h2>Knowledge base</h2>
 <form class="settings" action="/settings/root" method="post">
   <label>Directory


### PR DESCRIPTION
## Summary

Closes #269.

`read_settings`/`Config.for_root` warned to stderr and silently returned `{}`/defaults on a corrupt `config.json`, so a user who configured `ollama` and whose config got corrupted had their next sync silently switch to the `anthropic` cloud default — an unconsented local-to-cloud data path with zero UI signal for web/GUI users (CLI users at least saw the stderr warning, from #262/PR #268).

This gives a present-but-corrupt config its own loud halt instead of a silent fallback, enforced at the single seam every provider call passes through.

## Design

- **`Config.settings_error`**, set only when the file is PRESENT but unreadable/corrupt — a missing file is never an error, so a fresh KB never spuriously halts.
- **`ConfigCorruptError(RuntimeError)`**, deliberately NOT an `LLMError` subclass. This is load-bearing, not stylistic: several `except LLMError` blocks wrap the very `get_client()` call sites this guards, and would otherwise silently swallow the halt into a generic, misleading message — reviewer found 6 such sites during review, two of which would have caused an unrelated state write (`translation_failed`/`_fail_pending_translations`) rather than just a bad message.
- **Enforcement at the `get_client()` chokepoint** (`llm/factory.py`), mirroring the existing `DuckDBFactTermStoreError` wiring (a registered exception handler only) rather than the heavier `PolicyMissingError` middleware — this hazard is chokepoint-shaped (every provider call funnels through one function), not blanket-write-shaped, so a broad request middleware would over-block unrelated KB-local mutations for zero confidentiality benefit. Verified repo-wide: all 4 adapter constructions and every `get_client` caller (web + CLI) sit downstream of the guard, with no route enumeration needed for correctness.
- **Explicit checkpoints** at the other places that resolve or rely on a `Config`: a synchronous hoist at the top of `_start_source_extraction` (so a triggering request gets an immediate 409 instead of silently queuing a doomed job), the startup resume path, root-switch (refuses before installing a corrupt cfg, leaving the old healthy one active), and CLI dispatch (mirrors the existing `_refuse_on_halted_kb` gate).
- **Frozen-verdict model**: the corruption verdict is resolved once, at `Config` construction, and the (immutable) `Config` object is cached rather than re-read per request. This was a genuine design choice, not an oversight — a naive per-request re-derivation would produce false-positive halts on mid-session corruption where the app is still safely serving the last-known-good cached config.

## Consensus record (`/implementation-flow`)

- **reviewer-269**: initial CHANGES REQUESTED (1 blocker, 1 major, both documentation-accuracy issues, no logic defects) → APPROVE after revision. Independently confirmed the confidentiality guarantee via adapter-construction-site enumeration, spy probes proving zero adapter construction on every corrupt-config path, and an independent worker-thread mutation-test reproduction.
- **architect-269**: CONCUR, with a genuine retraction — its own Phase 1 guide had recommended a broad middleware; on the evidence of the implemented design, it now assesses the chokepoint approach as objectively better (a middleware re-derivation would have caused false-positive halts on mid-session corruption).
- **critic-269**: CONCUR. Independently traced the worker thread's closure to confirm it only ever captures the frozen `cfg` it was given, never a fresher one — the assumption the whole design rests on.

## Revision (prose-only, no logic changes)

reviewer-269's first pass found two documentation-accuracy issues, both fixed by amending the same commit:
- The worker-thread `except ConfigCorruptError` clause's justifying comment (and the commit message, and a test docstring) claimed it guards a "mid-run disk race" — reviewer empirically disproved this is reachable today (`get_client` reads a frozen `cfg` snapshot; the worker thread uses the exact same object that already passed the synchronous hoist, so it can never independently observe fresher corruption). Reworded as defense-in-depth against a hypothetical future change, not a currently-reachable path.
- `config_corrupt.html` claimed "verinote resumes on its own once the file can be read again" — false for the restore-from-backup recovery path the page lists first (a passive on-disk fix doesn't clear the halt without a re-save or restart/re-open). Copy corrected to describe both recovery paths accurately.

## Follow-up filed (out of scope here, not blocking)

- #369 — `Config.for_root` reads `config.json` twice during construction (once for the provider, once independently for the corruption marker), not atomically. Both audit voices found this independently during Phase 4 and rated it LOW: the actual reported #269 hazard (a file that corrupts and stays corrupt) is fully covered since both reads see the same state; only a narrow concurrent-write race landing in the gap between the two reads could desync them, and it self-heals at the next re-resolution. Bundles a related minor nit (`/kb/select` lacks the inline `ConfigCorruptError` handling `/settings/root` has — three independent voices found this, all rated it a safe, non-blocking UX asymmetry).

## Test plan

- [x] Full suite: 1594 passed, 7 skipped (verified independently at each stage, not just trusted).
- [x] `ruff check` (0.15.18): all checks passed.
- [x] Adapter-spy tests prove no provider adapter is ever constructed on a corrupt-config path (a 409 alone would not prove no bytes left the machine).
- [x] Absent-file discriminator (a fresh KB with no config.json never halts) and `ConfigCorruptError`-is-not-`LLMError` contract both pinned.
- [x] Read-only routes stay reachable under corruption; `/settings` stays reachable and warns instead of silently presenting the fallback provider as chosen; re-saving valid settings clears the halt.
- [x] Mid-session corruption is caught at the next re-resolution; launching the UI on a corrupt config resumes no jobs (paired with a healthy-config complement that does resume); switching root to a corrupt KB is refused inline with the old cfg still active.
- [x] Worker-thread regression: mutation-tested three times independently (implementer, reviewer, architect) — removing the dedicated except clause reliably buries the job in `failed` with a misleading message; the clause is confirmed load-bearing.
- [x] CLI: a write subcommand refuses before constructing a client; `status`/`coverage`/`ui`/`policy_reset` remain exempt.
