### PR TITLE
fix: recover deterministic planner-empty repairs

### DIFF
--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -20,6 +20,18 @@ def _store_with_review_required(tmp_path):
     return s, qid
 
 
+def _store_with_deterministic_planner_empty(tmp_path):
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    qid = s.add_question("What is Sample Person's birth place?")
+    s.set_question_query(
+        qid,
+        'review_required("What is Sample Person\'s birth place?")',
+        "review_required",
+    )
+    return s, qid
+
+
 def test_repair_accepts_engine_valid_planned_query(tmp_path, fake_client, intent_payload):
     s, qid = _store_with_review_required(tmp_path)
     s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
@@ -291,21 +303,79 @@ def test_repair_persists_ambiguous_lifecycle_outcome(
     assert "ambiguous" not in (load_query(s) or "")
 
 
-def test_repair_default_runs_direct_datalog_fallback(
+def test_repair_default_runs_direct_datalog_for_deterministic_planner_empty(
+    tmp_path, fake_client
+):
+    s, qid = _store_with_deterministic_planner_empty(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        query=lambda q, i: f'answer_q{i}(O) :- relation("Sample Person", "born_in", O).',
+    )
+    client.extract_query_intent = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("deterministic planner-empty repair must not extract intent")
+    )
+    # No flag passed: exercises the production default wiring.
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert client.calls == 1
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    assert s.questions()[0]["status"] == "translated"
+    assert f"answer_q{qid}" in (load_query(s) or "")
+
+
+def test_repair_disabled_fallback_keeps_deterministic_planner_empty_under_review(
+    tmp_path, fake_client
+):
+    s, qid = _store_with_deterministic_planner_empty(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client()
+    client.extract_query_intent = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("deterministic planner-empty repair must not extract intent")
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("disabled fallback must not call direct Datalog")
+    )
+
+    results = repair_questions(
+        s, client, root=tmp_path, allow_direct_datalog_fallback=False
+    )
+
+    assert client.calls == 0
+    assert results == [
+        {
+            "id": qid,
+            "accepted": False,
+            "reason": "no query candidates matched the schema",
+        }
+    ]
+    assert s.questions()[0]["status"] == "review_required"
+
+
+def test_repair_llm_supported_planner_empty_does_not_call_direct_fallback(
     tmp_path, fake_client, intent_payload
 ):
     s, qid = _store_with_review_required(tmp_path)
     s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
     client = fake_client(
-        intent=intent_payload("unknown_or_unsupported", reason="planner cannot map"),
-        query=lambda q, i: f'answer_q{i}(O) :- relation("Sample Person", "born_in", O).',
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="missing_relation"
+        )
     )
-    # No flag passed: exercises the production default wiring.
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("LLM-supported planner-empty repair must not call direct Datalog")
+    )
+
     results = repair_questions(s, client, root=tmp_path)
 
-    assert results == [{"id": qid, "accepted": True, "reason": ""}]
-    assert s.questions()[0]["status"] == "translated"
-    assert f"answer_q{qid}" in (load_query(s) or "")
+    assert client.calls == 1
+    assert results == [
+        {
+            "id": qid,
+            "accepted": False,
+            "reason": "no query candidates matched the schema",
+        }
+    ]
+    assert s.questions()[0]["status"] == "review_required"
 
 
 def test_repair_rejects_fallback_answering_a_different_question(
@@ -511,11 +581,7 @@ def test_repair_llm_error_costs_one_provider_call(tmp_path, fake_client):
 def test_repair_unsupported_intent_still_reaches_fallback(
     tmp_path, fake_client, intent_payload
 ):
-    """Refusing the fallback on `LLMError` must not disarm the supported path.
-
-    An intent extraction that *succeeds* with `unknown_or_unsupported` is the
-    fallback's reason to exist, so it still costs the second call.
-    """
+    """An LLM-confirmed unsupported intent still costs the fallback call."""
     s, qid = _store_with_review_required(tmp_path)
     s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
     client = fake_client(

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -211,6 +211,9 @@ def _schema_aware_query_flow_result(
 
     snapshot = build_query_schema_snapshot(store)
     intent = deterministic_query_intent(question)
+    deterministic_intent_supported = (
+        intent.kind != QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
     if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
         try:
             intent = client.extract_query_intent(
@@ -284,6 +287,12 @@ def _schema_aware_query_flow_result(
         )
     if evaluation.outcome == QueryCandidateSetOutcome.EMPTY:
         reason = _short_reason(plan.reason or "no query candidates matched the schema")
+        return _QueryFlowResult(
+            "review_required",
+            f"review_required({_lit(reason)})",
+            reason,
+            allow_direct_datalog_fallback=deterministic_intent_supported,
+        )
     elif evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR:
         reason = _short_reason("engine/policy error: " + _evaluation_reason(evaluation))
     else:

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -38,12 +38,12 @@ def repair_questions(
     question. A model declaring `no_answer`/`ambiguous` is recorded as a reason
     and the question stays flagged, so a later run can still repair it.
 
-    With `allow_direct_datalog_fallback` (the default), a question the planner
-    reports it cannot support costs two provider calls: intent extraction, then
-    the direct Datalog fallback. A question whose intent extraction *failed*
-    costs one: a provider that errors has not reported the question unsupported,
-    so the fallback does not retry it and an outage or rate limit stays at one
-    failed call per question.
+    With `allow_direct_datalog_fallback` (the default), an LLM-confirmed
+    unsupported intent costs two provider calls: intent extraction, then the
+    direct Datalog fallback. A deterministically supported intent whose planner
+    returns no candidates costs one provider call: the direct Datalog fallback.
+    An intent-extraction LLM error costs one failed call and never retries the
+    provider.
     """
     results: list[dict] = []
     for q in store.questions():


### PR DESCRIPTION
Closes #296

Adds the existing engine-gated direct Datalog fallback when a deterministic supported intent produces no planner candidates.

The change preserves the LLM-confirmed unsupported fallback and keeps all other planner outcomes fail-closed. It adds provider-call and disabled-fallback regression coverage using synthetic fixtures.

Validation: 1873 passed, 7 skipped.