### PR TITLE
fix: require amend input kinds

### DIFF
--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -551,7 +551,14 @@ def test_amend_lets_the_rule_promote_the_amended_fact(tmp_path):
 
     resp = client.post(
         f"/facts/{acted}/amend",
-        data={"subject": "Report", "relation": "author", "object": "Kim"},
+        data={
+            "subject": "Report",
+            "subject_kind": "string",
+            "relation": "author",
+            "relation_kind": "string",
+            "object": "Kim",
+            "object_kind": "string",
+        },
     )
 
     assert resp.status_code == 200
@@ -688,7 +695,14 @@ def test_missing_amend_target_does_not_run_auto_accept(tmp_path):
 
     resp = client.post(
         "/facts/999999/amend",
-        data={"subject": "Ledger", "relation": "owner", "object": "Park"},
+        data={
+            "subject": "Ledger",
+            "subject_kind": "string",
+            "relation": "owner",
+            "relation_kind": "string",
+            "object": "Park",
+            "object_kind": "string",
+        },
     )
 
     assert resp.status_code == 200
@@ -709,8 +723,11 @@ def test_replayed_amend_does_not_run_auto_accept(tmp_path):
         f"/facts/{target}/amend",
         data={
             "subject": "Ledger",
+            "subject_kind": "string",
             "relation": "owner",
+            "relation_kind": "string",
             "object": "Park",
+            "object_kind": "string",
             "note": "unchanged",
         },
     )

--- a/tests/test_superseded_terminal.py
+++ b/tests/test_superseded_terminal.py
@@ -432,7 +432,14 @@ def test_amend_route_on_a_superseded_fact_answers_without_a_server_error(tmp_pat
 
     resp = client.post(
         f"/facts/{fact_id}/amend",
-        data={"subject": "Ledger", "relation": "owner", "object": "Choi"},
+        data={
+            "subject": "Ledger",
+            "subject_kind": "string",
+            "relation": "owner",
+            "relation_kind": "string",
+            "object": "Choi",
+            "object_kind": "string",
+        },
     )
 
     assert resp.status_code == 200

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2052,13 +2052,53 @@ def test_amend_endpoint_updates_and_audits(tmp_path):
     c = _client(tmp_path)
     r = c.post(
         f"/facts/{c.fact_id}/amend",
-        data={"subject": "NewSubj", "relation": "became", "object": "NewObj", "note": "n"},
+        data={
+            "subject": "NewSubj",
+            "subject_kind": "string",
+            "relation": "became",
+            "relation_kind": "string",
+            "object": "NewObj",
+            "object_kind": "string",
+            "note": "n",
+        },
     )
     assert r.status_code == 200
     assert "NewSubj" in r.text and "NewObj" in r.text
     store = c.app.state.store
     assert store.get_fact(c.fact_id)["subject"] == "NewSubj"
     assert any(e["action"] == "amended" for e in store.fact_log(c.fact_id))
+
+
+@pytest.mark.parametrize("missing_kind", ["subject_kind", "relation_kind", "object_kind"])
+def test_amend_endpoint_rejects_missing_kind_without_writing(tmp_path, missing_kind):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    fid = store.add_fact(
+        structural_term('person("Ada")'),
+        structural_term("has_role"),
+        structural_term('role(person("Ada"), "PI")'),
+        status="needs_review",
+        note="original",
+    )
+    before_row = dict(store.get_fact(fid))
+    before_terms = store.get_fact_terms(fid)
+    data = {
+        "subject": 'person("Ada")',
+        "subject_kind": "term",
+        "relation": "has_role",
+        "relation_kind": "term",
+        "object": 'role(person("Ada"), "PI")',
+        "object_kind": "term",
+        "note": "changed",
+    }
+    del data[missing_kind]
+
+    r = c.post(f"/facts/{fid}/amend", data=data)
+
+    assert r.status_code == 422
+    assert dict(store.get_fact(fid)) == before_row
+    assert store.get_fact_terms(fid) == before_terms
+    assert store.fact_log(fid) == []
 
 
 def test_edit_form_preserves_structural_fact_input_kinds(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1333,9 +1333,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         subject: str = Form(...),
         relation: str = Form(...),
         object: str = Form(...),
-        subject_kind: str = Form("string"),
-        relation_kind: str = Form("string"),
-        object_kind: str = Form("string"),
+        subject_kind: str = Form(...),
+        relation_kind: str = Form(...),
+        object_kind: str = Form(...),
         note: str = Form(""),
     ):
         try:


### PR DESCRIPTION
## Summary
- require explicit kind fields for fact amend requests
- reject omitted kinds before any persistence work
- cover each omitted kind and update explicit string callers

## Root cause
The amend route defaulted omitted kind fields to string, which could silently turn existing structural terms into string values.

## Validation
- .venv/bin/python -m pytest tests/test_web.py -q
- .venv/bin/python -m pytest tests/test_review_gate.py tests/test_superseded_terminal.py -q
- .venv/bin/python -m pytest -q