### PR TITLE
fix: run web repairs as durable jobs

### DIFF
--- a/tests/test_repair_jobs.py
+++ b/tests/test_repair_jobs.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Durable question-repair lifecycle coverage."""
+
+from verinote.llm.base import LLMError
+from verinote.pipeline.repair import process_repair_job
+from verinote.pipeline.policy_state import POLICY_RELPATH, assert_writable, write_default_policy
+from verinote.store import Store
+
+
+class _OutageClient:
+    def __init__(self):
+        self.calls = 0
+
+    def extract_query_intent(self, *, question, schema_hint):
+        self.calls += 1
+        raise LLMError("synthetic provider outage")
+
+
+class _NoCallClient:
+    def extract_query_intent(self, *, question, schema_hint):
+        raise AssertionError("skipped question must not reach the provider")
+
+
+def _store(tmp_path):
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def _review_question(store, text):
+    qid = store.add_question(text)
+    store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    return qid
+
+
+def test_enqueue_repair_job_snapshots_and_reuses_live_job(tmp_path):
+    store = _store(tmp_path)
+    first = _review_question(store, "What is synthetic one?")
+    second = _review_question(store, "What is synthetic two?")
+
+    job, created = store.enqueue_repair_job(provider="fake", model="m")
+    duplicate, duplicate_created = store.enqueue_repair_job(provider="fake", model="m")
+
+    assert created is True
+    assert duplicate_created is False
+    assert int(duplicate["id"]) == int(job["id"])
+    assert [int(item["question_id"]) for item in store.repair_job_items(int(job["id"]))] == [
+        first,
+        second,
+    ]
+
+
+def test_repair_resume_never_adopts_a_live_lease(tmp_path):
+    store = _store(tmp_path)
+    _review_question(store, "What is synthetic?")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+    job_id = int(job["id"])
+
+    assert store.claim_repair_job(job_id, "live-owner")
+    assert store.repair_jobs_to_resume() == []
+
+    store._conn.execute(
+        "UPDATE repair_jobs SET lease_until = datetime('now', '-1 second') WHERE id = ?",
+        (job_id,),
+    )
+    assert [int(row["id"]) for row in store.repair_jobs_to_resume()] == [job_id]
+
+
+def test_expired_item_is_reclaimed_and_stale_owner_is_fenced(tmp_path):
+    old = _store(tmp_path)
+    new = Store(tmp_path / "kb.sqlite")
+    new.init_schema()
+    qid = _review_question(old, "What is synthetic?")
+    job, _ = old.enqueue_repair_job(provider="fake", model="m")
+    job_id = int(job["id"])
+
+    assert old.claim_repair_job(job_id, "old")
+    old_item = old.claim_next_repair_item(job_id, "old")
+    new._conn.execute(
+        "UPDATE repair_jobs SET lease_until = datetime('now', '-1 second') WHERE id = ?",
+        (job_id,),
+    )
+    assert old.renew_repair_job_lease(job_id, "old") is False
+    assert new.claim_repair_job(job_id, "new")
+
+    assert old.finish_repair_item(int(old_item["id"]), "old", status="done") is False
+    assert old.persist_repair_question(
+        job_id, int(old_item["id"]), "old", qid, "old write", "translated", ""
+    ) is False
+    wrote = []
+    assert old.write_owned_repair_query_file(
+        job_id, "old", policy_guard=lambda: None, writer=lambda: wrote.append(True)
+    ) is False
+    assert wrote == []
+    assert old.repair_job_question(qid)["status"] == "review_required"
+    reclaimed = new.claim_next_repair_item(job_id, "new")
+    assert int(reclaimed["id"]) == int(old_item["id"])
+    assert reclaimed["owner_token"] == "new"
+
+
+def test_policy_deleted_during_provider_call_leaves_job_recoverable(tmp_path):
+    store = _store(tmp_path)
+    qid = _review_question(store, "What is synthetic?")
+    write_default_policy(store, tmp_path, origin="scaffold")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+
+    class DeletingClient:
+        def extract_query_intent(self, *, question, schema_hint):
+            (tmp_path / POLICY_RELPATH).unlink()
+            raise LLMError("synthetic provider outage")
+
+    try:
+        process_repair_job(
+            store, DeletingClient(), job_id=int(job["id"]), root=tmp_path,
+            policy_guard=lambda: assert_writable(store),
+        )
+    except Exception as exc:
+        assert "policy" in str(exc).lower()
+    else:
+        raise AssertionError("deleted policy must stop the worker before persistence")
+
+    assert store.repair_job_question(qid)["status"] == "review_required"
+    assert store.get_repair_job(int(job["id"]))["status"] == "running"
+    assert store.repair_job_items(int(job["id"]))[0]["status"] == "running"
+
+
+def test_query_file_failure_is_retried_without_recalling_completed_question(
+    tmp_path, monkeypatch, fake_client, intent_payload,
+):
+    import verinote.pipeline.repair as repair
+
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    _review_question(store, "Where was Sample Person born?")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+    client = fake_client(intent=intent_payload("lookup_object", subject="Sample Person", relation="born_in"))
+    original_writer = repair.write_query_file
+    monkeypatch.setattr(repair, "write_query_file", lambda store, root: (_ for _ in ()).throw(OSError("synthetic disk full")))
+
+    process_repair_job(store, client, job_id=int(job["id"]), root=tmp_path)
+
+    assert store.get_repair_job(int(job["id"]))["status"] == "pending"
+    assert store.repair_job_items(int(job["id"]))[0]["status"] == "done"
+    monkeypatch.setattr(repair, "write_query_file", original_writer)
+    process_repair_job(store, _NoCallClient(), job_id=int(job["id"]), root=tmp_path)
+    assert store.get_repair_job(int(job["id"]))["status"] == "done"
+
+
+def test_provider_failure_stops_after_first_snapshot_item(tmp_path):
+    store = _store(tmp_path)
+    _review_question(store, "What is synthetic one?")
+    _review_question(store, "What is synthetic two?")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+    client = _OutageClient()
+
+    process_repair_job(store, client, job_id=int(job["id"]), root=tmp_path)
+
+    assert client.calls == 1
+    saved = store.get_repair_job(int(job["id"]))
+    assert saved["status"] == "failed"
+    assert [item["status"] for item in store.repair_job_items(int(job["id"]))] == [
+        "failed",
+        "pending",
+    ]
+
+
+def test_repair_job_skips_deleted_and_no_longer_review_question(tmp_path):
+    store = _store(tmp_path)
+    deleted = _review_question(store, "What is deleted?")
+    changed = _review_question(store, "What is changed?")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+    store.delete_question(deleted)
+    store.set_question_query(changed, None, "no_answer", "already resolved")
+
+    process_repair_job(store, _NoCallClient(), job_id=int(job["id"]), root=tmp_path)
+
+    saved = store.get_repair_job(int(job["id"]))
+    assert saved["status"] == "done"
+    assert int(saved["skipped_items"]) == 2
+    assert [item["status"] for item in store.repair_job_items(int(job["id"]))] == [
+        "skipped",
+        "skipped",
+    ]
+
+
+def test_repair_job_processes_the_enqueued_snapshot(tmp_path, fake_client, intent_payload):
+    store = _store(tmp_path)
+    store.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    first = _review_question(store, "Where was Sample Person born?")
+    second = _review_question(store, "Where was Sample Person born again?")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+    client = fake_client(
+        intent=intent_payload("lookup_object", subject="Sample Person", relation="born_in")
+    )
+
+    process_repair_job(store, client, job_id=int(job["id"]), root=tmp_path)
+
+    assert store.get_repair_job(int(job["id"]))["status"] == "done"
+    assert [item["status"] for item in store.repair_job_items(int(job["id"]))] == [
+        "done",
+        "done",
+    ]
+    assert [store.repair_job_question(qid)["status"] for qid in (first, second)] == [
+        "translated",
+        "translated",
+    ]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3141,6 +3141,7 @@ def test_questions_page_recovers_reason_from_non_executable_query(tmp_path):
 
 
 def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client, intent_payload):
+    import time
     monkeypatch.setattr(
         webapp,
         "get_client",
@@ -3160,7 +3161,80 @@ def test_repair_action_accepts_valid_fix(tmp_path, monkeypatch, fake_client, int
 
     r = c.post("/questions/repair", follow_redirects=False)
     assert r.status_code == 303
+    for _ in range(100):
+        if store.questions()[0]["status"] == "translated":
+            break
+        time.sleep(0.01)
     assert store.questions()[0]["status"] == "translated"
+
+
+def test_repair_post_enqueues_without_constructing_a_client(tmp_path, monkeypatch):
+    class ThreadRecorder:
+        def __init__(self):
+            self.started = []
+
+        def Thread(self, *, target, name, daemon):  # noqa: N802 - threading API
+            recorder = self
+
+            class Handle:
+                def start(self):
+                    recorder.started.append(name)
+
+            return Handle()
+
+    recorder = ThreadRecorder()
+    monkeypatch.setattr(webapp, "threading", recorder)
+    monkeypatch.setattr(
+        webapp, "get_client", lambda cfg: (_ for _ in ()).throw(AssertionError("request called LLM"))
+    )
+    c = _client(tmp_path)
+    store = c.app.state.store
+    _id = store.add_question("What is synthetic?")
+    store.set_question_query(_id, 'review_required("synthetic")', "review_required")
+
+    response = c.post("/questions/repair", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert recorder.started == ["verinote-question-repair-1"]
+    assert store.latest_repair_job()["status"] == "pending"
+
+
+def test_questions_page_shows_live_repair_progress_and_terminal_failure(tmp_path):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    qid = store.add_question("What is synthetic?")
+    store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+
+    live = c.get("/questions").text
+    assert "Repair job #1: pending" in live
+    assert 'hx-trigger="every 2s"' in live
+
+    store.fail_pending_repair_job(int(job["id"]), "Repair failed: synthetic provider outage")
+    terminal = c.get("/questions").text
+    assert "synthetic provider outage" in terminal
+    assert 'hx-trigger="every 2s"' not in terminal
+
+
+def test_questions_progress_counts_real_failed_item(tmp_path):
+    from verinote.pipeline.repair import process_repair_job
+
+    class OutageClient:
+        def extract_query_intent(self, *, question, schema_hint):
+            raise LLMError("synthetic provider outage")
+
+    c = _client(tmp_path)
+    store = c.app.state.store
+    for text in ("What is synthetic one?", "What is synthetic two?"):
+        qid = store.add_question(text)
+        store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+    process_repair_job(store, OutageClient(), job_id=int(job["id"]), root=tmp_path)
+
+    body = c.get("/questions").text
+    assert "Repair job #1: failed" in body
+    assert "1/2 processed" in body
+    assert "synthetic provider outage" in body
 
 
 def test_settings_page_renders(tmp_path):

--- a/verinote/pipeline/__init__.py
+++ b/verinote/pipeline/__init__.py
@@ -27,7 +27,7 @@ from verinote.pipeline.ingest import (
     supported_suffixes,
 )
 from verinote.pipeline.query import translate_questions, write_query_file
-from verinote.pipeline.repair import repair_questions
+from verinote.pipeline.repair import process_repair_job, repair_question, repair_questions
 from verinote.pipeline.trust import fact_trust_summary
 from verinote.pipeline.verify import verify
 
@@ -53,5 +53,7 @@ __all__ = [
     "translate_questions",
     "write_query_file",
     "repair_questions",
+    "repair_question",
+    "process_repair_job",
     "fact_trust_summary",
 ]

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -53,6 +53,7 @@ class _QueryFlowResult:
     query_dl: str | None
     reason: str
     allow_direct_datalog_fallback: bool = False
+    provider_failed: bool = False
 
 
 def query_path(root: Path) -> Path:
@@ -239,6 +240,7 @@ def _schema_aware_query_flow_result(
                 "review_required",
                 f"review_required({_lit(reason)})",
                 reason,
+                provider_failed=True,
             )
 
     if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
@@ -323,15 +325,17 @@ def _translate_direct_datalog_fallback(
     qid: int,
     question: str,
     llm_error_status: str,
-) -> tuple[str, str | None, str]:
+) -> _QueryFlowResult:
     try:
         line = client.translate_query(question=question, qid=qid)
     except LLMError as exc:
         reason = _short_reason(exc)
         if llm_error_status == "translation_failed":
-            return "translation_failed", None, reason
+            return _QueryFlowResult("translation_failed", None, reason, provider_failed=True)
         reason = _short_reason(f"llm error: {exc}")
-        return "review_required", f"review_required({_lit(reason)})", reason
+        return _QueryFlowResult(
+            "review_required", f"review_required({_lit(reason)})", reason, provider_failed=True
+        )
 
     outcome = _non_executable_outcome(line)
     if outcome is None and _is_review_required(line):
@@ -346,9 +350,10 @@ def _translate_direct_datalog_fallback(
         # engine-derived `no_answer`/`ambiguous` (the candidate dry-run finding
         # no rows) keep those statuses.
         reason = _short_reason(f"unvalidated model claim: {declared}: {claim}")
-        return "review_required", f"review_required({_lit(reason)})", reason
+        return _QueryFlowResult("review_required", f"review_required({_lit(reason)})", reason)
     proposal = f".decl {ANSWER_PREFIX}{qid}(value: symbol)\n{line}"
-    return classify_query_draft(store, qid, proposal)
+    status, query_dl, reason = classify_query_draft(store, qid, proposal)
+    return _QueryFlowResult(status, query_dl, reason)
 
 
 def _evaluation_reason(evaluation) -> str:
@@ -393,13 +398,14 @@ def translate_questions(
             and status == "review_required"
             and flow.allow_direct_datalog_fallback
         ):
-            status, query_dl, reason = _translate_direct_datalog_fallback(
+            fallback = _translate_direct_datalog_fallback(
                 store,
                 client,
                 qid=q["id"],
                 question=q["text"],
                 llm_error_status="translation_failed",
             )
+            status, query_dl, reason = fallback.status, fallback.query_dl, fallback.reason
         store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
             {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from dataclasses import dataclass
+import threading
+from uuid import uuid4
 
 from verinote.llm.base import LLMClient
 from verinote.pipeline.query import (
@@ -19,8 +22,82 @@ from verinote.pipeline.query import (
     write_query_file,
 )
 from verinote.store import Store
+from verinote.pipeline.policy_state import PolicyMissingError
 
 _log = logging.getLogger("verinote.repair")
+
+
+@dataclass(frozen=True)
+class RepairQuestionResult:
+    id: int
+    accepted: bool
+    reason: str
+    provider_failed: bool = False
+
+
+@dataclass(frozen=True)
+class _PreparedRepair:
+    result: RepairQuestionResult
+    status: str
+    query_dl: str | None
+
+
+def _prepare_repair_question(
+    store: Store, client: LLMClient, *, question_id: int, question: str,
+    previous_query_dl: str | None, allow_direct_datalog_fallback: bool = True,
+) -> _PreparedRepair:
+    """Run the shared repair decision without committing its result."""
+    flow = _schema_aware_query_flow_result(
+        store, client, qid=question_id, question=question, llm_error_status="review_required"
+    )
+    if (
+        allow_direct_datalog_fallback
+        and flow.status == "review_required"
+        and flow.allow_direct_datalog_fallback
+    ):
+        flow = _translate_direct_datalog_fallback(
+            store, client, qid=question_id, question=question, llm_error_status="review_required"
+        )
+    query_dl = flow.query_dl
+    if flow.status == "review_required" and query_dl is not None and flow.provider_failed:
+        query_dl = previous_query_dl
+    accepted = flow.status == "translated"
+    return _PreparedRepair(
+        RepairQuestionResult(question_id, accepted, "" if accepted else flow.reason, flow.provider_failed),
+        flow.status,
+        query_dl,
+    )
+
+
+def repair_question(
+    store: Store,
+    client: LLMClient,
+    *,
+    question_id: int,
+    question: str,
+    root: Path,
+    allow_direct_datalog_fallback: bool = True,
+) -> RepairQuestionResult:
+    """Repair one current question and persist its engine-gated outcome.
+
+    ``provider_failed`` is deliberately structured metadata, rather than a
+    conclusion drawn from the human-facing reason string. Job workers use it to
+    stop after the first provider failure while the synchronous CLI retains its
+    historic all-question behavior.
+    """
+    previous = store.repair_job_question(question_id)
+    prepared = _prepare_repair_question(
+        store, client, question_id=question_id, question=question,
+        previous_query_dl=previous["query_dl"] if previous is not None else None,
+        allow_direct_datalog_fallback=allow_direct_datalog_fallback,
+    )
+    store.set_question_query(
+        question_id, prepared.query_dl, prepared.status, prepared.result.reason
+    )
+    write_query_file(store, root)
+    if not prepared.result.accepted:
+        _log.warning("repair q%d kept %s: %s", question_id, prepared.status, prepared.result.reason)
+    return prepared.result
 
 
 def repair_questions(
@@ -50,39 +127,120 @@ def repair_questions(
         if q["status"] != "review_required":
             continue
         qid = q["id"]
-        flow = _schema_aware_query_flow_result(
-            store,
-            client,
-            qid=qid,
-            question=q["text"],
-            llm_error_status="review_required",
+        result = repair_question(
+            store, client, question_id=qid, question=q["text"], root=root,
+            allow_direct_datalog_fallback=allow_direct_datalog_fallback,
         )
-        status, query_dl, reason = flow.status, flow.query_dl, flow.reason
-        if (
-            allow_direct_datalog_fallback
-            and status == "review_required"
-            and flow.allow_direct_datalog_fallback
-        ):
-            status, query_dl, reason = _translate_direct_datalog_fallback(
-                store,
-                client,
-                qid=qid,
-                question=q["text"],
-                llm_error_status="review_required",
-            )
-        if (
-            status == "review_required"
-            and query_dl is not None
-            and reason.startswith("llm error:")
-        ):
-            query_dl = q["query_dl"]
-        store.set_question_query(qid, query_dl, status, reason)
-        accepted = status == "translated"
+        accepted = result.accepted
         results.append(
-            {"id": qid, "accepted": accepted, "reason": "" if accepted else reason}
+            {"id": qid, "accepted": accepted, "reason": result.reason}
         )
-        if not accepted:
-            _log.warning("repair q%d kept %s: %s", qid, status, reason)
-
-    write_query_file(store, root)
     return results
+
+
+def process_repair_job(
+    store: Store, client: LLMClient, *, job_id: int, root: Path, policy_guard=lambda: None,
+) -> None:
+    """Process one durable snapshot sequentially, stopping on provider failure.
+
+    A heartbeat keeps normal long provider calls owned. Crash recovery is still
+    at-least-once: an expired caller may already have sent a provider request.
+    """
+    owner_token = uuid4().hex
+    if not store.claim_repair_job(job_id, owner_token):
+        return
+    stop_heartbeat = threading.Event()
+
+    def heartbeat() -> None:
+        # A second worker-owned connection avoids sharing SQLite state with the
+        # provider call. Policy is checked before this durable renewal too.
+        with Store(store.db_path) as heartbeat_store:
+            heartbeat_store.init_schema()
+            while not stop_heartbeat.wait(5):
+                try:
+                    policy_guard()
+                except PolicyMissingError:
+                    return
+                if not heartbeat_store.renew_repair_job_lease(job_id, owner_token):
+                    return
+
+    thread = threading.Thread(target=heartbeat, name=f"verinote-repair-heartbeat-{job_id}", daemon=True)
+    thread.start()
+    try:
+        while True:
+            item = store.claim_next_repair_item(job_id, owner_token)
+            if item is None:
+                try:
+                    if not store.write_owned_repair_query_file(
+                        job_id, owner_token, policy_guard=policy_guard,
+                        writer=lambda: write_query_file(store, root),
+                    ):
+                        return
+                except PolicyMissingError:
+                    raise
+                except Exception as exc:
+                    store.defer_repair_job(
+                        job_id, owner_token, f"Query draft regeneration pending: {' '.join(str(exc).split())[:200]}"
+                    )
+                    return
+                store.finish_repair_job(job_id, owner_token)
+                return
+            question = store.repair_job_question(int(item["question_id"]))
+            if question is None:
+                store.finish_repair_item(int(item["id"]), owner_token, status="skipped", reason="question deleted")
+                continue
+            if question["status"] != "review_required":
+                store.finish_repair_item(
+                    int(item["id"]), owner_token, status="skipped", reason="question no longer requires review"
+                )
+                continue
+            # This is immediately before provider work, not merely before job claim.
+            policy_guard()
+            try:
+                prepared = _prepare_repair_question(
+                    store, client, question_id=int(question["id"]), question=str(question["text"]),
+                    previous_query_dl=question["query_dl"],
+                )
+                # A policy can disappear during the provider call. Check before
+                # every DB/query-write boundary, before any result is persisted.
+                policy_guard()
+                persisted = store.persist_repair_question(
+                    job_id, int(item["id"]), owner_token, int(question["id"]),
+                    prepared.query_dl, prepared.status, prepared.result.reason,
+                )
+                if not persisted:
+                    return
+            except PolicyMissingError:
+                raise
+            except Exception as exc:
+                reason = " ".join(str(exc).split())[:240]
+                store.finish_repair_item(int(item["id"]), owner_token, status="failed", reason=reason)
+                store.finish_repair_job(job_id, owner_token, failed=True, message=f"Repair failed: {reason}")
+                raise
+            if prepared.result.provider_failed:
+                store.finish_repair_item(int(item["id"]), owner_token, status="failed", reason=prepared.result.reason)
+                store.finish_repair_job(
+                    job_id, owner_token, failed=True, message=f"Repair failed: {prepared.result.reason}"
+                )
+                return
+            store.finish_repair_item(int(item["id"]), owner_token, status="done", reason=prepared.result.reason)
+            # Keep the existing derived writer close to each committed result.
+            # If it fails, the item remains done and a later worker regenerates
+            # the file without calling that question's provider again.
+            try:
+                if not store.write_owned_repair_query_file(
+                    job_id, owner_token, policy_guard=policy_guard,
+                    writer=lambda: write_query_file(store, root),
+                ):
+                    return
+            except PolicyMissingError:
+                raise
+            except Exception as exc:
+                store.defer_repair_job(
+                    job_id, owner_token,
+                    f"Query draft regeneration pending: {' '.join(str(exc).split())[:200]}",
+                )
+                return
+    finally:
+        stop_heartbeat.set()
+        thread.join(timeout=1)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -2063,6 +2063,230 @@ class Store:
         with self._lock:
             self._conn.execute("DELETE FROM questions WHERE id = ?", (question_id,))
 
+    # --- durable question repair jobs -----------------------------------
+    def enqueue_repair_job(self, *, provider: str | None, model: str | None) -> tuple[sqlite3.Row, bool]:
+        """Create a snapshot repair pass, or return the existing live pass.
+
+        The partial unique index is the cross-process backstop; this method's
+        transaction makes the snapshot and live-job decision one operation.
+        """
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                live = self._conn.execute(
+                    "SELECT * FROM repair_jobs WHERE status IN ('pending','running') "
+                    "ORDER BY id DESC LIMIT 1"
+                ).fetchone()
+                if live is not None:
+                    self._conn.execute("COMMIT")
+                    return live, False
+                ids = [
+                    int(row["id"])
+                    for row in self._conn.execute(
+                        "SELECT id FROM questions WHERE status = 'review_required' ORDER BY id"
+                    )
+                ]
+                status = "pending" if ids else "done"
+                message = "Pending repair" if ids else "No review_required questions to repair."
+                cur = self._conn.execute(
+                    "INSERT INTO repair_jobs(status, provider, model, total_items, message) "
+                    "VALUES(?,?,?,?,?) RETURNING id",
+                    (status, provider, model, len(ids), message),
+                )
+                job_id = int(cur.fetchone()[0])
+                self._conn.executemany(
+                    "INSERT INTO repair_job_items(job_id, question_id) VALUES(?,?)",
+                    [(job_id, question_id) for question_id in ids],
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._rollback_quietly()
+                raise
+            job = self.get_repair_job(job_id)
+            assert job is not None
+            return job, True
+
+    def get_repair_job(self, job_id: int) -> sqlite3.Row | None:
+        return self._conn.execute("SELECT * FROM repair_jobs WHERE id = ?", (job_id,)).fetchone()
+
+    def latest_repair_job(self) -> sqlite3.Row | None:
+        return self._conn.execute("SELECT * FROM repair_jobs ORDER BY id DESC LIMIT 1").fetchone()
+
+    def repair_job_items(self, job_id: int) -> list[sqlite3.Row]:
+        return list(self._conn.execute("SELECT * FROM repair_job_items WHERE job_id = ? ORDER BY id", (job_id,)))
+
+    def repair_jobs_to_resume(self) -> list[sqlite3.Row]:
+        """Return pending jobs and expired leases, never an apparently live owner."""
+        return list(self._conn.execute(
+            "SELECT * FROM repair_jobs WHERE status = 'pending' OR "
+            "(status = 'running' AND lease_until IS NOT NULL AND lease_until < datetime('now')) "
+            "ORDER BY id"
+        ))
+
+    def claim_repair_job(self, job_id: int, owner_token: str) -> bool:
+        """Take an expired/pending job and reclaim its abandoned running items.
+
+        Ownership is at-least-once: a crashed owner can have already sent a
+        provider request.  The token fences every later item/question/file write.
+        """
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = self._conn.execute(
+                "UPDATE repair_jobs SET status = 'running', owner_token = ?, "
+                "lease_until = datetime('now', '+30 seconds'), updated_at = datetime('now'), "
+                "message = 'Repairing questions' WHERE id = ? AND (status = 'pending' OR "
+                "(status = 'running' AND lease_until IS NOT NULL AND lease_until < datetime('now'))) ",
+                (owner_token, job_id),
+                )
+                if cur.rowcount != 1:
+                    self._conn.execute("ROLLBACK")
+                    return False
+                self._conn.execute(
+                    "UPDATE repair_job_items SET status = 'pending', owner_token = NULL, "
+                    "updated_at = datetime('now') WHERE job_id = ? AND status = 'running'",
+                    (job_id,),
+                )
+                self._conn.execute("COMMIT")
+                return True
+            except Exception:
+                self._rollback_quietly()
+                raise
+
+    def renew_repair_job_lease(self, job_id: int, owner_token: str) -> bool:
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE repair_jobs SET lease_until = datetime('now', '+30 seconds'), "
+                "updated_at = datetime('now') WHERE id = ? AND status = 'running' AND owner_token = ? "
+                "AND lease_until >= datetime('now')",
+                (job_id, owner_token),
+            )
+            return cur.rowcount == 1
+
+    def claim_next_repair_item(self, job_id: int, owner_token: str) -> sqlite3.Row | None:
+        """CAS-claim one snapshot item. A job owner still claims items explicitly."""
+        with self._lock:
+            if not self.renew_repair_job_lease(job_id, owner_token):
+                return None
+            row = self._conn.execute(
+                "SELECT * FROM repair_job_items WHERE job_id = ? AND status = 'pending' ORDER BY id LIMIT 1",
+                (job_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            cur = self._conn.execute(
+                "UPDATE repair_job_items SET status = 'running', owner_token = ?, "
+                "updated_at = datetime('now') WHERE id = ? AND status = 'pending' "
+                "AND EXISTS (SELECT 1 FROM repair_jobs WHERE id = ? AND status = 'running' "
+                "AND owner_token = ? AND lease_until >= datetime('now'))",
+                (owner_token, row["id"], job_id, owner_token),
+            )
+            if cur.rowcount != 1:
+                return None
+            return self._conn.execute("SELECT * FROM repair_job_items WHERE id = ?", (row["id"],)).fetchone()
+
+    def repair_job_question(self, question_id: int) -> sqlite3.Row | None:
+        return self._conn.execute("SELECT * FROM questions WHERE id = ?", (question_id,)).fetchone()
+
+    def finish_repair_item(self, item_id: int, owner_token: str, *, status: str, reason: str = "") -> bool:
+        if status not in {"done", "skipped", "failed"}:
+            raise ValueError(f"unknown repair item status: {status}")
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE repair_job_items SET status = ?, reason = ?, owner_token = NULL, "
+                "updated_at = datetime('now') WHERE id = ? AND status = 'running' AND owner_token = ? "
+                "AND EXISTS (SELECT 1 FROM repair_jobs WHERE id = repair_job_items.job_id "
+                "AND status = 'running' AND owner_token = ? AND lease_until >= datetime('now'))",
+                (status, reason, item_id, owner_token, owner_token),
+            )
+            return cur.rowcount == 1
+
+    def persist_repair_question(
+        self, job_id: int, item_id: int, owner_token: str, question_id: int,
+        query_dl: str | None, status: str, reason: str,
+    ) -> bool:
+        """Persist only while this worker still owns the running snapshot item."""
+        if status not in QUESTION_STATUSES:
+            raise ValueError(f"unknown question status: {status}")
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE questions SET query_dl = ?, status = ?, reason = ? WHERE id = ? "
+                "AND status = 'review_required' AND EXISTS (SELECT 1 FROM repair_job_items "
+                "WHERE id = ? AND job_id = ? AND status = 'running' AND owner_token = ?) "
+                "AND EXISTS (SELECT 1 FROM repair_jobs WHERE id = ? AND status = 'running' "
+                "AND owner_token = ? AND lease_until >= datetime('now'))",
+                (query_dl, status, reason, question_id, item_id, job_id, owner_token, job_id, owner_token),
+            )
+            return cur.rowcount == 1
+
+    def write_owned_repair_query_file(self, job_id: int, owner_token: str, *, policy_guard, writer) -> bool:
+        """Fence the derived-file boundary against a reclaimed owner.
+
+        This intentionally uses the existing writer; it does not attempt #388's
+        cross-process publication redesign.  The short SQLite write transaction
+        simply prevents a new owner from claiming between the ownership check and
+        this workflow's derived-file regeneration.
+        """
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                owned = self._conn.execute(
+                    "SELECT 1 FROM repair_jobs WHERE id = ? AND status = 'running' AND owner_token = ? "
+                    "AND lease_until >= datetime('now')",
+                    (job_id, owner_token),
+                ).fetchone()
+                if owned is None:
+                    self._conn.execute("ROLLBACK")
+                    return False
+                policy_guard()
+                writer()
+                self._conn.execute("COMMIT")
+                return True
+            except Exception:
+                self._rollback_quietly()
+                raise
+
+    def finish_repair_job(self, job_id: int, owner_token: str, *, failed: bool = False, message: str = "") -> None:
+        with self._lock:
+            counts = self._conn.execute(
+                "SELECT SUM(status = 'done') AS done, SUM(status = 'skipped') AS skipped, "
+                "SUM(status = 'failed') AS failed FROM repair_job_items WHERE job_id = ?", (job_id,)
+            ).fetchone()
+            done = int(counts["done"] or 0)
+            skipped = int(counts["skipped"] or 0)
+            failed_items = int(counts["failed"] or 0)
+            status = "failed" if failed else "done"
+            if not message:
+                message = (f"Repair failed: {failed_items} item(s) failed" if failed else
+                           f"Repair complete: {done} repaired, {skipped} skipped")
+            self._conn.execute(
+                "UPDATE repair_jobs SET status = ?, completed_items = ?, skipped_items = ?, "
+                "failed_items = ?, message = ?, lease_until = NULL, updated_at = datetime('now') "
+                "WHERE id = ? AND status = 'running' AND owner_token = ? "
+                "AND lease_until >= datetime('now')",
+                (status, done + skipped + failed_items, skipped, failed_items, message, job_id, owner_token),
+            )
+
+    def defer_repair_job(self, job_id: int, owner_token: str, message: str) -> bool:
+        """Release a job whose derived query file needs a later regeneration."""
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE repair_jobs SET status = 'pending', owner_token = NULL, lease_until = NULL, "
+                "message = ?, updated_at = datetime('now') WHERE id = ? AND status = 'running' "
+                "AND owner_token = ? AND lease_until >= datetime('now')",
+                (message, job_id, owner_token),
+            )
+            return cur.rowcount == 1
+
+    def fail_pending_repair_job(self, job_id: int, message: str) -> None:
+        """Expose a pre-claim worker setup failure without adopting a live job."""
+        with self._lock:
+            self._conn.execute(
+                "UPDATE repair_jobs SET status = 'failed', message = ?, updated_at = datetime('now') "
+                "WHERE id = ? AND status = 'pending'",
+                (message, job_id),
+            )
+
     # --- audit -----------------------------------------------------------
     def fact_log(self, fact_id: int) -> list[sqlite3.Row]:
         """Audit trail (oldest first) for one fact — drives the provenance view."""
@@ -2414,6 +2638,11 @@ class Store:
             """
         )
         self._ensure_question_schema()
