### PR TITLE
fix: normalize uploaded source identity to NFC

### DIFF
--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
+import hashlib
 import io
+import unicodedata
 
 import pytest
 
 from verinote.pipeline import ingest_bytes, ingest_file, supported_suffixes
-from verinote.pipeline.ingest import IngestError
+from verinote.pipeline.ingest import IngestError, store_source
 from verinote.pipeline.ingest import register_converter
 from verinote.store import Store
 
@@ -63,6 +65,24 @@ def test_ingest_file_registers_text_source(tmp_path):
     assert [(r["path"], r["kind"], r["fact_count"]) for r in rows] == [
         ("sources/doc.txt", "text", 0)
     ]
+
+
+def test_store_source_normalizes_filename_and_text_but_preserves_raw_bytes(tmp_path):
+    s = _store(tmp_path)
+    nfd_filename = unicodedata.normalize("NFD", "\ubb38\uc11c.txt")
+    nfc_filename = unicodedata.normalize("NFC", nfd_filename)
+    nfd_text = unicodedata.normalize("NFD", "\uac00\uac01 \uc815\ubcf4")
+    nfc_text = unicodedata.normalize("NFC", nfd_text)
+    raw = nfd_text.encode("utf-8")
+
+    result = store_source(s, tmp_path, nfd_filename, raw, nfd_text, "text")
+
+    digest = hashlib.sha256(nfc_text.encode("utf-8")).hexdigest()
+    assert result["citation"] == f"sources/{nfc_filename}"
+    assert result["text"] == nfc_text
+    assert result["artifact_path"] == f"artifacts/sources/1/{digest}.txt"
+    assert (tmp_path / "sources" / nfc_filename).read_bytes() == raw
+    assert (tmp_path / result["artifact_path"]).read_text(encoding="utf-8") == nfc_text
 
 
 def test_ingest_file_converts_binary_source(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -777,6 +777,54 @@ def test_upload_extracts_and_redirects(tmp_path, monkeypatch, fake_client):
     _wait_for(extracted)
 
 
+def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypatch):
+    nfd_filename = unicodedata.normalize("NFD", "\ubb38\uc11c.txt")
+    nfc_filename = unicodedata.normalize("NFC", nfd_filename)
+    nfd_text = unicodedata.normalize("NFD", "\uac00\uac01 \uc815\ubcf4")
+    nfc_text = unicodedata.normalize("NFC", nfd_text)
+    assert nfd_filename != nfc_filename
+    assert nfd_text != nfc_text
+
+    chunk_inputs = []
+    real_create_chunked_job = webapp.create_chunked_extraction_job
+
+    def capture_chunk_job(store, **kwargs):
+        chunk_inputs.append(kwargs["source_text"])
+        return real_create_chunked_job(store, **kwargs)
+
+    monkeypatch.setattr(webapp, "create_chunked_extraction_job", capture_chunk_job)
+    monkeypatch.setattr(webapp, "get_client", lambda _cfg: object())
+    monkeypatch.setattr(
+        webapp,
+        "process_extraction_job",
+        lambda *_args, **_kwargs: type("Result", (), {"failed_chunks": 1})(),
+    )
+    c = _client(tmp_path)
+
+    first = c.post(
+        "/sources",
+        files={"file": (nfd_filename, nfd_text.encode("utf-8"), "text/plain")},
+        follow_redirects=False,
+    )
+    assert (tmp_path / "sources" / nfc_filename).read_bytes() == nfd_text.encode("utf-8")
+    source = c.app.state.store.get_source_by_path(f"sources/{nfc_filename}")
+    assert source is not None
+    artifact = c.app.state.store.latest_source_text_artifact(int(source["id"]))
+    assert artifact is not None
+    assert (tmp_path / artifact["path"]).read_text(encoding="utf-8") == nfc_text
+    second = c.post(
+        "/sources",
+        files={"file": (nfc_filename, nfc_text.encode("utf-8"), "text/plain")},
+        follow_redirects=False,
+    )
+
+    assert first.status_code == second.status_code == 303
+    sources = c.app.state.store.sources()
+    assert len(sources) == 1
+    assert sources[0]["path"] == f"sources/{nfc_filename}"
+    assert chunk_inputs == [nfc_text, nfc_text]
+
+
 def test_upload_rejects_unsupported_type(tmp_path):
     c = _client(tmp_path)
     r = c.post("/sources", files={"file": ("blob.bin", b"\x00\x01", "application/octet-stream")})

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -17,7 +17,7 @@ from verinote.config import Config, ConfigCorruptError, save_settings  # noqa: E
 from verinote.engine import CheckReport, DEFAULT_POLICY, FindingDetail  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
