### PR TITLE
test: guard non-colour state signals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ packages = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = ["contract: opt-in tests that call a real LLM provider (issue #241)"]
 
 [tool.ruff]

--- a/tests/css_signal_guard.py
+++ b/tests/css_signal_guard.py
@@ -33,7 +33,8 @@ def parse_rules(css: str) -> list[tuple[str, str]]:
     """Return flat CSS rules after removing comments.
 
     This is deliberately shallow static analysis: it does not model nesting,
-    selector specificity, inheritance, or the cascade.
+    selector specificity, or inheritance.  For repeated exact selectors it does
+    apply declaration order (and ``!important``) within that selector scope.
     """
     css = re.sub(r"/\*.*?\*/", "", css, flags=re.S)
     return [(match.group("selector").strip(), match.group("body")) for match in RULE.finditer(css)]
@@ -64,6 +65,25 @@ def selector_declarations(css: str, selectors: Sequence[str]) -> list[tuple[str,
     return found
 
 
+def effective_selector_declarations(
+    css: str, selectors: Sequence[str]
+) -> list[tuple[str, str]]:
+    """Return the final applicable declaration per exact selector scope and property.
+
+    The parser intentionally only knows exact selectors, so this is not a general
+    cascade implementation.  Within one exact selector, though, later declarations
+    win unless an earlier declaration is ``!important``.
+    """
+    effective: dict[str, tuple[str, bool]] = {}
+    for prop, value in selector_declarations(css, selectors):
+        clean_value = value.removesuffix("!important").rstrip()
+        important = clean_value != value
+        previous = effective.get(prop)
+        if previous is None or important or not previous[1]:
+            effective[prop] = (clean_value, important)
+    return [(prop, value) for prop, (value, _) in effective.items()]
+
+
 def _paints(text: str) -> bool:
     return any(unicodedata.category(char) not in INVISIBLE_CATEGORIES for char in text)
 
@@ -91,24 +111,26 @@ def non_colour_drawn_signals(css: str, selectors: Sequence[str]) -> frozenset[tu
     A ``::before`` rule without non-empty drawn ``content`` is ignored entirely: without
     a glyph it is not a usable drawn signal for this guard.
     """
-    declarations = selector_declarations(css, selectors)
-    pseudo_has_content = any(
-        prop == "::before|content" and _drawn(prop, value) is not None
-        for prop, value in declarations
-    )
     signals = set()
-    for prop, value in declarations:
-        scope, base = prop.split("|", 1)
-        if scope == "::before" and not pseudo_has_content:
-            continue
-        if COLOUR_PROPERTY.match(base) or not SIGNAL_PROPERTY.match(base):
-            continue
-        stripped = " ".join(COLOUR_VAR.sub(" ", value).split())
-        if not stripped:
-            continue
-        drawn = _drawn(prop, stripped)
-        if drawn is not None:
-            signals.add((prop, drawn))
+    for selector in selectors:
+        declarations = effective_selector_declarations(css, (selector,))
+        values = dict(declarations)
+        pseudo_has_content = _drawn(
+            "::before|content", values.get("::before|content", "none")
+        ) is not None
+        pseudo_is_displayed = values.get("::before|display") != "none"
+        for prop, value in declarations:
+            scope, base = prop.split("|", 1)
+            if scope == "::before" and (not pseudo_has_content or not pseudo_is_displayed):
+                continue
+            if COLOUR_PROPERTY.match(base) or not SIGNAL_PROPERTY.match(base):
+                continue
+            stripped = " ".join(COLOUR_VAR.sub(" ", value).split())
+            if not stripped:
+                continue
+            drawn = _drawn(prop, stripped)
+            if drawn is not None:
+                signals.add((prop, drawn))
     return frozenset(signals)
 
 

--- a/tests/css_signal_guard.py
+++ b/tests/css_signal_guard.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Small CSS declaration guard for state signals that must survive without colour."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+import unicodedata
+
+RULE = re.compile(r"(?P<selector>[^{}]+)\{(?P<body>[^{}]*)\}")
+COLOUR_PROPERTY = re.compile(r"^(color|background|border(-[a-z]+)*-color|outline-color)$")
+COLOUR_VAR = re.compile(
+    r"var\(\s*--(?:ok|warn|danger|accent|line|muted|panel|fg|bg|term)[a-z-]*\s*\)"
+)
+BORDER_STYLE = re.compile(r"^(border|outline)(-[a-z]+)*-style$")
+BORDER_WIDTH = re.compile(r"^(border|outline)(-[a-z]+)*-width$")
+DRAWN_BORDER_STYLES = frozenset(
+    {"solid", "dashed", "dotted", "double", "groove", "ridge", "inset", "outset"}
+)
+INERT_VALUES = frozenset({"none", "normal", "hidden", "auto", "initial", "unset", "revert"})
+ZERO_LENGTH = re.compile(r"^0[a-z%]*$")
+DRAWN_CONTENT = re.compile(r'^"([^"]*)"')
+CSS_ESCAPE = re.compile(r"\\([0-9a-fA-F]{1,6})\s?")
+INVISIBLE_CATEGORIES = frozenset({"Zs", "Zl", "Zp", "Cc", "Cf"})
+SIGNAL_PROPERTY = re.compile(
+    r"^((border|outline)(-[a-z]+)*|box-shadow|content|background-image"
+    r"|text-decoration(-[a-z]+)?|font-weight|font-style|text-transform)$"
+)
+FUNCTION_EDGE_WHITESPACE = re.compile(r"(?<=[(,])\s+|\s+(?=[,)])")
+
+
+def parse_rules(css: str) -> list[tuple[str, str]]:
+    """Return flat CSS rules after removing comments.
+
+    This is deliberately shallow static analysis: it does not model nesting,
+    selector specificity, inheritance, or the cascade.
+    """
+    css = re.sub(r"/\*.*?\*/", "", css, flags=re.S)
+    return [(match.group("selector").strip(), match.group("body")) for match in RULE.finditer(css)]
+
+
+def _declarations(body: str) -> list[tuple[str, str]]:
+    declarations = []
+    for chunk in body.split(";"):
+        prop, sep, value = chunk.partition(":")
+        if sep:
+            normalized = " ".join(value.split())
+            declarations.append(
+                (prop.strip(), FUNCTION_EDGE_WHITESPACE.sub("", normalized))
+            )
+    return declarations
+
+
+def selector_declarations(css: str, selectors: Sequence[str]) -> list[tuple[str, str]]:
+    """Collect exact selectors' declarations, tagging element or ``::before`` scope."""
+    wanted = set(selectors)
+    found = []
+    for selector, body in parse_rules(css):
+        for part in (part.strip() for part in selector.split(",")):
+            if part not in wanted:
+                continue
+            scope = "::before" if part.endswith("::before") else ""
+            found.extend((f"{scope}|{prop}", value) for prop, value in _declarations(body))
+    return found
+
+
+def _paints(text: str) -> bool:
+    return any(unicodedata.category(char) not in INVISIBLE_CATEGORIES for char in text)
+
+
+def _drawn(prop: str, value: str) -> str | None:
+    base = prop.split("|")[-1]
+    if value in INERT_VALUES:
+        return None
+    if BORDER_STYLE.match(base):
+        return value if value in DRAWN_BORDER_STYLES else None
+    if BORDER_WIDTH.match(base):
+        return None if ZERO_LENGTH.match(value) else value
+    if base == "content":
+        match = DRAWN_CONTENT.match(value)
+        if not match:
+            return None
+        glyph = CSS_ESCAPE.sub(lambda match: chr(int(match.group(1), 16)), match.group(1))
+        return glyph if _paints(glyph) else None
+    return value
+
+
+def non_colour_drawn_signals(css: str, selectors: Sequence[str]) -> frozenset[tuple[str, str]]:
+    """Return visible, non-colour signals for an exact selector group.
+
+    A ``::before`` rule without non-empty drawn ``content`` is ignored entirely: without
+    a glyph it is not a usable drawn signal for this guard.
+    """
+    declarations = selector_declarations(css, selectors)
+    pseudo_has_content = any(
+        prop == "::before|content" and _drawn(prop, value) is not None
+        for prop, value in declarations
+    )
+    signals = set()
+    for prop, value in declarations:
+        scope, base = prop.split("|", 1)
+        if scope == "::before" and not pseudo_has_content:
+            continue
+        if COLOUR_PROPERTY.match(base) or not SIGNAL_PROPERTY.match(base):
+            continue
+        stripped = " ".join(COLOUR_VAR.sub(" ", value).split())
+        if not stripped:
+            continue
+        drawn = _drawn(prop, stripped)
+        if drawn is not None:
+            signals.add((prop, drawn))
+    return frozenset(signals)
+
+
+def assert_pairwise_distinct_signals(
+    css: str, selector_groups: Mapping[str, Sequence[str]]
+) -> dict[str, frozenset[tuple[str, str]]]:
+    """Assert every selector group has a unique non-colour drawn signal set.
+
+    A baseline state may intentionally have no extra signal.  It is sufficient that
+    its actual set differs from every other state, rather than requiring every state
+    to contribute a signal beyond a common intersection.
+    """
+    signals = {
+        name: non_colour_drawn_signals(css, selectors)
+        for name, selectors in selector_groups.items()
+    }
+    assert len(set(signals.values())) == len(signals), (
+        "selector groups do not have pairwise distinct non-colour signals: "
+        f"{ {name: sorted(found) for name, found in signals.items()} }"
+    )
+    return signals

--- a/tests/test_css_signal_guard.py
+++ b/tests/test_css_signal_guard.py
@@ -8,7 +8,7 @@ import re
 
 import pytest
 
-from tests.css_signal_guard import assert_pairwise_distinct_signals, non_colour_drawn_signals
+from css_signal_guard import assert_pairwise_distinct_signals, non_colour_drawn_signals
 
 CSS_PATH = Path(__file__).resolve().parents[1] / "verinote" / "web" / "static" / "app.css"
 
@@ -88,6 +88,25 @@ def test_pseudo_without_non_empty_content_does_not_count_as_a_signal(
         (".ask-verdict-verified .ask-verdict", selector),
     )
     assert not any(prop == "::before|content" for prop, _ in signals)
+
+
+@pytest.mark.parametrize("declaration", ('content: none;', 'content: "";', 'display: none;'))
+def test_later_pseudo_declaration_overrides_an_earlier_glyph(declaration: str) -> None:
+    """An exact selector's later declaration controls whether its pseudo can signal."""
+    selector = ".ask-verdict-verified .ask-verdict::before"
+    baseline = non_colour_drawn_signals(
+        _css(),
+        (".ask-verdict-verified .ask-verdict", selector),
+    )
+    assert ("::before|content", "✓") in baseline
+
+    mutated = f"{_css()}\n{selector} {{ {declaration} }}\n"
+    signals = non_colour_drawn_signals(
+        mutated,
+        (".ask-verdict-verified .ask-verdict", selector),
+    )
+
+    assert not any(prop.startswith("::before|") for prop, _ in signals)
 
 
 def test_colour_only_mutation_fails_the_progress_guard() -> None:

--- a/tests/test_css_signal_guard.py
+++ b/tests/test_css_signal_guard.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Cross-component regression guard for non-colour CSS state signals."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+from tests.css_signal_guard import assert_pairwise_distinct_signals, non_colour_drawn_signals
+
+CSS_PATH = Path(__file__).resolve().parents[1] / "verinote" / "web" / "static" / "app.css"
+
+ASK_VERDICTS = {
+    "verified": (
+        ".ask-verdict-verified .ask-verdict",
+        ".ask-verdict-verified .ask-verdict::before",
+    ),
+    "verified-negative": (
+        ".ask-verdict-verified-negative .ask-verdict",
+        ".ask-verdict-verified-negative .ask-verdict::before",
+    ),
+    "unverified": (
+        ".ask-verdict-unverified .ask-verdict",
+        ".ask-verdict-unverified .ask-verdict::before",
+    ),
+}
+BANNERS = {
+    "ok": (".ok-note", ".ok-note::before"),
+    "warn": (".warn", ".warn::before"),
+    "error": (".error", ".error::before"),
+}
+BADGES = {
+    "confirmed": (".badge-confirmed", ".badge-confirmed::before"),
+    "accepted": (".badge-accepted", ".badge-accepted::before"),
+}
+PROGRESS = {
+    "running": (".progress-complete",),
+    "done": (".progress.is-done .progress-complete",),
+}
+SIGNAL_REGISTRY = (ASK_VERDICTS, BANNERS, BADGES, PROGRESS)
+
+
+def _css() -> str:
+    return CSS_PATH.read_text(encoding="utf-8")
+
+
+def _mutate_declaration(
+    css: str, selector: str, property_name: str, replacement: str | None
+) -> str:
+    """Replace or remove a declaration without making rule-formatting assumptions."""
+    rule = re.compile(
+        rf"(?P<start>{re.escape(selector)}\s*\{{)(?P<body>[^}}]*)(?P<end>\}})"
+    )
+    match = rule.search(css)
+    assert match, f"missing CSS rule for {selector}"
+    declaration = rf"\s*{re.escape(property_name)}\s*:\s*[^;]*;"
+    if replacement is None:
+        body, count = re.subn(declaration, "", match["body"], count=1)
+    else:
+        body, count = re.subn(
+            rf"({re.escape(property_name)}\s*:\s*)[^;]*(;)",
+            lambda declaration: f"{declaration[1]}{replacement}{declaration[2]}",
+            match["body"],
+            count=1,
+        )
+    assert count == 1, f"{selector} has no {property_name} declaration"
+    return css[: match.start()] + match["start"] + body + match["end"] + css[match.end() :]
+
+
+@pytest.mark.parametrize("selector_groups", SIGNAL_REGISTRY)
+def test_state_selector_groups_have_pairwise_distinct_non_colour_signals(
+    selector_groups: dict[str, tuple[str, ...]],
+) -> None:
+    assert_pairwise_distinct_signals(_css(), selector_groups)
+
+
+@pytest.mark.parametrize("replacement", ['"" / ""', None])
+def test_pseudo_without_non_empty_content_does_not_count_as_a_signal(
+    replacement: str | None,
+) -> None:
+    selector = ".ask-verdict-verified .ask-verdict::before"
+    mutated = _mutate_declaration(_css(), selector, "content", replacement)
+
+    signals = non_colour_drawn_signals(
+        mutated,
+        (".ask-verdict-verified .ask-verdict", selector),
+    )
+    assert not any(prop == "::before|content" for prop, _ in signals)
+
+
+def test_colour_only_mutation_fails_the_progress_guard() -> None:
+    mutated = _mutate_declaration(
+        _css(),
+        ".progress.is-done .progress-complete",
+        "background-image",
+        None,
+    )
+
+    with pytest.raises(AssertionError, match="colour alone|pairwise distinct"):
+        assert_pairwise_distinct_signals(mutated, PROGRESS)
+
+
+def test_done_progress_uses_a_repeating_terminal_pattern() -> None:
+    signals = non_colour_drawn_signals(_css(), PROGRESS["done"])
+    assert any(
+        prop == "|background-image" and value.startswith("repeating-linear-gradient(")
+        for prop, value in signals
+    )

--- a/tests/test_sources_progress.py
+++ b/tests/test_sources_progress.py
@@ -464,6 +464,22 @@ def test_the_bar_markup_is_not_styled_by_a_class_the_stylesheet_never_defines(pa
     )
 
 
+def test_terminal_progress_complete_uses_a_repeating_gradient_pattern() -> None:
+    """A completed terminal bar must remain distinguishable without colour alone."""
+    css = CSS_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"\.progress\.is-done\s+\.progress-complete\s*\{(?P<body>[^}]*)\}",
+        css,
+        flags=re.DOTALL,
+    )
+
+    assert match, "app.css has no rule for completed terminal progress"
+    assert re.search(
+        r"background-image\s*:\s*repeating-linear-gradient\s*\(",
+        match.group("body"),
+    ), "completed terminal progress must use a repeating-linear-gradient pattern"
+
+
 # --- the poll (#228, second half) -------------------------------------------
 
 

--- a/tests/test_sources_progress.py
+++ b/tests/test_sources_progress.py
@@ -480,6 +480,78 @@ def test_terminal_progress_complete_uses_a_repeating_gradient_pattern() -> None:
     ), "completed terminal progress must use a repeating-linear-gradient pattern"
 
 
+def _terminal_progress_palette_tokens(css: str, palette: str) -> dict[str, str]:
+    """Return the declarations of the requested root palette."""
+    if palette == "dark":
+        match = re.search(r"^:root\s*\{(?P<body>[^{}]*)\}", css, re.MULTILINE)
+    else:
+        match = re.search(
+            r"@media\s*\(\s*prefers-color-scheme\s*:\s*light\s*\)\s*"
+            r"\{\s*:root\s*\{(?P<body>[^{}]*)\}",
+            css,
+            re.DOTALL,
+        )
+    assert match, f"app.css has no {palette} root palette"
+    return {
+        name: value.strip()
+        for name, value in re.findall(r"(--[A-Za-z0-9_-]+)\s*:\s*([^;]+);", match.group("body"))
+    }
+
+
+def _terminal_progress_rgb(value: str, tokens: dict[str, str]) -> tuple[int, int, int]:
+    """Resolve an opaque hex colour or palette var used by the terminal progress bar."""
+    var = re.fullmatch(r"var\(\s*(--[A-Za-z0-9_-]+)\s*\)", value.strip())
+    if var:
+        assert var.group(1) in tokens, f"{var.group(1)} is absent from this palette"
+        return _terminal_progress_rgb(tokens[var.group(1)], tokens)
+    hex_value = value.strip().removeprefix("#")
+    assert re.fullmatch(r"[0-9a-fA-F]{6}", hex_value), (
+        f"terminal progress colour {value!r} is not an opaque six-digit hex colour"
+    )
+    return tuple(int(hex_value[i : i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
+
+
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+    channels = []
+    for channel in rgb:
+        value = channel / 255
+        channels.append(value / 12.92 if value <= 0.04045 else ((value + .055) / 1.055) ** 2.4)
+    return .2126 * channels[0] + .7152 * channels[1] + .0722 * channels[2]
+
+
+def _contrast_ratio(first: tuple[int, int, int], second: tuple[int, int, int]) -> float:
+    low, high = sorted((_relative_luminance(first), _relative_luminance(second)))
+    return (high + .05) / (low + .05)
+
+
+@pytest.mark.parametrize("palette", ("dark", "light"))
+def test_terminal_progress_stripe_has_wcag_non_text_contrast(palette: str) -> None:
+    """The terminal-only stripe clears 3:1 against the completed fill in each palette."""
+    css = CSS_PATH.read_text(encoding="utf-8")
+    rule = re.search(
+        r"\.progress\.is-done\s+\.progress-complete\s*\{(?P<body>[^}]*)\}",
+        css,
+        flags=re.DOTALL,
+    )
+    assert rule, "app.css has no terminal completed-progress rule"
+    tokens = _terminal_progress_palette_tokens(css, palette)
+    fill = re.search(r"background\s*:\s*([^;]+);", rule.group("body"))
+    stripe = re.search(
+        r"repeating-linear-gradient\([^)]*?\b(var\(\s*--[A-Za-z0-9_-]+\s*\))",
+        rule.group("body"),
+        flags=re.DOTALL,
+    )
+    assert fill and stripe, "terminal progress must define both fill and palette stripe colours"
+    ratio = _contrast_ratio(
+        _terminal_progress_rgb(fill.group(1), tokens),
+        _terminal_progress_rgb(stripe.group(1), tokens),
+    )
+    assert ratio >= 3.0, (
+        f"terminal progress stripe in the {palette} palette is {ratio:.3f}:1 against "
+        "the completed fill; WCAG non-text contrast requires at least 3.0:1"
+    )
+
+
 # --- the poll (#228, second half) -------------------------------------------
 
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -173,6 +173,7 @@ def _declarations(body: str) -> dict[str, str]:
 # palettes so neither can regress.
 
 WCAG_AA_NORMAL = 4.5
+NON_TEXT_CONTRAST = 3.0
 
 # banner selector -> (tint token, text token), both resolved within one palette.
 BANNER_CONTRAST = {selector: (f"--{stem}-bg", f"--{stem}") for selector, stem in BANNERS.items()}
@@ -280,6 +281,23 @@ def _banner_contrast(palette_block: str, selector: str) -> tuple[float, tuple[fl
 def _palette_blocks() -> dict[str, str]:
     css = _read_css()
     return {"dark": _dark_root_block(css), "light": _light_media_block(css)}
+
+
+def _terminal_progress_contrast(palette_block: str) -> float:
+    """Contrast between the terminal progress fill and its opaque stripe."""
+    rules = _rules(_rule_bodies(_read_css()))
+    body = rules.get(".progress.is-done .progress-complete")
+    assert body is not None, "app.css has no terminal progress fill rule"
+    declarations = _declarations(body)
+    tokens = _palette_tokens(palette_block)
+    fill = _resolve_rgba(declarations["background"], tokens)
+    stripe_match = re.search(
+        r"var\(\s*(--[A-Za-z0-9_-]+)\s*\)", declarations["background-image"]
+    )
+    assert stripe_match, "terminal progress gradient has no palette stripe colour"
+    stripe = _resolve_rgba(f"var({stripe_match.group(1)})", tokens)
+    assert fill[3] == stripe[3] == 1.0, "terminal progress colours must be opaque"
+    return _contrast_ratio(fill[:3], stripe[:3])
 
 
 def test_rule_bodies_are_not_empty_after_cutting_palettes() -> None:
@@ -524,3 +542,13 @@ def test_banner_tints_are_translucent_so_the_composite_matters(palette: str) -> 
             f"{selector}'s tint {tint_token} in the {palette} palette is opaque "
             f"(alpha {alpha}); the contrast test would never exercise compositing."
         )
+
+
+@pytest.mark.parametrize("palette", sorted(_palette_blocks()))
+def test_terminal_progress_stripe_has_non_text_contrast(palette: str) -> None:
+    """Terminal stripes must remain visible against the completed fill in both palettes."""
+    ratio = _terminal_progress_contrast(_palette_blocks()[palette])
+    assert ratio >= NON_TEXT_CONTRAST, (
+        f"terminal progress stripe in the {palette} palette is {ratio:.3f}:1 against "
+        f"the completed fill, under the {NON_TEXT_CONTRAST}:1 non-text contrast floor"
+    )

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -337,5 +337,12 @@ tr.editing td { background: var(--editing-bg); }
 .progress { display: flex; width: 100%; height: 4px; margin: .4rem 0 .15rem;
   border-radius: 999px; overflow: hidden; background: var(--line); }
 .progress-complete { background: var(--accent); }
-.progress.is-done .progress-complete { background: var(--ok); }
+.progress.is-done .progress-complete {
+  background: var(--ok);
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0 .25rem,
+    rgb(0 0 0 / .18) .25rem .5rem
+  );
+}
 .progress-failed { background: var(--danger); }

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -2,6 +2,7 @@
   color-scheme: dark;
   --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
   --muted: #8b93a5; --accent: #5b9dff; --ok: #3fb950; --warn: #d29922; --danger: #f0526d;
+  --progress-terminal-stripe: #0f1115;
   --on-accent: #06101f;
   --editing-bg: rgba(91, 157, 255, .06);
   --ok-bg: rgba(63, 185, 80, .12);
@@ -16,6 +17,7 @@
     color-scheme: light;
     --bg: #f6f8fa; --panel: #ffffff; --line: #d0d7de; --fg: #1f2328;
     --muted: #59636e; --accent: #0969da; --ok: #116329; --warn: #7d4e00; --danger: #a40e26;
+    --progress-terminal-stripe: #ffffff;
     --on-accent: #ffffff;
     --editing-bg: rgba(9, 105, 218, .06);
     --ok-bg: rgba(26, 127, 55, .10);
@@ -333,7 +335,9 @@ tr.editing td { background: var(--editing-bg); }
    the job reports `done`. Failed chunks keep the danger tone in both states -- a run
    that finished with failures is not a clean pass, and the segment is the only place
    on the bar that says so. Colour is not the sole channel for that: the bar sits
-   beside the status badge and the "N failed" text, which both say it in words. */
+   beside the status badge and the "N failed" text, which both say it in words. The
+   stripe marks terminal completion, not success: a done job can still have failed
+   chunks. */
 .progress { display: flex; width: 100%; height: 4px; margin: .4rem 0 .15rem;
   border-radius: 999px; overflow: hidden; background: var(--line); }
 .progress-complete { background: var(--accent); }
@@ -342,7 +346,7 @@ tr.editing td { background: var(--editing-bg); }
   background-image: repeating-linear-gradient(
     135deg,
     transparent 0 .25rem,
-    rgb(0 0 0 / .18) .25rem .5rem
+    var(--progress-terminal-stripe) .25rem .5rem
   );
 }
 .progress-failed { background: var(--danger); }


### PR DESCRIPTION
## Summary
- add a shared static CSS guard for visible non-colour state signals
- register Ask verdicts, banners, badges, and terminal progress states
- give terminal progress a repeating pattern in addition to its colour

Closes #357

## Verification
- `.venv/bin/python -m pytest tests/test_css_signal_guard.py tests/test_sources_progress.py tests/test_ask_verdict.py tests/test_banner_verdict_glyphs.py tests/test_badge_actor_css.py` (64 passed)
- `.venv/bin/python -m pytest -q`
- `git diff --check`