### PR TITLE
fix: publish query drafts atomically

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 import unicodedata
+import os
+import stat
+import threading
 
 import pytest
 
@@ -10,7 +13,9 @@ from verinote.pipeline.query import (
     query_path,
     query_schema_hint,
     translate_questions,
+    write_query_file,
 )
+import verinote.pipeline.query as query_module
 from verinote.pipeline.corroboration import CorroborationPolicyError
 from verinote.pipeline.query_intent import deterministic_query_intent
 from verinote.store import Store
@@ -52,6 +57,212 @@ def test_translate_persists_query_and_writes_file(tmp_path, fake_client, intent_
     assert draft.is_file()
     assert load_query(s) == draft.read_text(encoding="utf-8")
     assert f"answer_q{qid}" in load_query(s)
+
+
+def _translated_question(store: Store, text: str, rule: str) -> int:
+    qid = store.add_question(text)
+    store.set_question_query(qid, rule, "translated")
+    return qid
+
+
+def test_query_file_publishers_from_independent_stores_serialize(tmp_path, monkeypatch):
+    first = _store(tmp_path)
+    second = Store(tmp_path / "kb.sqlite")
+    second.init_schema()
+    _translated_question(first, "Synthetic one?", ".decl answer_q1()\nanswer_q1().")
+    _translated_question(first, "Synthetic two?", ".decl answer_q2()\nanswer_q2().")
+
+    entered_replace = threading.Event()
+    release_replace = threading.Event()
+    original_replace = os.replace
+
+    def paused_replace(source, destination):
+        entered_replace.set()
+        assert release_replace.wait(2)
+        original_replace(source, destination)
+
+    monkeypatch.setattr("verinote.pipeline.query.os.replace", paused_replace)
+    first_done = threading.Event()
+    second_done = threading.Event()
+    t1 = threading.Thread(target=lambda: (write_query_file(first, tmp_path), first_done.set()))
+    t2 = threading.Thread(target=lambda: (write_query_file(second, tmp_path), second_done.set()))
+    t1.start()
+    assert entered_replace.wait(2)
+    t2.start()
+    assert not second_done.wait(0.1)
+    release_replace.set()
+    t1.join(2)
+    t2.join(2)
+    assert first_done.is_set() and second_done.is_set()
+    expected = "\n".join(q["query_dl"] for q in second.questions() if q["status"] == "translated") + "\n"
+    assert query_path(tmp_path).read_text(encoding="utf-8") == expected
+
+
+def test_query_file_readers_keep_old_complete_output_while_staging(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    path = query_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("old complete output\n", encoding="utf-8")
+    entered_replace = threading.Event()
+    release_replace = threading.Event()
+    original_replace = os.replace
+
+    def paused_replace(source, destination):
+        entered_replace.set()
+        assert release_replace.wait(2)
+        original_replace(source, destination)
+
+    monkeypatch.setattr("verinote.pipeline.query.os.replace", paused_replace)
+    thread = threading.Thread(target=lambda: write_query_file(store, tmp_path))
+    thread.start()
+    assert entered_replace.wait(2)
+    assert path.read_text(encoding="utf-8") == "old complete output\n"
+    release_replace.set()
+    thread.join(2)
+    assert not thread.is_alive()
+
+
+@pytest.mark.parametrize("failure", ["fsync", "replace"])
+def test_query_file_staging_or_replace_failure_keeps_existing_output_and_cleans_temp(
+    tmp_path, monkeypatch, failure
+):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    path = query_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("old complete output\n", encoding="utf-8")
+    if failure == "fsync":
+        monkeypatch.setattr("verinote.pipeline.query.os.fsync", lambda *_: (_ for _ in ()).throw(OSError("synthetic")))
+    else:
+        monkeypatch.setattr("verinote.pipeline.query.os.replace", lambda *_: (_ for _ in ()).throw(OSError("synthetic")))
+
+    with pytest.raises(OSError, match="synthetic"):
+        write_query_file(store, tmp_path)
+
+    assert path.read_text(encoding="utf-8") == "old complete output\n"
+    assert not list(path.parent.glob(".query.dl.*"))
+
+
+def test_query_file_preserves_existing_mode(tmp_path):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    path = query_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("old\n", encoding="utf-8")
+    path.chmod(0o640)
+
+    write_query_file(store, tmp_path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+def test_query_file_uses_0644_for_new_file(tmp_path):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+
+    path = write_query_file(store, tmp_path)
+
+    assert path is not None
+    assert stat.S_IMODE(path.stat().st_mode) == 0o644
+
+
+def test_query_file_mode_does_not_require_fchmod(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    monkeypatch.delattr(query_module.os, "fchmod", raising=False)
+
+    path = write_query_file(store, tmp_path)
+
+    assert path is not None
+    assert stat.S_IMODE(path.stat().st_mode) == 0o644
+
+
+def test_query_file_applies_mode_before_staged_file_fsync(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    calls = []
+    original_chmod = os.chmod
+    original_fsync = os.fsync
+
+    def record_chmod(*args):
+        calls.append("chmod")
+        return original_chmod(*args)
+
+    def record_fsync(*args):
+        calls.append("fsync")
+        return original_fsync(*args)
+
+    monkeypatch.setattr(query_module.os, "chmod", record_chmod)
+    monkeypatch.setattr(query_module.os, "fsync", record_fsync)
+
+    write_query_file(store, tmp_path)
+
+    assert calls.index("chmod") < calls.index("fsync")
+
+
+def test_directory_fsync_is_called_after_query_file_replacement(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    calls = []
+    monkeypatch.setattr(query_module, "_fsync_directory", lambda path: calls.append(path))
+
+    write_query_file(store, tmp_path)
+
+    assert calls == [query_path(tmp_path).parent]
+
+
+def test_directory_fsync_skips_platforms_without_directory_open_support(tmp_path, monkeypatch):
+    monkeypatch.delattr(query_module.os, "O_DIRECTORY", raising=False)
+    monkeypatch.setattr(query_module.os, "open", lambda *_: pytest.fail("directory must not be opened"))
+
+    query_module._fsync_directory(tmp_path)
+
+
+def test_directory_fsync_ignores_unsupported_sync_error(tmp_path, monkeypatch):
+    closed = []
+    monkeypatch.setattr(query_module.os, "open", lambda *_: 42)
+    monkeypatch.setattr(
+        query_module.os,
+        "fsync",
+        lambda _: (_ for _ in ()).throw(OSError(query_module.errno.EINVAL, "unsupported")),
+    )
+    monkeypatch.setattr(query_module.os, "close", closed.append)
+
+    query_module._fsync_directory(tmp_path)
+
+    assert closed == [42]
+
+
+def test_directory_fsync_propagates_supported_platform_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(query_module.os, "open", lambda *_: 42)
+    monkeypatch.setattr(
+        query_module.os,
+        "fsync",
+        lambda _: (_ for _ in ()).throw(OSError(query_module.errno.EIO, "synthetic")),
+    )
+    monkeypatch.setattr(query_module.os, "close", lambda _: None)
+
+    with pytest.raises(OSError, match="synthetic"):
+        query_module._fsync_directory(tmp_path)
+
+
+def test_directory_fsync_failure_reports_failed_publish_after_replace(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _translated_question(store, "Synthetic?", ".decl answer_q1()\nanswer_q1().")
+    path = query_path(tmp_path)
+    path.parent.mkdir()
+    path.write_text("old complete output\n", encoding="utf-8")
+    monkeypatch.setattr(
+        query_module,
+        "_fsync_directory",
+        lambda _: (_ for _ in ()).throw(OSError("synthetic directory fsync failure")),
+    )
+
+    with pytest.raises(OSError, match="directory fsync failure"):
+        write_query_file(store, tmp_path)
+
+    assert path.read_text(encoding="utf-8") == ".decl answer_q1()\nanswer_q1().\n"
 
 
 def test_translate_survives_a_reason_on_a_well_classified_intent(

--- a/tests/test_repair_jobs.py
+++ b/tests/test_repair_jobs.py
@@ -87,15 +87,22 @@ def test_expired_item_is_reclaimed_and_stale_owner_is_fenced(tmp_path):
     assert old.persist_repair_question(
         job_id, int(old_item["id"]), "old", qid, "old write", "translated", ""
     ) is False
-    wrote = []
-    assert old.write_owned_repair_query_file(
-        job_id, "old", policy_guard=lambda: None, writer=lambda: wrote.append(True)
-    ) is False
-    assert wrote == []
+    from verinote.pipeline.query import write_query_file
+
+    assert write_query_file(
+        old,
+        tmp_path,
+        publication_guard=lambda conn: Store.repair_query_publication_owned(conn, job_id, "old"),
+    ) is None
     assert old.repair_job_question(qid)["status"] == "review_required"
     reclaimed = new.claim_next_repair_item(job_id, "new")
     assert int(reclaimed["id"]) == int(old_item["id"])
     assert reclaimed["owner_token"] == "new"
+    assert write_query_file(
+        new,
+        tmp_path,
+        publication_guard=lambda conn: Store.repair_query_publication_owned(conn, job_id, "new"),
+    ) == tmp_path / "facts" / "query.dl"
 
 
 def test_policy_deleted_during_provider_call_leaves_job_recoverable(tmp_path):

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -12,10 +12,16 @@ evaluation. Non-executable outcomes are tracked in the DB only.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import errno
 from itertools import product
+import os
 from pathlib import Path
 import re
+import sqlite3
+import stat
+import tempfile
 import unicodedata
+from typing import Callable
 
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
 from verinote.engine.terms import Atom, StringLit, render_term
@@ -58,6 +64,42 @@ class _QueryFlowResult:
 
 def query_path(root: Path) -> Path:
     return root / QUERY_RELPATH
+
+
+_UNSUPPORTED_DIRECTORY_SYNC_ERRORS = frozenset(
+    {
+        errno.EINVAL,
+        errno.ENOTSUP,
+        errno.EOPNOTSUPP,
+    }
+)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist a replacement's directory entry where the platform supports it."""
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if directory_flag is None:
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY | directory_flag)
+    except OSError as exc:
+        if _directory_sync_is_unsupported(exc):
+            return
+        raise
+    try:
+        os.fsync(fd)
+    except OSError as exc:
+        if _directory_sync_is_unsupported(exc):
+            return
+        raise
+    finally:
+        os.close(fd)
+
+
+def _directory_sync_is_unsupported(exc: OSError) -> bool:
+    return exc.errno in _UNSUPPORTED_DIRECTORY_SYNC_ERRORS or (
+        os.name == "nt" and exc.errno in {errno.EACCES, errno.EPERM}
+    )
 
 
 def _is_review_required(line: str) -> bool:
@@ -414,16 +456,51 @@ def translate_questions(
     return results
 
 
-def write_query_file(store: Store, root: Path) -> Path:
+def write_query_file(
+    store: Store,
+    root: Path,
+    *,
+    publication_guard: Callable[[sqlite3.Connection], bool] | None = None,
+) -> Path | None:
     """Write the engine query draft (translated rules only) to `<root>/facts/query.dl`."""
-    lines = [
-        q["query_dl"]
-        for q in store.questions()
-        if q["status"] == "translated" and q["query_dl"]
-    ]
     path = query_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    staged: Path | None = None
+    try:
+        with store.immediate_transaction() as conn:
+            if publication_guard is not None and not publication_guard(conn):
+                return None
+            rows = conn.execute(
+                "SELECT query_dl FROM questions WHERE status = 'translated' "
+                "AND query_dl IS NOT NULL ORDER BY id"
+            )
+            lines = [row["query_dl"] for row in rows]
+            contents = "\n".join(lines) + ("\n" if lines else "")
+            mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o644
+            fd, staged_name = tempfile.mkstemp(prefix=".query.dl.", dir=path.parent)
+            staged = Path(staged_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    fd = -1
+                    handle.write(contents)
+                    handle.flush()
+                    # chmod(path) is available on Windows, unlike os.fchmod().
+                    os.chmod(staged, mode)
+                    os.fsync(handle.fileno())
+                os.replace(staged, path)
+                staged = None
+                # The old name is no longer available to restore if this fails.
+                _fsync_directory(path.parent)
+            except BaseException:
+                if fd != -1:
+                    os.close(fd)
+                raise
+    finally:
+        if staged is not None:
+            try:
+                staged.unlink()
+            except FileNotFoundError:
+                pass
     return path
 
 

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from dataclasses import dataclass
+import sqlite3
 import threading
 from uuid import uuid4
 
@@ -166,15 +167,20 @@ def process_repair_job(
 
     thread = threading.Thread(target=heartbeat, name=f"verinote-repair-heartbeat-{job_id}", daemon=True)
     thread.start()
+
+    def publish_query_file() -> bool:
+        def guard(conn: sqlite3.Connection) -> bool:
+            policy_guard()
+            return Store.repair_query_publication_owned(conn, job_id, owner_token)
+
+        return write_query_file(store, root, publication_guard=guard) is not None
+
     try:
         while True:
             item = store.claim_next_repair_item(job_id, owner_token)
             if item is None:
                 try:
-                    if not store.write_owned_repair_query_file(
-                        job_id, owner_token, policy_guard=policy_guard,
-                        writer=lambda: write_query_file(store, root),
-                    ):
+                    if not publish_query_file():
                         return
                 except PolicyMissingError:
                     raise
@@ -228,10 +234,7 @@ def process_repair_job(
             # If it fails, the item remains done and a later worker regenerates
             # the file without calling that question's provider again.
             try:
-                if not store.write_owned_repair_query_file(
-                    job_id, owner_token, policy_guard=policy_guard,
-                    writer=lambda: write_query_file(store, root),
-                ):
+                if not publish_query_file():
                     return
             except PolicyMissingError:
                 raise

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -14,6 +14,7 @@ import datetime
 import json
 import sqlite3
 import threading
+from contextlib import contextmanager
 from importlib import resources
 from pathlib import Path
 from typing import Any, Iterable
@@ -265,6 +266,28 @@ class Store:
             self._fact_terms.close()
             self._fact_terms = None
         self._conn.close()
+
+    @contextmanager
+    def immediate_transaction(self):
+        """Hold this store's lock and SQLite's cross-process write mutex.
+
+        Callers must keep the work here short.  In particular, this is suitable
+        for publishing a derived file from a fresh SQLite projection, but never
+        for provider or network work.
+        """
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                yield self._conn
+            except BaseException:
+                self._rollback_quietly()
+                raise
+            else:
+                try:
+                    self._conn.execute("COMMIT")
+                except BaseException:
+                    self._rollback_quietly()
+                    raise
 
     @property
     def inference_cache(self):
@@ -2219,32 +2242,16 @@ class Store:
             )
             return cur.rowcount == 1
 
-    def write_owned_repair_query_file(self, job_id: int, owner_token: str, *, policy_guard, writer) -> bool:
-        """Fence the derived-file boundary against a reclaimed owner.
-
-        This intentionally uses the existing writer; it does not attempt #388's
-        cross-process publication redesign.  The short SQLite write transaction
-        simply prevents a new owner from claiming between the ownership check and
-        this workflow's derived-file regeneration.
-        """
-        with self._lock:
-            self._conn.execute("BEGIN IMMEDIATE")
-            try:
-                owned = self._conn.execute(
-                    "SELECT 1 FROM repair_jobs WHERE id = ? AND status = 'running' AND owner_token = ? "
-                    "AND lease_until >= datetime('now')",
-                    (job_id, owner_token),
-                ).fetchone()
-                if owned is None:
-                    self._conn.execute("ROLLBACK")
-                    return False
-                policy_guard()
-                writer()
-                self._conn.execute("COMMIT")
-                return True
-            except Exception:
-                self._rollback_quietly()
-                raise
+    @staticmethod
+    def repair_query_publication_owned(
+        conn: sqlite3.Connection, job_id: int, owner_token: str
+    ) -> bool:
+        """Whether a repair worker may publish while its transaction is held."""
+        return conn.execute(
+            "SELECT 1 FROM repair_jobs WHERE id = ? AND status = 'running' AND owner_token = ? "
+            "AND lease_until >= datetime('now')",
+            (job_id, owner_token),
+        ).fetchone() is not None
 
     def finish_repair_job(self, job_id: int, owner_token: str, *, failed: bool = False, message: str = "") -> None:
         with self._lock:


### PR DESCRIPTION
Closes #388

Serializes query.dl publication with SQLite, snapshots translated rules inside the publication transaction, and publishes staged output with an atomic replacement.

The change preserves query-file mode, handles Windows-compatible staging, syncs directory metadata where supported, and keeps durable repair owner fencing inside the same critical section.

Validation: focused publication and workflow tests passed; full local suite was run before the final portability fixes.