### PR TITLE
fix: centralize fact status vocabulary

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.ingest import register_converter
 from verinote.pipeline.query_intent import parse_query_intent
 from verinote.store import Store, engine_statuses
+from verinote.store import db as store_db
 from verinote.store.fact_input import structural_term
 
 
@@ -1848,6 +1849,53 @@ def test_seed_accepts_a_kb_whose_path_holds_a_uri_metacharacter(tmp_path, monkey
     store = Store(root / "kb.sqlite")
     assert len(store.facts()) == len(cli._DEMO_FACTS)
     store.close()
+
+
+def test_status_lists_fact_statuses_from_the_call_time_order_accessor(
+    tmp_path, monkeypatch, capsys
+):
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.add_fact("A", "is_a", "B", status="candidate")
+    store.add_fact("C", "is_a", "D", status="superseded")
+    store.close()
+
+    monkeypatch.setattr(store_db, "ALL_FACT_STATUSES", frozenset({"candidate"}))
+
+    assert cli.main(["status"]) == 0
+    output = capsys.readouterr().out
+    assert "candidate" in output
+    assert "superseded" not in output
+
+
+def test_status_keeps_legacy_order_then_sorts_runtime_statuses(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.close()
+
+    monkeypatch.setattr(
+        store_db,
+        "ALL_FACT_STATUSES",
+        store_db.ALL_FACT_STATUSES | {"archived", "draft"},
+    )
+
+    assert cli.main(["status"]) == 0
+    statuses = [
+        line.split()[0]
+        for line in capsys.readouterr().out.splitlines()
+        if line.startswith("  ")
+    ]
+    assert statuses == [
+        "candidate",
+        "needs_review",
+        "confirmed",
+        "accepted",
+        "superseded",
+        "archived",
+        "draft",
+    ]
 
 
 def test_status_on_absent_kb_refuses_and_creates_nothing(tmp_path, monkeypatch, capsys):

--- a/tests/test_review_actions.py
+++ b/tests/test_review_actions.py
@@ -21,6 +21,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from verinote.config import Config  # noqa: E402
+from verinote.store import db as store_db  # noqa: E402
 from verinote.store.tiers import engine_statuses, review_statuses  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
@@ -122,3 +123,15 @@ def test_queued_row_in_the_review_page_keeps_every_action(tmp_path):
     body = c.get("/review").text
 
     assert _offered(body, c.fact_id) == set(ALL_ACTIONS)
+
+
+def test_non_actionable_status_row_fails_closed(tmp_path, monkeypatch):
+    c = _client(tmp_path)
+    fact_id = c.store.add_fact("C", "is_a", "D", status="candidate", confidence=0.9)
+    monkeypatch.setattr(store_db, "REVIEW_STATUSES", frozenset({"needs_review"}))
+
+    body = c.get(f"/facts/{fact_id}/row").text
+
+    assert _offered(body, fact_id) == set()
+    assert f"/facts/{fact_id}/provenance" in body
+    assert "no further action" in body

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -23,6 +23,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 from verinote.config import Config  # noqa: E402
 from verinote.pipeline import acceptance  # noqa: E402
 from verinote.store import Store  # noqa: E402
+from verinote.store import db as store_db  # noqa: E402
 from verinote.store.db import ENGINE_STATUSES  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
@@ -656,7 +657,7 @@ def test_accept_on_a_superseded_fact_does_not_run_auto_accept(tmp_path):
 
     resp = client.post(f"/facts/{target}/accept")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     assert store.get_fact(target)["status"] == "superseded"
     _assert_untouched(store, eligible, resp)
 
@@ -669,7 +670,7 @@ def test_replayed_reject_does_not_run_auto_accept(tmp_path):
 
     resp = client.post(f"/facts/{target}/reject")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     assert store.get_fact(target)["status"] == "superseded"
     _assert_untouched(store, eligible, resp)
 
@@ -682,12 +683,12 @@ def test_toggle_on_a_superseded_fact_does_not_run_auto_accept(tmp_path):
 
     resp = client.post(f"/facts/{target}/toggle")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     assert store.get_fact(target)["status"] == "superseded"
     _assert_untouched(store, eligible, resp)
 
 
-def test_missing_amend_target_does_not_run_auto_accept(tmp_path):
+def test_missing_amend_target_returns_not_found_without_running_auto_accept(tmp_path):
     # A stale inline-edit POST for a fact that no longer exists writes nothing,
     # so it must not become an excuse to promote unrelated eligible facts.
     client, store = _auto_accept_client(tmp_path)
@@ -705,8 +706,32 @@ def test_missing_amend_target_does_not_run_auto_accept(tmp_path):
         },
     )
 
