### PR TITLE
fix(#200): normalize facts to NFC at every write boundary

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1110,6 +1110,19 @@ def test_seed_run_twice_does_not_double_demo_facts(tmp_path):
     store.close()
 
 
+def test_seed_stores_demo_triples_verbatim(tmp_path):
+    # The demo literals are ASCII, so the write boundary's NFC pass is a faithful
+    # no-op — this pins the seeded triples byte-identical to _DEMO_FACTS (#200).
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+
+    cli._seed(store)
+
+    stored = {(f["subject"], f["relation"], f["object"]) for f in store.facts()}
+    store.close()
+    assert stored == {(subj, rel, obj) for subj, rel, obj, *_ in cli._DEMO_FACTS}
+
+
 def test_init_help_does_not_promise_verinote_root_only(capsys):
     with pytest.raises(SystemExit):
         cli.main(["init", "--help"])

--- a/tests/test_engine_input.py
+++ b/tests/test_engine_input.py
@@ -11,6 +11,7 @@ a vocabulary list.
 """
 
 from pathlib import Path
+import unicodedata
 
 import pytest
 
@@ -29,6 +30,7 @@ from verinote.engine.policy_vocabulary import (
 from verinote.engine.terms import StringLit, bare_label
 from verinote.llm.base import ExtractedFact
 from verinote.pipeline import extract_source
+from verinote.pipeline.extract import _candidate_rows, _extracted_value
 from verinote.pipeline.engine_input import annotate_source_labels, engine_relation_rows
 from verinote.pipeline.query import query_path
 from verinote.pipeline.report_trace import report_trace
@@ -606,6 +608,124 @@ def test_findings_for_unaliased_relations_are_left_alone(tmp_path):
     rep = verify(s)
 
     assert rep.findings == ["ERROR functional_conflict: 회사 established_on"]
+
+
+def test_extracted_value_normalizes_every_string_slot_value():
+    """#200: the string write path NFC-normalizes whatever slot it is given.
+
+    `_extracted_value(value, "string")` takes no slot argument, so subject,
+    relation and object share this one path (proven per-slot end-to-end in the
+    `_candidate_rows` test below). Three distinct NFD strings, each proven to
+    differ from its NFC form first, so a green assertion means something.
+    """
+    for base in ("café", "résumé", "naïve"):
+        nfd_value = unicodedata.normalize("NFD", base)
+        nfc_value = unicodedata.normalize("NFC", base)
+        assert nfd_value != nfc_value
+        result = _extracted_value(nfd_value, "string")
+        assert result == nfc_value
+        assert result != nfd_value
+
+
+def test_extracted_value_normalizes_an_escape_encoded_nfd_term_leaf():
+    """#200's real discriminator: a 100%-ASCII term source that DECODES to NFD.
+
+    The source is all `\\uXXXX` escapes — pure ASCII — so a whole-string `nfc()`
+    applied BEFORE parsing is a no-op and leaves the decoded leaf in NFD. Only
+    normalizing the PARSED term's `StringLit` leaf (what `nfc_term` does) fixes
+    it, so this test fails on any pre-parse implementation.
+    """
+    source = 'note("caf\\u0065\\u0301")'
+    assert source.isascii()
+    nfc_cafe = unicodedata.normalize("NFC", "café")
+    nfd_cafe = unicodedata.normalize("NFD", "café")
+    assert nfc_cafe != nfd_cafe
+
+    term = _extracted_value(source, "term")
+
+    leaf = term.args[0]
+    assert isinstance(leaf, StringLit)
+    assert leaf.value == nfc_cafe
+    assert leaf.value != nfd_cafe
+
+
+def test_extracted_value_normalizes_a_plain_literal_nfd_term_leaf():
+    """The non-discriminating companion: NFD text sitting literally in the source.
+
+    Here the NFD codepoints are in the source string itself, so even a naive
+    pre-parse `nfc()` would catch them — it passes under both the correct and the
+    naive implementation. It exists only to confirm the escape case above is what
+    actually separates the two.
+    """
+    nfd_cafe = unicodedata.normalize("NFD", "café")
+    nfc_cafe = unicodedata.normalize("NFC", "café")
+    source = f'note("{nfd_cafe}")'
+
+    term = _extracted_value(source, "term")
+
+    assert term.args[0] == StringLit(nfc_cafe)
+
+
+def test_candidate_rows_normalize_subject_relation_and_object_to_nfc():
+    """#200 per-slot: subject, relation AND object each land NFC through the rows.
+
+    Latin+combining fixtures (café/résumé/naïve) with a plain-Latin source dodge
+    the Hangul/Han/metric drop filters entirely, so the row survives and each of
+    the three slots is asserted independently — one is not allowed to stand in
+    for the others.
+    """
+    nfd_subject = unicodedata.normalize("NFD", "café")
+    nfd_relation = unicodedata.normalize("NFD", "résumé")
+    nfd_object = unicodedata.normalize("NFD", "naïve")
+    nfc_subject = unicodedata.normalize("NFC", "café")
+    nfc_relation = unicodedata.normalize("NFC", "résumé")
+    nfc_object = unicodedata.normalize("NFC", "naïve")
+    fact = ExtractedFact(nfd_subject, nfd_relation, nfd_object, 0.9)
+
+    rows = _candidate_rows([fact], "café résumé naïve")
+
+    assert len(rows) == 1
+    subject, relation, obj, _f = rows[0]
+    assert subject == nfc_subject and subject != nfd_subject
+    assert relation == nfc_relation and relation != nfd_relation
+    assert obj == nfc_object and obj != nfd_object
+
+
+def test_extracted_nfd_fact_answers_an_nfc_engine_query(tmp_path, fake_client):
+    """#200 end-to-end at the DuckDB engine: NFD in, NFC at rest, NFC query answers.
+
+    A fact the model emits in NFD is stored NFC at rest by the write boundary, so
+    a query written in NFC joins it at the engine level. This is the join the
+    engine CANNOT make against an NFD-stored row — it does no runtime
+    normalization, so an NFC query over an NFD fact returns nothing. The stored
+    form here IS NFC (asserted), which is exactly what closes that gap.
+    """
+    s = _store(tmp_path)
+    nfd_subject = unicodedata.normalize("NFD", "Café")
+    nfc_subject = unicodedata.normalize("NFC", "Café")
+    assert nfd_subject != nfc_subject
+    client = fake_client([ExtractedFact(nfd_subject, "mentions", "Report", 0.9)])
+
+    extract_source(
+        s, client, source_path="sources/x.txt", source_text="Café mentions Report"
+    )
+    for fact in s.facts():
+        s.accept_fact(int(fact["id"]))
+
+    # Stored NFC at rest — not the NFD the model emitted.
+    assert {f["subject"] for f in s.facts()} == {nfc_subject}
+
+    qp = query_path(Path(s.db_path).parent)
+    qp.parent.mkdir(parents=True, exist_ok=True)
+    qp.write_text(
+        ".decl answer_q1(value: symbol)\n"
+        f'answer_q1(O) :- relation("{nfc_subject}", "mentions", O).\n',
+        encoding="utf-8",
+    )
+
+    trace = report_trace(s)
+
+    assert [(answer.qid, answer.value) for answer in trace.answers] == [("1", "Report")]
 
 
 def _text(term: object) -> str:

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The one Unicode normalizer, and the term-aware wrapper that feeds it leaves."""
+
+import unicodedata
+
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var
+from verinote.store.fact_input import nfc_term
+from verinote.text import nfc
+
+NFD_CAFE = unicodedata.normalize("NFD", "café")
+NFC_CAFE = unicodedata.normalize("NFC", "café")
+
+
+def test_nfd_input_normalizes_to_nfc():
+    # The fixture proves nothing unless the two forms differ in bytes first.
+    assert NFD_CAFE != NFC_CAFE
+    assert nfc(NFD_CAFE) == NFC_CAFE
+
+
+def test_nfc_is_idempotent():
+    once = nfc(NFD_CAFE)
+    assert nfc(once) == once
+
+
+def test_ascii_passes_through_unchanged():
+    assert nfc("plain ascii 123") == "plain ascii 123"
+
+
+def test_nfc_term_normalizes_a_string_leaf():
+    assert nfc_term(StringLit(NFD_CAFE)) == StringLit(NFC_CAFE)
+
+
+def test_nfc_term_recurses_into_compound_args_normalizing_only_string_leaves():
+    term = Compound("note", (StringLit(NFD_CAFE), NumberLit(7), Atom("plain")))
+    assert nfc_term(term) == Compound(
+        "note", (StringLit(NFC_CAFE), NumberLit(7), Atom("plain"))
+    )
+
+
+def test_nfc_term_recurses_into_nested_compounds():
+    term = Compound("outer", (Compound("inner", (StringLit(NFD_CAFE),)),))
+    assert nfc_term(term) == Compound(
+        "outer", (Compound("inner", (StringLit(NFC_CAFE),)),)
+    )
+
+
+def test_nfc_term_leaves_non_string_term_kinds_untouched():
+    # Atoms, functors, numbers, and variables are ASCII-only by construction, so
+    # StringLit is the only leaf that can hold non-NFC text. The others return
+    # the very same object, unchanged.
+    for term in (NumberLit(5), Atom("plain"), Var("X")):
+        assert nfc_term(term) is term

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4,6 +4,7 @@ import logging
 import re
 import threading
 import time
+import unicodedata
 from html import unescape
 
 import pytest
@@ -2235,6 +2236,75 @@ def test_amend_endpoint_saves_term_looking_text_as_stringlit_in_string_mode(tmp_
         StringLit('role(person("Ada"), "PI")'),
     )
     assert 'class="subj term-string">"person(\\"Ada\\")"' in unescape(r.text)
+
+
+def test_amend_normalizes_an_nfd_string_slot_to_nfc(tmp_path):
+    """#200 web boundary: an NFD value posted to the amend form is stored NFC.
+
+    `_fact_input` NFC-normalizes string-kind slots, so the fact is NFC at rest
+    and byte-matches an NFC query at the DuckDB engine level. The NFD input is
+    proven byte-different from its NFC form first, so the assertion means
+    something.
+    """
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact("A", "is_a", "B", status="needs_review")
+    nfd_subject = unicodedata.normalize("NFD", "café")
+    nfc_subject = unicodedata.normalize("NFC", "café")
+    assert nfd_subject != nfc_subject
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": nfd_subject,
+            "subject_kind": "string",
+            "relation": "is_a",
+            "relation_kind": "string",
+            "object": "B",
+            "object_kind": "string",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 200
+    assert store.get_fact_terms(fid)[0] == StringLit(nfc_subject)
+    assert store.get_fact(fid)["subject"] != nfd_subject
+
+
+def test_amend_normalizes_an_escape_encoded_nfd_term_leaf_to_nfc(tmp_path):
+    """#200 web boundary, the discriminating case: an ASCII term source -> NFD leaf.
+
+    The posted object is 100% ASCII (all \\uXXXX escapes) yet DECODES to an NFD
+    `StringLit` leaf after parsing. Only `nfc_term` running post-parse on the
+    amend path stores it NFC; a pre-parse whole-string `nfc()` would leave the
+    escape-encoded leaf in NFD, so this fails on the wrong implementation.
+    """
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact("A", "is_a", "B", status="needs_review")
+    term_source = 'note("caf\\u0065\\u0301")'
+    assert term_source.isascii()
+    nfc_cafe = unicodedata.normalize("NFC", "café")
+    nfd_cafe = unicodedata.normalize("NFD", "café")
+    assert nfc_cafe != nfd_cafe
+
+    r = c.post(
+        f"/facts/{fid}/amend",
+        data={
+            "subject": "A",
+            "subject_kind": "string",
+            "relation": "is_a",
+            "relation_kind": "string",
+            "object": term_source,
+            "object_kind": "term",
+            "note": "",
+        },
+    )
+
+    assert r.status_code == 200
+    obj_term = store.get_fact_terms(fid)[2]
+    assert obj_term == Compound("note", (StringLit(nfc_cafe),))
+    assert obj_term.args[0].value != nfd_cafe
 
 
 def _corrupt_sidecar_kb(tmp_path, *, status="needs_review", with_query=False):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -15,6 +15,7 @@ from verinote.config import Config, local_root
 from verinote.pipeline.question_outcome import format_question_outcome
 from verinote.store import Store, engine_statuses
 from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreLockedError
+from verinote.text import nfc
 
 # Local commands own their KB location: they never inherit the KB the web UI
 # last selected, so `verinote init` cannot scribble into somebody else's data.
@@ -251,7 +252,13 @@ def _seed(store: Store) -> None:
     for subj, rel, obj, status, conf, src, note in _DEMO_FACTS:
         sid = store.add_source(src)
         store.reconcile_fact(
-            subj, rel, obj, status=status, confidence=conf, source_id=sid, note=note
+            nfc(subj),
+            nfc(rel),
+            nfc(obj),
+            status=status,
+            confidence=conf,
+            source_id=sid,
+            note=note,
         )
 
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -24,7 +24,8 @@ from verinote.pipeline.normalize import normalize_for_extraction
 from verinote.pipeline.policy_state import PolicyMissingError, assert_writable
 from verinote.prompts import PromptError, render_prompt
 from verinote.store import Store
-from verinote.store.fact_input import structural_term
+from verinote.store.fact_input import nfc_term, structural_term
+from verinote.text import nfc
 
 
 class ExtractionJobBusyError(Exception):
@@ -867,8 +868,8 @@ def _has_han_run_not_in_source(value: str, source_text: str) -> bool:
 
 def _extracted_value(value: str, kind: str) -> object:
     if kind == "term":
-        return structural_term(value)
-    return value
+        return nfc_term(structural_term(value))
+    return nfc(value)
 
 
 @dataclass(frozen=True)

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-import unicodedata
 
 from verinote.pipeline.corroboration import relation_label_matches
 from verinote.pipeline.query_intent import QueryIntent, QueryIntentKind
@@ -16,6 +15,7 @@ from verinote.pipeline.query_schema import (
     SnapshotFact,
     TermRef,
 )
+from verinote.text import nfc as _nfc
 
 
 @dataclass(frozen=True)
@@ -562,7 +562,3 @@ def _dedupe_candidates(candidates: list[QueryCandidate]) -> tuple[QueryCandidate
         )
         deduped.setdefault(key, candidate)
     return tuple(deduped.values())
-
-
-def _nfc(value: str) -> str:
-    return unicodedata.normalize("NFC", value)

--- a/verinote/pipeline/query_schema.py
+++ b/verinote/pipeline/query_schema.py
@@ -11,7 +11,6 @@ observed KB data.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import unicodedata
 from typing import Iterable, Mapping
 
 from verinote.engine.terms import (
@@ -31,6 +30,7 @@ from verinote.pipeline.corroboration import (
 )
 from verinote.pipeline.engine_input import engine_relation_rows
 from verinote.store import Store, engine_statuses
+from verinote.text import nfc as _nfc
 
 
 @dataclass(frozen=True)
@@ -401,7 +401,3 @@ def _fact_sort_key(fact: _Fact) -> tuple[object, ...]:
         fact.object.key,
         fact.fact_id,
     )
-
-
-def _nfc(value: str) -> str:
-    return unicodedata.normalize("NFC", value)

--- a/verinote/store/fact_input.py
+++ b/verinote/store/fact_input.py
@@ -8,7 +8,15 @@ intentionally wants Datalog term syntax parsed as a logical term.
 
 from __future__ import annotations
 
-from verinote.engine.terms import Compound, Term, TermParseError, Var, parse_term
+from verinote.engine.terms import (
+    Compound,
+    StringLit,
+    Term,
+    TermParseError,
+    Var,
+    parse_term,
+)
+from verinote.text import nfc
 
 
 def structural_term(text: str) -> Term:
@@ -23,6 +31,22 @@ def structural_term(text: str) -> Term:
     return term
 
 
+def nfc_term(term: Term) -> Term:
+    """Normalize every StringLit leaf in `term` to NFC, recursively.
+
+    Only StringLit can hold non-ASCII text; Compound recurses, everything else
+    passes through unchanged. Must run AFTER parsing, not before: a term's
+    source text can be pure ASCII (e.g. \\uXXXX-escaped) yet decode to
+    non-NFC codepoints, which whole-string normalization before parsing would
+    never touch (#200).
+    """
+    if isinstance(term, StringLit):
+        return StringLit(nfc(term.value))
+    if isinstance(term, Compound):
+        return Compound(term.functor, tuple(nfc_term(a) for a in term.args))
+    return term
+
+
 def is_ground_term(term: Term) -> bool:
     """Return True when a term contains no variables."""
     return not _has_var(term)
@@ -30,8 +54,6 @@ def is_ground_term(term: Term) -> bool:
 
 def term_input_kind(term: Term) -> str:
     """Return the edit/input kind for a stored term."""
-    from verinote.engine.terms import StringLit
-
     return "string" if isinstance(term, StringLit) else "term"
 
 

--- a/verinote/text.py
+++ b/verinote/text.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MPL-2.0
+"""One Unicode normalizer, so the write and query halves of a comparison agree."""
+
+from __future__ import annotations
+
+import unicodedata
+
+
+def nfc(value: str) -> str:
+    """Return `value` in NFC (canonical composed) form."""
+    return unicodedata.normalize("NFC", value)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -97,7 +97,8 @@ from verinote.store import (
 # read at call time so the web layer cannot pin a stale copy of the constant.
 from verinote.store import db as store_db
 from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
-from verinote.store.fact_input import structural_term, term_input_kind
+from verinote.store.fact_input import nfc_term, structural_term, term_input_kind
+from verinote.text import nfc
 
 logger = logging.getLogger(__name__)
 
@@ -509,9 +510,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     def _fact_input(value: str, kind: str):
         if kind == "string":
-            return value
+            return nfc(value)
         if kind == "term":
-            return structural_term(value)
+            return nfc_term(structural_term(value))
         raise ValueError(f"unknown fact input kind: {kind}")
 
     def _review_filters() -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary

Closes #200.

Korean (or any non-ASCII) facts extracted from source text could be stored with NFD (decomposed) Unicode for `subject`/`relation`/`object`. The DuckDB engine does no runtime Unicode normalization — it canonicalizes a fact term to JSON and joins on byte-equality — so an NFD-stored fact never byte-matches an NFC-form query at the engine level, and the answer silently comes back empty.

## The issue's own text had partly gone stale — verified against current code, not assumed

Two of the issue's original premises no longer held by the time this was picked up:
- It claimed `relation` was already NFC-normalized elsewhere. False today: an earlier commit (#252, merged 9 days after #200 was filed) removed the mechanism that used to normalize it as a side effect, for an unrelated reason (write-time relation *aliasing* was the bug #252 fixed — a different operation from NFC form normalization, which this PR restores narrowly via the shared helper, with no risk of resurrecting #252's bug).
- It implicitly framed this as "fixing matching." The Python query-schema layer (`query_planner.py`/`query_schema.py`) already self-normalizes both sides of its own comparisons and already matches an NFD-stored fact to an NFC query today — proven by an existing, currently-passing test (`tests/test_query_schema.py:240`). The actual, unaddressed gap is specifically at the DuckDB engine level, which has no such runtime step. This fix's real value: new writes become NFC "at rest" so they engine-join correctly.

## Design

- New `verinote/text.py`: a bare `nfc(value)` — the single normalizer the write and query halves of every comparison now agree on. No strip/casefold/None-handling, deliberately byte-identical to the two private `_nfc()` wrappers it replaces in `query_planner.py`/`query_schema.py` (migrated in this same commit, a provable no-op).
- New `nfc_term()` in `store/fact_input.py`, walking a parsed `Term` tree and normalizing only `StringLit` leaves. This must run **after** parsing, never on the raw string before parsing: a term's source can be 100% ASCII (all `\uXXXX` escape sequences) yet decode to non-NFC codepoints during parsing, which whole-string normalization before parsing would never touch. Verified concretely: `parse_term('note("caf\uXXXX...")')` — a pure-ASCII source — decodes to an NFD-form `StringLit` leaf; only post-parse normalization catches it.
- Wired at all four enumerated write boundaries: the extraction path (`extract.py`'s `_extracted_value`, covering subject/relation/object for both string and term slots), the web amend route (`web/app.py`'s `_fact_input`), and the CLI demo seed (`cli.py`'s `_seed`, currently a no-op on ASCII demo data but closes the last path so "every write boundary normalizes" is a true invariant).
- Deliberately lives in the write-boundary **builders**, never the shared `Store.add_fact`/`reconcile_fact`/`amend_fact` sink — normalizing in the sink would break `tests/test_query_schema.py:240`'s existing, deliberately-NFD-seeding test, which proves the write side is correctly untouched by that test's own design.

## Consensus record (`/implementation-flow`)

- **reviewer-200**: APPROVE (0 blocker/major/minor). Independently reproduced the escape-decoding discriminator from scratch; checked out the *parent* commit in an isolated worktree and confirmed all 5 new tests genuinely fail there; independently proved the engine-level gap via a real `report_trace`/DuckDB run.
- **architect-200**: CONCUR, with a precise retraction of its own Phase 1 position (it had recommended leaving term-kind values untouched) — named two specific reasoning errors after re-verifying against the shipped code.
- **critic-200**: CONCUR. Independently reproduced the escape discriminator via a replica probe; found and the team closed one coverage gap (see below) before finalizing.

## Post-consensus polish (folded into the same commit before merge)

critic-200's Phase 4 audit found the web amend route's NFC behavior had zero regression test coverage (though the behavior itself was already confirmed correct via critic's own replica probe) — closed by adding two tests through the real HTTP route: the requested string-kind case, plus a bonus term-kind escape-encoded-leaf case proving the discriminating scenario survives HTTP transit correctly.

## Test plan

- [x] Full suite: 1611 passed, 7 skipped (verified independently at every stage: design, implementation, review, and audit each reproduced the key escape-decoding claim separately, plus the final polish).
- [x] `ruff check` (0.15.18): all checks passed.
- [x] Per-slot write-boundary tests (subject/relation/object independently) for both string and term-kind values.
- [x] The escape-encoded-term regression: a 100%-ASCII term source that decodes to an NFD leaf — reproduced independently by design, implementation, review, and audit, each with different concrete examples, confirming it's a genuine, non-vacuous discriminator (fails under a naive pre-parse implementation).
- [x] Real DuckDB engine round-trip: an NFD-sourced fact answers a real NFC-form Datalog query — confirmed to fail on the parent commit, pass on the fix.
- [x] Tripwire: `tests/test_query_schema.py`'s existing deliberately-NFD-seeding test is completely untouched and passes, proving the fix landed in the correct layer.
- [x] Both wrapper migrations (`query_planner.py`/`query_schema.py`) proven behavior-neutral — all existing tests in those files pass unchanged.
- [x] Web amend route NFC coverage (string and escape-encoded term cases), closed during Phase 4 polish.

## Scope, stated honestly

This normalizes **new writes only**. It does not retroactively repair already-stored NFD facts — that backfill is #201's scope. Re-extracting an existing source inserts a fresh NFC candidate; it does not rewrite an already-stored NFD row. Source-file-path normalization is #199's separate scope. The verified claim is narrow: a fact's canonical form at rest is now NFC, closing the DuckDB engine-level join gap — not a claim that Python-layer matching was ever broken (it wasn't).
