### PR TITLE
fix: normalize persisted fact terms to NFC

### DIFF
--- a/tests/test_duckdb_fact_terms.py
+++ b/tests/test_duckdb_fact_terms.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+import json
 import sys
 
 import pytest
 
-from verinote.engine.duckdb_terms import term_to_duckdb_value
+from verinote.engine.duckdb_terms import DuckDBTermError, duckdb_value_to_term, term_to_duckdb_value
 from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var
 from verinote.store.duckdb_fact_terms import (
     FACT_TERMS_FILENAME,
     DuckDBFactTermStore,
     DuckDBFactTermStoreError,
     fact_term_token,
+    fact_term_token_from_values,
     fact_terms_path,
 )
+from verinote.text import nfc
 
 
 def _duckdb():
@@ -53,6 +56,48 @@ def _cyclic_compound() -> Compound:
     term = Compound("synthetic", ())
     object.__setattr__(term, "args", (term,))
     return term
+
+
+def _legacy_term_value(payload: dict[str, object]) -> str:
+    """Build a canonical payload from before StringLit NFC encoding."""
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _create_raw_fact_terms(
+    path, rows: list[tuple[object, ...]], *, has_term_token: bool = True
+) -> None:
+    duckdb = _duckdb()
+    con = duckdb.connect(str(path))
+    try:
+        token_column = ", term_token VARCHAR" if has_term_token else ""
+        placeholders = "?, ?, ?, ?, ?" if has_term_token else "?, ?, ?, ?"
+        con.execute(
+            f"""
+            CREATE TABLE fact_terms (
+                fact_id BIGINT PRIMARY KEY,
+                subject VARCHAR NOT NULL,
+                rel VARCHAR NOT NULL,
+                object VARCHAR NOT NULL{token_column}
+            )
+            """
+        )
+        con.executemany(f"INSERT INTO fact_terms VALUES ({placeholders})", rows)
+    finally:
+        con.close()
+
+
+def _raw_fact_term_row(path, fact_id: int) -> tuple[object, ...]:
+    duckdb = _duckdb()
+    con = duckdb.connect(str(path), read_only=True)
+    try:
+        row = con.execute(
+            "SELECT subject, rel, object, term_token FROM fact_terms WHERE fact_id = ?",
+            [fact_id],
+        ).fetchone()
+        assert row is not None
+        return row
+    finally:
+        con.close()
 
 
 _INVALID_FACT_SLOTS = (
@@ -274,7 +319,7 @@ def test_store_schema_initialization_is_idempotent(tmp_path):
         second.close()
 
 
-def test_store_migrates_existing_fact_terms_table_to_add_token(tmp_path):
+def test_direct_store_leaves_existing_four_column_table_unchanged(tmp_path):
     duckdb = _duckdb()
     path = fact_terms_path(tmp_path)
     con = duckdb.connect(str(path))
@@ -301,14 +346,221 @@ def test_store_migrates_existing_fact_terms_table_to_add_token(tmp_path):
 
     store = DuckDBFactTermStore(path)
     try:
-        record = store.get_fact_term_record(1)
-        assert record is not None
-        assert record.terms == (StringLit("A"), StringLit("r"), StringLit("B"))
-        assert record.term_token is None
-        store.put_fact_terms(1, "A", "r", "B")
-        assert store.get_fact_term_record(1).term_token == fact_term_token("A", "r", "B")
+        plan = store.plan_nfc_migration()
+        assert plan.needs_term_token is True
+        assert len(plan.rewrites) == 1
+        assert plan.rewrites[0].new_values == (
+            term_to_duckdb_value(StringLit("A")),
+            term_to_duckdb_value(StringLit("r")),
+            term_to_duckdb_value(StringLit("B")),
+        )
     finally:
         store.close()
+
+    con = duckdb.connect(str(path), read_only=True)
+    try:
+        columns = {row[1] for row in con.execute("PRAGMA table_info('fact_terms')").fetchall()}
+        assert columns == {"fact_id", "subject", "rel", "object"}
+    finally:
+        con.close()
+
+
+def test_direct_store_rejects_legacy_nfd_payloads_without_mutating_them(tmp_path):
+    _duckdb()
+    path = fact_terms_path(tmp_path)
+    nfd_value = "Cafe\u0301"
+    nfc_value = nfc(nfd_value)
+    legacy_values = (
+        _legacy_term_value(
+            {
+                "t": "compound",
+                "f": "person",
+                "a": [{"t": "string", "v": nfd_value}],
+            }
+        ),
+        _legacy_term_value({"t": "string", "v": "has_label"}),
+        _legacy_term_value(
+            {
+                "t": "compound",
+                "f": "record",
+                "a": [
+                    {
+                        "t": "compound",
+                        "f": "label",
+                        "a": [{"t": "string", "v": nfd_value}],
+                    }
+                ],
+            }
+        ),
+    )
+    _create_raw_fact_terms(
+        path,
+        [(1, *legacy_values, fact_term_token_from_values(legacy_values))],
+    )
+
+    # The production decoder stays strict; only initialization can read this
+    # former, structurally canonical encoding.
+    with pytest.raises(DuckDBTermError, match="not canonical"):
+        duckdb_value_to_term(legacy_values[0])
+
+    store = DuckDBFactTermStore(path)
+    try:
+        plan = store.plan_nfc_migration()
+        assert len(plan.rewrites) == 1
+        with pytest.raises(DuckDBFactTermStoreError, match="not canonical"):
+            store.get_fact_terms(1)
+    finally:
+        store.close()
+
+    assert _raw_fact_term_row(path, 1) == (
+        *legacy_values,
+        fact_term_token_from_values(legacy_values),
+    )
+
+
+def test_new_direct_and_nested_nfd_terms_have_nfc_identical_storage_and_tokens():
+    _duckdb()
+    store = DuckDBFactTermStore(None)
+    nfd_value = "Cafe\u0301"
+    nfc_value = nfc(nfd_value)
+    direct_nfd = (StringLit(nfd_value), StringLit("rel"), StringLit(nfd_value))
+    direct_nfc = (StringLit(nfc_value), StringLit("rel"), StringLit(nfc_value))
+    nested_nfd = (
+        Compound("outer", (StringLit(nfd_value), Compound("inner", (StringLit(nfd_value),)))),
+        Atom("rel"),
+        Compound("target", (StringLit(nfd_value),)),
+    )
+    nested_nfc = (
+        Compound("outer", (StringLit(nfc_value), Compound("inner", (StringLit(nfc_value),)))),
+        Atom("rel"),
+        Compound("target", (StringLit(nfc_value),)),
+    )
+    try:
+        store.put_fact_terms(1, *direct_nfd)
+        store.put_fact_terms(2, *direct_nfc)
+        store.put_fact_terms(3, *nested_nfd)
+        store.put_fact_terms(4, *nested_nfc)
+
+        with store._operation() as con:
+            rows = {
+                int(row[0]): row[1:]
+                for row in con.execute(
+                    "SELECT fact_id, subject, rel, object, term_token FROM fact_terms ORDER BY fact_id"
+                ).fetchall()
+            }
+        assert rows[1] == rows[2]
+        assert rows[3] == rows[4]
+        assert rows[1][-1] == fact_term_token(*direct_nfc)
+        assert rows[3][-1] == fact_term_token(*nested_nfc)
+        assert store.get_fact_terms(1) == direct_nfc
+        assert store.get_fact_terms(3) == nested_nfc
+    finally:
+        store.close()
+
+
+def test_direct_nfc_migration_planning_is_idempotent_without_mutation(tmp_path):
+    _duckdb()
+    path = fact_terms_path(tmp_path)
+    nfd_value = "Cafe\u0301"
+    legacy_values = (
+        _legacy_term_value({"t": "string", "v": nfd_value}),
+        _legacy_term_value({"t": "string", "v": "rel"}),
+        _legacy_term_value({"t": "string", "v": nfd_value}),
+    )
+    _create_raw_fact_terms(
+        path,
+        [(1, *legacy_values, fact_term_token_from_values(legacy_values))],
+    )
+
+    first = DuckDBFactTermStore(path)
+    try:
+        first_plan = first.plan_nfc_migration()
+    finally:
+        first.close()
+    after_first_plan = _raw_fact_term_row(path, 1)
+
+    second = DuckDBFactTermStore(path)
+    try:
+        second_plan = second.plan_nfc_migration()
+    finally:
+        second.close()
+
+    assert second_plan == first_plan
+    assert _raw_fact_term_row(path, 1) == after_first_plan
+
+
+def test_nfc_fact_term_migration_rolls_back_when_a_legacy_row_is_malformed(tmp_path):
+    _duckdb()
+    path = fact_terms_path(tmp_path)
+    nfd_value = "Cafe\u0301"
+    valid_values = (
+        _legacy_term_value({"t": "string", "v": nfd_value}),
+        _legacy_term_value({"t": "string", "v": "rel"}),
+        _legacy_term_value({"t": "string", "v": nfd_value}),
+    )
+    malformed_values = (
+        "not json",
+        _legacy_term_value({"t": "string", "v": "rel"}),
+        _legacy_term_value({"t": "string", "v": "value"}),
+    )
+    _create_raw_fact_terms(
+        path,
+        [
+            (1, *valid_values, fact_term_token_from_values(valid_values)),
+            (2, *malformed_values, fact_term_token_from_values(malformed_values)),
+        ],
+    )
+
+    store = DuckDBFactTermStore(path)
+    try:
+        with pytest.raises(
+            DuckDBFactTermStoreError, match="fact_id=2 column=subject"
+        ):
+            store.plan_nfc_migration()
+    finally:
+        store.close()
+
+    assert _raw_fact_term_row(path, 1) == (*valid_values, fact_term_token_from_values(valid_values))
+
+
+def test_nfc_migration_keeps_a_malformed_four_column_table_unchanged(tmp_path):
+    duckdb = _duckdb()
+    path = fact_terms_path(tmp_path)
+    nfd_value = "Cafe\u0301"
+    valid_values = (
+        _legacy_term_value({"t": "string", "v": nfd_value}),
+        _legacy_term_value({"t": "string", "v": "rel"}),
+        _legacy_term_value({"t": "string", "v": nfd_value}),
+    )
+    malformed_values = (
+        "not json",
+        _legacy_term_value({"t": "string", "v": "rel"}),
+        _legacy_term_value({"t": "string", "v": "value"}),
+    )
+    _create_raw_fact_terms(
+        path,
+        [(1, *valid_values), (2, *malformed_values)],
+        has_term_token=False,
+    )
+
+    store = DuckDBFactTermStore(path)
+    try:
+        with pytest.raises(
+            DuckDBFactTermStoreError, match="fact_id=2 column=subject"
+        ):
+            store.plan_nfc_migration()
+    finally:
+        store.close()
+
+    con = duckdb.connect(str(path), read_only=True)
+    try:
+        columns = {row[1] for row in con.execute("PRAGMA table_info('fact_terms')").fetchall()}
+        assert columns == {"fact_id", "subject", "rel", "object"}
+        assert con.execute(
+            "SELECT subject, rel, object FROM fact_terms WHERE fact_id = ?", [1]
+        ).fetchone() == valid_values
+    finally:
+        con.close()
 
 
 @pytest.mark.parametrize("fact_id", [0, -1, True, "1"])

--- a/tests/test_duckdb_fact_terms.py
+++ b/tests/test_duckdb_fact_terms.py
@@ -369,7 +369,6 @@ def test_direct_store_rejects_legacy_nfd_payloads_without_mutating_them(tmp_path
     _duckdb()
     path = fact_terms_path(tmp_path)
     nfd_value = "Cafe\u0301"
-    nfc_value = nfc(nfd_value)
     legacy_values = (
         _legacy_term_value(
             {

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -672,9 +672,9 @@ def test_engine_fact_terms_rejects_missing_modern_sidecar_terms(tmp_path):
     assert s.get_fact_terms(fid) is None
 
 
-def test_store_init_schema_refuses_a_corrupt_existing_sidecar(tmp_path):
-    # Existing sidecars are opened at initialization so corruption cannot be
-    # deferred until a later SQLite write transaction first accesses fact_terms.
+def test_store_init_schema_defers_a_corrupt_existing_sidecar(tmp_path):
+    # Sidecar availability failures remain deferred so web callers can render
+    # their normal halt state instead of failing before a route is selected.
     seed = _store(tmp_path)
     fid = seed.add_fact(
         Compound("person", (StringLit("Ada"),)),
@@ -688,9 +688,10 @@ def test_store_init_schema_refuses_a_corrupt_existing_sidecar(tmp_path):
 
     store = Store(tmp_path / "kb.sqlite")
     try:
+        store.init_schema()
         with pytest.raises(DuckDBFactTermStoreError, match="failed to open DuckDB fact-term store"):
-            store.init_schema()
-        # SQLite was not modified before the corrupt sidecar error surfaced.
+            store.fact_terms
+        # Initialization and the deferred open failure leave SQLite unchanged.
         assert store.get_fact(fid)["term_token"] == token
     finally:
         store.close()

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
+import json
 import sqlite3
 
 import pytest
@@ -14,11 +15,14 @@ from verinote.engine.terms import (
 from verinote.store import Store
 from verinote.store.db import FACT_TERMS_MARKER_KEY
 from verinote.store.duckdb_fact_terms import (
+    DuckDBFactTermStore,
     DuckDBFactTermStoreError,
     fact_term_token,
+    fact_term_token_from_values,
     fact_terms_path,
 )
 from verinote.store.fact_input import structural_term
+from verinote.text import nfc
 
 
 def _malformed_stringlit() -> StringLit:
@@ -89,6 +93,297 @@ def _store(tmp_path) -> Store:
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
     return s
+
+
+def _legacy_string_value(value: str) -> str:
+    return json.dumps({"t": "string", "v": value}, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def test_store_init_schema_keeps_a_fresh_kb_without_a_fact_term_sidecar(tmp_path):
+    s = _store(tmp_path)
+    try:
+        assert not fact_terms_path(tmp_path).exists()
+    finally:
+        s.close()
+
+
+def test_store_init_schema_migrates_paired_nfd_tokens_before_write_transactions(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    bootstrap = _store(tmp_path)
+    bootstrap.close()
+    nfd_value = "Cafe\u0301"
+    legacy_values = (
+        _legacy_string_value(nfd_value),
+        _legacy_string_value("rel"),
+        _legacy_string_value(nfd_value),
+    )
+    legacy_token = fact_term_token_from_values(legacy_values)
+    sqlite_con = sqlite3.connect(tmp_path / "kb.sqlite")
+    try:
+        cur = sqlite_con.execute(
+            """
+            INSERT INTO facts(subject, relation, object, status, term_token)
+            VALUES (?, ?, ?, 'confirmed', ?) RETURNING id
+            """,
+            (nfd_value, "rel", nfd_value, legacy_token),
+        )
+        fact_id = int(cur.fetchone()[0])
+        sqlite_con.commit()
+    finally:
+        sqlite_con.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)))
+    try:
+        con.execute(
+            """
+            CREATE TABLE fact_terms (
+                fact_id BIGINT PRIMARY KEY,
+                subject VARCHAR NOT NULL,
+                rel VARCHAR NOT NULL,
+                object VARCHAR NOT NULL,
+                term_token VARCHAR
+            )
+            """
+        )
+        con.execute(
+            "INSERT INTO fact_terms VALUES (?, ?, ?, ?, ?)",
+            [fact_id, *legacy_values, legacy_token],
+        )
+    finally:
+        con.close()
+
+    direct = DuckDBFactTermStore(fact_terms_path(tmp_path))
+    try:
+        with pytest.raises(DuckDBFactTermStoreError, match="not canonical"):
+            direct.get_fact_terms(fact_id)
+    finally:
+        direct.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)), read_only=True)
+    try:
+        assert con.execute(
+            "SELECT subject, rel, object, term_token FROM fact_terms WHERE fact_id = ?", [fact_id]
+        ).fetchone() == (*legacy_values, legacy_token)
+    finally:
+        con.close()
+
+    s = _store(tmp_path)
+    nfc_value = nfc(nfd_value)
+    expected_terms = (StringLit(nfc_value), StringLit("rel"), StringLit(nfc_value))
+    expected_token = fact_term_token(*expected_terms)
+    try:
+        # `add_fact` opens a SQLite write transaction, then accesses fact_terms.
+        # It is safe because init_schema already coordinated the legacy rewrite.
+        s.add_fact("new", "rel", "value", status="candidate")
+        assert s.engine_fact_terms() == [
+            {
+                "id": fact_id,
+                "subject": expected_terms[0],
+                "relation": expected_terms[1],
+                "object": expected_terms[2],
+            }
+        ]
+        assert s.get_fact(fact_id)["term_token"] == expected_token
+        record = s.fact_terms.get_fact_term_record(fact_id)
+        assert record is not None
+        assert record.term_token == record.content_token == expected_token
+    finally:
+        s.close()
+
+    reopened = _store(tmp_path)
+    try:
+        assert reopened.fact_terms.get_fact_term_record(fact_id) == record
+    finally:
+        reopened.close()
+
+
+def test_store_backfills_tokens_for_a_canonical_four_column_sidecar(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    bootstrap = _store(tmp_path)
+    bootstrap.close()
+    legacy_values = (
+        _legacy_string_value("subject"),
+        _legacy_string_value("rel"),
+        _legacy_string_value("object"),
+    )
+    token = fact_term_token_from_values(legacy_values)
+    sqlite_con = sqlite3.connect(tmp_path / "kb.sqlite")
+    try:
+        cur = sqlite_con.execute(
+            """
+            INSERT INTO facts(subject, relation, object, status, term_token)
+            VALUES ('subject', 'rel', 'object', 'confirmed', ?) RETURNING id
+            """,
+            (token,),
+        )
+        fact_id = int(cur.fetchone()[0])
+        sqlite_con.commit()
+    finally:
+        sqlite_con.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)))
+    try:
+        con.execute(
+            """
+            CREATE TABLE fact_terms (
+                fact_id BIGINT PRIMARY KEY,
+                subject VARCHAR NOT NULL,
+                rel VARCHAR NOT NULL,
+                object VARCHAR NOT NULL
+            )
+            """
+        )
+        con.execute("INSERT INTO fact_terms VALUES (?, ?, ?, ?)", [fact_id, *legacy_values])
+    finally:
+        con.close()
+
+    s = _store(tmp_path)
+    try:
+        assert s.engine_fact_terms() == [
+            {
+                "id": fact_id,
+                "subject": StringLit("subject"),
+                "relation": StringLit("rel"),
+                "object": StringLit("object"),
+            }
+        ]
+        assert s.get_fact(fact_id)["term_token"] == token
+        record = s.fact_terms.get_fact_term_record(fact_id)
+        assert record is not None
+        assert record.term_token == record.content_token == token
+    finally:
+        s.close()
+
+
+def test_stale_four_column_nfc_migration_fails_during_store_initialization(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    bootstrap = _store(tmp_path)
+    bootstrap.close()
+    nfd_value = "Cafe\u0301"
+    legacy_values = (
+        _legacy_string_value(nfd_value),
+        _legacy_string_value("rel"),
+        _legacy_string_value(nfd_value),
+    )
+    sqlite_con = sqlite3.connect(tmp_path / "kb.sqlite")
+    try:
+        cur = sqlite_con.execute(
+            """
+            INSERT INTO facts(subject, relation, object, status, term_token)
+            VALUES (?, ?, ?, 'confirmed', ?) RETURNING id
+            """,
+            (nfd_value, "rel", nfd_value, "stale-token"),
+        )
+        fact_id = int(cur.fetchone()[0])
+        sqlite_con.commit()
+    finally:
+        sqlite_con.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)))
+    try:
+        con.execute(
+            """
+            CREATE TABLE fact_terms (
+                fact_id BIGINT PRIMARY KEY,
+                subject VARCHAR NOT NULL,
+                rel VARCHAR NOT NULL,
+                object VARCHAR NOT NULL
+            )
+            """
+        )
+        con.execute("INSERT INTO fact_terms VALUES (?, ?, ?, ?)", [fact_id, *legacy_values])
+    finally:
+        con.close()
+
+    s = Store(tmp_path / "kb.sqlite")
+    try:
+        with pytest.raises(DuckDBFactTermStoreError, match="stale DuckDB fact terms"):
+            s.init_schema()
+    finally:
+        s.close()
+
+    sqlite_con = sqlite3.connect(tmp_path / "kb.sqlite")
+    try:
+        assert sqlite_con.execute(
+            "SELECT term_token FROM facts WHERE id = ?", (fact_id,)
+        ).fetchone() == ("stale-token",)
+    finally:
+        sqlite_con.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)), read_only=True)
+    try:
+        columns = {row[1] for row in con.execute("PRAGMA table_info('fact_terms')").fetchall()}
+        assert columns == {"fact_id", "subject", "rel", "object"}
+        assert con.execute(
+            "SELECT subject, rel, object FROM fact_terms WHERE fact_id = ?", [fact_id]
+        ).fetchone() == legacy_values
+    finally:
+        con.close()
+
+
+def test_sqlite_commit_failure_compensates_a_four_column_nfc_migration(tmp_path, monkeypatch):
+    duckdb = pytest.importorskip("duckdb")
+    bootstrap = _store(tmp_path)
+    bootstrap.close()
+    nfd_value = "Cafe\u0301"
+    legacy_values = (
+        _legacy_string_value(nfd_value),
+        _legacy_string_value("rel"),
+        _legacy_string_value(nfd_value),
+    )
+    legacy_token = fact_term_token_from_values(legacy_values)
+    sqlite_con = sqlite3.connect(tmp_path / "kb.sqlite")
+    try:
+        cur = sqlite_con.execute(
+            """
+            INSERT INTO facts(subject, relation, object, status, term_token)
+            VALUES (?, ?, ?, 'confirmed', ?) RETURNING id
+            """,
+            (nfd_value, "rel", nfd_value, legacy_token),
+        )
+        fact_id = int(cur.fetchone()[0])
+        sqlite_con.commit()
+    finally:
+        sqlite_con.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)))
+    try:
+        con.execute(
+            """
+            CREATE TABLE fact_terms (
+                fact_id BIGINT PRIMARY KEY,
+                subject VARCHAR NOT NULL,
+                rel VARCHAR NOT NULL,
+                object VARCHAR NOT NULL
+            )
+            """
+        )
+        con.execute("INSERT INTO fact_terms VALUES (?, ?, ?, ?)", [fact_id, *legacy_values])
+    finally:
+        con.close()
+
+    s = Store(tmp_path / "kb.sqlite")
+
+    def fail_commit() -> None:
+        raise sqlite3.OperationalError("forced SQLite commit failure")
+
+    monkeypatch.setattr(s, "_commit_nfc_sqlite_migration", fail_commit)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="forced SQLite commit failure"):
+            s.init_schema()
+    finally:
+        s.close()
+
+    sqlite_con = sqlite3.connect(tmp_path / "kb.sqlite")
+    try:
+        assert sqlite_con.execute(
+            "SELECT term_token FROM facts WHERE id = ?", (fact_id,)
+        ).fetchone() == (legacy_token,)
+    finally:
+        sqlite_con.close()
+    con = duckdb.connect(str(fact_terms_path(tmp_path)), read_only=True)
+    try:
+        columns = {row[1] for row in con.execute("PRAGMA table_info('fact_terms')").fetchall()}
+        assert columns == {"fact_id", "subject", "rel", "object"}
+        assert con.execute(
+            "SELECT subject, rel, object FROM fact_terms WHERE fact_id = ?", [fact_id]
+        ).fetchone() == legacy_values
+    finally:
+        con.close()
 
 
 def test_add_fact_writes_sqlite_metadata_and_stringlit_terms(tmp_path):
