### PR TITLE
fix: require explicit engine policies

### DIFF
--- a/tests/contract/test_extraction_contract.py
+++ b/tests/contract/test_extraction_contract.py
@@ -106,7 +106,8 @@ def test_functional_conflict_fires_on_two_dates(require_opt_in):
         [
             {"subject": "Acme Robotics", "relation": rel, "object": "2020"},
             {"subject": "Acme Robotics", "relation": rel, "object": "2021"},
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
     assert conflict.engine_available is True
     assert conflict.errors == 1
@@ -118,6 +119,7 @@ def test_functional_conflict_fires_on_two_dates(require_opt_in):
         [
             {"subject": "Acme Robotics", "relation": non_functional, "object": "2020"},
             {"subject": "Acme Robotics", "relation": non_functional, "object": "2021"},
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
     assert clean.errors == 0

--- a/tests/test_answer_qid_order.py
+++ b/tests/test_answer_qid_order.py
@@ -36,20 +36,26 @@ def _qids_in_order(rep):
     return [answer.split(":")[0] for answer in rep.answers]
 
 
-def _wirelog_check(query_dl=None, policy_dl=None):
+def _wirelog_check(query_dl=None, policy_dl=_RELATION_DECL):
     return run_check(compile_dl(_FACTS), policy_dl=policy_dl, query_dl=query_dl)
 
 
 def test_duckdb_answers_order_by_question_number():
     _duckdb()
-    rep = run_check_duckdb(_FACTS, query_dl=_query_for(range(1, 13)))
+    rep = run_check_duckdb(
+        _FACTS, policy_dl=_RELATION_DECL, query_dl=_query_for(range(1, 13))
+    )
 
     assert _qids_in_order(rep) == [f"q{n}" for n in range(1, 13)]
 
 
 def test_duckdb_answers_order_across_the_hundreds_boundary():
     _duckdb()
-    rep = run_check_duckdb(_FACTS, query_dl=_query_for([9, 10, 99, 100, 101]))
+    rep = run_check_duckdb(
+        _FACTS,
+        policy_dl=_RELATION_DECL,
+        query_dl=_query_for([9, 10, 99, 100, 101]),
+    )
 
     assert _qids_in_order(rep) == ["q9", "q10", "q99", "q100", "q101"]
 

--- a/tests/test_corroboration.py
+++ b/tests/test_corroboration.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 import unicodedata
 
+import pytest
+
 from verinote.pipeline.corroboration import (
     CorroborationPolicyError,
     corroboration,
@@ -33,6 +35,11 @@ functional("quoted \" relation").
         "established_on",
         'quoted " relation',
     }
+
+
+def test_functional_relations_rejects_none_policy():
+    with pytest.raises(TypeError, match="policy_dl"):
+        functional_relations(None)
 
 
 def test_store_relation_aliases_include_default_policy(tmp_path):

--- a/tests/test_dead_rule_warn.py
+++ b/tests/test_dead_rule_warn.py
@@ -111,7 +111,7 @@ def test_run_check_surfaces_dead_rule_as_nonblocking_finding():
             {"subject": "Org", "relation": "is_a", "object": "company"},
         ]
     )
-    rep = run_check(dl)
+    rep = run_check(dl, policy_dl=DEFAULT_POLICY)
     assert rep.ok is True
     assert rep.errors == 0
     assert rep.warnings >= 1
