### PR TITLE
fix: protect partial KB recovery in seed

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1196,8 +1196,9 @@ def test_seed_rejects_an_empty_db_file_instead_of_creating_a_schema(
 
     assert db.read_bytes() == b""  # no schema was created behind our back
     err = capsys.readouterr().err
-    assert "is not a verinote KB" in err
-    assert f"verinote init {root}" in err  # recovery path
+    assert cli.KB_NO_SCHEMA in err
+    assert "move it aside" in err
+    assert "backup" not in err
 
 
 def test_seed_rejects_a_corrupt_db_file_without_a_traceback(tmp_path, monkeypatch, capsys):
@@ -1211,8 +1212,143 @@ def test_seed_rejects_a_corrupt_db_file_without_a_traceback(tmp_path, monkeypatc
 
     assert db.read_bytes() == b"definitely not sqlite\n"
     err = capsys.readouterr().err
-    assert "is not a verinote KB" in err
+    assert cli.KB_UNREADABLE in err
+    assert "restore it from backup" in err
     assert f"verinote init {root}" in err
+    assert "Traceback" not in err
+
+
+def test_seed_refuses_a_data_bearing_partial_schema_with_backup_guidance(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts(id INTEGER PRIMARY KEY, subject, relation, object, status)"
+    )
+    conn.executemany(
+        "INSERT INTO facts (subject, relation, object, status) VALUES (?, ?, ?, ?)",
+        [
+            ("Example Org", "is_a", "participant", "confirmed"),
+            ("Example Org", "established_on", "2020-01-01", "superseded"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    before = db.read_bytes()
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    assert db.read_bytes() == before
+    err = capsys.readouterr().err
+    assert "holds 2 fact(s)" in err
+    assert "backup" in err
+    assert "move it aside" not in err
+    assert "Traceback" not in err
+
+
+def test_seed_refuses_a_partial_schema_with_corrupt_data_pages_safely(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts(id INTEGER PRIMARY KEY, subject, relation, object, status)"
+    )
+    conn.executemany(
+        "INSERT INTO facts (subject, relation, object, status) VALUES (?, ?, ?, ?)",
+        [
+            (f"Subject-{i}", "is_a", f"Object-{i}-padding-padding-padding", "confirmed")
+            for i in range(5000)
+        ],
+    )
+    conn.commit()
+    conn.close()
+    with open(db, "r+b") as f:
+        f.seek(4096 * 3)
+        f.write(b"\xff" * 200)
+
+    problem = cli._kb_schema_problem(db)
+    assert problem is not None and problem.startswith(cli.KB_PARTIAL_SCHEMA)
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert "backup" in err or "could not be read" in err
+    assert "move it aside" not in err
+    assert "Traceback" not in err
+
+
+def test_seed_keeps_generic_guidance_for_an_empty_partial_schema(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "partial"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE facts(id INTEGER PRIMARY KEY, subject, relation, object, status)"
+    )
+    conn.commit()
+    conn.close()
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert cli.KB_PARTIAL_SCHEMA in err
+    assert "move it aside" in err
+    assert "backup" not in err
+    assert "holds" not in err
+
+
+def test_seed_keeps_generic_guidance_for_a_schema_less_sqlite_database(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "empty"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    sqlite3.connect(db).close()
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert cli.KB_NO_SCHEMA in err
+    assert "move it aside" in err
+    assert "backup" not in err
+
+
+def test_seed_keeps_foreign_facts_out_of_the_partial_schema_count(
+    tmp_path, monkeypatch, capsys
+):
+    _isolated(monkeypatch, tmp_path)
+    root = tmp_path / "foreign"
+    root.mkdir()
+    db = root / "kb.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE facts(a, b)")
+    conn.execute("INSERT INTO facts VALUES (1, 2)")
+    conn.commit()
+    conn.close()
+
+    def _boom(cfg):
+        raise AssertionError("_facts_row_count must not run for KB_ALIEN_FACTS")
+
+    monkeypatch.setattr(cli, "_facts_row_count", _boom)
+
+    assert cli.main(["seed", str(root)]) == 1
+
+    err = capsys.readouterr().err
+    assert cli.KB_ALIEN_FACTS in err
+    assert "move it aside" in err
+    assert "backup" not in err
 
 
 def test_init_refuses_a_corrupt_db_instead_of_raising(tmp_path, monkeypatch, capsys):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -509,6 +509,33 @@ def cmd_seed(cfg: Config, args: argparse.Namespace) -> int:
         return 1
     problem = _kb_schema_problem(cfg.db_path)
     if problem is not None:
+        # A damaged database may be the only copy of a user's review decisions.
+        # `seed` never writes on this path, but telling the user to move it aside
+        # invites a manual discard before they can restore it. Keep this recovery
+        # advice aligned with `init`'s cautious branches.
+        if problem == KB_UNREADABLE:
+            print(
+                f"cannot seed {cfg.root}: {cfg.db_path} exists and is {KB_UNREADABLE}. "
+                "If it is a damaged KB, restore it from backup; if it is not a KB at all, "
+                f"move it aside and run `verinote init {cfg.root}` to scaffold one.",
+                file=sys.stderr,
+            )
+            return 1
+        if problem.startswith(KB_PARTIAL_SCHEMA):
+            rows = _facts_row_count(cfg)
+            if rows != 0:  # rows > 0, or None when data pages cannot be read
+                held = (
+                    "may hold facts that could not be read"
+                    if rows is None
+                    else f"holds {rows} fact(s)"
+                )
+                print(
+                    f"cannot seed {cfg.root}: {cfg.db_path} is not a verinote KB "
+                    f"({problem}), but it {held}. Restore it from a backup instead of "
+                    "moving it aside.",
+                    file=sys.stderr,
+                )
+                return 1
         print(
             f"{cfg.db_path} is not a verinote KB ({problem}); move it aside and run "
             f"`verinote init {cfg.root}` to scaffold one",


### PR DESCRIPTION
## Summary

- give `verinote seed` the same cautious recovery guidance as `init` for data-bearing partial databases
- avoid suggesting manual displacement for a partial database that holds facts or whose data pages cannot be read
- add explicit recovery guidance for unreadable databases
- preserve the existing scaffold guidance for empty partial, foreign, and schema-less databases

## Root cause

`seed` used one generic refusal message for every invalid database shape. For a partial KB containing facts, that message encouraged the user to move aside what might be their only recoverable data copy.

## Validation

- `.venv/bin/python -m pytest tests/test_cli.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

The focused CLI suite passed 104 tests. The complete local suite completed successfully.