-    assert resp.status_code == 200
+    assert resp.status_code == 404
     _assert_untouched(store, eligible, resp)
+
+
+def test_tier_mutation_blocks_direct_reject_and_amend(tmp_path, monkeypatch):
+    client, store = _auto_accept_client(tmp_path)
+    fact_id = store.add_fact("Ledger", "owner", "Park", status="candidate", note="original")
+    before = dict(store.get_fact(fact_id))
+    monkeypatch.setattr(store_db, "REVIEW_STATUSES", frozenset({"needs_review"}))
+
+    rejected = client.post(f"/facts/{fact_id}/reject")
+    amended = client.post(
+        f"/facts/{fact_id}/amend",
+        data={
+            "subject": "Changed",
+            "subject_kind": "string",
+            "relation": "owner",
+            "relation_kind": "string",
+            "object": "Other",
+            "object_kind": "string",
+            "note": "changed",
+        },
+    )
+
+    assert rejected.status_code == amended.status_code == 400
+    assert dict(store.get_fact(fact_id)) == before
 
 
 def test_replayed_amend_does_not_run_auto_accept(tmp_path):

--- a/tests/test_status_tiers.py
+++ b/tests/test_status_tiers.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import re
 
 import pytest
 
@@ -33,6 +34,12 @@ from verinote.pipeline.report_trace import report_trace
 from verinote.pipeline.trust import fact_trust_summary
 from verinote.pipeline.workbench import trust_workbench
 from verinote.store import Store, db
+from verinote.store.tiers import (
+    all_fact_statuses,
+    fact_status_order,
+    is_actionable_fact_status,
+    terminal_fact_statuses,
+)
 
 
 def _store(tmp_path) -> Store:
@@ -44,6 +51,41 @@ def _store(tmp_path) -> Store:
 def _widen(monkeypatch) -> None:
     """Add `superseded` to the engine-input tier, the reviewer's mutation."""
     monkeypatch.setattr(db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"})
+
+
+def test_fact_status_constants_match_the_schema_check_exactly(tmp_path):
+    """The vocabulary has one schema-backed definition, with no phantom status."""
+    store = _store(tmp_path)
+    schema = store._conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'facts'"
+    ).fetchone()["sql"]
+    match = re.search(
+        r"status\s+TEXT NOT NULL DEFAULT 'candidate'\s+"
+        r"CHECK \(status IN \(([^)]*)\)\)",
+        schema,
+    )
+
+    assert match is not None
+    assert frozenset(re.findall(r"'([^']+)'", match.group(1))) == db.ALL_FACT_STATUSES
+    assert all_fact_statuses() == db.ALL_FACT_STATUSES
+    assert terminal_fact_statuses() == db.TERMINAL_STATUSES
+    assert fact_status_order() == db.FACT_STATUS_ORDER
+    assert all(
+        is_actionable_fact_status(status)
+        == (status in db.REVIEW_STATUSES | db.ENGINE_STATUSES)
+        for status in db.ALL_FACT_STATUSES
+    )
+
+
+def test_fact_status_order_sorts_runtime_extensions_and_rejects_duplicates(monkeypatch):
+    monkeypatch.setattr(
+        db, "ALL_FACT_STATUSES", db.ALL_FACT_STATUSES | {"archived", "draft"}
+    )
+    assert fact_status_order() == db.FACT_STATUS_ORDER + ("archived", "draft")
+
+    monkeypatch.setattr(db, "FACT_STATUS_ORDER", ("candidate", "candidate"))
+    with pytest.raises(ValueError, match="duplicates"):
+        fact_status_order()
 
 
 def test_engine_input_readers_agree_after_the_tier_is_widened(tmp_path, monkeypatch):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -855,8 +855,7 @@ def test_source_artifacts_are_upserted_and_listed_with_counts(tmp_path):
     assert rows[0]["path"] == "sources/report.pdf"
     assert rows[0]["kind"] == "binary"
     assert rows[0]["fact_count"] == 1