@@ -143,7 +143,8 @@ def test_duckdb_production_path_surfaces_dead_rule_with_consistent_count():
         [
             {"subject": "Org", "relation": "established_on", "object": "2020"},
             {"subject": "Org", "relation": "is_a", "object": "company"},
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
 
     assert rep.ok is True
@@ -245,7 +246,8 @@ def test_duckdb_conflict_and_dead_rule_coexist_without_suppression():
             {"subject": "Org", "relation": "established_on", "object": "2020"},
             {"subject": "Org", "relation": "established_on", "object": "2021"},
             {"subject": "Org", "relation": "is_a", "object": "company"},
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
 
     assert rep.ok is False

--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -4,9 +4,12 @@ import builtins
 import pytest
 
 import verinote.engine.duckdb_backend as duckdb_backend
+from verinote.engine import DEFAULT_POLICY
 from verinote.engine.duckdb_backend import DuckDBInferenceCache, run_check_duckdb
 from verinote.engine.duckdb_terms import term_to_duckdb_value
 from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
+
+_RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
 
 
 def _duckdb():
@@ -31,12 +34,28 @@ def test_duckdb_backend_missing_duckdb_is_blocking(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    rep = run_check_duckdb([])
+    rep = run_check_duckdb([], policy_dl=DEFAULT_POLICY)
 
     assert rep.ok is False
     assert rep.engine_available is False
     assert rep.errors == 1
     assert "DuckDB is not installed" in rep.text
+
+
+@pytest.mark.parametrize("kwargs", ({}, {"policy_dl": None}))
+def test_duckdb_backend_requires_an_explicit_string_policy(kwargs):
+    with pytest.raises(TypeError, match="policy_dl"):
+        run_check_duckdb([], **kwargs)
+
+
+@pytest.mark.parametrize("kwargs", ({}, {"policy_dl": None}))
+def test_duckdb_inference_cache_requires_an_explicit_string_policy(kwargs):
+    cache = DuckDBInferenceCache()
+    try:
+        with pytest.raises(TypeError, match="policy_dl"):
+            cache.run_check([], **kwargs)
+    finally:
+        cache.close()
 
 
 def test_duckdb_backend_default_policy_flags_functional_conflict():
@@ -46,7 +65,8 @@ def test_duckdb_backend_default_policy_flags_functional_conflict():
             {"subject": "Org", "relation": "established_on", "object": "2020"},
             {"subject": "Org", "relation": "established_on", "object": "2021"},
             {"subject": "Org", "relation": "is_a", "object": "company"},
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
 
     assert rep.engine_available is True
@@ -80,7 +100,8 @@ def test_duckdb_backend_compares_equivalent_atom_string_and_number_terms():
                 "relation": Atom("born_on"),
                 "object": NumberLit(1900),
             },
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
 
     assert rep.ok is False
@@ -104,7 +125,8 @@ def test_duckdb_backend_treats_equal_number_and_string_values_as_equal():
                 "relation": Atom("born_on"),
                 "object": NumberLit(1815),
             },
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
 
     assert rep.ok is True
@@ -150,7 +172,8 @@ def test_duckdb_backend_consistent_kb_is_ok():
         [
             {"subject": "Org", "relation": "established_on", "object": "2020"},
             {"subject": "Org", "relation": "is_a", "object": "company"},
-        ]
+        ],
+        policy_dl=DEFAULT_POLICY,
     )
 
     # No functional conflict, so the gate stays open — but the shipped default
@@ -193,6 +216,7 @@ def test_duckdb_backend_answer_query_format_matches_check_report():
             {"subject": "Ada", "relation": "born_in", "object": "London"},
             {"subject": "Ada", "relation": "is_a", "object": "mathematician"},
         ],
+        policy_dl=DEFAULT_POLICY,
         query_dl=query,
     )
 
@@ -206,6 +230,7 @@ def test_duckdb_backend_omits_answer_bucket_when_query_has_no_rows():
     query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Other", "born_in", O).\n'
     rep = run_check_duckdb(
         [{"subject": "Ada", "relation": "born_in", "object": "London"}],
+        policy_dl=DEFAULT_POLICY,
         query_dl=query,
     )
 
@@ -323,6 +348,7 @@ def test_duckdb_backend_supports_compound_terms_in_base_relation():
                 ),
             }
         ],
+        policy_dl=DEFAULT_POLICY,
         query_dl=query,
     )
 
@@ -436,7 +462,7 @@ def test_duckdb_backend_string_values_are_parameterized():
 
 def test_duckdb_backend_check_report_fields_are_compatible():
     _duckdb()
-    rep = run_check_duckdb([])
+    rep = run_check_duckdb([], policy_dl=DEFAULT_POLICY)
 
     assert isinstance(rep.ok, bool)
     assert isinstance(rep.errors, int)
@@ -464,8 +490,8 @@ def test_duckdb_inference_cache_reuses_unchanged_relation(monkeypatch):
     cache = DuckDBInferenceCache()
     try:
         facts = [{"subject": "Org", "relation": "is_a", "object": "company"}]
-        assert cache.run_check(facts).ok is True
-        assert cache.run_check(list(facts)).ok is True
+        assert cache.run_check(facts, policy_dl=DEFAULT_POLICY).ok is True
+        assert cache.run_check(list(facts), policy_dl=DEFAULT_POLICY).ok is True
     finally:
         cache.close()
 
@@ -485,13 +511,15 @@ def test_duckdb_inference_cache_reloads_changed_relation(monkeypatch):
     cache = DuckDBInferenceCache()
     try:
         assert cache.run_check(
-            [{"subject": "Org", "relation": "established_on", "object": "2020"}]
+            [{"subject": "Org", "relation": "established_on", "object": "2020"}],
+            policy_dl=DEFAULT_POLICY,
         ).ok is True
         assert cache.run_check(
             [
                 {"subject": "Org", "relation": "established_on", "object": "2020"},
                 {"subject": "Org", "relation": "established_on", "object": "2021"},
-            ]
+            ],
+            policy_dl=DEFAULT_POLICY,
         ).ok is False
     finally:
         cache.close()
