### PR TITLE
fix: preserve immutable policy marker evidence

### DIFF
--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -2,11 +2,13 @@
 """A lost logic policy must never read as a consistent KB (#155)."""
 
 import importlib
+import json
 
 import pytest
 
 import verinote.cli as cli
 import verinote.pipeline.acceptance as acceptance
+import verinote.store.db as store_db
 from verinote.engine import CheckReport, DEFAULT_POLICY
 from verinote.pipeline.acceptance import AcceptRecommendation
 from verinote.pipeline.corroboration import store_functional_relations
@@ -23,8 +25,10 @@ from verinote.pipeline.policy_state import (
     assert_writable,
     ensure_policy_marker,
     policy_cli_line,
+    policy_missing_message,
     policy_sha256,
     resolve_policy,
+    write_default_policy,
 )
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import load_policy, verify
@@ -122,6 +126,312 @@ def test_hash_mismatch_is_not_an_error(tmp_path):
     state = resolve_policy(store)
     assert state.status is PolicyStatus.PRESENT
     assert verify(store).ok is True
+
+
+# --- marker evidence: first observation is immutable; unchanged opens are reads ---
+
+
+def _kb_meta_writes(statements: list[str]) -> list[str]:
+    return [
+        statement
+        for statement in statements
+        if "INSERT INTO KB_META" in statement.upper()
+        or "UPDATE KB_META" in statement.upper()
+    ]
+
+
+def test_unchanged_policy_open_preserves_evidence_without_metadata_write(
+    tmp_path, monkeypatch
+):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    monkeypatch.setattr(store_db, "_utc_now", lambda: "2030-01-01T00:00:00Z")
+    marker_before = store.record_policy_marker(
+        policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold"
+    )
+    statements: list[str] = []
+    store._conn.set_trace_callback(statements.append)
+
+    state = ensure_policy_marker(store, tmp_path)
+
+    store._conn.set_trace_callback(None)
+    assert state.status is PolicyStatus.PRESENT
+    assert state.marker == marker_before
+    assert store.policy_marker() == marker_before
+    assert _kb_meta_writes(statements) == []
+    store.close()
+
+
+def test_recording_same_v2_policy_marker_performs_no_metadata_write(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    sha = policy_sha256(FUNCTIONAL_POLICY)
+    monkeypatch.setattr(store_db, "_utc_now", lambda: "2030-01-01T00:00:00Z")
+    marker_before = store.record_policy_marker(sha, origin="scaffold")
+    statements: list[str] = []
+    store._conn.set_trace_callback(statements.append)
+
+    marker_after = store.record_policy_marker(sha, origin="scaffold")
+
+    store._conn.set_trace_callback(None)
+    assert marker_after == marker_before
+    assert _kb_meta_writes(statements) == []
+    store.close()
+
+
+def test_refresh_preserves_unrecognized_existing_marker_origin(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    original = {
+        "sha256": policy_sha256(path.read_text(encoding="utf-8")),
+        "first_recorded_at": "2030-01-01T00:00:00Z",
+        "last_seen_at": "2030-01-01T00:00:00Z",
+        "origin": "imported_v1",
+    }
+    store._set_meta("policy.logic", json.dumps(original))
+    monkeypatch.setattr(store_db, "_utc_now", lambda: "2030-01-02T00:00:00Z")
+    path.write_text(FUNCTIONAL_POLICY + "// synthetic changed policy\n", encoding="utf-8")
+
+    state = ensure_policy_marker(store, tmp_path)
+
+    assert state.marker is not None
+    assert state.marker["origin"] == "imported_v1"
+    assert state.marker["first_recorded_at"] == original["first_recorded_at"]
+    store.close()
+
+
+def test_changed_policy_preserves_first_evidence_and_refreshes_last_seen(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    clock = iter(["2030-01-01T00:00:00Z", "2030-01-02T00:00:00Z"])
+    monkeypatch.setattr(store_db, "_utc_now", lambda: next(clock))
+    first_marker = store.record_policy_marker(
+        policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold"
+    )
+    changed_policy = FUNCTIONAL_POLICY + "// synthetic changed policy\n"
+    path.write_text(changed_policy, encoding="utf-8")
+
+    state = ensure_policy_marker(store, tmp_path)
+
+    assert state.marker is not None
+    assert state.marker["sha256"] == policy_sha256(changed_policy)
+    assert state.marker["origin"] == "scaffold"
+    assert state.marker["first_recorded_at"] == first_marker["first_recorded_at"]
+    assert state.marker["last_seen_at"] == "2030-01-02T00:00:00Z"
+    store.close()
+
+
+def test_legacy_marker_stays_read_only_until_a_real_marker_write(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    sha = policy_sha256(path.read_text(encoding="utf-8"))
+    legacy = {
+        "sha256": sha,
+        "recorded_at": "2020-01-01T00:00:00Z",
+        "origin": "scaffold",
+    }
+    store._set_meta("policy.logic", json.dumps(legacy))
+    statements: list[str] = []
+    store._conn.set_trace_callback(statements.append)
+
+    state = ensure_policy_marker(store, tmp_path)
+
+    store._conn.set_trace_callback(None)
+    assert state.marker == legacy
+    assert store.policy_marker() == legacy
+    assert _kb_meta_writes(statements) == []
+    path.unlink()
+    message = policy_missing_message(resolve_policy(store))
+    assert "first_recorded_at=unavailable" in message
+    assert "last_observed_at=2020-01-01T00:00:00Z" in message
+
+    path.write_text(FUNCTIONAL_POLICY + "// synthetic changed policy\n", encoding="utf-8")
+    monkeypatch.setattr(store_db, "_utc_now", lambda: "2030-01-02T00:00:00Z")
+    migrated = ensure_policy_marker(store, tmp_path).marker
+
+    assert migrated is not None
+    assert migrated["first_recorded_at"] == "2030-01-02T00:00:00Z"
+    assert migrated["last_seen_at"] == "2030-01-02T00:00:00Z"
+    assert "recorded_at" not in migrated
+    store.close()
+
+
+def test_read_only_cli_reports_legacy_marker_evidence_without_writing(
+    tmp_path, monkeypatch, capsys
+):
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    store._set_meta(
+        "policy.logic",
+        json.dumps(
+            {
+                "sha256": policy_sha256(path.read_text(encoding="utf-8")),
+                "recorded_at": "2020-01-01T00:00:00Z",
+                "origin": "scaffold",
+            }
+        ),
+    )
+    store.close()
+    path.unlink()
+    db = tmp_path / "kb.sqlite"
+    before = db.read_bytes()
+
+    assert cli.main(["status"]) == 0
+
+    captured = capsys.readouterr()
+    assert "first_recorded_at=unavailable" in captured.err
+    assert "last_observed_at=2020-01-01T00:00:00Z" in captured.err
+    assert db.read_bytes() == before
+
+
+def test_missing_policy_message_cites_immutable_first_recorded_evidence(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path)
+    monkeypatch.setattr(store_db, "_utc_now", lambda: "2030-01-01T00:00:00Z")
+    store.record_policy_marker(policy_sha256(FUNCTIONAL_POLICY), origin="scaffold")
+    path.unlink()
+
+    message = policy_missing_message(resolve_policy(store))
+
+    assert "first_recorded_at=2030-01-01T00:00:00Z" in message
+    assert ", recorded_at=" not in message
+    store.close()
+
+
+def test_forced_reset_preserves_first_evidence_and_refreshes_last_seen(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    path = _write_policy(tmp_path, DEFAULT_POLICY)
+    clock = iter(["2030-01-01T00:00:00Z", "2030-01-02T00:00:00Z"])
+    monkeypatch.setattr(store_db, "_utc_now", lambda: next(clock))
+    original = store.record_policy_marker(
+        policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold"
+    )
+
+    write_default_policy(store, tmp_path, origin="reset")
+
+    reset = store.policy_marker()
+    assert reset is not None
+    assert reset["origin"] == "reset"
+    assert reset["sha256"] == original["sha256"]
+    assert reset["first_recorded_at"] == original["first_recorded_at"]
+    assert reset["last_seen_at"] == "2030-01-02T00:00:00Z"
+    store.close()
+
+
+@pytest.mark.parametrize(
+    ("recorded_policy", "stale_policy"),
+    [
+        (FUNCTIONAL_POLICY, DEFAULT_POLICY),
+        (DEFAULT_POLICY, DEFAULT_POLICY + "// synthetic stale policy\n"),
+    ],
+    ids=["different_sha", "same_sha"],
+)
+def test_stale_ensure_cannot_overwrite_a_forced_reset_marker(
+    tmp_path, monkeypatch, recorded_policy, stale_policy
+):
+    """A reset wins if it lands after another store has read its old evidence."""
+    stale_store = _store(tmp_path)
+    reset_store = Store(tmp_path / "kb.sqlite")
+    path = _write_policy(tmp_path, recorded_policy)
+    stale_store.record_policy_marker(
+        policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold"
+    )
+    path.write_text(stale_policy, encoding="utf-8")
+    original_record = stale_store.record_policy_marker
+    reset_done = False
+
+    def interleaved_record(*args, **kwargs):
+        nonlocal reset_done
+        if not reset_done:
+            reset_done = True
+            write_default_policy(reset_store, tmp_path, origin="reset")
+        return original_record(*args, **kwargs)
+
+    monkeypatch.setattr(stale_store, "record_policy_marker", interleaved_record)
+
+    state = ensure_policy_marker(stale_store, tmp_path)
+
+    marker = reset_store.policy_marker()
+    assert state.marker == marker
+    assert marker is not None
+    assert marker["origin"] == "reset"
+    assert marker["sha256"] == policy_sha256(DEFAULT_POLICY)
+    stale_store.close()
+    reset_store.close()
+
+
+def test_stale_ensure_cannot_overwrite_a_same_time_equivalent_forced_reset(
+    tmp_path, monkeypatch
+):
+    """A reset publication beats a stale snapshot even when its evidence repeats."""
+    stale_store = _store(tmp_path)
+    reset_store = Store(tmp_path / "kb.sqlite")
+    monkeypatch.setattr(store_db, "_utc_now", lambda: "2030-01-01T00:00:00Z")
+    write_default_policy(stale_store, tmp_path, origin="reset")
+    initial = stale_store.policy_marker()
+    assert initial is not None
+    path = tmp_path / "policy" / "logic-policy.dl"
+    path.write_text(DEFAULT_POLICY + "// synthetic stale policy\n", encoding="utf-8")
+    original_record = stale_store.record_policy_marker
+    reset_marker = None
+
+    def interleaved_record(*args, **kwargs):
+        nonlocal reset_marker
+        if reset_marker is None:
+            write_default_policy(reset_store, tmp_path, origin="reset")
+            reset_marker = reset_store.policy_marker()
+        return original_record(*args, **kwargs)
+
+    monkeypatch.setattr(stale_store, "record_policy_marker", interleaved_record)
+
+    state = ensure_policy_marker(stale_store, tmp_path)
+
+    marker = reset_store.policy_marker()
+    assert reset_marker is not None
+    assert {
+        key: value for key, value in reset_marker.items() if key != "revision"
+    } == {key: value for key, value in initial.items() if key != "revision"}
+    assert reset_marker["revision"] == initial["revision"] + 1
+    assert state.marker == reset_marker
+    assert marker == reset_marker
+    assert marker["origin"] == "reset"
+    stale_store.close()
+    reset_store.close()
+
+
+def test_stale_ensure_retries_after_a_genuine_policy_edit(tmp_path, monkeypatch):
+    """Another ensure's fresh evidence must beat an older file observation."""
+    stale_store = _store(tmp_path)
+    edit_store = Store(tmp_path / "kb.sqlite")
+    path = _write_policy(tmp_path)
+    stale_store.record_policy_marker(
+        policy_sha256(path.read_text(encoding="utf-8")), origin="scaffold"
+    )
+    stale_policy = FUNCTIONAL_POLICY + "// synthetic stale policy\n"
+    edited_policy = FUNCTIONAL_POLICY + "// synthetic current policy\n"
+    path.write_text(stale_policy, encoding="utf-8")
+    original_record = stale_store.record_policy_marker
+    edit_done = False
+
+    def interleaved_record(*args, **kwargs):
+        nonlocal edit_done
+        if not edit_done:
+            edit_done = True
+            path.write_text(edited_policy, encoding="utf-8")
+            ensure_policy_marker(edit_store, tmp_path)
+        return original_record(*args, **kwargs)
+
+    monkeypatch.setattr(stale_store, "record_policy_marker", interleaved_record)
+
+    state = ensure_policy_marker(stale_store, tmp_path)
+
+    marker = edit_store.policy_marker()
+    assert state.text == edited_policy
+    assert state.marker == marker
+    assert marker is not None
+    assert marker["sha256"] == policy_sha256(edited_policy)
+    stale_store.close()
+    edit_store.close()
 
 
 # --- 2. fresh KB: no file, no marker -> default policy, but loudly ---

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -469,9 +469,19 @@ def _policy_marker_ro(conn: sqlite3.Connection) -> dict[str, object] | None:
     try:
         marker = json.loads(raw["value"])
     except json.JSONDecodeError:
-        return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+        return {
+            "sha256": "",
+            "first_recorded_at": "",
+            "last_seen_at": "",
+            "origin": "unknown",
+        }
     if not isinstance(marker, dict):
-        return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+        return {
+            "sha256": "",
+            "first_recorded_at": "",
+            "last_seen_at": "",
+            "origin": "unknown",
+        }
     return marker
 
 

--- a/verinote/pipeline/policy_state.py
+++ b/verinote/pipeline/policy_state.py
@@ -15,8 +15,9 @@ the judgement here.
 
 The marker stores a sha256 as *evidence* (so a report can say what was there),
 not as a verdict: editing a policy is normal and a hash mismatch is never an
-error. The `.dl` file remains the owner of the policy text; the DB never stores
-its body.
+error. It also records immutable `first_recorded_at` evidence and the most
+recent content observation in `last_seen_at`. The `.dl` file remains the owner
+of the policy text; the DB never stores its body.
 
 Four states, one resolution point:
 
@@ -197,13 +198,35 @@ def runnable_policy_text(state: PolicyState) -> str:
 def policy_missing_message(state: PolicyState) -> str:
     """The loud, actionable message for a recorded-but-missing policy."""
     marker = state.marker or {}
-    origin = str(marker.get("origin") or "unknown")
-    recorded_at = str(marker.get("recorded_at") or "unknown")
-    sha = str(marker.get("sha256") or "")
+    origin_value = marker.get("origin")
+    origin = origin_value if isinstance(origin_value, str) and origin_value else "unknown"
+    first_value = marker.get("first_recorded_at")
+    first_recorded_at = (
+        first_value if isinstance(first_value, str) and first_value else None
+    )
+    last_value = marker.get("last_seen_at")
+    legacy_recorded_at = marker.get("recorded_at")
+    last_observed_at = (
+        last_value
+        if isinstance(last_value, str) and last_value
+        else legacy_recorded_at
+        if isinstance(legacy_recorded_at, str) and legacy_recorded_at
+        else "unknown"
+    )
+    timestamp_evidence = (
+        f"first_recorded_at={first_recorded_at}"
+        if first_recorded_at is not None
+        else (
+            "first_recorded_at=unavailable, "
+            f"last_observed_at={last_observed_at}"
+        )
+    )
+    sha_value = marker.get("sha256")
+    sha = sha_value if isinstance(sha_value, str) else ""
     sha_text = sha[:12] if sha else "unknown"
     return (
         f"policy file {state.path} is missing, but this KB recorded one "
-        f"(origin={origin}, recorded_at={recorded_at}, sha256={sha_text}). "
+        f"(origin={origin}, {timestamp_evidence}, sha256={sha_text}). "
         "Verification is halted instead of silently falling back to the shipped "
         "default policy. Recover by either (1) restoring the policy file from a "
         "backup or version control, or (2) running `verinote policy reset --force` "
@@ -269,11 +292,14 @@ def assert_writable(store: "Store") -> PolicyState:
 
 
 def ensure_policy_marker(store: "Store", root: Path | None = None) -> PolicyState:
-    """Record/refresh the policy marker when a KB is opened.
+    """Record policy evidence when a KB is opened.
 
     * file present, no marker  -> adopt it (`origin="adopted"`); pre-marker KBs
       keep working, and any *later* loss of the file is loud.
-    * file present, marker     -> refresh the evidence hash (never an error).
+    * file present, changed marker -> refresh the evidence hash and `last_seen_at`
+      (never an error).
+    * file present, same marker -> do nothing. Opening an unchanged KB must not
+      write SQLite metadata.
     * file present but empty    -> record NOTHING and return `PRESENT_EMPTY` with
       the marker as read: recording `sha256("")` here would silently overwrite a
       real policy's marker, so merely opening a KB whose file was truncated — which
@@ -283,24 +309,41 @@ def ensure_policy_marker(store: "Store", root: Path | None = None) -> PolicyStat
       distinguishable and must stay that way.
     """
     path = (root / POLICY_RELPATH) if root is not None else policy_path(store)
-    marker = store.policy_marker()
-    if not path.is_file():
-        status = (
-            PolicyStatus.MISSING_RECORDED if marker is not None else PolicyStatus.UNRECORDED_DEFAULT
+    while True:
+        marker = store.policy_marker()
+        if not path.is_file():
+            status = (
+                PolicyStatus.MISSING_RECORDED
+                if marker is not None
+                else PolicyStatus.UNRECORDED_DEFAULT
+            )
+            return PolicyState(status=status, path=path, marker=marker)
+        text = path.read_text(encoding="utf-8")
+        if _policy_text_is_empty(text):
+            return PolicyState(
+                status=PolicyStatus.PRESENT_EMPTY, path=path, text=text, marker=marker
+            )
+        sha = policy_sha256(text)
+        marker_sha = marker.get("sha256") if marker else None
+        if isinstance(marker_sha, str) and marker_sha == sha:
+            return PolicyState(
+                status=PolicyStatus.PRESENT, path=path, text=text, marker=marker
+            )
+        origin_value = marker.get("origin") if marker else None
+        origin = (
+            "adopted"
+            if marker is None
+            else origin_value
+            if isinstance(origin_value, str) and origin_value
+            else "unknown"
         )
-        return PolicyState(status=status, path=path, marker=marker)
-    text = path.read_text(encoding="utf-8")
-    if _policy_text_is_empty(text):
-        return PolicyState(
-            status=PolicyStatus.PRESENT_EMPTY, path=path, text=text, marker=marker
+        refreshed = store.record_policy_marker(
+            sha, origin=origin, expected_previous_marker=marker
         )
-    origin = str(marker.get("origin")) if marker else "adopted"
-    if origin not in POLICY_ORIGINS:
-        origin = "adopted"
-    refreshed = store.record_policy_marker(policy_sha256(text), origin=origin)
-    return PolicyState(
-        status=PolicyStatus.PRESENT, path=path, text=text, marker=refreshed
-    )
+        if refreshed is not None:
+            return PolicyState(
+                status=PolicyStatus.PRESENT, path=path, text=text, marker=refreshed
+            )
 
 
 def write_default_policy(store: "Store", root: Path | None = None, *, origin: str) -> Path:
@@ -318,5 +361,7 @@ def write_default_policy(store: "Store", root: Path | None = None, *, origin: st
     # these two lines and the only recovery path starts tripping over the very
     # halt it exists to clear.
     path.write_text(DEFAULT_POLICY, encoding="utf-8")
-    store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin=origin)
+    store.record_policy_marker(
+        policy_sha256(DEFAULT_POLICY), origin=origin, force_seen=True
+    )
     return path

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -42,6 +42,56 @@ FACT_STATUS_ORDER = (
 MAX_EVIDENCE_SNIPPET_CHARS = 1000
 
 
+class _PolicyMarkerExpectedUnset:
+    pass
+
+
+_POLICY_MARKER_EXPECTED_UNSET = _PolicyMarkerExpectedUnset()
+
+
+def _invalid_policy_marker() -> dict[str, object]:
+    """A malformed marker remains evidence that a policy once existed."""
+    return {
+        "sha256": "",
+        "first_recorded_at": "",
+        "last_seen_at": "",
+        "origin": "unknown",
+    }
+
+
+def _marker_text(marker: dict[str, object] | None, key: str) -> str | None:
+    """Return a non-empty string field from an untrusted marker payload."""
+    if marker is None:
+        return None
+    value = marker.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _marker_revision(marker: dict[str, object] | None) -> int | None:
+    """Return a valid marker publication revision, if this is a v2 marker."""
+    if marker is None:
+        return None
+    value = marker.get("revision")
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0
+        else None
+    )
+
+
+def _policy_marker_matches_expected(
+    actual: dict[str, object] | None, expected: dict[str, object] | None
+) -> bool:
+    """Compare a marker snapshot without allowing a publication ABA."""
+    actual_revision = _marker_revision(actual)
+    expected_revision = _marker_revision(expected)
+    if actual_revision is not None or expected_revision is not None:
+        return actual_revision == expected_revision and actual == expected
+    # Legacy markers predate revisions. Preserve their former comparison until
+    # a publication upgrades the stored marker to include one.
+    return actual == expected
+
+
 def _validate_fact_status_vocabulary() -> None:
     if len(FACT_STATUS_ORDER) != len(set(FACT_STATUS_ORDER)):
         raise RuntimeError("fact status order contains duplicates")
@@ -499,20 +549,70 @@ class Store:
         try:
             marker = json.loads(raw)
         except json.JSONDecodeError:
-            return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+            return _invalid_policy_marker()
         if not isinstance(marker, dict):
-            return {"sha256": "", "recorded_at": "", "origin": "unknown"}
+            return _invalid_policy_marker()
         return marker
 
-    def record_policy_marker(self, sha256: str, *, origin: str) -> dict[str, object]:
-        """Record that this KB has a policy file. Hash is evidence, not a verdict."""
-        marker: dict[str, object] = {
-            "sha256": sha256,
-            "recorded_at": _utc_now(),
-            "origin": origin,
-        }
-        self._set_meta(POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False))
-        return marker
+    def record_policy_marker(
+        self,
+        sha256: str,
+        *,
+        origin: str,
+        force_seen: bool = False,
+        expected_previous_marker: (
+            dict[str, object] | None | _PolicyMarkerExpectedUnset
+        ) = _POLICY_MARKER_EXPECTED_UNSET,
+    ) -> dict[str, object] | None:
+        """Record policy evidence while preserving its immutable first observation.
+
+        `recorded_at` belongs to the old marker contract and was refreshed on
+        every open. It is consequently only legacy *last-observed* evidence;
+        never carry it into `first_recorded_at`. A conversion records a fresh
+        first observation under the new contract instead. Each publication
+        receives a durable, monotonic `revision`, so an expected marker makes
+        this an ABA-safe optimistic compare-and-set: a None return means
+        another writer published newer policy evidence after the caller
+        observed it.
+        """
+        with self.immediate_transaction():
+            previous = self.policy_marker()
+            if (
+                expected_previous_marker is not _POLICY_MARKER_EXPECTED_UNSET
+                and not _policy_marker_matches_expected(
+                    previous, expected_previous_marker
+                )
+            ):
+                return None
+            previous_sha = _marker_text(previous, "sha256")
+            previous_first_recorded_at = _marker_text(previous, "first_recorded_at")
+            previous_last_seen_at = _marker_text(previous, "last_seen_at")
+            if (
+                not force_seen
+                and previous_sha == sha256
+                and previous_first_recorded_at is not None
+                and previous_last_seen_at is not None
+            ):
+                return previous
+
+            now = _utc_now()
+            first_recorded_at = previous_first_recorded_at or now
+            last_seen_at = (
+                now
+                if force_seen or previous_sha != sha256 or previous_last_seen_at is None
+                else previous_last_seen_at
+            )
+            marker: dict[str, object] = {
+                "sha256": sha256,
+                "first_recorded_at": first_recorded_at,
+                "last_seen_at": last_seen_at,
+                "origin": origin,
+                "revision": (_marker_revision(previous) or 0) + 1,
+            }
+            self._set_meta_unlocked(
+                POLICY_MARKER_KEY, json.dumps(marker, ensure_ascii=False)
+            )
+            return marker
 
     def fact_terms_marker(self) -> dict[str, object] | None:
         """The KB's declaration that DuckDB owns canonical fact terms, or None."""


### PR DESCRIPTION
Closes #181

## Summary
- preserve immutable first-recorded policy evidence while tracking changed content observations
- avoid metadata writes when an unchanged policy is opened
- make concurrent marker updates ABA-safe and preserve forced reset provenance
- retain legacy marker compatibility and improve missing-policy diagnostics

## Validation
- `.venv/bin/python -m pytest -q tests/test_policy_state.py tests/test_cli.py tests/test_web.py` (341 passed)
- `git diff --check`