### PR TITLE
fix: diagnose BOM-only policy files

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -946,6 +946,8 @@ def test_status_halts_on_an_empty_policy_file(tmp_path, monkeypatch, capsys):
 _EMPTY_POLICY_TEXTS = [
     pytest.param("", id="zero_byte"),
     pytest.param("   \n\t  \n", id="whitespace_only"),
+    pytest.param("\ufeff", id="bom_only"),
+    pytest.param("\ufeff \n\t", id="bom_then_whitespace"),
 ]
 
 
@@ -973,6 +975,19 @@ def test_empty_policy_file_resolves_to_present_empty(tmp_path, text, with_marker
 
     assert state.status is PolicyStatus.PRESENT_EMPTY
     assert state.path == path
+    store.close()
+
+
+def test_bom_prefixed_nonempty_policy_remains_present(tmp_path):
+    store = _store(tmp_path)
+    text = "\ufeff" + FUNCTIONAL_POLICY
+    path = _write_policy(tmp_path, text)
+
+    state = resolve_policy(store)
+
+    assert state.status is PolicyStatus.PRESENT
+    assert state.path == path
+    assert state.text == text
     store.close()
 
 

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -143,14 +143,15 @@ def policy_sha256(text: str) -> str:
 def _policy_text_is_empty(text: str) -> bool:
     """Whether a present policy file declares nothing at all (#171).
 
-    A 0-byte file and a whitespace-only one are byte-different but behave
+    A 0-byte file, a whitespace-only one, and a BOM-only one are byte-different but behave
     identically: both parse to an empty program and fail the engine's later
-    `relation/3` check. `text.strip() == ""` is the whole definition on purpose —
-    a comment-only file or one that declares `functional` but not literally
-    `relation` is *not* empty and is left to the engine, not caught here. The CLI's
-    read-only resolver shares this helper so the two cannot drift apart.
+    `relation/3` check. A leading UTF-8 BOM is not policy content, so it is
+    removed before the whitespace check; a BOM-prefixed policy with real content
+    remains present. A comment-only file or one that declares `functional` but
+    not literally `relation` is *not* empty and is left to the engine, not caught
+    here. The CLI's read-only resolver shares this helper so the two cannot drift.
     """
-    return text.strip() == ""
+    return text.lstrip("\ufeff").strip() == ""
 
 
 def policy_path(store: "Store") -> Path:


### PR DESCRIPTION
## Summary
- classify BOM-only and BOM-plus-whitespace policy files as empty
- preserve BOM-prefixed policy bodies that contain real rules
- extend shared policy-state coverage for marker and CLI behavior

## Root cause
A UTF-8 BOM is not removed by str.strip(), so a logically empty policy could bypass the existing empty-policy diagnostic and reach the engine.

## Validation
- .venv/bin/python -m pytest tests/test_policy_state.py -q
- .venv/bin/python -m pytest tests/test_verify.py -q
- .venv/bin/python -m pytest -q