### PR TITLE
fix: reject non-ground DuckDB fact terms

### DIFF
--- a/tests/test_duckdb_backend.py
+++ b/tests/test_duckdb_backend.py
@@ -7,7 +7,7 @@ import verinote.engine.duckdb_backend as duckdb_backend
 from verinote.engine import DEFAULT_POLICY
 from verinote.engine.duckdb_backend import DuckDBInferenceCache, run_check_duckdb
 from verinote.engine.duckdb_terms import term_to_duckdb_value
-from verinote.engine.terms import Atom, Compound, NumberLit, StringLit
+from verinote.engine.terms import Atom, Compound, NumberLit, StringLit, Var
 
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
 
@@ -134,6 +134,40 @@ def test_duckdb_backend_treats_equal_number_and_string_values_as_equal():
 
     assert rep.ok is True
     assert rep.errors == 0
+
+
+@pytest.mark.parametrize(
+    "term",
+    [
+        Var("Value"),
+        Compound("pair", (StringLit("fixed"), Var("Value"))),
+    ],
+)
+def test_duckdb_backend_rejects_non_ground_base_relation_terms(term):
+    with pytest.raises(duckdb_backend.DuckDBBackendError, match="fact terms must be ground"):
+        duckdb_backend._coerce_fact_term(term)
+
+
+@pytest.mark.parametrize(
+    "term",
+    [
+        Atom("item"),
+        Compound("pair", (Atom("item"), StringLit("fixed"))),
+        NumberLit(7),
+        StringLit("fixed"),
+    ],
+)
+def test_duckdb_backend_accepts_ground_base_relation_terms(term):
+    assert duckdb_backend._coerce_fact_term(term) is term
+
+
+def test_duckdb_backend_stringifies_raw_base_relation_values():
+    class _RawValue:
+        def __str__(self) -> str:
+            return "raw value"
+
+    assert duckdb_backend._coerce_fact_term(7) == StringLit("7")
+    assert duckdb_backend._coerce_fact_term(_RawValue()) == StringLit("raw value")
 
 
 def test_duckdb_backend_keeps_compounds_distinct_from_same_display_string():

--- a/verinote/engine/duckdb_backend.py
+++ b/verinote/engine/duckdb_backend.py
@@ -46,6 +46,7 @@ from verinote.engine.wirelog import (
     answer_qid,
     dead_rule_warnings,
 )
+from verinote.store.fact_input import validate_fact_slot
 
 _ERROR_PREFIX = "error_"
 _WARN_PREFIX = "warn_"
@@ -278,7 +279,10 @@ def _load_extensional_facts(
 
 def _coerce_fact_term(value: object) -> Term:
     if isinstance(value, (Atom, Compound, NumberLit, StringLit, Var)):
-        return value
+        try:
+            return validate_fact_slot(value)
+        except ValueError as exc:
+            raise DuckDBBackendError(str(exc)) from exc
     return StringLit(str(value))
 
 


### PR DESCRIPTION
## Summary
- enforce the store ground-term invariant at the DuckDB backend boundary
- reject top-level and nested variables before base-relation serialization
- preserve raw value stringification and add regression coverage

Closes #260

## Verification
- `.venv/bin/python -m pytest -q` (2071 passed, 7 skipped)
- `.venv/bin/python -m pytest tests/test_duckdb_terms.py tests/test_duckdb_backend.py` (101 passed)
- `git diff --check`