@@ -506,8 +534,8 @@ def test_duckdb_inference_cache_does_not_leak_query_answers():
         facts = [{"subject": "Ada", "relation": "born_in", "object": "London"}]
         query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n'
 
-        first = cache.run_check(facts, query_dl=query)
-        second = cache.run_check(facts)
+        first = cache.run_check(facts, policy_dl=DEFAULT_POLICY, query_dl=query)
+        second = cache.run_check(facts, policy_dl=DEFAULT_POLICY)
     finally:
         cache.close()
 
@@ -638,6 +666,7 @@ def test_duckdb_backend_escapes_control_characters_in_answers():
                 "object": "alpha\nbeta\tgamma\rdelta",
             }
         ],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -659,6 +688,7 @@ def test_duckdb_backend_keeps_meaningful_joiners_in_answers():
     value = "Ba\u200cnu \U0001f468\u200d\U0001f469\u200d\U0001f467"
     rep = run_check_duckdb(
         [{"subject": "Widget", "relation": "located_in", "object": value}],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -676,6 +706,7 @@ def test_duckdb_backend_neutralizes_bidi_overrides_in_answers():
                 "object": "safe\u202edangerous",
             }
         ],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -688,6 +719,7 @@ def test_duckdb_backend_escaping_is_lossless():
     _duckdb()
     rep = run_check_duckdb(
         [{"subject": "Widget", "relation": "located_in", "object": "alpha\nbeta"}],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -699,10 +731,12 @@ def test_duckdb_backend_keeps_literal_backslash_distinct_from_newline():
     _duckdb()
     literal = run_check_duckdb(
         [{"subject": "Widget", "relation": "located_in", "object": "alpha\\nbeta"}],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
     newline = run_check_duckdb(
         [{"subject": "Widget", "relation": "located_in", "object": "alpha\nbeta"}],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -716,6 +750,7 @@ def test_duckdb_backend_keeps_non_ascii_values_intact():
     _duckdb()
     rep = run_check_duckdb(
         [{"subject": "Widget", "relation": "located_in", "object": "제작소 Gizmo"}],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -726,6 +761,7 @@ def test_duckdb_backend_plain_string_answers_stay_unquoted():
     _duckdb()
     rep = run_check_duckdb(
         [{"subject": "Widget", "relation": "located_in", "object": "Gadget Works"}],
+        policy_dl=_RELATION_DECL,
         query_dl=_ANSWER_QUERY,
     )
 
@@ -831,6 +867,7 @@ def test_duckdb_backend_answer_comma_cannot_forge_two_answers():
     )
     rep = run_check_duckdb(
         [{"subject": "Ada", "relation": "worked_at", "object": "Analytical Engine, Ltd"}],
+        policy_dl=_RELATION_DECL,
         query_dl=query,
     )
 
@@ -855,6 +892,7 @@ def test_duckdb_backend_answers_keep_distinct_tuples_that_render_alike():
             {"subject": "Subj", "relation": "role", "object": _c("pair", Atom("a"), Atom("b"))},
             {"subject": "Subj", "relation": "role", "object": "pair(a, b)"},
         ],
+        policy_dl=_RELATION_DECL,
         query_dl=_ROLE_QUERY,
     )
 
@@ -884,6 +922,7 @@ def test_duckdb_backend_multi_column_answer_columns_cannot_forge_each_other():
             {"subject": "A B", "relation": "pair", "object": "C"},
             {"subject": "A", "relation": "pair", "object": "B C"},
         ],
+        policy_dl=_RELATION_DECL,
         query_dl=_PAIR_QUERY,
     )
 

--- a/tests/test_duckdb_fact_terms_concurrency.py
+++ b/tests/test_duckdb_fact_terms_concurrency.py
@@ -20,10 +20,10 @@ from verinote.config import local_root
 from verinote.engine.terms import StringLit
 from verinote.store import duckdb_fact_terms
 from verinote.store.duckdb_fact_terms import (
+    FACT_TERMS_FILENAME,
     DuckDBFactTermStore,
     DuckDBFactTermStoreError,
     DuckDBFactTermStoreLockedError,
-    FACT_TERMS_FILENAME,
 )
 
 # The subprocess tests read child output through `select`, which does not work on