+        repair_item_columns = {
+            row["name"] for row in self._conn.execute("PRAGMA table_info(repair_job_items)")
+        }
+        if repair_item_columns and "owner_token" not in repair_item_columns:
+            self._conn.execute("ALTER TABLE repair_job_items ADD COLUMN owner_token TEXT")
 
     def _ensure_question_schema(self) -> None:
         columns = {

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -208,6 +208,47 @@ CREATE TABLE IF NOT EXISTS questions (
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Durable, KB-scoped repair passes.  Unlike extraction jobs these snapshot
+-- question ids, because repairing is a question lifecycle operation and must
+-- never borrow source-analysis ownership or progress.
+CREATE TABLE IF NOT EXISTS repair_jobs (
+    id              INTEGER PRIMARY KEY,
+    status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending','running','done','failed')),
+    provider        TEXT,
+    model           TEXT,
+    total_items     INTEGER NOT NULL DEFAULT 0,
+    completed_items INTEGER NOT NULL DEFAULT 0,
+    skipped_items   INTEGER NOT NULL DEFAULT 0,
+    failed_items    INTEGER NOT NULL DEFAULT 0,
+    message         TEXT NOT NULL DEFAULT '',
+    owner_token     TEXT,
+    lease_until     TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- question_id intentionally has no FK: a user may delete a snapshot question
+-- while the job is queued, and the worker records that item as skipped.
+CREATE TABLE IF NOT EXISTS repair_job_items (
+    id          INTEGER PRIMARY KEY,
+    job_id      INTEGER NOT NULL REFERENCES repair_jobs(id) ON DELETE CASCADE,
+    question_id INTEGER NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending','running','done','skipped','failed')),
+    owner_token TEXT,
+    reason      TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(job_id, question_id)
+);
+
+-- One live repair pass per KB. Terminal history remains available for display.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_jobs_one_live
+    ON repair_jobs(status) WHERE status IN ('pending','running');
+CREATE INDEX IF NOT EXISTS idx_repair_job_items_status
+    ON repair_job_items(job_id, status, id);
+
 -- Append-only audit of human review decisions (toggle/accept/reject/amend),
 -- mirroring the "decisions are preserved" property of the borrowed concept.
 CREATE TABLE IF NOT EXISTS review_log (

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -11,6 +11,7 @@ from importlib import resources
 import logging
 from pathlib import Path
 import threading
+from threading import Lock
 import unicodedata
 from urllib.parse import urlencode
 
@@ -41,9 +42,9 @@ from verinote.pipeline import (
     is_live_extraction_job,
     latest_source_job_ids,
     process_extraction_job,
+    process_repair_job,
     store_source,
     supported_suffixes,
-    repair_questions,
     translate_questions,
     verify,
     write_query_file,
@@ -142,6 +143,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app = FastAPI(title="verinote")
     app.state.cfg = cfg
     app.state.store = None
+    app.state.repair_scheduler_lock = Lock()
+    app.state.repair_scheduled = set()
     if cfg is not None:
         store = Store(cfg.db_path)
         store.init_schema()
@@ -1080,6 +1083,65 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 )
             _start_source_extraction(int(job["id"]), app.state.cfg)
 
+    def _start_repair_job(job_id: int, cfg: Config) -> None:
+        """Schedule durable repair work; the request path never reaches an LLM."""
+        assert_settings_intact(cfg)
+
+        with app.state.repair_scheduler_lock:
+            if job_id in app.state.repair_scheduled:
+                return
+            app.state.repair_scheduled.add(job_id)
+
+        def run() -> None:
+            try:
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    # Repeat both gates in the worker: settings and policy may have
+                    # changed after enqueue but before this daemon gets CPU time.
+                    assert_settings_intact(cfg)
+                    assert_writable(worker_store)
+                    client = get_client(cfg)
+                    process_repair_job(
+                        worker_store, client, job_id=job_id, root=cfg.root,
+                        policy_guard=lambda: assert_writable(worker_store),
+                    )
+            except PolicyMissingError as exc:
+                # Do not write a halted KB merely to annotate a background job.
+                logger.warning("repair job %s halted (KB policy missing): %s", job_id, exc)
+            except ConfigCorruptError as exc:
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    worker_store.fail_pending_repair_job(job_id, f"repair failed: {exc}")
+            except LLMError as exc:
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    worker_store.fail_pending_repair_job(job_id, f"repair failed: {exc}")
+            except Exception as exc:  # noqa: BLE001 - durable UI-visible worker error
+                logger.exception("repair job %s failed", job_id)
+                with Store(cfg.db_path) as worker_store:
+                    worker_store.init_schema()
+                    worker_store.fail_pending_repair_job(job_id, f"repair failed: {_short_error(exc)}")
+            finally:
+                with app.state.repair_scheduler_lock:
+                    app.state.repair_scheduled.discard(job_id)
+
+        threading.Thread(
+            target=run, name=f"verinote-question-repair-{job_id}", daemon=True
+        ).start()
+
+    def _resume_repair_jobs() -> None:
+        """Schedule only pending or expired-lease repair jobs, never live owners."""
+        if app.state.store is None or app.state.cfg is None:
+            return
+        try:
+            assert_settings_intact(app.state.cfg)
+            assert_writable(app.state.store)
+        except (ConfigCorruptError, PolicyMissingError) as exc:
+            logger.warning("not resuming repair jobs: %s", exc)
+            return
+        for job in app.state.store.repair_jobs_to_resume():
+            _start_repair_job(int(job["id"]), app.state.cfg)
+
     @app.get("/", response_class=HTMLResponse)
     def dashboard(request: Request):
         return _dashboard(request)
@@ -1424,6 +1486,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "questions": [question_outcome_view(q) for q in store.questions()],
                 "answers": rep.answers,
                 "error": page_error,
+                "repair_job": store.latest_repair_job(),
             },
             status_code=status_code,
         )
@@ -1492,11 +1555,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def repair(request: Request):
         store = _active_store()
         cfg = _active_cfg()
-        try:
-            client = get_client(app.state.cfg)
-        except LLMError as e:
-            return _questions(request, error=f"repair failed: {e}", status_code=502)
-        repair_questions(store, client, root=cfg.root)
+        # This is intentionally the only synchronous validation. Constructing a
+        # client can touch provider configuration; LLM work belongs to the worker.
+        assert_settings_intact(cfg)
+        job, _created = store.enqueue_repair_job(provider=cfg.provider, model=cfg.model)
+        if job["status"] == "pending":
+            _start_repair_job(int(job["id"]), cfg)
         return RedirectResponse("/questions", status_code=303)
 
     @app.get("/report", response_class=HTMLResponse)
@@ -1681,6 +1745,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
 
     _resume_source_extraction_jobs()
+    _resume_repair_jobs()
 
     return app
 

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -25,8 +25,17 @@
   </button>
 </p>
 
+{% if repair_job %}
+<section id="repair-progress"{% if repair_job.status in ('pending', 'running') %} hx-get="/questions" hx-trigger="every 2s" hx-target="body" hx-swap="outerHTML"{% endif %}>
+  <p class="muted">Repair job #{{ repair_job.id }}: {{ repair_job.status }}
+    ({{ repair_job.completed_items }}/{{ repair_job.total_items }} processed{% if repair_job.skipped_items %}, {{ repair_job.skipped_items }} skipped{% endif %}{% if repair_job.failed_items %}, {{ repair_job.failed_items }} failed{% endif %}).
+    {% if repair_job.message %}{{ repair_job.message }}{% endif %}
+  </p>
+</section>
+{% endif %}
+
 {% if questions %}
-<table class="counts">
+<table id="questions-table" class="counts">
   <thead><tr><th>#</th><th>Question</th><th>Outcome</th><th>Query</th><th>Actions</th></tr></thead>
   <tbody>
     {% for q in questions %}


### PR DESCRIPTION
Closes #295

Moves web review repair into a durable, single-owner background job. The request returns immediately, duplicate clicks reuse a live job, progress is visible while work runs, and a provider failure stops the job after one failed item.

The worker uses owner fencing, an expiring heartbeat lease, policy checks at provider and write boundaries, and recovery that does not repeat completed provider calls. CLI repair remains synchronous.

Follow-up #388 tracks atomic cross-process publication for every query.dl writer.

Validation: 1884 passed, 7 skipped.