### PR TITLE
fix: validate fact values at write boundaries

### DIFF
--- a/tests/test_duckdb_fact_terms.py
+++ b/tests/test_duckdb_fact_terms.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from verinote.engine.duckdb_terms import term_to_duckdb_value
-from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var
 from verinote.store.duckdb_fact_terms import (
     FACT_TERMS_FILENAME,
     DuckDBFactTermStore,
@@ -17,6 +17,69 @@ from verinote.store.duckdb_fact_terms import (
 
 def _duckdb():
     return pytest.importorskip("duckdb")
+
+
+def _malformed_stringlit() -> StringLit:
+    term = StringLit("synthetic")
+    object.__setattr__(term, "value", 7)
+    return term
+
+
+def _malformed_atom() -> Atom:
+    term = Atom("synthetic")
+    object.__setattr__(term, "name", "Synthetic")
+    return term
+
+
+def _malformed_numberlit() -> NumberLit:
+    term = NumberLit(1)
+    object.__setattr__(term, "value", True)
+    return term
+
+
+def _malformed_compound_functor() -> Compound:
+    term = Compound("synthetic", (StringLit("value"),))
+    object.__setattr__(term, "functor", "Synthetic")
+    return term
+
+
+def _malformed_compound_args() -> Compound:
+    term = Compound("synthetic", (StringLit("value"),))
+    object.__setattr__(term, "args", [])
+    return term
+
+
+def _cyclic_compound() -> Compound:
+    term = Compound("synthetic", ())
+    object.__setattr__(term, "args", (term,))
+    return term
+
+
+_INVALID_FACT_SLOTS = (
+    7,
+    1.5,
+    True,
+    None,
+    [],
+    (),
+    {},
+    {"value"},
+    object(),
+    _malformed_stringlit(),
+    Compound("person", (_malformed_stringlit(),)),
+    _malformed_atom(),
+    Compound("person", (_malformed_atom(),)),
+    _malformed_numberlit(),
+    Compound("person", (_malformed_numberlit(),)),
+    _malformed_compound_functor(),
+    Compound("person", (_malformed_compound_functor(),)),
+    _malformed_compound_args(),
+    Compound("person", (_malformed_compound_args(),)),
+    _cyclic_compound(),
+    Compound("person", (_cyclic_compound(),)),
+    Var("Slot"),
+    Compound("person", (Var("Name"),)),
+)
 
 
 def test_fact_terms_path_uses_kb_root():
@@ -126,6 +189,24 @@ def test_store_rejects_a_supplied_token_that_does_not_match_payload():
         with pytest.raises(DuckDBFactTermStoreError, match="token does not match"):
             store.put_fact_terms(1, "A", "r", "B", term_token="0" * 64)
         assert store.get_fact_terms(1) is None
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("value", _INVALID_FACT_SLOTS)
+def test_sidecar_and_token_reject_invalid_slots_without_partial_state(value):
+    _duckdb()
+    store = DuckDBFactTermStore(None)
+    try:
+        store.put_fact_terms(1, "A", "rel", "B")
+        before = store.get_fact_term_record(1)
+
+        with pytest.raises(DuckDBFactTermStoreError):
+            store.put_fact_terms(1, "A2", "rel", value)
+        with pytest.raises(DuckDBFactTermStoreError):
+            fact_term_token("A2", "rel", value)
+
+        assert store.get_fact_term_record(1) == before
     finally:
         store.close()
 

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -21,6 +21,70 @@ from verinote.store.duckdb_fact_terms import (
 from verinote.store.fact_input import structural_term
 
 
+def _malformed_stringlit() -> StringLit:
+    term = StringLit("synthetic")
+    object.__setattr__(term, "value", 7)
+    return term
+
+
+def _malformed_atom() -> Atom:
+    term = Atom("synthetic")
+    object.__setattr__(term, "name", "Synthetic")
+    return term
+
+
+def _malformed_numberlit() -> NumberLit:
+    term = NumberLit(1)
+    object.__setattr__(term, "value", True)
+    return term
+
+
+def _malformed_compound_functor() -> Compound:
+    term = Compound("synthetic", (StringLit("value"),))
+    object.__setattr__(term, "functor", "Synthetic")
+    return term
+
+
+def _malformed_compound_args() -> Compound:
+    term = Compound("synthetic", (StringLit("value"),))
+    object.__setattr__(term, "args", [])
+    return term
+
+
+def _cyclic_compound() -> Compound:
+    term = Compound("synthetic", ())
+    object.__setattr__(term, "args", (term,))
+    return term
+
+
+_INVALID_FACT_SLOTS = (
+    7,
+    1.5,
+    True,
+    None,
+    [],
+    (),
+    {},
+    {"value"},
+    object(),
+    _malformed_stringlit(),
+    Compound("person", (_malformed_stringlit(),)),
+    _malformed_atom(),
+    Compound("person", (_malformed_atom(),)),
+    _malformed_numberlit(),
+    Compound("person", (_malformed_numberlit(),)),
+    _malformed_compound_functor(),
+    Compound("person", (_malformed_compound_functor(),)),
+    _malformed_compound_args(),
+    Compound("person", (_malformed_compound_args(),)),
+    _cyclic_compound(),
+    Compound("person", (_cyclic_compound(),)),
+    Var("Slot"),
+    Compound("person", (Var("Name"),)),
+)
+_INVALID_CONFIDENCES = (True, None, "0.5", float("nan"), float("inf"), -0.1, 1.1)
+
+
 def _store(tmp_path) -> Store:
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
@@ -68,6 +132,27 @@ def test_add_fact_accepts_structural_terms_without_parsing_strings(tmp_path):
     )
 
 
+def test_add_fact_accepts_a_shared_acyclic_compound_dag(tmp_path):
+    s = _store(tmp_path)
+    shared = Compound("child", (StringLit("synthetic"),))
+    parent = Compound("parent", (shared, shared))
+
+    assert parent.args[0] is parent.args[1]
+    fid = s.add_fact(parent, "rel", "object")
+
+    assert s.get_fact_terms(fid) == (
+        Compound(
+            "parent",
+            (
+                Compound("child", (StringLit("synthetic"),)),
+                Compound("child", (StringLit("synthetic"),)),
+            ),
+        ),
+        StringLit("rel"),
+        StringLit("object"),
+    )
+
+
 def test_structural_term_is_an_explicit_input_boundary(tmp_path):
     s = _store(tmp_path)
 
@@ -112,6 +197,30 @@ def test_store_rejects_direct_nonground_term_inputs_without_writing(tmp_path):
 
     assert s.facts() == []
     assert s.fact_terms.get_many_fact_terms([1, 2]) == {}
+
+
+@pytest.mark.parametrize("value", _INVALID_FACT_SLOTS)
+def test_add_fact_rejects_invalid_slots_before_any_storage_write(tmp_path, value):
+    s = _store(tmp_path)
+
+    with pytest.raises(ValueError):
+        s.add_fact(value, "rel", "object")
+
+    assert s.facts() == []
+    assert not fact_terms_path(tmp_path).exists()
+    assert s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("confidence", _INVALID_CONFIDENCES)
+def test_add_fact_rejects_invalid_confidence_before_any_storage_write(tmp_path, confidence):
+    s = _store(tmp_path)
+
+    with pytest.raises(ValueError, match="confidence"):
+        s.add_fact("subject", "rel", "object", confidence=confidence)
+
+    assert s.facts() == []
+    assert not fact_terms_path(tmp_path).exists()
+    assert s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0] == 0
 
 
 def test_fact_terms_sidecar_persists_across_store_reopen(tmp_path):
@@ -495,6 +604,69 @@ def test_amend_fact_rejects_direct_nonground_terms_and_restores_state(tmp_path):
     assert dict(s.get_fact(fid)) == before
     assert s.get_fact_terms(fid) == before_terms
     assert s.fact_log(fid) == []
+
+
+@pytest.mark.parametrize("value", _INVALID_FACT_SLOTS)
+def test_amend_fact_rejects_invalid_slots_without_partial_state(tmp_path, value):
+    s = _store(tmp_path)
+    fid = s.add_fact("A", "rel", "B", status="needs_review", note="original")
+    before = dict(s.get_fact(fid))
+    before_terms = s.get_fact_terms(fid)
+
+    with pytest.raises(ValueError):
+        s.amend_fact(fid, subject="A2", relation="rel", obj=value, note="changed")
+
+    assert dict(s.get_fact(fid)) == before
+    assert s.get_fact_terms(fid) == before_terms
+    assert s.fact_log(fid) == []
+
+
+@pytest.mark.parametrize("confidence", _INVALID_CONFIDENCES)
+def test_reconcile_duplicate_rejects_invalid_confidence_without_suppression_event(
+    tmp_path, confidence
+):
+    s = _store(tmp_path)
+    source_id = s.add_source("synthetic-source.txt")
+    fid = s.add_fact("A", "rel", "B", source_id=source_id)
+    s.reject_fact(fid)
+    before_events = s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0]
+
+    with pytest.raises(ValueError, match="confidence"):
+        s.reconcile_fact("A", "rel", "B", source_id=source_id, confidence=confidence)
+
+    assert len(s.facts()) == 1
+    assert s.get_fact_terms(fid) == (StringLit("A"), StringLit("rel"), StringLit("B"))
+    assert s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0] == before_events
+
+
+def test_reconcile_duplicate_rejects_invalid_slot_without_suppression_event(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("synthetic-source.txt")
+    fid = s.add_fact("A", "rel", "36", source_id=source_id)
+    s.reject_fact(fid)
+    before_events = s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0]
+
+    with pytest.raises(ValueError):
+        s.reconcile_fact("A", "rel", 36, source_id=source_id)
+
+    assert len(s.facts()) == 1
+    assert s.get_fact_terms(fid) == (StringLit("A"), StringLit("rel"), StringLit("36"))
+    assert s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0] == before_events
+
+
+def test_reconcile_rejects_nested_malformed_stringlit_without_partial_state(tmp_path):
+    s = _store(tmp_path)
+    source_id = s.add_source("synthetic-source.txt")
+    fid = s.add_fact("A", "rel", "B", source_id=source_id)
+    before_events = s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0]
+    malformed = Compound("person", (_malformed_stringlit(),))
+
+    with pytest.raises(ValueError, match="StringLit"):
+        s.reconcile_fact("A", "rel", malformed, source_id=source_id)
+
+    assert len(s.facts()) == 1
+    assert s.get_fact_terms(fid) == (StringLit("A"), StringLit("rel"), StringLit("B"))
+    assert s._conn.execute("SELECT COUNT(*) FROM fact_events").fetchone()[0] == before_events
 
 
 def test_amend_fact_audit_failure_rolls_back_sqlite_and_restores_terms(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1059,6 +1059,9 @@ class Store:
         already in the review queue or the engine and nothing is being suppressed.
         """
         from verinote.store.duckdb_fact_terms import fact_term_token
+        from verinote.store.fact_input import validate_fact_slots
+
+        validate_fact_slots(subject, relation, obj)
 
         row = self._conn.execute(
             "SELECT id, status FROM facts "
@@ -1249,11 +1252,15 @@ class Store:
         job_id: int | None = None,
         note: str = "",
     ) -> int:
+        from verinote.store.fact_input import validate_fact_confidence, validate_fact_slots
+
+        terms = validate_fact_slots(subject, relation, obj)
+        confidence = validate_fact_confidence(confidence)
         with self._lock:
             from verinote.store.duckdb_fact_terms import fact_term_token
 
             fact_id: int | None = None
-            token = fact_term_token(subject, relation, obj)
+            token = fact_term_token(*terms)
             self._conn.execute("BEGIN")
             try:
                 cur = self._conn.execute(
@@ -1276,7 +1283,7 @@ class Store:
                 )
                 fact_id = int(cur.fetchone()[0])
                 self.fact_terms.put_fact_terms(
-                    fact_id, subject, relation, obj, term_token=token
+                    fact_id, *terms, term_token=token
                 )
                 self._record_fact_terms_marker_unlocked(origin="write")
                 self._add_fact_event(
@@ -1348,6 +1355,10 @@ class Store:
         seed has no run (`run_id` is None); a re-seed is a rare, human-initiated
         act, so each occurrence is itself signal and is emitted unconditionally.
         """
+        from verinote.store.fact_input import validate_fact_confidence, validate_fact_slots
+
+        validate_fact_slots(subject, relation, obj)
+        validate_fact_confidence(confidence)
         with self._lock:
             existing = self.existing_fact_for_source(
                 source_id=source_id, subject=subject, relation=relation, obj=obj
@@ -1980,6 +1991,9 @@ class Store:
         frozen with it. The schema enforces this too; the check here exists to
         name the refusal rather than surface a trigger's IntegrityError.
         """
+        from verinote.store.fact_input import validate_fact_slots
+
+        requested_terms = validate_fact_slots(subject, relation, obj)
         with self._lock:
             from verinote.store.duckdb_fact_terms import fact_term_token
 
@@ -1995,8 +2009,7 @@ class Store:
             # only on genuine corruption, never on a healthy sidecar, so an
             # intentional kind="string" downgrade stays allowed.
             previous_terms = self.fact_terms.get_fact_terms(fact_id)
-            requested_terms = _stored_fact_terms(subject, relation, obj)
-            token = fact_term_token(subject, relation, obj)
+            token = fact_term_token(*requested_terms)
             # Treat the amend as a no-op only when BOTH stores already hold the
             # request. Comparing SQLite's own term_token here (not just the DuckDB
             # terms + note) is what lets a retry recover the residual divergence
@@ -2053,7 +2066,7 @@ class Store:
                 # (the stale-token check), and self-healed on retry by the no-op
                 # guard above, which compares SQLite's own term_token.
                 self.fact_terms.put_fact_terms(
-                    fact_id, subject, relation, obj, term_token=token
+                    fact_id, *requested_terms, term_token=token
                 )
                 self._conn.execute("COMMIT")
             except BaseException:
@@ -2791,9 +2804,9 @@ def _display_fact_value(value: object) -> str:
 
 
 def _stored_fact_terms(subject: object, relation: object, obj: object):
-    from verinote.store.duckdb_fact_terms import _coerce_term
+    from verinote.store.fact_input import validate_fact_slots
 
-    return (_coerce_term(subject), _coerce_term(relation), _coerce_term(obj))
+    return validate_fact_slots(subject, relation, obj)
 
 
 def _json_payload(value: dict[str, object] | sqlite3.Row | None) -> str | None:

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -19,7 +19,8 @@ from verinote.engine.duckdb_terms import (
     duckdb_value_to_term,
     term_to_duckdb_value,
 )
-from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Term, Var
+from verinote.engine.terms import Term
+from verinote.store.fact_input import validate_fact_slot
 
 FACT_TERMS_FILENAME = "facts.duckdb"
 
@@ -364,17 +365,10 @@ def _validate_fact_id(fact_id: int) -> int:
 
 
 def _coerce_term(value: object) -> Term:
-    if isinstance(value, Var):
-        raise DuckDBFactTermStoreError("fact terms must be ground")
-    if isinstance(value, Compound):
-        from verinote.store.fact_input import is_ground_term
-
-        if not is_ground_term(value):
-            raise DuckDBFactTermStoreError("fact terms must be ground")
-        return value
-    if isinstance(value, (Atom, NumberLit, StringLit)):
-        return value
-    return StringLit(str(value))
+    try:
+        return validate_fact_slot(value)
+    except ValueError as exc:
+        raise DuckDBFactTermStoreError(str(exc)) from exc
 
 
 def _duckdb_term_values(subject: object, relation: object, obj: object) -> tuple[str, str, str]:

--- a/verinote/store/fact_input.py
+++ b/verinote/store/fact_input.py
@@ -8,8 +8,12 @@ intentionally wants Datalog term syntax parsed as a logical term.
 
 from __future__ import annotations
 
+import math
+
 from verinote.engine.terms import (
+    Atom,
     Compound,
+    NumberLit,
     StringLit,
     Term,
     TermParseError,
@@ -52,6 +56,45 @@ def is_ground_term(term: Term) -> bool:
     return not _has_var(term)
 
 
+def validate_fact_slots(
+    subject: object, relation: object, obj: object
+) -> tuple[Term, Term, Term]:
+    """Validate and normalize one fact triple into engine terms.
+
+    Plain strings are deliberate data strings, not term syntax. Every other
+    accepted value must already be a concrete, ground engine term.
+    """
+    return (
+        validate_fact_slot(subject),
+        validate_fact_slot(relation),
+        validate_fact_slot(obj),
+    )
+
+
+def validate_fact_slot(value: object) -> Term:
+    """Validate and normalize one fact slot into an engine term."""
+    if isinstance(value, str):
+        return StringLit(value)
+    if isinstance(value, Compound):
+        _validate_fact_term(value)
+        return value
+    if isinstance(value, (Atom, NumberLit, StringLit)):
+        _validate_fact_term(value)
+        return value
+    if isinstance(value, Var):
+        raise ValueError("fact terms must be ground")
+    raise ValueError("fact slots must be plain strings or ground engine terms")
+
+
+def validate_fact_confidence(confidence: object) -> float:
+    """Validate a fact confidence before it reaches any storage backend."""
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        raise ValueError("fact confidence must be a finite number between 0 and 1")
+    if not 0.0 <= confidence <= 1.0 or not math.isfinite(confidence):
+        raise ValueError("fact confidence must be a finite number between 0 and 1")
+    return float(confidence)
+
+
 def term_input_kind(term: Term) -> str:
     """Return the edit/input kind for a stored term."""
     return "string" if isinstance(term, StringLit) else "term"
@@ -63,3 +106,39 @@ def _has_var(term: Term) -> bool:
     if isinstance(term, Compound):
         return any(_has_var(arg) for arg in term.args)
     return False
+
+
+def _validate_fact_term(term: Term, active_compounds: set[int] | None = None) -> None:
+    """Reject non-ground terms and terms whose public invariants do not hold."""
+    if isinstance(term, StringLit):
+        if not isinstance(term.value, str):
+            raise ValueError("fact StringLit values must be strings")
+        return
+    if isinstance(term, Atom):
+        _validate_term_invariant(lambda: Atom(term.name), "Atom")
+        return
+    if isinstance(term, NumberLit):
+        _validate_term_invariant(lambda: NumberLit(term.value), "NumberLit")
+        return
+    if isinstance(term, Var):
+        raise ValueError("fact terms must be ground")
+    if isinstance(term, Compound):
+        _validate_term_invariant(lambda: Compound(term.functor, term.args), "Compound")
+        if active_compounds is None:
+            active_compounds = set()
+        compound_id = id(term)
+        if compound_id in active_compounds:
+            raise ValueError("fact terms must be acyclic")
+        active_compounds.add(compound_id)
+        try:
+            for arg in term.args:
+                _validate_fact_term(arg, active_compounds)
+        finally:
+            active_compounds.remove(compound_id)
+
+
+def _validate_term_invariant(make_term, term_name: str) -> None:
+    try:
+        make_term()
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid fact {term_name}") from exc


### PR DESCRIPTION
Closes #166

Reject invalid or malformed fact values before SQLite, DuckDB, tokens, events, or reconciliation side effects. Fact slots now require plain strings or valid ground engine terms; confidence must be finite and within [0, 1].

Validation: focused store, sidecar, pipeline, and web tests passed locally; CI verifies ruff and all supported Python versions.