@@ -187,6 +187,79 @@ def test_retry_succeeds_when_holder_releases_within_budget(tmp_path):
         assert store.get_fact_terms(1) is None
     finally:
         _terminate(holder)
+
+
+def test_first_schema_create_retries_the_catalog_write_conflict(tmp_path, monkeypatch):
+    """The exact concurrent-create error closes, reopens, and retries once."""
+    _duckdb()
+    root = tmp_path / "kb"
+    root.mkdir()
+    monkeypatch.setattr(duckdb_fact_terms, "_LOCK_POLL_SECONDS", 0.0)
+    original_run = DuckDBFactTermStore._run
+    original_open = DuckDBFactTermStore._open_with_retry
+    create_calls = 0
+    open_calls = 0
+
+    def conflict_once(self, con, sql, params=None):
+        nonlocal create_calls
+        if "CREATE TABLE IF NOT EXISTS fact_terms" in sql:
+            create_calls += 1
+            if create_calls == 1:
+                raise DuckDBFactTermStoreError(
+                    "DuckDB fact-term store error: TransactionContext Error: "
+                    'Catalog write-write conflict on create with "Schema\\0main\\0main\\0'
+                    'Table\\0main\\0fact_terms"'
+                )
+        return original_run(self, con, sql, params)
+
+    def count_open(self):
+        nonlocal open_calls
+        open_calls += 1
+        return original_open(self)
+
+    monkeypatch.setattr(DuckDBFactTermStore, "_run", conflict_once)
+    monkeypatch.setattr(DuckDBFactTermStore, "_open_with_retry", count_open)
+    store = DuckDBFactTermStore.for_root(root)
+    try:
+        assert store.get_fact_terms(1) is None
+        assert create_calls == 2
+        assert open_calls == 2
+    finally:
+        store.close()
+
+
+def test_first_schema_create_does_not_retry_other_errors(tmp_path, monkeypatch):
+    """Only DuckDB's exact catalog-create conflict is considered transient."""
+    _duckdb()
+    root = tmp_path / "kb"
+    root.mkdir()
+    original_run = DuckDBFactTermStore._run
+    original_open = DuckDBFactTermStore._open_with_retry
+    create_calls = 0
+    open_calls = 0
+
+    def fail_create(self, con, sql, params=None):
+        nonlocal create_calls
+        if "CREATE TABLE IF NOT EXISTS fact_terms" in sql:
+            create_calls += 1
+            raise DuckDBFactTermStoreError("DuckDB fact-term store error: malformed sidecar")
+        return original_run(self, con, sql, params)
+
+    def count_open(self):
+        nonlocal open_calls
+        open_calls += 1
+        return original_open(self)
+
+    monkeypatch.setattr(DuckDBFactTermStore, "_run", fail_create)
+    monkeypatch.setattr(DuckDBFactTermStore, "_open_with_retry", count_open)
+    store = DuckDBFactTermStore.for_root(root)
+    try:
+        with pytest.raises(DuckDBFactTermStoreError, match="malformed sidecar"):
+            store.get_fact_terms(1)
+        assert create_calls == 1
+        assert open_calls == 1
+    finally:
+        store.close()
 
 
 @_posix_only

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -32,6 +32,7 @@ _CONSISTENT = compile_dl(
         {"subject": "Org", "relation": "is_a", "object": "company"},
     ]
 )
+_RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
 
 
 def _require_pyrewire():
@@ -43,9 +44,15 @@ def test_parse_relation_facts_roundtrips_escaping():
     assert wl._parse_relation_facts(dl) == [('a"b', "r", "c")]
 
 
+@pytest.mark.parametrize("kwargs", ({}, {"policy_dl": None}))
+def test_wirelog_run_check_requires_an_explicit_string_policy(kwargs):
+    with pytest.raises(TypeError, match="policy_dl"):
+        run_check(_CONFLICT, **kwargs)
+
+
 def test_run_check_flags_functional_conflict():
     _require_pyrewire()
-    rep = run_check(_CONFLICT)
+    rep = run_check(_CONFLICT, policy_dl=DEFAULT_POLICY)
     assert rep.engine_available is True
     assert rep.errors > 0
     assert rep.ok is False
@@ -57,7 +64,7 @@ def test_run_check_flags_functional_conflict():
 
 def test_run_check_consistent_is_ok():
     _require_pyrewire()
-    rep = run_check(_CONSISTENT)
+    rep = run_check(_CONSISTENT, policy_dl=DEFAULT_POLICY)
     assert rep.errors == 0
     assert rep.ok is True
     # A consistent KB gates clean: no ERROR findings. (Non-blocking dead_rule