-    assert rows[0]["candidate_count"] == 1
-    assert rows[0]["needs_review_count"] == 0
+    assert rows[0]["review_count"] == 1
     assert rows[0]["engine_count"] == 0
     assert "artifact_paths" not in rows[0].keys()
 
@@ -908,7 +907,7 @@ def test_sources_with_counts_includes_latest_analysis_summary(tmp_path):
     assert row["model"] == "qwen3.5:9b"
 
 
-def test_sources_with_counts_engine_count_follows_engine_statuses(tmp_path, monkeypatch):
+def test_sources_with_counts_status_counts_follow_their_tiers(tmp_path, monkeypatch):
     """The Sources page's "N confirmed" must mean the same thing as coverage.
 
     `engine_count` is derived from ENGINE_STATUSES, so widening the tier moves
@@ -924,8 +923,7 @@ def test_sources_with_counts_engine_count_follows_engine_statuses(tmp_path, monk
 
     before = s.sources_with_counts()[0]
     assert before["engine_count"] == 0
-    # The per-status count columns are a different question and must not move.
-    assert before["candidate_count"] == 1
+    assert before["review_count"] == 1
     assert before["fact_count"] == 3
 
     monkeypatch.setattr(db, "ENGINE_STATUSES", db.ENGINE_STATUSES | {"superseded"})
@@ -935,8 +933,13 @@ def test_sources_with_counts_engine_count_follows_engine_statuses(tmp_path, monk
     assert after["engine_count"] == len(
         [r for r in s.facts(statuses=db.ENGINE_STATUSES) if r["source_id"] == sid]
     )
-    assert after["candidate_count"] == 1
+    assert after["review_count"] == 1
     assert after["fact_count"] == 3
+
+    monkeypatch.setattr(db, "REVIEW_STATUSES", frozenset({"superseded"}))
+
+    after_review_change = s.sources_with_counts()[0]
+    assert after_review_change["review_count"] == superseded_count
 
 
 def test_sources_with_counts_engine_count_matches_coverage(tmp_path, monkeypatch):

--- a/tests/test_superseded_terminal.py
+++ b/tests/test_superseded_terminal.py
@@ -388,7 +388,7 @@ def _client(tmp_path):
     return client, client.app.state.store
 
 
-def test_edit_route_hands_back_a_read_only_row_for_a_superseded_fact(tmp_path):
+def test_edit_route_rejects_a_superseded_fact(tmp_path):
     # fact_row.html has always hidden the edit control on a superseded row, but
     # the control being absent from one render is not the same as the route
     # refusing. Anyone holding the URL — or a page opened before the reject
@@ -398,11 +398,7 @@ def test_edit_route_hands_back_a_read_only_row_for_a_superseded_fact(tmp_path):
 
     resp = client.get(f"/facts/{fact_id}/edit")
 
-    assert resp.status_code == 200
-    # The distinguishing mark of the edit partial is the amend form; the row
-    # says why there is nothing to do instead.
-    assert f'hx-post="/facts/{fact_id}/amend"' not in resp.text
-    assert "rejected" in resp.text
+    assert resp.status_code == 400
 
 
 def test_edit_route_still_serves_a_form_for_a_live_fact(tmp_path):
@@ -416,16 +412,11 @@ def test_edit_route_still_serves_a_form_for_a_live_fact(tmp_path):
     assert f'hx-post="/facts/{fact_id}/amend"' in resp.text
 
 
-def test_amend_route_on_a_superseded_fact_answers_without_a_server_error(tmp_path):
+def test_amend_route_rejects_a_superseded_fact_without_mutating_it(tmp_path):
     # The store raises TerminalFactError, which is a ValueError; unhandled it
     # would be a 500. Reachable from a form that was already open when someone
     # else rejected the fact, so it has to answer cleanly.
     #
-    # 200 rather than 4xx on purpose: htmx's default responseHandling does not
-    # swap 4xx, so an error status would leave the stale form on screen still
-    # offering a save that cannot succeed. Asserting the swapped-in row is what
-    # makes this a guard on the user-visible result and not just on the status
-    # code.
     client, store = _client(tmp_path)
     fact_id = _rejected_fact(store)
     before = _row(store, fact_id)
@@ -442,8 +433,7 @@ def test_amend_route_on_a_superseded_fact_answers_without_a_server_error(tmp_pat
         },
     )
 
-    assert resp.status_code == 200
-    assert "rejected" in resp.text
+    assert resp.status_code == 400
     assert _row(store, fact_id) == before
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -135,6 +135,14 @@ def _engine_input_card(body: str) -> int:
     return int(match.group(1))
 
 
+def _review_card(body: str) -> int:
+    match = re.search(
+        r'<div class="num">(\d+)</div><div class="lbl">needs review</div>', body
+    )
+    assert match is not None, "needs review card not found in dashboard"
+    return int(match.group(1))
+
+
 def test_dashboard_engine_input_card_follows_engine_statuses(tmp_path, monkeypatch):
     """The dashboard's headline card must answer from ENGINE_STATUSES too.
 