@@ -377,11 +672,9 @@ def test_engine_fact_terms_rejects_missing_modern_sidecar_terms(tmp_path):
     assert s.get_fact_terms(fid) is None
 
 
-def test_amend_fact_refuses_and_writes_nothing_when_sidecar_is_corrupt(tmp_path):
-    # Guard the write at the store, not only the web route, so every caller (CLI,
-    # any future writer) is protected. The pre-write read of the structural terms
-    # forces the sidecar open, so genuine corruption aborts the amend before any
-    # SQLite write -- both stores are left untouched.
+def test_store_init_schema_refuses_a_corrupt_existing_sidecar(tmp_path):
+    # Existing sidecars are opened at initialization so corruption cannot be
+    # deferred until a later SQLite write transaction first accesses fact_terms.
     seed = _store(tmp_path)
     fid = seed.add_fact(
         Compound("person", (StringLit("Ada"),)),
@@ -393,13 +686,14 @@ def test_amend_fact_refuses_and_writes_nothing_when_sidecar_is_corrupt(tmp_path)
     seed.close()
     fact_terms_path(tmp_path).write_bytes(b"not a duckdb database file" * 500)
 
-    store = _store(tmp_path)
-    with pytest.raises(DuckDBFactTermStoreError):
-        store.amend_fact(fid, subject="Ada", relation="born_in", obj="Paris", note="")
-
-    # get_fact reads SQLite only, so it stays legible through the corruption; an
-    # unchanged token proves the amend wrote nothing to either store.
-    assert store.get_fact(fid)["term_token"] == token
+    store = Store(tmp_path / "kb.sqlite")
+    try:
+        with pytest.raises(DuckDBFactTermStoreError, match="failed to open DuckDB fact-term store"):
+            store.init_schema()
+        # SQLite was not modified before the corrupt sidecar error surfaced.
+        assert store.get_fact(fid)["term_token"] == token
+    finally:
+        store.close()
 
 
 def test_engine_fact_terms_rejects_stale_modern_sidecar_terms(tmp_path):

--- a/verinote/engine/duckdb_terms.py
+++ b/verinote/engine/duckdb_terms.py
@@ -26,6 +26,7 @@ from verinote.engine.terms import (
     Var,
     term_compare_key,
 )
+from verinote.text import nfc
 
 # Re-exported for the backend, which reads storage encoding and equality from
 # one place. `term_compare_key` itself belongs to `engine.terms`: it is the term
@@ -61,6 +62,25 @@ def term_to_duckdb_value(term: Term) -> str:
         sort_keys=True,
         separators=(",", ":"),
     )
