### PR TITLE
fix: preserve schema hint in legacy sync

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,31 @@ def test_sync_file_inserts_candidates(tmp_path, monkeypatch, capsys, fake_client
     assert [f["subject"] for f in s.review_queue()] == ["A"]
 
 
+def test_sync_legacy_path_passes_configured_extraction_schema_hint(
+    tmp_path, monkeypatch
+):
+    from verinote.pipeline.extract import SyncResult
+
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VERINOTE_EXTRACTION_MAX_FACTS_PER_CHUNK", "3")
+    source = tmp_path / "note.txt"
+    source.write_text("synthetic source text", encoding="utf-8")
+    received: dict[str, object] = {}
+
+    def sync_sources(store, client, sources, **kwargs):
+        received["schema_hint"] = kwargs["schema_hint"]
+        return SyncResult(run_id=1, per_source=[(path, 0) for path, _ in sources])
+
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
+    monkeypatch.setattr("verinote.pipeline.sync_sources", sync_sources)
+
+    assert cli.main(["sync", str(source)]) == 0
+    assert received["schema_hint"] == (
+        "Extract at most 3 facts from this chunk. Prefer the most explicit "
+        "source-backed facts when more facts are available."
+    )
+
+
 def test_sync_missing_file_errors(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     rc = cli.main(["sync", str(tmp_path / "nope.txt")])

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -834,7 +834,14 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
             # LLMError and exits rc 1 below, so every outcome reaching here is a
             # success with zero completed/failed chunks.
             pairs = [(source.source_path, source.text) for source in sources]
-            legacy = sync_sources(store, client, pairs, provider=cfg.provider, model=cfg.model)
+            legacy = sync_sources(
+                store,
+                client,
+                pairs,
+                provider=cfg.provider,
+                model=cfg.model,
+                schema_hint=extraction_schema_hint(),
+            )
             result = _SyncSummary(
                 per_source=[
                     _SourceSyncOutcome(path, n, 0, 0) for path, n in legacy.per_source


### PR DESCRIPTION
Closes #259

Pass the configured extraction schema hint through the synchronous legacy `sync` path, matching extraction jobs.

Validation: `.venv/bin/python -m pytest -q tests/test_cli.py` (105 passed); full test suite exited successfully.