@@ -67,7 +74,7 @@ def test_run_check_consistent_is_ok():
 
 def test_run_check_empty_kb_is_ok():
     _require_pyrewire()
-    rep = run_check("")
+    rep = run_check("", policy_dl=DEFAULT_POLICY)
     assert rep.ok is True and rep.errors == 0
 
 
@@ -94,7 +101,7 @@ def test_run_check_surfaces_policy_error():
 
 def test_run_check_degrades_without_engine(monkeypatch):
     monkeypatch.setattr(wl, "_load_engine", lambda: None)
-    rep = run_check(_CONFLICT)
+    rep = run_check(_CONFLICT, policy_dl=DEFAULT_POLICY)
     assert rep.engine_available is False
     assert rep.ok is True and rep.errors == 0  # cannot gate without the engine
     assert "not installed" in rep.text
@@ -114,7 +121,7 @@ def test_run_check_evaluates_query():
         ]
     )
     query = '.decl answer_q1(value: symbol)\nanswer_q1(O) :- relation("Ada", "born_in", O).\n'
-    rep = run_check(dl, query_dl=query)
+    rep = run_check(dl, policy_dl=_RELATION_DECL, query_dl=query)
     assert rep.ok is True
     assert rep.answers == ["q1: London"]
     assert "q1: London" in rep.text
@@ -123,7 +130,7 @@ def test_run_check_evaluates_query():
 def test_run_check_without_query_has_no_answers():
     _require_pyrewire()
     dl = compile_dl([{"subject": "Ada", "relation": "is_a", "object": "x"}])
-    assert run_check(dl).answers == []
+    assert run_check(dl, policy_dl=DEFAULT_POLICY).answers == []
 
 
 def test_validate_query_accepts_relation_only():
@@ -291,7 +298,7 @@ def test_degraded_wirelog_report_cannot_echo_forged_lines(monkeypatch):
     )
     monkeypatch.setattr(wl, "_load_engine", lambda: None)
 
-    rep = run_check(dl)
+    rep = run_check(dl, policy_dl=DEFAULT_POLICY)
 
     assert rep.engine_available is False
     assert not any(line.startswith("ERROR forged") for line in rep.text.splitlines())
@@ -468,7 +475,7 @@ def test_run_check_orders_two_findings_of_the_same_level():
     this sort before happened to derive at most one tuple per level.
     """
     _require_pyrewire()
-    rep = run_check(_TWO_CONFLICTS)
+    rep = run_check(_TWO_CONFLICTS, policy_dl=DEFAULT_POLICY)
 
     assert rep.errors == 2
     errors = [f for f in rep.findings if f.startswith("ERROR ")]
@@ -525,7 +532,7 @@ def test_wirelog_finding_row_carries_a_shape_the_annotator_can_read():
     `test_wirelog_finding_shape.py`.
     """
     _require_pyrewire()
-    rep = run_check(_CONFLICT)
+    rep = run_check(_CONFLICT, policy_dl=DEFAULT_POLICY)
 
     # The level prefix picks the error rows; the count pins this to the one
     # conflict. The dead-rule WARN notes this policy also emits are not what the

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -10,6 +10,7 @@ trusting a now-empty table and reporting a false "consistent" result.
 import pytest
 
 import verinote.engine.duckdb_backend as duckdb_backend
+from verinote.engine import DEFAULT_POLICY
 from verinote.engine.duckdb_backend import DuckDBInferenceCache
 
 # Same subject established on two different dates: the default policy's
@@ -49,7 +50,7 @@ def test_cache_reloads_after_a_failed_reload(monkeypatch):
     cache = DuckDBInferenceCache()
     try:
         # 1) Load the conflict facts cleanly: the conflict is detected.
-        first = cache.run_check(_CONFLICT_FACTS)
+        first = cache.run_check(_CONFLICT_FACTS, policy_dl=DEFAULT_POLICY)
         assert first.ok is False
         assert first.findings == _CONFLICT_FINDINGS
 
@@ -62,7 +63,7 @@ def test_cache_reloads_after_a_failed_reload(monkeypatch):
             raise RuntimeError(boom)
 
         monkeypatch.setattr(duckdb_backend, "_load_relation_facts", raising_load)
-        failed = cache.run_check(_OTHER_FACTS)
+        failed = cache.run_check(_OTHER_FACTS, policy_dl=DEFAULT_POLICY)
         assert failed.ok is False
         assert failed.findings == [f"ERROR internal engine error: {boom}"]
 
