### PR TITLE
refactor: limit direct Datalog fallback to repair

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1043,7 +1043,7 @@ def test_query_prints_review_required_outcome(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
 
-    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+    def translate(store, client, *, root):
         q = store.questions(pending_only=True)[0]
         reason = "unsupported synthetic question"
         store.set_question_query(
@@ -1066,7 +1066,7 @@ def test_query_prints_no_answer_outcome(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
 
-    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+    def translate(store, client, *, root):
         q = store.questions(pending_only=True)[0]
         reason = "no confirmed facts match"
         store.set_question_query(q["id"], f'no_answer("{reason}")', "no_answer", reason)
@@ -1084,7 +1084,7 @@ def test_query_prints_ambiguous_outcome(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
 
-    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+    def translate(store, client, *, root):
         q = store.questions(pending_only=True)[0]
         reason = "multiple synthetic candidates matched"
         store.set_question_query(q["id"], f'ambiguous("{reason}")', "ambiguous", reason)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -605,24 +605,36 @@ def test_invalid_intent_output_fails_translation_and_skips_draft(tmp_path, fake_
     assert load_query(s) == ""
 
 
-def test_query_intent_errors_are_catchable_and_separate_from_datalog_translation(
-    tmp_path, fake_client
-):
+def test_query_intent_errors_are_catchable(tmp_path, fake_client):
     intent_client = fake_client(intent="not json")
     with pytest.raises(LLMError, match="query intent output was not JSON"):
         intent_client.extract_query_intent(question="What is the sample answer?")
 
+
+def test_translation_never_calls_direct_datalog_fallback(
+    tmp_path, fake_client, intent_payload
+):
     s = _store(tmp_path)
     qid = s.add_question("What is the sample answer?")
-    datalog_client = fake_client(query=lambda question, qid: "this is not datalog")
-
-    results = translate_questions(
-        s, datalog_client, root=tmp_path, allow_direct_datalog_fallback=True
+    client = fake_client(
+        intent=intent_payload(
+            "unknown_or_unsupported", reason="requires a synthetic relation"
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("ordinary translation must not call direct Datalog fallback")
     )
 
-    assert results[0]["id"] == qid
-    assert results[0]["status"] == "review_required"
-    assert "invalid query:" in results[0]["reason"]
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results == [
+        {
+            "id": qid,
+            "status": "review_required",
+            "query_dl": 'review_required("requires a synthetic relation")',
+            "reason": "requires a synthetic relation",
+        }
+    ]
 
 
 def test_planner_no_candidates_requires_review(tmp_path, fake_client, intent_payload):
@@ -764,7 +776,7 @@ def test_quality_policy_review_required_outcome_is_persisted(
     assert load_query(s) == ""
 
 
-def test_supported_planner_review_required_does_not_call_direct_fallback(
+def test_supported_planner_review_required_does_not_call_direct_datalog(
     tmp_path, fake_client, intent_payload
 ):
     s = _store(tmp_path)
@@ -780,12 +792,7 @@ def test_supported_planner_review_required_does_not_call_direct_fallback(
         AssertionError("planner-supported review must not call direct Datalog fallback")
     )
 
-    results = translate_questions(
-        s,
-        client,
-        root=tmp_path,
-        allow_direct_datalog_fallback=True,
-    )
+    results = translate_questions(s, client, root=tmp_path)
 
     assert results == [
         {

--- a/tests/test_query_planning_e2e.py
+++ b/tests/test_query_planning_e2e.py
@@ -403,7 +403,7 @@ def test_relation_alias_and_canonical_relation_names_are_honored(tmp_path):
     ]
 
 
-def test_no_answer_is_distinct_from_translation_failed(tmp_path):
+def test_unsupported_intent_is_distinct_from_translation_failed(tmp_path):
     class NoAnswerThenInvalidIntentClient:
         name = "no-answer-then-invalid-intent"
 
@@ -420,73 +420,27 @@ def test_no_answer_is_distinct_from_translation_failed(tmp_path):
             return parse_query_intent({"kind": "lookup_object"})
 
         def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
-            return (
-                f'answer_q{qid}(O) :- relation("Missing Synthetic Subject", '
-                '"synthetic_relation", O).'
-            )
+            raise AssertionError("ordinary translation must not call direct Datalog fallback")
 
     store = _store(tmp_path)
     store.add_fact("Synthetic Subject", "synthetic_relation", "Value", status="confirmed")
     store.add_question("Which value is recorded for the missing subject?")
     store.add_question("Which value has invalid model output?")
 
-    results = translate_questions(
-        store,
-        NoAnswerThenInvalidIntentClient(),
-        root=tmp_path,
-        allow_direct_datalog_fallback=True,
-    )
+    results = translate_questions(store, NoAnswerThenInvalidIntentClient(), root=tmp_path)
 
     assert [result["status"] for result in results] == [
-        "no_answer",
+        "review_required",
         "translation_failed",
     ]
-    assert results[0]["query_dl"] == 'no_answer("no confirmed facts match")'
-    assert results[0]["reason"] == "no confirmed facts match"
+    assert results[0]["query_dl"] == 'review_required("synthetic fallback coverage")'
+    assert results[0]["reason"] == "synthetic fallback coverage"
     assert results[1]["query_dl"] is None
     assert "query intent output did not match schema:" in results[1]["reason"]
     rows = store.questions()
-    assert [row["status"] for row in rows] == ["no_answer", "translation_failed"]
+    assert [row["status"] for row in rows] == ["review_required", "translation_failed"]
     assert all(row["status"] != "pending" for row in rows)
     assert query_path(tmp_path).read_text(encoding="utf-8") == ""
-
-
-def test_invalid_direct_datalog_fallback_is_visible_but_not_written(tmp_path):
-    class InvalidDatalogClient:
-        name = "invalid-datalog"
-
-        def extract_query_intent(self, *, question: str, schema_hint: str = ""):
-            from verinote.pipeline.query_intent import parse_query_intent
-
-            return parse_query_intent(
-                _intent(
-                    "unknown_or_unsupported",
-                    reason="synthetic fallback coverage",
-                )
-            )
-
-        def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
-            return "not valid datalog"
-
-    store = _store(tmp_path)
-    qid = store.add_question("Which value requires fallback?")
-
-    results = translate_questions(
-        store,
-        InvalidDatalogClient(),
-        root=tmp_path,
-        allow_direct_datalog_fallback=True,
-    )
-
-    assert results[0]["id"] == qid
-    assert results[0]["status"] == "review_required"
-    assert results[0]["query_dl"].startswith("review_required(")
-    assert "invalid query:" in results[0]["reason"]
-    question = store.questions()[0]
-    assert question["status"] == "review_required"
-    assert question["status"] != "pending"
-    assert "not valid datalog" not in question["query_dl"]
-    assert "not valid datalog" not in query_path(tmp_path).read_text(encoding="utf-8")
 
 
 def _typed_compare_payload(

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -178,16 +178,39 @@ def test_repair_fallback_accepts_valid_proposal_without_pyrewire(
     assert s.questions()[0]["status"] == "translated"
 
 
-def test_repair_rejects_engine_invalid_proposal(tmp_path, fake_client):
+def test_repair_fallback_schema_hint_is_advisory_and_engine_rejects_invalid_proposal(
+    tmp_path, fake_client
+):
     s, qid = _store_with_review_required(tmp_path)
-    # references an undeclared predicate -> engine rejects, question untouched
-    client = fake_client(query=lambda q, i: f"answer_q{i}(O) :- bogus(O).")
-    results = repair_questions(
-        s, client, root=tmp_path, allow_direct_datalog_fallback=True
+    s.add_fact(
+        "Synthetic Private Subject",
+        "synthetic_relation",
+        "Synthetic Private Object",
+        status="confirmed",
     )
+    client = fake_client()
+    schema_hints = []
 
+    def translate_query(*, question: str, qid: int, schema_hint: str = "") -> str:
+        schema_hints.append(schema_hint)
+        return (
+            f'answer_q{qid}(O) :- relation("Synthetic Private Subject", '
+            '"synthetic_relation", O), bogus(O).'
+        )
+
+    client.translate_query = translate_query
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert results[0]["id"] == qid
     assert results[0]["accepted"] is False
     assert "bogus" in results[0]["reason"]
+    assert len(schema_hints) == 1
+    hint = schema_hints[0]
+    assert "Observed relations:" in hint
+    assert "synthetic_relation" in hint
+    assert "Synthetic Private Subject" not in hint
+    assert "Synthetic Private Object" not in hint
     q = s.questions()[0]
     assert q["status"] == "review_required"
     assert q["reason"] == results[0]["reason"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3123,7 +3123,7 @@ def test_translate_shows_invalid_model_output_reason_in_question_row(
 ):
     monkeypatch.setattr(webapp, "get_client", lambda cfg: object())
 
-    def translate(store, client, *, root, allow_direct_datalog_fallback=False):
+    def translate(store, client, *, root):
         q = store.questions(pending_only=True)[0]
         reason = "invalid model output: missing answer rule"
         store.set_question_query(

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -58,6 +58,7 @@ class _QueryFlowResult:
     status: str
     query_dl: str | None
     reason: str
+    # Repair-only eligibility: ordinary translation is always schema-only.
     allow_direct_datalog_fallback: bool = False
     provider_failed: bool = False
 
@@ -376,8 +377,13 @@ def _translate_direct_datalog_fallback(
     question: str,
     llm_error_status: str,
 ) -> _QueryFlowResult:
+    """Run the repair-only direct-Datalog fallback with a schema-only hint."""
     try:
-        line = client.translate_query(question=question, qid=qid)
+        line = client.translate_query(
+            question=question,
+            qid=qid,
+            schema_hint=query_schema_hint(build_query_schema_snapshot(store)),
+        )
     except LLMError as exc:
         reason = _short_reason(exc)
         if llm_error_status == "translation_failed":
@@ -425,9 +431,8 @@ def translate_questions(
     client: LLMClient,
     *,
     root: Path,
-    allow_direct_datalog_fallback: bool = False,
 ) -> list[dict]:
-    """Translate pending and previously failed questions, persist drafts, rewrite `query.dl`.
+    """Translate pending and previously failed questions through the schema-only flow.
 
     Returns one dict per processed question: {id, status, query_dl, reason}.
     """
@@ -443,19 +448,6 @@ def translate_questions(
             llm_error_status="translation_failed",
         )
         status, query_dl, reason = flow.status, flow.query_dl, flow.reason
-        if (
-            allow_direct_datalog_fallback
-            and status == "review_required"
-            and flow.allow_direct_datalog_fallback
-        ):
-            fallback = _translate_direct_datalog_fallback(
-                store,
-                client,
-                qid=q["id"],
-                question=q["text"],
-                llm_error_status="translation_failed",
-            )
-            status, query_dl, reason = fallback.status, fallback.query_dl, fallback.reason
         store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
             {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -5,6 +5,9 @@ The LLM proposes a corrected query line for each `review_required` question, but
 the proposal is only accepted if the deterministic engine validates it — the
 engine, not the model, has the final say. Rejected proposals leave the question
 untouched and the reason is logged.
+
+Schema vocabulary supplied to the repair fallback is advisory; only the engine
+gate approves a proposal.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- remove the unused direct-Datalog fallback API from ordinary translation
- retain repair-only fallback eligibility and pass it a bounded schema hint
- verify ordinary translation never calls the fallback and repair keeps engine-gated approval

Closes #283

## Verification
- `.venv/bin/python -m pytest tests/test_query.py tests/test_repair.py tests/test_query_planning_e2e.py tests/test_cli.py tests/test_web.py`
- `git diff --check`