+
+
+def _legacy_duckdb_value_to_term(value: object) -> Term:
+    """Decode a pre-NFC canonical value for the fact-term migration only.
+
+    This deliberately preserves the former JSON format's exactness while
+    allowing StringLit leaves that are not NFC. Production reads must continue
+    through `duckdb_value_to_term`, which requires the current encoding.
+    """
+    if not isinstance(value, str):
+        raise DuckDBTermError(f"DuckDB term value must be a string, got {type(value)!r}")
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise DuckDBTermError(f"invalid DuckDB term JSON: {exc}") from exc
+    term = _payload_to_term(payload)
+    if _legacy_term_to_duckdb_value(term) != value:
+        raise DuckDBTermError("legacy DuckDB term value is not canonical")
+    return term
 
 
 def duckdb_value_to_term(value: object) -> Term:
@@ -112,18 +132,31 @@ def create_decl_table_sql(declaration: Declaration) -> str:
     )
 
 
-def _term_to_payload(term: Term) -> dict[str, Any]:
+def _legacy_term_to_duckdb_value(term: Term) -> str:
+    """Return the canonical term encoding used before StringLit NFC storage."""
+    return json.dumps(
+        _term_to_payload(term, normalize_strings=False),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _term_to_payload(term: Term, *, normalize_strings: bool = True) -> dict[str, Any]:
     if isinstance(term, Atom):
         return {"t": "atom", "v": term.name}
     if isinstance(term, Var):
         return {"t": "var", "v": term.name}
     if isinstance(term, StringLit):
-        return {"t": "string", "v": term.value}
+        return {"t": "string", "v": nfc(term.value) if normalize_strings else term.value}
     if isinstance(term, NumberLit):
         return {"t": "number", "v": term.value}
     if isinstance(term, Compound):
         return {
-            "a": [_term_to_payload(arg) for arg in term.args],
+            "a": [
+                _term_to_payload(arg, normalize_strings=normalize_strings)
+                for arg in term.args
+            ],
             "f": term.functor,
             "t": "compound",
         }

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -257,6 +257,28 @@ class Store:
     def init_schema(self) -> None:
         self._conn.executescript(_load_schema())
         self._ensure_schema_migrations()
+        # A legacy sidecar must migrate before any later SQLite write transaction
+        # reaches `fact_terms`: its NFC rewrite also updates SQLite tokens and
+        # therefore needs to start its own short transaction. Keep a new KB lazy
+        # by doing this only when the sidecar already exists.
+        from verinote.store.duckdb_fact_terms import (
+            DuckDBFactTermStoreError,
+            DuckDBFactTermStoreLockedError,
+            fact_terms_path,
+        )
+
+        if fact_terms_path(self.db_path.parent).is_file():
+            try:
+                _ = self.fact_terms
+            except DuckDBFactTermStoreError as exc:
+                # Only conditions that can clear without changing the sidecar
+                # are deferred. Corrupt/open failures and structured migration
+                # failures must surface now, before a later write transaction
+                # can retry coordination.
+                if isinstance(exc, DuckDBFactTermStoreLockedError) or str(exc) == "DuckDB is not installed":
+                    pass
+                else:
+                    raise
 
     def close(self) -> None:
         if self._inference_cache is not None:
@@ -302,10 +324,79 @@ class Store:
     def fact_terms(self):
         """Per-KB DuckDB sidecar for structural fact terms."""
         if self._fact_terms is None:
-            from verinote.store.duckdb_fact_terms import DuckDBFactTermStore
+            from verinote.store.duckdb_fact_terms import DuckDBFactTermStore, fact_terms_path
 
-            self._fact_terms = DuckDBFactTermStore.for_root(self.db_path.parent)
+            fact_terms = DuckDBFactTermStore.for_root(self.db_path.parent)
+            try:
+                if fact_terms_path(self.db_path.parent).exists():
+                    plan = fact_terms.plan_nfc_migration()
+                    self._migrate_nfc_fact_terms(fact_terms, plan)
+                fact_terms.init_schema()
+            except BaseException:
+                fact_terms.close()
+                raise
+            self._fact_terms = fact_terms
         return self._fact_terms
+
+    def _migrate_nfc_fact_terms(self, fact_terms, plan) -> None:
+        """Coordinate a planned sidecar NFC migration with SQLite tokens.
+
+        A fact token is a cross-store corruption guard, not display metadata.
+        Therefore a row is eligible only when it still has the legacy token (or
+        predates SQLite tokens entirely); a different token remains stale. The
+        SQLite transaction stages those guarded updates, DuckDB applies its
+        schema/payload transaction, and SQLite commits last. If that final
+        commit fails, DuckDB compensates the exact plan, including a legacy
+        four-column schema.
+        """
+        if not plan.needs_apply:
+            return
+        if self._conn.in_transaction:
+            from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+
+            raise DuckDBFactTermStoreError(
+                "cannot coordinate NFC fact-term migration inside an existing SQLite transaction"
+            )
+        duckdb_applied = False
+        self._conn.execute("BEGIN")
+        try:
+            for migration in plan.rewrites:
+                row = self._conn.execute(
+                    "SELECT term_token FROM facts WHERE id = ?", (migration.fact_id,)
+                ).fetchone()
+                if row is None:
+                    continue
+                sqlite_token = row["term_token"]
+                if sqlite_token == migration.new_term_token:
+                    continue
+                if sqlite_token not in {None, migration.legacy_content_token}:
+                    raise _stale_fact_terms_error([migration.fact_id])
+                cur = self._conn.execute(
+                    "UPDATE facts SET term_token = ? WHERE id = ? AND term_token IS ?",
+                    (migration.new_term_token, migration.fact_id, sqlite_token),
+                )
+                if cur.rowcount != 1:
+                    raise _stale_fact_terms_error([migration.fact_id])
+            fact_terms.apply_nfc_migration(plan)
+            duckdb_applied = True
+            self._commit_nfc_sqlite_migration()
+        except BaseException:
+            self._rollback_quietly()
+            if duckdb_applied:
+                try:
+                    fact_terms.revert_nfc_migration(plan)
+                except Exception as exc:
+                    from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+
+                    raise DuckDBFactTermStoreError(
+                        "failed to restore DuckDB fact terms after SQLite NFC token "
+                        "synchronization failed"
+                    ) from exc
+            raise
+
+    def _commit_nfc_sqlite_migration(self) -> None:
+        """Commit the SQLite half after DuckDB has applied a migration plan."""
+        self._conn.execute("COMMIT")
 
     def __enter__(self) -> "Store":
         return self
@@ -1431,17 +1522,25 @@ class Store:
         """Return confirmed/accepted facts using DuckDB terms as logical values."""
         with self._lock:
             rows = self.facts(statuses=ENGINE_STATUSES)
+            if not rows:
+                return []
+            # Initializing the sidecar may migrate legacy NFD terms and update
+            # their SQLite coherence tokens. Read the authoritative metadata
+            # only after that coordinator step, not from a stale pre-migration
+            # snapshot.
+            fact_terms = self.fact_terms
+            rows = self.facts(statuses=ENGINE_STATUSES)
             ids = [int(row["id"]) for row in rows]
             if not ids:
                 return []
 
-            records = self.fact_terms.get_many_fact_term_records(ids)
+            records = fact_terms.get_many_fact_term_records(ids)
             missing = [fact_id for fact_id in ids if fact_id not in records]
             if missing:
                 if self._has_fact_terms_marker():
                     raise _missing_fact_terms_error(missing)
                 self.backfill_fact_terms()
-                records = self.fact_terms.get_many_fact_term_records(ids)
+                records = fact_terms.get_many_fact_term_records(ids)
                 missing = [fact_id for fact_id in ids if fact_id not in records]
             if missing:
                 raise _missing_fact_terms_error(missing)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -271,11 +271,16 @@ class Store:
             try:
                 _ = self.fact_terms
             except DuckDBFactTermStoreError as exc:
-                # Only conditions that can clear without changing the sidecar
-                # are deferred. Corrupt/open failures and structured migration
-                # failures must surface now, before a later write transaction
-                # can retry coordination.
-                if isinstance(exc, DuckDBFactTermStoreLockedError) or str(exc) == "DuckDB is not installed":
+                # Availability failures remain deferred so callers can render
+                # their established sidecar-halt state. Legacy NFC migration
+                # semantic failures (malformed payloads or stale tokens) are
+                # deliberately not in this set: they must surface before a
+                # later SQLite write transaction retries coordination.
+                if (
+                    isinstance(exc, DuckDBFactTermStoreLockedError)
+                    or str(exc) == "DuckDB is not installed"
+                    or str(exc).startswith("failed to open DuckDB fact-term store:")
+                ):
                     pass
                 else:
                     raise

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -16,6 +16,7 @@ from typing import Iterable, Iterator
 
 from verinote.engine.duckdb_terms import (
     DuckDBTermError,
+    _legacy_duckdb_value_to_term,
     duckdb_value_to_term,
     term_to_duckdb_value,
 )
@@ -61,6 +62,37 @@ class FactTermRecord:
     content_token: str
 
 
+@dataclass(frozen=True)
+class NfcFactTermRewrite:
+    """One fact-term row rewritten from the legacy non-NFC encoding."""
+
+    fact_id: int
+    old_values: tuple[str, str, str]
+    old_term_token: str | None
+    legacy_content_token: str
+    new_values: tuple[str, str, str]
+    new_term_token: str
+
+
+@dataclass(frozen=True)
+class NfcFactTermMigrationPlan:
+    """A non-mutating NFC migration plan for one existing sidecar."""
+
+    has_fact_terms_table: bool
+    has_term_token: bool
+    rewrites: tuple[NfcFactTermRewrite, ...]
+
+    @property
+    def needs_term_token(self) -> bool:
+        """Whether applying this plan must add the legacy missing column."""
+        return self.has_fact_terms_table and not self.has_term_token
+
+    @property
+    def needs_apply(self) -> bool:
+        """Whether this plan makes any DuckDB schema or payload change."""
+        return self.needs_term_token or bool(self.rewrites)
+
+
 class DuckDBFactTermStore:
     """Low-level DuckDB store for logical fact terms keyed by SQLite fact ids."""
 
@@ -89,11 +121,19 @@ class DuckDBFactTermStore:
         return cls(fact_terms_path(root))
 
     def init_schema(self) -> None:
-        """Create the fact term table if it does not already exist."""
+        """Create a missing fact-term table without rewriting existing rows."""
         with self._operation() as con:
             self._init_schema_on(con)
 
     def _init_schema_on(self, con) -> None:
+        if _fact_terms_columns(
+            self._run(
+                con,
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'fact_terms'",
+            ).fetchall()
+        ):
+            return
         self._run(
             con,
             """
@@ -106,12 +146,138 @@ class DuckDBFactTermStore:
             )
             """,
         )
-        columns = {
-            row[1]
-            for row in self._run(con, "PRAGMA table_info('fact_terms')").fetchall()
-        }
-        if "term_token" not in columns:
-            self._run(con, "ALTER TABLE fact_terms ADD COLUMN term_token VARCHAR")
+
+    def plan_nfc_migration(self) -> NfcFactTermMigrationPlan:
+        """Inspect an existing sidecar without changing its schema or rows."""
+        with self._existing_operation() as con:
+            columns = _fact_terms_columns(
+                self._run(
+                    con,
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'fact_terms'",
+                ).fetchall()
+            )
+            if not columns:
+                return NfcFactTermMigrationPlan(False, False, ())
+            required = {"fact_id", "subject", "rel", "object"}
+            if not required.issubset(columns):
+                raise DuckDBFactTermStoreError("DuckDB fact-term table has an invalid schema")
+            has_term_token = "term_token" in columns
+            token_sql = "term_token" if has_term_token else "NULL AS term_token"
+            rows = self._run(
+                con,
+                "SELECT fact_id, subject, rel, object, " + token_sql + " FROM fact_terms ORDER BY fact_id",
+            ).fetchall()
+        rewrites: list[NfcFactTermRewrite] = []
+        for row in rows:
+            fact_id = _validate_fact_id(row[0])
+            values = (row[1], row[2], row[3])
+            terms = _decode_legacy_row(fact_id, values)
+            normalized_values = (
+                term_to_duckdb_value(terms[0]),
+                term_to_duckdb_value(terms[1]),
+                term_to_duckdb_value(terms[2]),
+            )
+            legacy_token = _validate_legacy_token(fact_id, values, row[4])
+            # Adding term_token to a four-column sidecar must also backfill
+            # every existing row, even when its payload was already NFC.
+            if normalized_values != values or not has_term_token:
+                old_values = _string_values(values)
+                rewrites.append(
+                    NfcFactTermRewrite(
+                        fact_id=fact_id,
+                        old_values=old_values,
+                        old_term_token=legacy_token,
+                        legacy_content_token=fact_term_token_from_values(old_values),
+                        new_values=normalized_values,
+                        new_term_token=fact_term_token_from_values(normalized_values),
+                    )
+                )
+        return NfcFactTermMigrationPlan(True, has_term_token, tuple(rewrites))
+
+    def apply_nfc_migration(self, plan: NfcFactTermMigrationPlan) -> None:
+        """Apply a previously inspected plan in one guarded DuckDB transaction."""
+        if not plan.needs_apply:
+            return
+        with self._existing_operation() as con:
+            self._run(con, "BEGIN TRANSACTION")
+            try:
+                columns = _fact_terms_columns(
+                    self._run(
+                        con,
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_name = 'fact_terms'",
+                    ).fetchall()
+                )
+                if not plan.has_fact_terms_table or not columns:
+                    raise DuckDBFactTermStoreError("DuckDB fact-term table changed during migration")
+                if ("term_token" in columns) != plan.has_term_token:
+                    raise DuckDBFactTermStoreError("DuckDB fact-term schema changed during migration")
+                if plan.needs_term_token:
+                    self._run(con, "ALTER TABLE fact_terms ADD COLUMN term_token VARCHAR")
+                for rewrite in plan.rewrites:
+                    token_sql = "term_token" if plan.has_term_token else "NULL AS term_token"
+                    row = self._run(
+                        con,
+                        "SELECT subject, rel, object, " + token_sql + " FROM fact_terms WHERE fact_id = ?",
+                        [rewrite.fact_id],
+                    ).fetchone()
+                    if row != (*rewrite.old_values, rewrite.old_term_token):
+                        raise DuckDBFactTermStoreError(
+                            "DuckDB fact-term data changed during migration for "
+                            f"fact_id={rewrite.fact_id}"
+                        )
+                    self._run(
+                        con,
+                        """
+                        UPDATE fact_terms
+                        SET subject = ?, rel = ?, object = ?, term_token = ?
+                        WHERE fact_id = ?
+                        """,
+                        [*rewrite.new_values, rewrite.new_term_token, rewrite.fact_id],
+                    )
+                self._run(con, "COMMIT")
+            except BaseException:
+                self._rollback_on(con)
+                raise
+
+    def revert_nfc_migration(self, plan: NfcFactTermMigrationPlan) -> None:
+        """Compensate a committed plan after the paired SQLite commit fails."""
+        if not plan.needs_apply:
+            return
+        with self._existing_operation() as con:
+            self._run(con, "BEGIN TRANSACTION")
+            try:
+                for rewrite in plan.rewrites:
+                    row = self._run(
+                        con,
+                        "SELECT subject, rel, object, term_token FROM fact_terms WHERE fact_id = ?",
+                        [rewrite.fact_id],
+                    ).fetchone()
+                    if row != (*rewrite.new_values, rewrite.new_term_token):
+                        raise DuckDBFactTermStoreError(
+                            "cannot restore NFC migration because fact-term data changed "
+                            f"for fact_id={rewrite.fact_id}"
+                        )
+                    self._run(
+                        con,
+                        """
+                        UPDATE fact_terms
+                        SET subject = ?, rel = ?, object = ?, term_token = ?
+                        WHERE fact_id = ?
+                        """,
+                        [*rewrite.old_values, rewrite.old_term_token, rewrite.fact_id],
+                    )
+                self._run(con, "COMMIT")
+            except BaseException:
+                self._rollback_on(con)
+                raise
+        if plan.needs_term_token:
+            # DuckDB cannot commit a DROP COLUMN in the same transaction that
+            # restores rows after the original ADD COLUMN. Run the schema half
+            # in a fresh transaction after the original values are durable.
+            with self._existing_operation() as con:
+                self._run(con, "ALTER TABLE fact_terms DROP COLUMN term_token")
 
     def close(self) -> None:
         """Release the store.
@@ -143,6 +309,22 @@ class DuckDBFactTermStore:
             if not self._schema_ready:
                 self._init_schema_on(con)
                 self._schema_ready = True
+            yield con
+        finally:
+            con.close()
+
+    @contextmanager
+    def _existing_operation(self) -> Iterator[object]:
+        """Open an existing file-backed sidecar without initializing it."""
+        if self.path is None:
+            if self._con is None:
+                raise DuckDBFactTermStoreError("DuckDB fact-term store is closed")
+            yield self._con
+            return
+        if not self.path.exists():
+            raise DuckDBFactTermStoreError("DuckDB fact-term store does not exist")
+        con = self._open_with_retry()
+        try:
             yield con
         finally:
             con.close()
@@ -292,6 +474,12 @@ class DuckDBFactTermStore:
         except Exception as exc:
             raise DuckDBFactTermStoreError(f"DuckDB fact-term store error: {exc}") from exc
 
+    def _rollback_on(self, con) -> None:
+        try:
+            self._run(con, "ROLLBACK")
+        except DuckDBFactTermStoreError:
+            pass
+
 
 def fact_terms_path(root: str | Path) -> Path:
     """Return the default DuckDB fact-term store path for a KB root."""
@@ -377,6 +565,51 @@ def _duckdb_term_values(subject: object, relation: object, obj: object) -> tuple
         term_to_duckdb_value(_coerce_term(relation)),
         term_to_duckdb_value(_coerce_term(obj)),
     )
+
+
+def _fact_terms_columns(rows: Iterable[tuple[object, ...]]) -> set[str]:
+    """Return names from an `information_schema.columns` result."""
+    return {str(row[0]) for row in rows}
+
+
+def _decode_legacy_row(
+    fact_id: int, row: tuple[object, object, object]
+) -> tuple[Term, Term, Term]:
+    """Decode the former exact JSON encoding while an initialization runs."""
+    decoded: list[Term] = []
+    for column, value in zip(_TERM_COLUMNS, row, strict=True):
+        try:
+            decoded.append(_legacy_duckdb_value_to_term(value))
+        except DuckDBTermError as exc:
+            raise DuckDBFactTermStoreError(
+                f"malformed legacy DuckDB term for fact_id={fact_id} column={column}: {exc}"
+            ) from exc
+    return (decoded[0], decoded[1], decoded[2])
+
+
+def _string_values(values: tuple[object, object, object]) -> tuple[str, str, str]:
+    """Narrow decoded DuckDB VARCHAR values for token hashing."""
+    if not all(isinstance(value, str) for value in values):
+        raise DuckDBFactTermStoreError("malformed legacy DuckDB term payload")
+    return (values[0], values[1], values[2])
+
+
+def _validate_legacy_token(
+    fact_id: int, values: tuple[object, object, object], stored_token: object
+) -> str | None:
+    """Reject a legacy token that was not coherent with its original payload."""
+    if stored_token is None:
+        return None
+    if not isinstance(stored_token, str):
+        raise DuckDBFactTermStoreError(
+            f"malformed DuckDB term token for fact_id={fact_id}: {stored_token!r}"
+        )
+    legacy_values = _string_values(values)
+    if stored_token != fact_term_token_from_values(legacy_values):
+        raise DuckDBFactTermStoreError(
+            f"legacy DuckDB term token does not match payload for fact_id={fact_id}"
+        )
+    return stored_token
 
 
 def _decode_row(fact_id: int, row: tuple[object, object, object]) -> tuple[Term, Term, Term]:


### PR DESCRIPTION
Closes #201

Normalize persisted StringLit payloads to NFC and coordinate legacy fact-term migration with SQLite coherence tokens.

Validation: focused DuckDB term, fact-term, concurrency, and Store suites passed (280 tests).