@@ -70,7 +71,7 @@ def test_cache_reloads_after_a_failed_reload(monkeypatch):
         #    cache instance. The reload must run again (the base relation was
         #    emptied by the failed run), so the conflict is detected once more.
         monkeypatch.undo()
-        again = cache.run_check(_CONFLICT_FACTS)
+        again = cache.run_check(_CONFLICT_FACTS, policy_dl=DEFAULT_POLICY)
         assert again.ok is False
         assert again.findings == _CONFLICT_FINDINGS
     finally:

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 """A lost logic policy must never read as a consistent KB (#155)."""
 
+import importlib
+
 import pytest
 
 import verinote.cli as cli
 import verinote.pipeline.acceptance as acceptance
-from verinote.engine import DEFAULT_POLICY
+from verinote.engine import CheckReport, DEFAULT_POLICY
 from verinote.pipeline.acceptance import AcceptRecommendation
 from verinote.pipeline.corroboration import store_functional_relations
 from verinote.pipeline.policy_state import (
@@ -27,6 +29,8 @@ from verinote.pipeline.policy_state import (
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import load_policy, verify
 from verinote.store import Store
+
+verify_pipeline = importlib.import_module("verinote.pipeline.verify")
 
 # A human-written policy: `employed_by` is single-valued for a subject. This is
 # exactly the rule that evaporates in #155 when the policy file is deleted.
@@ -137,7 +141,28 @@ def test_unrecorded_policy_runs_default_with_a_warning(tmp_path):
     # the engine's clean-bill sentence must not survive into the report
     assert "consistent" not in rep.text
     assert resolve_policy(store).status is PolicyStatus.UNRECORDED_DEFAULT
-    assert load_policy(store) is None
+    assert load_policy(store) == DEFAULT_POLICY
+
+
+def test_unrecorded_policy_passes_explicit_default_to_verify(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    captured = {}
+
+    class CapturingCache:
+        def run_check(self, rows, *, policy_dl, query_dl=None):
+            captured["policy_dl"] = policy_dl
+            return CheckReport(ok=True, errors=0, warnings=0, text="clean")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(verify_pipeline, "engine_relation_rows", lambda _store: [])
+    store._inference_cache = CapturingCache()
+
+    report = verify(store)
+
+    assert captured["policy_dl"] == DEFAULT_POLICY
+    assert any("policy_unrecorded" in finding for finding in report.findings)
 
 
 def test_unrecorded_policy_still_reports_default_policy_errors(tmp_path):

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -38,7 +38,6 @@ from verinote.engine.terms import (
 )
 from verinote.engine.wirelog import (
     CheckReport,
-    DEFAULT_POLICY,
     NO_FINDINGS_TEXT,
     FindingRow,
     answer_bucket_sort_key,
@@ -73,10 +72,12 @@ class _Binding:
 def run_check_duckdb(
     facts: Iterable[Mapping[str, object]],
     *,
-    policy_dl: str | None = None,
+    policy_dl: str,
     query_dl: str | None = None,
 ) -> CheckReport:
     """Run supported non-recursive Datalog rules through an in-memory DuckDB DB."""
+    if not isinstance(policy_dl, str):
+        raise TypeError("policy_dl must be a str")
     cache = DuckDBInferenceCache()
     try:
         return cache.run_check(facts, policy_dl=policy_dl, query_dl=query_dl)
@@ -111,17 +112,18 @@ class DuckDBInferenceCache:
         self,
         facts: Iterable[Mapping[str, object]],
         *,
-        policy_dl: str | None = None,
+        policy_dl: str,
         query_dl: str | None = None,
     ) -> CheckReport:
         """Run a check while reusing the cached DuckDB base relation."""
+        if not isinstance(policy_dl, str):
+            raise TypeError("policy_dl must be a str")
         try:
             import duckdb
         except ImportError:
             return _engine_error("DuckDB is not installed", engine_available=False)
 
-        policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
-        source = policy + ("\n" + query_dl if query_dl else "")
+        source = policy_dl + ("\n" + query_dl if query_dl else "")
         try:
             program = parse_and_validate_program(source)
             _validate_relation_decl(program)
@@ -161,7 +163,7 @@ class DuckDBInferenceCache:
                     con,
                     declarations,
                     fact_rows,
-                    policy_dl=policy,
+                    policy_dl=policy_dl,
                     query_dl=query_dl,
                 )
         except DuckDBBackendError as exc:

--- a/verinote/engine/wirelog.py
+++ b/verinote/engine/wirelog.py
@@ -541,20 +541,20 @@ def _render_row(row: Iterable[object]) -> str:
     return " ".join(escape_string_value(str(value)) for value in row)
 
 
-def run_check(
-    dl_text: str, *, policy_dl: str | None = None, query_dl: str | None = None
-) -> CheckReport:
+def run_check(dl_text: str, *, policy_dl: str, query_dl: str | None = None) -> CheckReport:
     """Run the legacy pyrewire policy path over compiled facts.
 
     `dl_text` is `compile_dl` output (the verbatim engine input). `policy_dl`
-    defaults to `DEFAULT_POLICY`. `query_dl` holds `answer_q<id>(...)` query rules
+    is the policy to execute. `query_dl` holds `answer_q<id>(...)` query rules
     (see pipeline.query). Derived `error_*`/`warn_*` tuples become findings
     (`errors > 0` marks the report not-ok; it does not block promotion or query);
     `answer_q<id>` tuples become answers. If pyrewire is absent we still return a
     legacy compatibility report flagged
     `engine_available=False`.
     """
-    policy = policy_dl if policy_dl is not None else DEFAULT_POLICY
+    if not isinstance(policy_dl, str):
+        raise TypeError("policy_dl must be a str")
+    policy = policy_dl
     facts = _parse_relation_facts(dl_text)
     present = {rel for _, rel, _ in facts}
     dead = dead_rule_warnings(policy, present)

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -16,7 +16,6 @@ import re
 import unicodedata
 from typing import Any, Iterable, Mapping
 
-from verinote.engine import DEFAULT_POLICY
 from verinote.policy_defaults import (
     DEFAULT_RELATION_ALIASES,
     RELATION_ALIASES_RELPATH,
@@ -101,10 +100,11 @@ class TypedRelationSpec:
     units: dict[str, int] | None = None
 
 
-def functional_relations(policy_dl: str | None) -> set[str]:
+def functional_relations(policy_dl: str) -> set[str]:
     """Parse ``functional("rel").`` declarations from a policy program."""
-    text = DEFAULT_POLICY if policy_dl is None else policy_dl
-    return {_unescape(m.group(1)) for m in _FUNCTIONAL_RE.finditer(text)}
+    if not isinstance(policy_dl, str):
+        raise TypeError("policy_dl must be a str")
+    return {_unescape(m.group(1)) for m in _FUNCTIONAL_RE.finditer(policy_dl)}
 
 
 def store_functional_relations(store: Store) -> set[str]:

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -177,6 +177,23 @@ def resolve_policy(store: "Store") -> PolicyState:
     return PolicyState(status=PolicyStatus.UNRECORDED_DEFAULT, path=path)
 
 
+def runnable_policy_text(state: PolicyState) -> str:
+    """Return the policy text for a state that is allowed to reach an engine.
+
+    This is the sole default-policy resolution point. Callers must halt missing
+    or empty states before asking for runnable text.
+    """
+    if state.status is PolicyStatus.PRESENT:
+        if state.text is None:  # Defensive: a present file always supplies text.
+            raise RuntimeError("present policy state has no policy text")
+        return state.text
+    if state.status is PolicyStatus.UNRECORDED_DEFAULT:
+        from verinote.engine import DEFAULT_POLICY
+
+        return DEFAULT_POLICY
+    raise RuntimeError(f"policy state is not runnable: {state.status.value}")
+
+
 def policy_missing_message(state: PolicyState) -> str:
     """The loud, actionable message for a recorded-but-missing policy."""
     marker = state.marker or {}

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -26,6 +26,7 @@ from verinote.pipeline.policy_state import (
     policy_empty_message,
     policy_missing_message,
     policy_path,
+    runnable_policy_text,
     resolve_policy,
 )
 from verinote.store import Store
@@ -59,8 +60,8 @@ NO_REVIEW_RULES_NO_FINDINGS_TEXT = (
 )
 
 
-def load_policy(store: Store) -> str | None:
-    """The KB's policy text, or None to use the shipped default.
+def load_policy(store: Store) -> str:
+    """The explicit policy text that applies to this KB.
 
     Raises `PolicyMissingError` when the KB recorded a policy file that is now
     gone, and `PolicyEmptyError` (its subclass) when the file exists but is empty:
@@ -74,9 +75,7 @@ def load_policy(store: Store) -> str | None:
         raise PolicyMissingError(policy_missing_message(state))
     if state.status is PolicyStatus.PRESENT_EMPTY:
         raise PolicyEmptyError(policy_empty_message(state))
-    if state.status is PolicyStatus.PRESENT:
-        return state.text
-    return None
+    return runnable_policy_text(state)
 
 
 def verify(store: Store) -> CheckReport:
@@ -137,8 +136,9 @@ def verify(store: Store) -> CheckReport:
             findings=[f"ERROR policy error: {exc}"],
         )
 
+    policy_dl = runnable_policy_text(state)
     report = annotate_source_labels(
-        store.inference_cache.run_check(rows, policy_dl=state.text, query_dl=query_dl),
+        store.inference_cache.run_check(rows, policy_dl=policy_dl, query_dl=query_dl),
         rows,
     )
     if state.status is PolicyStatus.UNRECORDED_DEFAULT:
@@ -150,7 +150,7 @@ def verify(store: Store) -> CheckReport:
     if (
         state.status is PolicyStatus.PRESENT
         and report.errors == 0
-        and review_rule_count(state.text) == 0
+        and review_rule_count(policy_dl) == 0
     ):
         return _with_no_review_rules_warning(report)
     return report

--- a/verinote/store/duckdb_fact_terms.py
+++ b/verinote/store/duckdb_fact_terms.py
@@ -7,11 +7,11 @@ only the structural term payloads for fact triples, keyed by SQLite `facts.id`.
 
 from __future__ import annotations
 
+import hashlib
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
-import hashlib
 from pathlib import Path
-import time
 from typing import Iterable, Iterator
 
 from verinote.engine.duckdb_terms import (
@@ -38,6 +38,10 @@ _TERM_COLUMNS = ("subject", "rel", "object")
 _LOCK_TIMEOUT_SECONDS = 5.0
 _LOCK_POLL_SECONDS = 0.05
 _LOCK_MESSAGE_MARKERS = ("conflicting lock", "could not set lock")
+# Two same-process connections can both observe a missing table, then race on
+# DuckDB's transactional catalog update. This is distinct from the file-open
+# lock above: DuckDB reports it only when the losing CREATE executes.
+_SCHEMA_CREATE_CONFLICT_MARKER = "catalog write-write conflict on create"
 
 
 class DuckDBFactTermStoreError(ValueError):
@@ -304,11 +308,8 @@ class DuckDBFactTermStore:
                 raise DuckDBFactTermStoreError("DuckDB fact-term store is closed")
             yield self._con
             return
-        con = self._open_with_retry()
+        con = self._open_initialized_with_retry()
         try:
-            if not self._schema_ready:
-                self._init_schema_on(con)
-                self._schema_ready = True
             yield con
         finally:
             con.close()
@@ -354,6 +355,35 @@ class DuckDBFactTermStore:
                     ) from exc
                 time.sleep(min(poll, max(0.0, deadline - time.monotonic())))
                 poll = min(poll * 1.5, 0.25)
+
+    def _open_initialized_with_retry(self):
+        """Open a file-backed sidecar and safely initialize its schema once.
+
+        `CREATE TABLE IF NOT EXISTS` is not enough when two threads first open
+        the same brand-new sidecar: both can observe no table, and DuckDB aborts
+        one CREATE with a catalog write-write conflict. Retry only that known
+        transient conflict on a fresh connection. All other initialization
+        failures, including malformed sidecars, still surface immediately.
+        """
+        deadline = time.monotonic() + max(0.0, _LOCK_TIMEOUT_SECONDS)
+        poll = _LOCK_POLL_SECONDS
+        while True:
+            con = self._open_with_retry()
+            try:
+                if not self._schema_ready:
+                    self._init_schema_on(con)
+                    self._schema_ready = True
+            except DuckDBFactTermStoreError as exc:
+                con.close()
+                if not _is_schema_create_conflict(exc) or time.monotonic() >= deadline:
+                    raise
+                time.sleep(min(poll, max(0.0, deadline - time.monotonic())))
+                poll = min(poll * 1.5, 0.25)
+                continue
+            except BaseException:
+                con.close()
+                raise
+            return con
 
     def put_fact_terms(
         self,
@@ -542,6 +572,11 @@ def _is_lock_conflict(exc: Exception) -> bool:
     """
     message = str(exc).lower()
     return any(marker in message for marker in _LOCK_MESSAGE_MARKERS)
+
+
+def _is_schema_create_conflict(exc: Exception) -> bool:
+    """Whether DuckDB rejected a concurrent `fact_terms` table creation."""
+    return _SCHEMA_CREATE_CONFLICT_MARKER in str(exc).lower()
 
 
 def _validate_fact_id(fact_id: int) -> int:


### PR DESCRIPTION
Closes #180

Require an explicit policy at every engine and corroboration entry point. The shipped default is resolved only for unrecorded KBs at the policy-state boundary.

Validation: focused engine, cache, policy-state, verify, query, and corroboration tests passed (337 tests; three opt-in provider contract tests skipped).