### PR TITLE
fix(#335): warn before telling a data-bearing partial KB to move aside

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1260,8 +1260,16 @@ def test_init_refuses_a_foreign_facts_table(tmp_path, monkeypatch, capsys):
     db = root / "kb.sqlite"
     conn = sqlite3.connect(db)
     conn.execute("CREATE TABLE facts(a, b)")
+    conn.execute("INSERT INTO facts VALUES (1, 2)")
     conn.commit()
     conn.close()
+
+    # KB_ALIEN_FACTS must never reach the #335 row-count branch: its `facts`
+    # table isn't verinote's, so there is nothing of ours in it to count.
+    def _boom(cfg):
+        raise AssertionError("_facts_row_count must not run for KB_ALIEN_FACTS")
+
+    monkeypatch.setattr(cli, "_facts_row_count", _boom)
 
     assert cli.main(["init", str(root)]) == 1
 
@@ -1271,6 +1279,10 @@ def test_init_refuses_a_foreign_facts_table(tmp_path, monkeypatch, capsys):
     assert "Traceback" not in err
     assert _tables(db) == {"facts"}  # nothing verinote added
     assert not (root / "policy").exists()
+    # The discriminator must not over-fire onto the wrong case (#335).
+    assert "move it aside" in err
+    assert "backup" not in err
+    assert "holds" not in err
 
 
 def test_init_refuses_a_partial_schema(tmp_path, monkeypatch, capsys):
@@ -1293,6 +1305,89 @@ def test_init_refuses_a_partial_schema(tmp_path, monkeypatch, capsys):
     assert "is not a verinote KB" in err
     assert cli.KB_PARTIAL_SCHEMA in err
     assert _tables(db) == {"facts"}
+    # An EMPTY partial schema is disposable: pins the empty-vs-data split from the
+    # other direction, so an inverted `rows == 0` branch (#335) would fail this.
+    assert "move it aside" in err
+    assert "backup" not in err
+    assert "holds" not in err
+
+
+def test_init_refuses_a_data_bearing_partial_schema(tmp_path, monkeypatch, capsys):
+    # A partial schema is not always disposable: a bad file dropped in during
+    # recovery, a partial copy, or an accidentally-dropped core table can all
+    # leave real facts sitting in an otherwise-partial KB. Telling that user to
+    # "move it aside" risks discarding their only copy (#335).
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts(id INTEGER PRIMARY KEY, subject, relation, object, status)"
+    )
+    conn.executemany(
+        "INSERT INTO facts (subject, relation, object, status) VALUES (?, ?, ?, ?)",
+        [
+            ("Example Org", "is_a", "participant", "confirmed"),
+            ("Example Org", "established_on", "2020-01-01", "superseded"),
+            ("Demo Project", "has_participant", "Example Org", "rejected"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    before = db.read_bytes()
+
+    assert cli.main(["init", str(root)]) == 1
+
+    assert db.read_bytes() == before  # the refusal wrote nothing
+    err = capsys.readouterr().err
+    assert "is not a verinote KB" in err
+    assert "holds 3 fact(s)" in err
+    assert "backup" in err
+    assert "move it aside" not in err
+    assert "Traceback" not in err
+
+
+def test_init_refuses_a_partial_schema_with_corrupt_data_pages(tmp_path, monkeypatch, capsys):
+    # A partial schema's classification reads only schema metadata (table names,
+    # PRAGMA table_info), which can succeed even when the file's DATA pages are
+    # corrupted — exactly the "bad file during recovery" scenario #335 names. The
+    # row count must not crash init with a raw traceback when that happens.
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts(id INTEGER PRIMARY KEY, subject, relation, object, status)"
+    )
+    conn.executemany(
+        "INSERT INTO facts (subject, relation, object, status) VALUES (?, ?, ?, ?)",
+        [
+            (f"Subject-{i}", "is_a", f"Object-{i}-padding-padding-padding", "confirmed")
+            for i in range(5000)
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    # Corrupt a data page well past the schema page (page 1) without touching it,
+    # so `_kb_schema_problem`'s schema-only reads still succeed.
+    with open(db, "r+b") as f:
+        f.seek(4096 * 3)
+        f.write(b"\xff" * 200)
+
+    # Pin the precondition: this must land on the vulnerable branch, not some
+    # other classification.
+    problem = cli._kb_schema_problem(db)
+    assert problem is not None and problem.startswith(cli.KB_PARTIAL_SCHEMA)
+
+    assert cli.main(["init", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+    assert "backup" in err or "could not be read" in err
+    assert "move it aside" not in err
 
 
 def test_init_seed_on_a_foreign_facts_table_writes_nothing(tmp_path, monkeypatch, capsys):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -178,6 +178,25 @@ def cmd_init(cfg: Config, args: argparse.Namespace) -> int:
         # KB_NO_SCHEMA (a readable db with no `facts` table — init's whole
         # purpose) and a healthy KB (None — an idempotent re-init) may proceed.
         if problem is not None and problem != KB_NO_SCHEMA:
+            # A partial schema can still hold real data (e.g. a corrupted recovery
+            # copy), so it alone gets a row count before advising "move it aside" —
+            # KB_ALIEN_FACTS is excluded because its `facts` table isn't verinote's,
+            # so there is nothing of ours in it to count.
+            if problem.startswith(KB_PARTIAL_SCHEMA):
+                rows = _facts_row_count(cfg)
+                if rows != 0:  # rows > 0, or None (unreadable): may be the only copy of real data
+                    held = (
+                        "may hold facts that could not be read"
+                        if rows is None
+                        else f"holds {rows} fact(s)"
+                    )
+                    print(
+                        f"cannot initialise {cfg.root}: {cfg.db_path} is not a verinote KB "
+                        f"({problem}), but it {held}. Restore it from a backup instead of "
+                        f"moving it aside.",
+                        file=sys.stderr,
+                    )
+                    return 1
             print(
                 f"cannot initialise {cfg.root}: {cfg.db_path} is not a verinote KB "
                 f"({problem}); move it aside and run this again.",
@@ -367,6 +386,24 @@ def _read_only_conn(cfg: Config) -> sqlite3.Connection:
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
+
+
+def _facts_row_count(cfg: Config) -> int | None:
+    """Rows in `facts`, or None when they cannot be read.
+
+    Only meaningful once `_kb_schema_problem` has confirmed a verinote-shaped
+    `facts` table. A partial copy can pass that schema check yet have corrupt
+    data pages, so a bare COUNT(*) can still raise here (#335); returning None
+    keeps the refusal careful instead of crashing init with a raw traceback.
+    """
+    try:
+        conn = _read_only_conn(cfg)
+        try:
+            return int(conn.execute("SELECT COUNT(*) c FROM facts").fetchone()["c"])
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError:
+        return None
 
 
 def _read_only_columns(conn: sqlite3.Connection, table: str) -> set[str]:


### PR DESCRIPTION
## Summary

Closes #335.

`#290` added `KB_PARTIAL_SCHEMA`/`KB_ALIEN_FACTS` refusal to `verinote init`, but both problems shared the identical message: `"cannot initialise <root>: <db> is not a verinote KB (<problem>); move it aside and run this again."` A `KB_PARTIAL_SCHEMA` file (a `facts` table missing its sibling tables) can occur WITH real data intact — a bad file during recovery, a partial copy, an accidentally-dropped core table — and "move it aside" could make a user discard their only copy.

This is message-quality only: whether to refuse, the return code, and mutation-prevention were already correctly closed by #290 and are unchanged here.

## Fix

For the `KB_PARTIAL_SCHEMA` case specifically (discriminated via `problem.startswith(KB_PARTIAL_SCHEMA)`, since `_kb_schema_problem` always returns a decorated string naming the missing piece, never the bare constant), count `facts` rows via a new `_facts_row_count(cfg)` helper before choosing the message:
- Empty (`rows == 0`): today's message, unchanged.
- Non-empty, or unreadable due to data-page corruption (`rows is None`): a new message naming the row count (or "may hold facts that could not be read") that steers toward restoring from backup instead of moving the file aside.

`KB_ALIEN_FACTS` (someone else's `facts` table — nothing of ours to count) is excluded from the count entirely, not just from the wording change.

## A real correction found during design, not speculative

The initial design assumption (mine and architect-335's) was that a row count is always safe here, since `_kb_schema_problem` already confirms `facts` exists with the right columns before this branch runs. critic-335 empirically refuted this: schema classification only reads `sqlite_master` metadata and `PRAGMA table_info` — which can succeed even when the file's DATA pages are corrupted. A file can pass classification as `KB_PARTIAL_SCHEMA` while a full `SELECT COUNT(*) FROM facts` scan raises `sqlite3.DatabaseError: database disk image is malformed`. I independently reproduced this myself before finalizing the design (and again after implementation); reviewer-335 and architect-335 each reproduced it a third and fourth time with different parameters during review and audit. This is exactly the scenario the issue itself names ("a bad file during recovery, a partial copy") — the count is wrapped in `try/except sqlite3.DatabaseError`, and `None` (unreadable) is treated the same as "has data" (be cautious), never the same as "confirmed empty" (`rows != 0`, deliberately not `if not rows`, since `None` and `0` are both falsy but mean opposite things here).

## Consensus record (`/implementation-flow`)

- **reviewer-335**: APPROVE. Independently reproduced the data-page-corruption scenario with its own parameters, and ran three distinct mutation tests (removing the try/except, `rows != 0` → `if rows:`, and an inverted branch) confirming each new test fails uniquely and non-vacuously.
- **architect-335**: CONCUR, with a genuine retraction of its own Phase 1 "no fallback needed" position — named the exact reasoning error (conflating schema-readability with data-readability) after reproducing the corruption scenario a third way.
- **critic-335**: CONCUR. Reproduced the corruption scenario a fourth way, ran a sensitivity sweep confirming the regression test isn't flaky, and enumerated every other read against a partial/corrupt file in the `init` path to confirm no residual variant of the gap remains.

## Follow-up filed (out of scope here, not blocking)

- #371 — `verinote seed` has the identical hazard in its own, separately-worded refusal message ("...move it aside and run `verinote init` to scaffold one"). Out of scope for this fix (the issue's completion criteria name only `init`), recommended as a follow-up by all three review/audit voices independently. Note: this fix already provides a partial mitigation — if a user follows `seed`'s advice and actually runs `verinote init`, `init` will now correctly refuse and warn instead of silently scaffolding over real data; the residual hazard is a user manually discarding the file based on `seed`'s wording without running `init` at all.

## Test plan

- [x] Full suite: 1596 passed, 7 skipped (verified independently at every stage — design, implementation, review, and audit each reproduced the key scenario separately).
- [x] `ruff check` (0.15.18): all checks passed.
- [x] Data-bearing partial schema refuses, names the row count, steers to backup, never says "move it aside", writes nothing.
- [x] Empty partial schema and `KB_ALIEN_FACTS` keep today's message unchanged — the latter is pinned by a monkeypatch proving `_facts_row_count` is never even called for it, not just that the output text is unchanged.
- [x] Load-bearing regression: a schema-intact, data-page-corrupted partial file does not crash `init` with a raw traceback — mutation-tested four separate times (implementer, reviewer, architect, critic) with different corruption parameters each time, all confirming the try/except is genuinely load-bearing.
- [x] Confirm-green: `test_init_twice_is_idempotent`, `test_init_still_scaffolds_a_database_that_merely_has_no_schema`, `test_init_refuses_a_corrupt_db_instead_of_raising`.