-from verinote.pipeline import ExtractionJobBusyError  # noqa: E402
+from verinote.pipeline import ChunkedExtractionResult, ExtractionJobBusyError  # noqa: E402
 from verinote.pipeline.verify import _with_unrecorded_policy_warning  # noqa: E402
 from verinote.pipeline.policy_state import (  # noqa: E402
     POLICY_RELPATH,
@@ -794,10 +794,23 @@ def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypa
 
     monkeypatch.setattr(webapp, "create_chunked_extraction_job", capture_chunk_job)
     monkeypatch.setattr(webapp, "get_client", lambda _cfg: object())
+    processed_jobs = set()
+    processed_lock = threading.Lock()
+    workers_finished = threading.Event()
+
+    def complete_job(store, _client, *, job_id, **_kwargs):
+        assert store.claim_pending_extraction_job(job_id)
+        store.finish_extraction_job(job_id)
+        with processed_lock:
+            processed_jobs.add(job_id)
+            if len(processed_jobs) == 2:
+                workers_finished.set()
+        return ChunkedExtractionResult(job_id=job_id)
+
     monkeypatch.setattr(
         webapp,
         "process_extraction_job",
-        lambda *_args, **_kwargs: type("Result", (), {"failed_chunks": 1})(),
+        complete_job,
     )
     c = _client(tmp_path)
 
@@ -823,6 +836,7 @@ def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypa
     assert len(sources) == 1
     assert sources[0]["path"] == f"sources/{nfc_filename}"
     assert chunk_inputs == [nfc_text, nfc_text]
+    assert workers_finished.wait(timeout=2.0)
 
 
 def test_upload_rejects_unsupported_type(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -844,6 +844,101 @@ def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypa
     assert chunk_inputs == [nfc_text, nfc_text]
 
 
+def test_upload_nfd_korean_fact_and_query_match_nfc(
+    tmp_path, monkeypatch, fake_client, intent_payload
+):
+    """#411: NFC/NFD-equivalent Korean input must remain query-equivalent end to end."""
+    nfd_filename = unicodedata.normalize("NFD", "합성문서.txt")
+    nfc_filename = unicodedata.normalize("NFC", nfd_filename)
+    nfd_subject = unicodedata.normalize("NFD", "합성프로젝트")
+    nfc_subject = unicodedata.normalize("NFC", nfd_subject)
+    nfd_relation = unicodedata.normalize("NFD", "목적")
+    nfc_relation = unicodedata.normalize("NFC", nfd_relation)
+    nfd_object = unicodedata.normalize("NFD", "검증목표")
+    nfc_object = unicodedata.normalize("NFC", nfd_object)
+    nfd_text = f"{nfd_subject} {nfd_relation} {nfd_object}"
+    nfc_text = unicodedata.normalize("NFC", nfd_text)
+    assert nfd_text != nfc_text
+
+    nfc_question = f"사실 확인 {nfc_subject}"
+    nfd_question = unicodedata.normalize("NFD", nfc_question)
+    assert nfd_question != nfc_question
+
+    def intent_for(question: str):
+        assert question in {nfc_question, nfd_question}
+        return intent_payload(
+            "lookup_object",
+            subject=nfd_subject if question == nfd_question else nfc_subject,
+            relation=nfd_relation if question == nfd_question else nfc_relation,
+        )
+
+    client = fake_client(
+        [ExtractedFact(nfd_subject, nfd_relation, nfd_object, 0.9)], intent=intent_for
+    )
+    extraction_inputs = []
+    extract_facts = client.extract_facts
+
+    def capture_extract_facts(*, source_text: str, schema_hint: str = ""):
+        extraction_inputs.append(source_text)
+        return extract_facts(source_text=source_text, schema_hint=schema_hint)
+
+    monkeypatch.setattr(client, "extract_facts", capture_extract_facts)
+    monkeypatch.setattr(webapp, "get_client", lambda _cfg: client)
+    c = _client(tmp_path)
+
+    upload = c.post(
+        "/sources",
+        files={"file": (nfd_filename, nfd_text.encode("utf-8"), "text/plain")},
+        follow_redirects=False,
+    )
+    assert upload.status_code == 303
+
+    store = c.app.state.store
+
+    def extracted_fact():
+        facts = [fact for fact in store.review_queue() if fact["subject"] == nfc_subject]
+        assert len(facts) == 1
+
+    _wait_for(extracted_fact)
+    source = store.get_source_by_path(f"sources/{nfc_filename}")
+    assert source is not None
+    artifact = store.latest_source_text_artifact(int(source["id"]))
+    assert artifact is not None
+    assert (tmp_path / artifact["path"]).read_text(encoding="utf-8") == nfc_text
+    assert extraction_inputs == [nfc_text]
+
+    fact = next(fact for fact in store.review_queue() if fact["subject"] == nfc_subject)
+    assert (fact["subject"], fact["relation"], fact["object"]) == (
+        nfc_subject,
+        nfc_relation,
+        nfc_object,
+    )
+    assert store.get_fact_terms(int(fact["id"])) == (
+        StringLit(nfc_subject),
+        StringLit(nfc_relation),
+        StringLit(nfc_object),
+    )
+
+    accepted = c.post(f"/facts/{fact['id']}/accept", follow_redirects=False)
+    assert accepted.status_code == 200
+    assert store.get_fact(int(fact["id"]))["status"] == "confirmed"
+
+    answers = []
+    for question in (nfd_question, nfc_question):
+        response = c.post("/ask", data={"question": question})
+        assert response.status_code == 200
+        body = unescape(response.text)
+        assert "VERIFIED — engine" in body
+        match = re.search(
+            r'<div class="answer-box">\s*<pre>(.*?)</pre>', body, flags=re.DOTALL
+        )
+        assert match is not None
+        answers.append(match.group(1).strip())
+
+    assert answers[0] == answers[1]
+    assert answers[0].startswith(f"{nfc_subject}, {nfc_relation}, {nfc_object}")
+
+
 def test_upload_rejects_unsupported_type(tmp_path):
     c = _client(tmp_path)
     r = c.post("/sources", files={"file": ("blob.bin", b"\x00\x01", "application/octet-stream")})

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -796,15 +796,18 @@ def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypa
     monkeypatch.setattr(webapp, "get_client", lambda _cfg: object())
     processed_jobs = set()
     processed_lock = threading.Lock()
-    workers_finished = threading.Event()
+    first_worker_finished = threading.Event()
+    second_worker_finished = threading.Event()
 
     def complete_job(store, _client, *, job_id, **_kwargs):
         assert store.claim_pending_extraction_job(job_id)
         store.finish_extraction_job(job_id)
         with processed_lock:
             processed_jobs.add(job_id)
-            if len(processed_jobs) == 2:
-                workers_finished.set()
+            if len(processed_jobs) == 1:
+                first_worker_finished.set()
+            elif len(processed_jobs) == 2:
+                second_worker_finished.set()
         return ChunkedExtractionResult(job_id=job_id)
 
     monkeypatch.setattr(
@@ -819,6 +822,8 @@ def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypa
         files={"file": (nfd_filename, nfd_text.encode("utf-8"), "text/plain")},
         follow_redirects=False,
     )
+    assert first.status_code == 303
+    assert first_worker_finished.wait(timeout=2.0)
     assert (tmp_path / "sources" / nfc_filename).read_bytes() == nfd_text.encode("utf-8")
     source = c.app.state.store.get_source_by_path(f"sources/{nfc_filename}")
     assert source is not None
@@ -831,12 +836,12 @@ def test_upload_normalizes_nfc_source_identity_and_chunk_text(tmp_path, monkeypa
         follow_redirects=False,
     )
 
-    assert first.status_code == second.status_code == 303
+    assert second.status_code == 303
+    assert second_worker_finished.wait(timeout=2.0)
     sources = c.app.state.store.sources()
     assert len(sources) == 1
     assert sources[0]["path"] == f"sources/{nfc_filename}"
     assert chunk_inputs == [nfc_text, nfc_text]
-    assert workers_finished.wait(timeout=2.0)
 
 
 def test_upload_rejects_unsupported_type(tmp_path):

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Callable
 
 from verinote.store import Store
+from verinote.text import nfc
 
 # Stored as-is, no conversion.
 TEXT_SUFFIXES = {".txt", ".md"}
@@ -94,7 +95,8 @@ def store_source(
     """Persist an original source and its extraction text artifact."""
     sources_dir = root / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
-    name = Path(filename).name
+    name = nfc(Path(filename).name)
+    text = nfc(text)
     source_path = sources_dir / name
     source_path.write_bytes(raw)
     citation = f"sources/{name}"

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1195,7 +1195,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             store,
             source_id=int(source["id"]),
             artifact_id=int(result["artifact_id"]),
-            source_text=text,
+            source_text=result["text"],
             provider=cfg.provider,
             model=cfg.model,
             chunk_chars=cfg.extraction_chunk_chars,


### PR DESCRIPTION
## Summary
- canonicalize upload filenames and extraction text with the shared NFC helper
- preserve original uploaded bytes while using canonical artifact text and chunk input
- prevent equivalent Korean NFC/NFD upload names from creating duplicate source identities

Closes #411

## Verification
- `.venv/bin/python -m pytest tests/test_ingest.py tests/test_text.py tests/test_web.py -q`
- `git diff --check`