@@ -162,6 +170,28 @@ def test_dashboard_engine_input_card_follows_engine_statuses(tmp_path, monkeypat
     assert _engine_input_card(body) == len(
         store.facts(statuses=store_db.ENGINE_STATUSES)
     )
+
+
+def test_dashboard_uses_call_time_review_and_all_status_accessors(tmp_path, monkeypatch):
+    c = _client(tmp_path)
+    store = c.app.state.store
+    store.add_fact("C", "is_a", "D", status="candidate")
+    store.add_fact("E", "is_a", "F", status="confirmed")
+
+    assert _review_card(c.get("/").text) == 2
+
+    monkeypatch.setattr(store_db, "REVIEW_STATUSES", frozenset({"candidate"}))
+    monkeypatch.setattr(
+        store_db,
+        "ALL_FACT_STATUSES",
+        frozenset({"candidate", "confirmed", "superseded"}),
+    )
+
+    body = c.get("/").text
+    assert _review_card(body) == 1
+    assert '<span class="badge badge-needs_review">needs_review</span>' not in body
+    assert '<span class="badge badge-candidate">candidate</span>' in body
+    assert '<span class="badge badge-confirmed">confirmed</span>' in body
 
 
 def test_dashboard_shows_action_queue_counts_and_links(tmp_path):
@@ -682,7 +712,7 @@ def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
         assert "is_a" in c.get("/review").text
         body = c.get("/sources").text
         assert "Analysis complete: 1/1 chunk(s)" in body
-        assert "1 candidate(s)" in body
+        assert "1 awaiting review" in body
 
     _wait_for(extracted)
 
@@ -730,7 +760,7 @@ def test_sources_page_lists_sources(tmp_path):
     assert "failed" in r.text
     assert "1/2 chunk(s)" in r.text
     assert "provider down" in r.text
-    assert "1 candidate(s)" in r.text
+    assert "1 awaiting review" in r.text
     assert "1 unsupported" in r.text
     assert "ollama" in r.text
     assert "qwen3.5:9b" in r.text
@@ -812,7 +842,7 @@ def test_sources_accept_all_promotes_review_facts_for_that_source(tmp_path):
     assert store.fact_log(other_id) == []
 
     body = c.get("/sources").text
-    assert "0 candidate(s)" in body
+    assert "0 awaiting review" in body
 
 
 def test_sources_page_shows_trust_counts_and_evidence_snippets(tmp_path, monkeypatch):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from verinote import __version__
 from verinote.config import Config, local_root
 from verinote.pipeline.question_outcome import format_question_outcome
-from verinote.store import Store, engine_statuses
+from verinote.store import Store, engine_statuses, fact_status_order
 from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreLockedError
 from verinote.text import nfc
 
@@ -1343,7 +1343,7 @@ def _status(cfg: Config) -> int:
         print(f"KB: {cfg.root}")
         print(f"sources: {sources_count}")
         print(f"facts:   {sum(counts.values())}")
-        for s in ("candidate", "needs_review", "confirmed", "accepted", "superseded"):
+        for s in fact_status_order():
             print(f"  {s:<13} {counts.get(s, 0)}")
         # `status` stays rc=0 even when halted: it is one of the paths that must keep
         # working *on* a halted KB, and a diagnosis command that fails is not a

--- a/verinote/store/__init__.py
+++ b/verinote/store/__init__.py
@@ -11,10 +11,14 @@ from verinote.store.db import (
     TerminalFactError,
 )
 from verinote.store.tiers import (
+    all_fact_statuses,
     engine_statuses,
+    fact_status_order,
+    is_actionable_fact_status,
     is_engine_input,
     is_review_eligible,
     review_statuses,
+    terminal_fact_statuses,
 )
 
 # The raw `ENGINE_STATUSES` / `REVIEW_STATUSES` frozensets are deliberately not
@@ -28,8 +32,12 @@ __all__ = [
     "POLICY_MARKER_KEY",
     "engine_statuses",
     "review_statuses",
+    "terminal_fact_statuses",
+    "all_fact_statuses",
+    "fact_status_order",
     "is_engine_input",
     "is_review_eligible",
+    "is_actionable_fact_status",
     "DEFAULT_REVIEW_PAGE_SIZE",
     "REVIEW_PAGE_SIZES",
     "ReviewQueuePage",

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -28,7 +28,28 @@ POLICY_MARKER_KEY = "policy.logic"
 # kb_meta key declaring that fact logical terms are managed by facts.duckdb.
 FACT_TERMS_MARKER_KEY = "fact_terms.duckdb"
 ENGINE_STATUSES = frozenset({"confirmed", "accepted"})
+TERMINAL_STATUSES = frozenset({"superseded"})
+ALL_FACT_STATUSES = REVIEW_STATUSES | ENGINE_STATUSES | TERMINAL_STATUSES
+# The stable display order for the schema vocabulary. New statuses can be
+# appended by callers at runtime; tier accessors place those after this list.
+FACT_STATUS_ORDER = (
+    "candidate",
+    "needs_review",
+    "confirmed",
+    "accepted",
+    "superseded",
+)
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
+
+
+def _validate_fact_status_vocabulary() -> None:
+    if len(FACT_STATUS_ORDER) != len(set(FACT_STATUS_ORDER)):
+        raise RuntimeError("fact status order contains duplicates")
+    if set(FACT_STATUS_ORDER) != ALL_FACT_STATUSES:
+        raise RuntimeError("fact status order must cover the fact status vocabulary")
+
+
+_validate_fact_status_vocabulary()
 
 
 class TerminalFactError(ValueError):
@@ -790,22 +811,21 @@ class Store:
     def sources_with_counts(self) -> list[sqlite3.Row]:
         """Sources plus analysis and fact summaries for the Sources listing.
 
-        `engine_count` is derived from `ENGINE_STATUSES` (read at call time), so
-        the Sources page and the coverage report can never disagree about what
-        the engine actually reads.
+        `review_count` and `engine_count` are derived from their status tiers
+        at call time, so the Sources page cannot disagree with review actions
+        or coverage about which facts each workflow sees.
         """
-        placeholders, params = _status_filter(ENGINE_STATUSES)
+        review_placeholders, review_params = _status_filter(REVIEW_STATUSES)
+        engine_placeholders, engine_params = _status_filter(ENGINE_STATUSES)
         return list(
             self._conn.execute(
                 "SELECT s.id, s.path, s.kind, s.added_at, "
                 "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id) "
                 "AS fact_count, "
                 "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
-                "AND f.status = 'candidate') AS candidate_count, "
+                f"AND f.status IN ({review_placeholders})) AS review_count, "
                 "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
-                "AND f.status = 'needs_review') AS needs_review_count, "
-                "(SELECT COUNT(*) FROM facts f WHERE f.source_id = s.id "
-                f"AND f.status IN ({placeholders})) AS engine_count, "
+                f"AND f.status IN ({engine_placeholders})) AS engine_count, "
                 "j.id AS job_id, j.status AS analysis_status, "
                 "j.total_chunks, j.completed_chunks, j.failed_chunks, "
                 "j.candidate_count AS analysis_candidate_count, "
@@ -817,7 +837,7 @@ class Store:
                 "  WHERE j2.source_id = s.id"
                 ") "
                 "ORDER BY s.path",
-                params,
+                review_params + engine_params,
             )
         )
 

--- a/verinote/store/tiers.py
+++ b/verinote/store/tiers.py
@@ -11,8 +11,8 @@ planner's schema hint never see.
 
 So the raw frozensets are no longer re-exported from `verinote.store`. Every
 status-tier question goes through the accessors here, which resolve
-`db.ENGINE_STATUSES` / `db.REVIEW_STATUSES` at call time. One question, one
-answer, one runtime definition.
+`db.ENGINE_STATUSES` / `db.REVIEW_STATUSES` and the complete fact-status
+vocabulary at call time. One question, one answer, one runtime definition.
 
 The empty tier is refused here too, for the same reason `_status_filter`
 refuses it: an empty tier turns every membership test into a silent "no" —
@@ -41,6 +41,29 @@ def review_statuses() -> frozenset[str]:
     return _require_populated(_db.REVIEW_STATUSES, "review")
 
 
+def terminal_fact_statuses() -> frozenset[str]:
+    """The terminal fact-status tier, read at call time."""
+    return _require_populated(_db.TERMINAL_STATUSES, "terminal fact")
+
+
+def all_fact_statuses() -> frozenset[str]:
+    """Every schema-supported fact status, read at call time."""
+    return _require_populated(_db.ALL_FACT_STATUSES, "all fact")
+
+
+def fact_status_order() -> tuple[str, ...]:
+    """Known statuses in legacy order, followed by sorted runtime additions."""
+    statuses = all_fact_statuses()
+    known = tuple(status for status in _db.FACT_STATUS_ORDER if status in statuses)
+    extras = tuple(sorted(statuses - set(_db.FACT_STATUS_ORDER)))
+    ordered = known + extras
+    if len(ordered) != len(set(ordered)):
+        raise ValueError("fact status order contains duplicates")
+    if set(ordered) != statuses:
+        raise ValueError("fact status order does not cover every fact status")
+    return ordered
+
+
 def is_engine_input(status: object) -> bool:
     """Whether `status` is read by the deterministic engine, decided at call time."""
     return str(status) in engine_statuses()
@@ -49,3 +72,8 @@ def is_engine_input(status: object) -> bool:
 def is_review_eligible(status: object) -> bool:
     """Whether `status` sits in the human-review tier, decided at call time."""
     return str(status) in review_statuses()
+
+
+def is_actionable_fact_status(status: object) -> bool:
+    """Whether a fact may receive review actions, decided at call time."""
+    return str(status) in review_statuses() | engine_statuses()

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -15,7 +15,7 @@ from threading import Lock
 import unicodedata
 from urllib.parse import urlencode
 
-from fastapi import FastAPI, File, Form, Request, Response, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, Request, Response, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -93,11 +93,12 @@ from verinote.store import (
     ReviewQueuePage,
     Store,
     TerminalFactError,
+    engine_statuses,
+    fact_status_order,
+    is_actionable_fact_status,
+    is_engine_input,
     review_statuses,
 )
-# Imported as a module, not `from ... import ENGINE_STATUSES`: the tier must be
-# read at call time so the web layer cannot pin a stale copy of the constant.
-from verinote.store import db as store_db
 from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
 from verinote.store.fact_input import nfc_term, structural_term, term_input_kind
 from verinote.text import nfc
@@ -447,7 +448,20 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if fact and recommendations is None:
             recommendations = accept_recommendations(_active_store())
         recommendation = recommendations.get(int(fact["id"])) if fact else None
-        return {"f": view, "trust": trust, "recommendation": recommendation}
+        return {
+            "f": view,
+            "trust": trust,
+            "recommendation": recommendation,
+            "actionable": bool(fact and is_actionable_fact_status(fact["status"])),
+        }
+
+    def _actionable_fact_or_error(fact_id: int):
+        fact = _active_store().get_fact(fact_id)
+        if fact is None:
+            raise HTTPException(status_code=404, detail="fact not found")
+        if not is_actionable_fact_status(fact["status"]):
+            raise HTTPException(status_code=400, detail="fact is not actionable")
+        return fact
 
     def _maybe_apply_auto_accept(exclude_fact_ids: tuple[int, ...] = ()) -> list:
         if _active_cfg().auto_accept_recommendations:
@@ -698,7 +712,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         typed = store_typed_relations(store)
         support_sources: dict[tuple[str, str, tuple[str, object]], set[str]] = {}
         for fact in facts:
-            if str(fact["status"]) not in store_db.ENGINE_STATUSES:
+            if not is_engine_input(fact["status"]):
                 continue
             source_path = str(fact["source_path"] or "").strip()
             if not source_path:
@@ -818,9 +832,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # Derived here, not summed in the template: the dashboard's
                 # "engine input" card must answer the same question as coverage
                 # and the Sources badge, from the same constant.
-                "engine_input": sum(
-                    counts.get(status, 0) for status in store_db.ENGINE_STATUSES
-                ),
+                "engine_input": sum(counts.get(status, 0) for status in engine_statuses()),
+                "review_count": sum(counts.get(status, 0) for status in review_statuses()),
+                "all_fact_statuses": fact_status_order(),
                 "sources": store.sources(),
                 "coverage": coverage(store, root=cfg.root),
                 "corroboration": store_corroboration(store),
@@ -1331,6 +1345,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)
     def toggle(request: Request, fact_id: int):
+        _actionable_fact_or_error(fact_id)
         toggled = _active_store().toggle_review(fact_id)
         # A demotion parks the fact in exactly the tier auto-accept promotes
         # from, so an unrestricted pass would undo the user's click inside their
@@ -1351,6 +1366,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/facts/{fact_id}/accept", response_class=HTMLResponse)
     def accept(request: Request, fact_id: int):
+        _actionable_fact_or_error(fact_id)
         accepted = _active_store().accept_fact(fact_id)
         return _row_after_decision(
             request, accepted.fact, fact_id, decided=accepted.changed
@@ -1361,6 +1377,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # Reject runs auto-accept too: removing a fact's support (or freeing a
         # single-valued slot it conflicted on) also reshapes corroboration, so
         # keeping the trigger here matches the other decision routes.
+        _actionable_fact_or_error(fact_id)
         rejected = _active_store().reject_fact(fact_id)
         return _row_after_decision(
             request, rejected.fact, fact_id, decided=rejected.changed
@@ -1368,15 +1385,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get("/facts/{fact_id}/edit", response_class=HTMLResponse)
     def edit_fact(request: Request, fact_id: int):
-        fact = _active_store().get_fact(fact_id)
-        # #311: a superseded fact's content is frozen, so do not hand back a form
-        # that invites an edit the store will refuse. The row template already
-        # hides the edit control for these, so reaching here means a page that
-        # went stale (the fact was rejected while it was open) or a direct GET;
-        # re-rendering the read-only row answers both -- it swaps the stale
-        # controls for the current "rejected -- no further action" state.
-        if fact is not None and fact["status"] == "superseded":
-            return _row(request, fact)
+        fact = _actionable_fact_or_error(fact_id)
         return templates.TemplateResponse(
             request,
             "partials/fact_edit.html",
@@ -1400,6 +1409,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         object_kind: str = Form(...),
         note: str = Form(""),
     ):
+        _actionable_fact_or_error(fact_id)
         try:
             subject_value = _fact_input(subject, subject_kind)
             relation_value = _fact_input(relation, relation_kind)

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -7,7 +7,7 @@
 <section class="cards">
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>
   <div class="card"><div class="num">{{ total }}</div><div class="lbl">facts</div></div>
-  <div class="card"><div class="num">{{ counts.get('needs_review', 0) + counts.get('candidate', 0) }}</div><div class="lbl">needs review</div></div>
+  <div class="card"><div class="num">{{ review_count }}</div><div class="lbl">needs review</div></div>
   <div class="card ok"><div class="num">{{ engine_input }}</div><div class="lbl">engine input</div></div>
 </section>
 
@@ -31,7 +31,7 @@
 <h2>By status</h2>
 <table class="counts">
   <tbody>
-    {% for s in ['candidate','needs_review','confirmed','accepted','superseded'] %}
+    {% for s in all_fact_statuses %}
     <tr><td><span class="badge badge-{{ s }}">{{ s }}</span></td><td>{{ counts.get(s, 0) }}</td></tr>
     {% endfor %}
   </tbody>

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -63,22 +63,7 @@
        ever wanted, has to be its own explicit and audited action. The trust
        dossier stays reachable: a rejected fact is still evidence. #}
     <a class="btn ghost" href="/facts/{{ f['id'] }}/provenance" title="inspect trust dossier">Inspect</a>
-    {# FAIL-OPEN, knowingly and only for now. This asks "is it superseded?" and
-       hides the buttons if so; it does not ask "is it in the review or engine
-       tier?" and show them only then. Today those are the same question --
-       superseded is the one status outside both tiers -- but the day a status
-       is added (retracted, archived, ...) it lands in the else branch and gets
-       the full set back, toggle and accept included: the one-click way back
-       into the KB that #233 closed reopens by itself, silently.
-
-       The condition has to be inverted to
-         if is_review_eligible(f['status']) or is_engine_input(f['status'])
-       over the call-time tier accessors in verinote/store/tiers.py. That needs
-       the callables handed to Jinja (templates.env.globals / the row context)
-       in verinote/web/app.py, which PR #209 currently holds -- so it is not
-       done here. This literal is also the 6th hardcopy of the status
-       vocabulary tracked by #191; see the note there. #}
-    {% if f['status'] == 'superseded' %}
+    {% if not actionable %}
       <span class="muted">rejected — no further action</span>
     {% else %}
       <button hx-post="/facts/{{ f['id'] }}/toggle"

--- a/verinote/web/templates/review.html
+++ b/verinote/web/templates/review.html
@@ -79,6 +79,7 @@
       {% set f = row.f %}
       {% set trust = row.trust %}
       {% set recommendation = row.recommendation %}
+      {% set actionable = row.actionable %}
       {% include "partials/fact_row.html" %}
     {% endfor %}
   </tbody>

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -149,8 +149,7 @@
         {% endif %}
       </td>
       <td class="conf" id="trust-{{ s["id"] }}">
-        {{ s["candidate_count"] }} candidate(s)
-        {% if s["needs_review_count"] %}<br>{{ s["needs_review_count"] }} needs review{% endif %}
+        {{ s["review_count"] }} awaiting review
         {# Derived from ENGINE_STATUSES, which already includes `accepted`:
            label it by what it means (the engine reads it), not by one status. #}
         {% if s["engine_count"] %}<br>{{ s["engine_count"] }} engine input{% endif %}
@@ -184,7 +183,7 @@
         <form action="/sources/{{ s["id"] }}/reanalyze" method="post">
           <button class="btn ghost" id="reanalyze-{{ s["id"] }}" type="submit">Re-analyze</button>
         </form>
-        {% if s["candidate_count"] or s["needs_review_count"] %}
+        {% if s["review_count"] %}
         <form action="/sources/{{ s["id"] }}/accept-all" method="post">
           <button class="btn ghost" id="accept-all-{{ s["id"] }}" type="submit">Accept all</button>
         </form>


### PR DESCRIPTION
## Summary
- centralize review, engine, terminal, and complete fact status vocabulary
- derive CLI, dashboard, Sources, and row action behavior from call-time accessors
- fail closed for non-actionable fact mutations and lock schema vocabulary with tests

## Validation
- `.venv/bin/python -m pytest -q tests/test_status_tiers.py tests/test_review_actions.py tests/test_review_gate.py tests/test_superseded_terminal.py tests/test_store.py tests/test_web.py tests/test_cli.py`
- focused source/web regression tests: 4 passed
- `git diff --check`

## Data privacy
- synthetic fixtures only; no customer or source data included.