### PR TITLE
fix: repair verified Unicode source identity duplicates

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,6 +241,98 @@ def test_sync_keeps_nfd_citation_when_nfc_spelling_does_not_exist(
     assert paths == [nfd_name]
 
 
+def test_sources_repair_identities_is_dry_run_until_apply(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    nfd_name = unicodedata.normalize("NFD", "caf\u00e9.txt")
+    nfc_name = unicodedata.normalize("NFC", nfd_name)
+    assert nfd_name != nfc_name
+    nfd_path = f"sources/{nfd_name}"
+    nfc_path = f"sources/{nfc_name}"
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.add_source(nfd_path)
+    store.add_source(nfc_path)
+    store.close()
+
+    def samefile(self, other):
+        assert {self, other} == {tmp_path / nfd_path, tmp_path / nfc_path}
+        return True
+
+    monkeypatch.setattr(Path, "samefile", samefile)
+
+    assert cli.main(["sources", "repair-identities"]) == 0
+    dry_run = capsys.readouterr().out
+    assert "ready:" in dry_run
+    assert "dry-run: no sources changed" in dry_run
+    check = Store(tmp_path / "kb.sqlite")
+    assert len(check.sources()) == 2
+    check.close()
+
+    assert cli.main(["sources", "repair-identities", "--apply"]) == 0
+    applied = capsys.readouterr().out
+    assert "source identity repair: 1 repaired, 0 unchanged" in applied
+    check = Store(tmp_path / "kb.sqlite")
+    assert [(row["path"], row["kind"]) for row in check.sources()] == [(nfc_path, "text")]
+    check.close()
+
+
+def test_sources_repair_identities_dry_run_supports_legacy_kb_without_jobs(
+    tmp_path, monkeypatch, capsys
+):
+    _env(monkeypatch, tmp_path)
+    nfd_name = unicodedata.normalize("NFD", "caf\u00e9.txt")
+    nfc_name = unicodedata.normalize("NFC", nfd_name)
+    assert nfd_name != nfc_name
+    nfd_path = f"sources/{nfd_name}"
+    nfc_path = f"sources/{nfc_name}"
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.executescript(
+        """
+        CREATE TABLE sources (id INTEGER PRIMARY KEY, path TEXT NOT NULL, kind TEXT NOT NULL);
+        CREATE TABLE facts (
+            id INTEGER PRIMARY KEY,
+            subject TEXT NOT NULL,
+            relation TEXT NOT NULL,
+            object TEXT NOT NULL,
+            status TEXT NOT NULL
+        );
+        CREATE TABLE review_log (id INTEGER PRIMARY KEY);
+        CREATE TABLE runs (id INTEGER PRIMARY KEY);
+        """
+    )
+    conn.executemany(
+        "INSERT INTO sources(path, kind) VALUES(?, 'text')",
+        [(nfd_path,), (nfc_path,)],
+    )
+    conn.commit()
+    tables_before = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+        )
+    ]
+    conn.close()
+
+    def samefile(self, other):
+        assert {self, other} == {tmp_path / nfd_path, tmp_path / nfc_path}
+        return True
+
+    monkeypatch.setattr(Path, "samefile", samefile)
+
+    assert cli.main(["sources", "repair-identities"]) == 0
+    assert "dry-run: no sources changed" in capsys.readouterr().out
+
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    tables_after = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+        )
+    ]
+    conn.close()
+    assert tables_after == tables_before
+
+
 def test_ingest_registers_text_source(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     src = tmp_path / "doc.txt"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 import json
 import sqlite3
+import unicodedata
+from pathlib import Path
 
 import pytest
 
@@ -13,6 +15,13 @@ def _store(tmp_path) -> Store:
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
     return s
+
+
+def _unicode_source_paths() -> tuple[str, str]:
+    nfd_name = unicodedata.normalize("NFD", "caf\u00e9.txt")
+    nfc_name = unicodedata.normalize("NFC", nfd_name)
+    assert nfd_name != nfc_name
+    return f"sources/{nfd_name}", f"sources/{nfc_name}"
 
 
 def test_toggle_promotes_and_reverts(tmp_path):
@@ -2088,3 +2097,210 @@ def test_reconcile_fact_prefers_live_row_over_superseded_duplicate(tmp_path):
     assert result.matched_status == "needs_review"
     assert _suppression_events(s, rejected) == []
     assert _suppression_events(s, live) == []
+
+
+def test_source_identity_repair_rewires_every_surface_and_artifact_collision(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    nfd_path, nfc_path = _unicode_source_paths()
+    retired_id = s.add_source(nfd_path)
+    retained_id = s.add_source(nfc_path)
+    retired_artifact = s.add_source_artifact(
+        source_id=retired_id,
+        kind="original_text",
+        path="artifacts/synthetic-nfd.txt",
+        checksum="same-content",
+    )
+    retained_artifact = s.add_source_artifact(
+        source_id=retained_id,
+        kind="original_text",
+        path="artifacts/synthetic-nfc.txt",
+        checksum="same-content",
+    )
+    retired_job = s.create_extraction_job(
+        source_id=retired_id,
+        artifact_id=retired_artifact,
+        provider="fake",
+        model="m",
+        total_chunks=1,
+    )
+    retained_job = s.create_extraction_job(
+        source_id=retained_id,
+        artifact_id=retained_artifact,
+        provider="fake",
+        model="m",
+        total_chunks=1,
+    )
+    retired_chunk = s.add_source_chunks(
+        job_id=retired_job, source_id=retired_id, chunks=["synthetic chunk"]
+    )[0]
+    s.add_source_chunks(
+        job_id=retained_job, source_id=retained_id, chunks=["other synthetic chunk"]
+    )
+    s._conn.execute("UPDATE extraction_jobs SET status = 'done'")
+    fact_id = s.add_fact("Synthetic", "supports", "Repair", source_id=retired_id, job_id=retired_job)
+    evidence_id = s.add_fact_evidence(
+        fact_id=fact_id,
+        source_id=retired_id,
+        artifact_id=retired_artifact,
+        job_id=retired_job,
+        chunk_id=retired_chunk,
+        snippet="synthetic anchor",
+    )
+    event_id = s.add_fact_event(
+        fact_id=fact_id,
+        event_type="synthetic_repair_fixture",
+        source_id=retired_id,
+        job_id=retired_job,
+        chunk_id=retired_chunk,
+    )
+
+    def samefile(self, other):
+        assert {self, other} == {tmp_path / nfd_path, tmp_path / nfc_path}
+        return True
+
+    monkeypatch.setattr(Path, "samefile", samefile)
+    plan = s.plan_source_identity_repairs()
+    assert [group.status for group in plan.groups] == ["ready"]
+
+    result = s.apply_source_identity_repairs(plan)
+
+    assert [group.status for group in result.groups] == ["repaired"]
+    assert s.get_source(retired_id) is None
+    assert s.get_source(retained_id)["path"] == nfc_path
+    assert s.get_fact(fact_id)["source_id"] == retained_id
+    assert s.get_extraction_job(retired_job)["source_id"] == retained_id
+    assert s.get_extraction_job(retired_job)["artifact_id"] == retained_artifact
+    assert s.get_source_chunk(retired_chunk)["source_id"] == retained_id
+    evidence = s._conn.execute("SELECT * FROM fact_evidence WHERE id = ?", (evidence_id,)).fetchone()
+    assert (evidence["source_id"], evidence["artifact_id"]) == (retained_id, retained_artifact)
+    event = s._conn.execute("SELECT * FROM fact_events WHERE id = ?", (event_id,)).fetchone()
+    assert event["source_id"] == retained_id
+    assert s.get_source_artifact(retired_artifact) is None
+    assert [artifact["id"] for artifact in s.source_artifacts(retained_id)] == [retained_artifact]
+    audit = s._conn.execute("SELECT canonical_path, moves_json FROM source_identity_repair_log").fetchone()
+    assert audit["canonical_path"] == nfc_path
+    assert str(retired_id) in audit["moves_json"]
+    assert "synthetic anchor" not in audit["moves_json"]
+    assert list(s._conn.execute("PRAGMA foreign_key_check")) == []
+    s._validate_source_identity_repair_domain()
+    assert s.plan_source_identity_repairs().groups == ()
+    assert s.apply_source_identity_repairs(s.plan_source_identity_repairs()).groups == ()
+
+
+def test_source_identity_repair_aggregates_coverage_after_verified_merge(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    nfd_path, nfc_path = _unicode_source_paths()
+    retired_id = s.add_source(nfd_path)
+    retained_id = s.add_source(nfc_path)
+    s.add_fact("Retired confirmed", "supports", "Merge", status="confirmed", source_id=retired_id)
+    s.add_fact("Retired candidate", "supports", "Merge", status="candidate", source_id=retired_id)
+    s.add_fact("Retained accepted", "supports", "Merge", status="accepted", source_id=retained_id)
+    s.add_fact("Retained review", "supports", "Merge", status="needs_review", source_id=retained_id)
+
+    monkeypatch.setattr(Path, "samefile", lambda self, other: True)
+    plan = s.plan_source_identity_repairs()
+
+    result = s.apply_source_identity_repairs(plan)
+
+    assert [group.status for group in result.groups] == ["repaired"]
+    report = coverage(s, root=tmp_path)
+    assert len(report.sources) == 1
+    assert report.sources[0].path == nfc_path
+    assert report.sources[0].total_facts == 4
+    assert report.sources[0].engine_facts == 2
+
+
+def test_source_identity_repair_rolls_back_after_late_validation_failure(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    nfd_path, nfc_path = _unicode_source_paths()
+    retired_id = s.add_source(nfd_path)
+    retained_id = s.add_source(nfc_path)
+    retired_artifact = s.add_source_artifact(
+        source_id=retired_id,
+        kind="original_text",
+        path="artifacts/synthetic-nfd.txt",
+        checksum="synthetic-nfd",
+    )
+    retained_artifact = s.add_source_artifact(
+        source_id=retained_id,
+        kind="original_text",
+        path="artifacts/synthetic-nfc.txt",
+        checksum="synthetic-nfc",
+    )
+
+    monkeypatch.setattr(Path, "samefile", lambda self, other: True)
+    plan = s.plan_source_identity_repairs()
+
+    def fail_after_rewiring():
+        raise RuntimeError("late audit failure")
+
+    monkeypatch.setattr(s, "_validate_source_identity_repair_domain", fail_after_rewiring)
+    with pytest.raises(RuntimeError, match="late audit failure"):
+        s.apply_source_identity_repairs(plan)
+
+    assert s.get_source(retired_id)["path"] == nfd_path
+    assert s.get_source(retained_id)["path"] == nfc_path
+    assert s.get_source_artifact(retired_artifact)["source_id"] == retired_id
+    assert s.get_source_artifact(retained_artifact)["source_id"] == retained_id
+    assert s._conn.execute("SELECT COUNT(*) FROM source_identity_repair_log").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize(
+    ("samefile_result", "expected"),
+    [(False, "distinct_paths"), (FileNotFoundError("missing"), "unprovable_path")],
+)
+def test_source_identity_repair_leaves_distinct_or_missing_paths_unchanged(
+    tmp_path, monkeypatch, samefile_result, expected
+):
+    s = _store(tmp_path)
+    nfd_path, nfc_path = _unicode_source_paths()
+    nfd_id = s.add_source(nfd_path)
+    nfc_id = s.add_source(nfc_path)
+
+    def samefile(self, other):
+        if isinstance(samefile_result, BaseException):
+            raise samefile_result
+        return samefile_result
+
+    monkeypatch.setattr(Path, "samefile", samefile)
+    plan = s.plan_source_identity_repairs()
+    assert plan.groups[0].status == expected
+    result = s.apply_source_identity_repairs(plan)
+    assert result.groups[0].status == expected
+    assert s.get_source(nfd_id) is not None
+    assert s.get_source(nfc_id) is not None
+
+
+def test_source_identity_repair_blocks_active_jobs_and_mixed_kinds(tmp_path):
+    s = _store(tmp_path)
+    nfd_path, nfc_path = _unicode_source_paths()
+    mixed_nfd = nfd_path.replace("sources/", "sources/mixed-")
+    mixed_nfc = nfc_path.replace("sources/", "sources/mixed-")
+    s.add_source(mixed_nfd, kind="text")
+    s.add_source(mixed_nfc, kind="binary")
+    active_nfd = nfd_path.replace("sources/", "sources/active-")
+    active_nfc = nfc_path.replace("sources/", "sources/active-")
+    active_id = s.add_source(active_nfd)
+    s.add_source(active_nfc)
+    s.create_extraction_job(
+        source_id=active_id, provider="fake", model="m", total_chunks=1
+    )
+
+    plan = s.plan_source_identity_repairs()
+
+    assert {group.status for group in plan.groups} == {
+        "mixed_source_kind",
+        "active_extraction_job",
+    }
+    result = s.apply_source_identity_repairs(plan)
+    assert {group.status for group in result.groups} == {
+        "mixed_source_kind",
+        "active_extraction_job",
+    }
+    assert len(s.sources()) == 4

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -993,6 +993,40 @@ def cmd_ingest(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sources_repair_identities(cfg: Config, args: argparse.Namespace) -> int:
+    """Inspect or explicitly merge same-file NFC/NFD source identities."""
+    refusal = _require_existing_kb(cfg)
+    if refusal is not None:
+        return refusal
+    store = Store(cfg.db_path)
+    try:
+        # The default must not initialise or migrate the KB: planning is a pure
+        # scan.  --apply prepares the append-only audit table before it writes.
+        if args.apply:
+            store.init_schema()
+        plan = store.plan_source_identity_repairs()
+        if not plan.groups:
+            print("no NFC/NFD duplicate source identities found")
+            return 0
+        for group in plan.groups:
+            print(f"{group.status}: {group.canonical_path}")
+            for path in group.paths:
+                print(f"  {path}")
+        if not args.apply:
+            print("dry-run: no sources changed; rerun with --apply to repair ready groups")
+            return 0
+        result = store.apply_source_identity_repairs(plan)
+        repaired = sum(group.status == "repaired" for group in result.groups)
+        unchanged = len(result.groups) - repaired
+        for group in result.groups:
+            if group.status != "repaired":
+                print(f"unchanged: {group.status}: {group.canonical_path}")
+        print(f"source identity repair: {repaired} repaired, {unchanged} unchanged")
+        return 0
+    finally:
+        store.close()
+
+
 def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
     from verinote.pipeline import translate_questions, write_query_file
@@ -1463,6 +1497,19 @@ def build_parser() -> argparse.ArgumentParser:
     ingest.add_argument("path", help="a .txt/.md file, or a .docx/.pdf to convert")
     ingest.set_defaults(func=cmd_ingest, halt_safe=False)
 
+    sources = sub.add_parser("sources", help="inspect and repair registered sources")
+    sources_sub = sources.add_subparsers(dest="sources_command", required=True)
+    repair_identities = sources_sub.add_parser(
+        "repair-identities",
+        help="scan NFC/NFD duplicate source identities; --apply repairs verified groups",
+    )
+    repair_identities.add_argument(
+        "--apply",
+        action="store_true",
+        help="confirm repair of groups whose paths are samefile-verified",
+    )
+    repair_identities.set_defaults(func=cmd_sources_repair_identities, halt_safe=False)
+
     query = sub.add_parser("query", help="translate pending NL questions to Datalog queries")
     query.add_argument("question", nargs="?", help="a question to add before translating")
     query.set_defaults(func=cmd_query, halt_safe=False)
@@ -1532,7 +1579,12 @@ def main(argv: list[str] | None = None) -> int:
     # The single CLI enforcement point for a halted KB. It sits here, before
     # dispatch, because every subcommand goes through this one line — a guard
     # sprinkled per-command is a guard the next command will forget.
-    if not getattr(args, "halt_safe", False):
+    halt_safe = getattr(args, "halt_safe", False) or (
+        args.command == "sources"
+        and args.sources_command == "repair-identities"
+        and not args.apply
+    )
+    if not halt_safe:
         # Corrupt config first: it makes the resolved provider itself untrustworthy,
         # and unlike the halt check it opens no Store. Then the halted-KB check.
         refusal = _refuse_on_corrupt_config(cfg)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -19,6 +19,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Any, Iterable
 
+from verinote.text import nfc
+
 # Status tiers (kept in code so the web/pipeline layers share one definition).
 REVIEW_STATUSES = frozenset({"candidate", "needs_review"})
 # kb_meta key under which a KB declares that it owns a logic policy file.
@@ -96,6 +98,34 @@ class FactReconcileResult:
     fact_id: int  # existing row on a hit, or the newly created row
     created: bool  # True only when a new row was inserted
     matched_status: str | None  # status of the pre-existing row on a dedupe hit
+
+
+@dataclass(frozen=True)
+class SourceIdentityRepairGroup:
+    """One NFC-equivalent source group and its current repair verdict.
+
+    The plan deliberately carries source ids and paths only.  In particular it
+    never copies source or evidence text into an operator-facing plan or audit.
+    """
+
+    canonical_path: str
+    source_ids: tuple[int, ...]
+    paths: tuple[str, ...]
+    status: str
+
+
+@dataclass(frozen=True)
+class SourceIdentityRepairPlan:
+    """Read-only inventory of pre-existing NFC/NFD duplicate source rows."""
+
+    groups: tuple[SourceIdentityRepairGroup, ...]
+
+
+@dataclass(frozen=True)
+class SourceIdentityRepairResult:
+    """Outcome of applying a source-identity repair plan."""
+
+    groups: tuple[SourceIdentityRepairGroup, ...]
 
 
 REVIEW_PAGE_SIZES = (25, 50, 100)
@@ -526,6 +556,236 @@ class Store:
         return self._conn.execute(
             "SELECT * FROM sources WHERE path = ?", (path,)
         ).fetchone()
+
+    def plan_source_identity_repairs(self) -> SourceIdentityRepairPlan:
+        """Read-only plan for merging same-file NFC/NFD duplicate sources.
+
+        A plan is intentionally conservative.  It reports every NFC-equivalent
+        duplicate, but only marks a group ``ready`` when its kinds agree, no
+        extraction job is active, and every path can presently be proved to be
+        the same file.  Apply repeats each check while holding SQLite's write
+        lock, so this read-only result is never treated as an authority to write.
+        """
+        grouped: dict[str, list[sqlite3.Row]] = {}
+        for row in self._conn.execute("SELECT id, path, kind FROM sources ORDER BY id"):
+            grouped.setdefault(nfc(str(row["path"])), []).append(row)
+        groups: list[SourceIdentityRepairGroup] = []
+        for canonical_path, rows in sorted(grouped.items()):
+            if len(rows) < 2 or not any(str(row["path"]) != canonical_path for row in rows):
+                continue
+            groups.append(self._source_identity_group(rows, canonical_path))
+        return SourceIdentityRepairPlan(groups=tuple(groups))
+
+    def apply_source_identity_repairs(
+        self, plan: SourceIdentityRepairPlan
+    ) -> SourceIdentityRepairResult:
+        """Apply only the still-verified groups from a prior repair plan.
+
+        Each group gets its own short transaction.  A blocked or stale group is
+        reported unchanged, while another independently verified group may still
+        be repaired.  This makes re-running a plan idempotent and prevents a
+        filesystem or active-job race from turning a scan result into a merge.
+        """
+        outcomes: list[SourceIdentityRepairGroup] = []
+        for planned in plan.groups:
+            if planned.status != "ready":
+                outcomes.append(planned)
+                continue
+            with self._lock:
+                # This is deliberately adjacent to BEGIN IMMEDIATE rather than
+                # trusting the scan-time result.  The duplicate check below is
+                # repeated under the DB lock before the first UPDATE as well.
+                preflight = self._source_identity_samefile_status(planned.paths)
+                if preflight != "ready":
+                    outcomes.append(
+                        SourceIdentityRepairGroup(
+                            planned.canonical_path,
+                            planned.source_ids,
+                            planned.paths,
+                            preflight,
+                        )
+                    )
+                    continue
+                with self.immediate_transaction():
+                    placeholders = ",".join("?" for _ in planned.source_ids)
+                    rows = list(
+                        self._conn.execute(
+                            "SELECT id, path, kind FROM sources "
+                            f"WHERE id IN ({placeholders}) ORDER BY id",
+                            planned.source_ids,
+                        )
+                    )
+                    current = self._source_identity_group(rows, planned.canonical_path)
+                    if current.status != "ready":
+                        outcomes.append(current)
+                        continue
+                    self._apply_source_identity_group(rows, planned.canonical_path)
+                    outcomes.append(
+                        SourceIdentityRepairGroup(
+                            canonical_path=planned.canonical_path,
+                            source_ids=tuple(int(row["id"]) for row in rows),
+                            paths=tuple(str(row["path"]) for row in rows),
+                            status="repaired",
+                        )
+                    )
+        return SourceIdentityRepairResult(groups=tuple(outcomes))
+
+    def _source_identity_group(
+        self, rows: list[sqlite3.Row], canonical_path: str
+    ) -> SourceIdentityRepairGroup:
+        ids = tuple(int(row["id"]) for row in rows)
+        paths = tuple(str(row["path"]) for row in rows)
+        status = "ready"
+        if (
+            len(rows) < 2
+            or any(nfc(path) != canonical_path for path in paths)
+            or not any(path != canonical_path for path in paths)
+        ):
+            status = "stale_plan"
+        elif len({str(row["kind"]) for row in rows}) != 1:
+            status = "mixed_source_kind"
+        elif self._source_identity_has_active_job(ids):
+            status = "active_extraction_job"
+        else:
+            status = self._source_identity_samefile_status(paths)
+        return SourceIdentityRepairGroup(canonical_path, ids, paths, status)
+
+    def _source_identity_has_active_job(self, source_ids: tuple[int, ...]) -> bool:
+        has_extraction_jobs = self._conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'extraction_jobs'"
+        ).fetchone()
+        if has_extraction_jobs is None:
+            return False
+        placeholders = ",".join("?" for _ in source_ids)
+        row = self._conn.execute(
+            "SELECT 1 FROM extraction_jobs "
+            f"WHERE source_id IN ({placeholders}) AND status IN ('pending', 'running') "
+            "LIMIT 1",
+            source_ids,
+        ).fetchone()
+        return row is not None
+
+    def _source_identity_samefile_status(self, paths: tuple[str, ...]) -> str:
+        resolved = [self.db_path.parent / path for path in paths]
+        try:
+            for index, left in enumerate(resolved):
+                for right in resolved[index + 1 :]:
+                    if not left.samefile(right):
+                        return "distinct_paths"
+        except (OSError, ValueError):
+            return "unprovable_path"
+        return "ready"
+
+    def _apply_source_identity_group(
+        self, rows: list[sqlite3.Row], canonical_path: str
+    ) -> None:
+        # Prefer an existing canonical citation; otherwise retain the oldest
+        # source row and rename it only after the conflicting rows are gone.
+        retained = next(
+            (row for row in rows if str(row["path"]) == canonical_path), rows[0]
+        )
+        retained_id = int(retained["id"])
+        retired = [row for row in rows if int(row["id"]) != retained_id]
+        retired_ids = tuple(int(row["id"]) for row in retired)
+
+        for retired_id in retired_ids:
+            artifacts = list(
+                self._conn.execute(
+                    "SELECT id, kind, checksum FROM source_artifacts "
+                    "WHERE source_id = ? ORDER BY id",
+                    (retired_id,),
+                )
+            )
+            for artifact in artifacts:
+                artifact_id = int(artifact["id"])
+                retained_artifact = self._conn.execute(
+                    "SELECT id FROM source_artifacts "
+                    "WHERE source_id = ? AND kind = ? AND checksum = ?",
+                    (retained_id, artifact["kind"], artifact["checksum"]),
+                ).fetchone()
+                if retained_artifact is None:
+                    self._conn.execute(
+                        "UPDATE source_artifacts SET source_id = ? WHERE id = ?",
+                        (retained_id, artifact_id),
+                    )
+                    continue
+                retained_artifact_id = int(retained_artifact["id"])
+                self._conn.execute(
+                    "UPDATE extraction_jobs SET artifact_id = ? WHERE artifact_id = ?",
+                    (retained_artifact_id, artifact_id),
+                )
+                self._conn.execute(
+                    "UPDATE fact_evidence SET artifact_id = ? WHERE artifact_id = ?",
+                    (retained_artifact_id, artifact_id),
+                )
+                self._conn.execute("DELETE FROM source_artifacts WHERE id = ?", (artifact_id,))
+
+        # These are every source FK surface.  Keep this explicit rather than
+        # relying on ON DELETE actions, which would discard provenance.
+        placeholders = ",".join("?" for _ in retired_ids)
+        for table in (
+            "extraction_jobs",
+            "source_chunks",
+            "facts",
+            "fact_evidence",
+            "fact_events",
+        ):
+            self._conn.execute(
+                f"UPDATE {table} SET source_id = ? WHERE source_id IN ({placeholders})",
+                (retained_id, *retired_ids),
+            )
+
+        moves = {
+            "retained_source_id": retained_id,
+            "retired_sources": [
+                {"source_id": int(row["id"]), "path": str(row["path"])}
+                for row in retired
+            ],
+        }
+        self._conn.execute(
+            "INSERT INTO source_identity_repair_log(canonical_path, moves_json) VALUES(?, ?)",
+            (canonical_path, json.dumps(moves, ensure_ascii=False, sort_keys=True)),
+        )
+        self._conn.execute(
+            f"DELETE FROM sources WHERE id IN ({placeholders})", retired_ids
+        )
+        self._conn.execute(
+            "UPDATE sources SET path = ? WHERE id = ?", (canonical_path, retained_id)
+        )
+        self._validate_source_identity_repair_domain()
+
+    def _validate_source_identity_repair_domain(self) -> None:
+        if list(self._conn.execute("PRAGMA foreign_key_check")):
+            raise sqlite3.IntegrityError("source identity repair foreign key check failed")
+        checks = (
+            "SELECT 1 FROM extraction_jobs j JOIN source_artifacts a ON a.id = j.artifact_id "
+            "WHERE a.source_id != j.source_id LIMIT 1",
+            "SELECT 1 FROM source_chunks c JOIN extraction_jobs j ON j.id = c.job_id "
+            "WHERE c.source_id != j.source_id LIMIT 1",
+            "SELECT 1 FROM facts f JOIN extraction_jobs j ON j.id = f.job_id "
+            "WHERE f.source_id IS NOT NULL AND f.source_id != j.source_id LIMIT 1",
+            "SELECT 1 FROM fact_evidence e "
+            "LEFT JOIN facts f ON f.id = e.fact_id "
+            "LEFT JOIN source_artifacts a ON a.id = e.artifact_id "
+            "LEFT JOIN extraction_jobs j ON j.id = e.job_id "
+            "LEFT JOIN source_chunks c ON c.id = e.chunk_id "
+            "WHERE (f.source_id IS NOT NULL AND f.source_id != e.source_id) "
+            "OR (a.id IS NOT NULL AND a.source_id != e.source_id) "
+            "OR (j.id IS NOT NULL AND j.source_id != e.source_id) "
+            "OR (c.id IS NOT NULL AND c.source_id != e.source_id) "
+            "OR (c.id IS NOT NULL AND e.job_id IS NOT NULL AND c.job_id != e.job_id) LIMIT 1",
+            "SELECT 1 FROM fact_events e "
+            "LEFT JOIN facts f ON f.id = e.fact_id "
+            "LEFT JOIN extraction_jobs j ON j.id = e.job_id "
+            "LEFT JOIN source_chunks c ON c.id = e.chunk_id "
+            "WHERE (e.source_id IS NOT NULL AND f.source_id IS NOT NULL AND f.source_id != e.source_id) "
+            "OR (e.source_id IS NOT NULL AND j.id IS NOT NULL AND j.source_id != e.source_id) "
+            "OR (e.source_id IS NOT NULL AND c.id IS NOT NULL AND c.source_id != e.source_id) "
+            "OR (c.id IS NOT NULL AND e.job_id IS NOT NULL AND c.job_id != e.job_id) LIMIT 1",
+        )
+        if any(self._conn.execute(query).fetchone() is not None for query in checks):
+            raise sqlite3.IntegrityError("source identity repair domain check failed")
 
     def sources_with_counts(self) -> list[sqlite3.Row]:
         """Sources plus analysis and fact summaries for the Sources listing.
@@ -2763,6 +3023,28 @@ class Store:
                 ON fact_events(fact_id, id);
             CREATE INDEX IF NOT EXISTS idx_fact_events_job
                 ON fact_events(job_id);
+            """
+        )
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS source_identity_repair_log (
+                id             INTEGER PRIMARY KEY,
+                canonical_path TEXT NOT NULL,
+                moves_json     TEXT NOT NULL,
+                at             TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE TRIGGER IF NOT EXISTS source_identity_repair_log_no_update
+            BEFORE UPDATE ON source_identity_repair_log
+            FOR EACH ROW
+            BEGIN
+                SELECT RAISE(ABORT, 'source identity repair audit is append-only');
+            END;
+            CREATE TRIGGER IF NOT EXISTS source_identity_repair_log_no_delete
+            BEFORE DELETE ON source_identity_repair_log
+            FOR EACH ROW
+            BEGIN
+                SELECT RAISE(ABORT, 'source identity repair audit is append-only');
+            END;
             """
         )
         self._ensure_question_schema()

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -281,3 +281,27 @@ CREATE TABLE IF NOT EXISTS fact_events (
 
 CREATE INDEX IF NOT EXISTS idx_fact_events_fact ON fact_events(fact_id, id);
 CREATE INDEX IF NOT EXISTS idx_fact_events_job ON fact_events(job_id);
+
+-- Append-only record of an explicitly confirmed merge of source rows that
+-- resolved to the same filesystem object under NFC/NFD spellings.  It records
+-- ids and paths only: source/evidence text must never enter this audit trail.
+CREATE TABLE IF NOT EXISTS source_identity_repair_log (
+    id             INTEGER PRIMARY KEY,
+    canonical_path TEXT NOT NULL,
+    moves_json     TEXT NOT NULL,
+    at             TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TRIGGER IF NOT EXISTS source_identity_repair_log_no_update
+BEFORE UPDATE ON source_identity_repair_log
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'source identity repair audit is append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS source_identity_repair_log_no_delete
+BEFORE DELETE ON source_identity_repair_log
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'source identity repair audit is append-only');
+END;


### PR DESCRIPTION
## Summary
- add a read-only `sources repair-identities` scan with explicit `--apply` repair
- merge only NFC/NFD source rows proved by `samefile`, preserving source graph references and audit history
- report distinct, unprovable, active-job, and mixed-kind groups without changing them

## Validation
- `.venv/bin/python -m pytest -q tests/test_store.py tests/test_cli.py` (206 passed)
- `git diff --check`

## Data privacy
- Uses synthetic Unicode fixtures only; no customer or source data included.