### PR TITLE
fix: preserve committed decisions through sidecar halts

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1923,9 +1923,8 @@ def test_reconcile_fact_never_resurrects_a_legacy_superseded_row(tmp_path):
     # The token is cleared *before* the reject, not after: a legacy row has a NULL
     # token from creation and is rejected later, so this is the order the scenario
     # actually occurs in. The reverse order also trips the #311 content freeze,
-    # which is correct of it -- no production path rewrites a superseded row's
-    # term_token (backfill_fact_terms writes DuckDB, not facts.term_token), so
-    # only this fixture was doing it.
+    # which is correct of it -- backfill_fact_terms preserves terminal rows'
+    # NULL tokens, so only this fixture writes one before rejection.
     s = _store(tmp_path)
     sid = s.add_source("sources/sample.txt")
     fact_id = s.add_fact("A", "count", NumberLit(36), source_id=sid)

--- a/tests/test_store_fact_terms.py
+++ b/tests/test_store_fact_terms.py
@@ -624,6 +624,121 @@ def test_backfill_fact_terms_migrates_legacy_sqlite_text_as_stringlit(tmp_path):
     assert s.backfill_fact_terms() == 0
 
 
+def test_backfill_fact_terms_recovers_after_sqlite_commit_failure(tmp_path, monkeypatch):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ("Synthetic report", "published_year", "2024", "needs_review"),
+    )
+    fact_id = int(cur.fetchone()[0])
+    token = fact_term_token("Synthetic report", "published_year", "2024")
+    original_conn = s._conn
+
+    class CommitFailingConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, params=()):
+            if sql == "COMMIT":
+                raise sqlite3.OperationalError("forced SQLite commit failure")
+            return self._conn.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(s, "_conn", CommitFailingConnection(original_conn))
+        with pytest.raises(sqlite3.OperationalError, match="forced SQLite commit failure"):
+            s.backfill_fact_terms()
+
+    # DuckDB commits independently before the failed SQLite commit, while the
+    # SQLite token and marker both roll back with that transaction.
+    assert s.get_fact(fact_id)["term_token"] is None
+    assert s._get_meta(FACT_TERMS_MARKER_KEY) is None
+    record = s.fact_terms.get_fact_term_record(fact_id)
+    assert record is not None
+    assert record.term_token == record.content_token == token
+
+    # A retry recognizes the committed canonical sidecar row and repairs the
+    # SQLite half, including the marker, without rewriting DuckDB.
+    assert s.backfill_fact_terms() == 0
+    assert s.get_fact(fact_id)["term_token"] == token
+    assert s._get_meta(FACT_TERMS_MARKER_KEY) is not None
+
+
+def test_backfill_fact_terms_duckdb_failure_rolls_back_sqlite_token_and_marker(
+    tmp_path, monkeypatch
+):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ("Synthetic report", "published_year", "2024", "needs_review"),
+    )
+    fact_id = int(cur.fetchone()[0])
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("sidecar down")
+
+    monkeypatch.setattr(s.fact_terms, "put_fact_terms", fail)
+
+    with pytest.raises(RuntimeError, match="sidecar down"):
+        s.backfill_fact_terms()
+
+    assert s.get_fact(fact_id)["term_token"] is None
+    assert s._get_meta(FACT_TERMS_MARKER_KEY) is None
+    assert s.get_fact_terms(fact_id) is None
+
+
+def test_backfill_fact_terms_preserves_superseded_legacy_content_and_null_token(tmp_path):
+    s = _store(tmp_path)
+    content = ("Synthetic terminal report", "published_year", "2024")
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        (*content, "superseded"),
+    )
+    fact_id = int(cur.fetchone()[0])
+    before = tuple(
+        s._conn.execute(
+            "SELECT subject, relation, object, term_token FROM facts WHERE id = ?", (fact_id,)
+        ).fetchone()
+    )
+
+    assert s.backfill_fact_terms() == 1
+
+    assert tuple(
+        s._conn.execute(
+            "SELECT subject, relation, object, term_token FROM facts WHERE id = ?", (fact_id,)
+        ).fetchone()
+    ) == before == (*content, None)
+    assert s.get_fact_terms(fact_id) == tuple(StringLit(value) for value in content)
+
+
+def test_backfill_fact_terms_keeps_unchanged_legacy_amend_event_free(tmp_path):
+    s = _store(tmp_path)
+    cur = s._conn.execute(
+        "INSERT INTO facts(subject, relation, object, status) VALUES(?,?,?,?) RETURNING id",
+        ("Synthetic Report", "published_year", "2024", "needs_review"),
+    )
+    fact_id = int(cur.fetchone()[0])
+    token = fact_term_token("Synthetic Report", "published_year", "2024")
+
+    assert s.backfill_fact_terms() == 1
+    assert s.get_fact(fact_id)["term_token"] == token
+    record = s.fact_terms.get_fact_term_record(fact_id)
+    assert record is not None
+    assert record.term_token == record.content_token == token
+
+    decision = s.amend_fact(
+        fact_id,
+        subject="Synthetic Report",
+        relation="published_year",
+        obj="2024",
+    )
+
+    assert decision.changed is False
+    assert s.fact_log(fact_id) == []
+
+
 def test_store_migrates_existing_facts_table_to_add_term_token(tmp_path):
     conn = sqlite3.connect(tmp_path / "kb.sqlite")
     conn.execute(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2746,6 +2746,99 @@ def test_fact_terms_unavailable_page_renders_without_touching_terms(tmp_path):
     assert "Fact terms unavailable" in r.text
 
 
+@pytest.mark.parametrize(
+    ("action", "expected_status"),
+    [
+        ("toggle", "confirmed"),
+        ("accept", "confirmed"),
+        ("reject", "superseded"),
+    ],
+)
+def test_committed_decision_over_htmx_carries_saved_notice_to_sidecar_halt(
+    tmp_path, action, expected_status
+):
+    """A corrupt term sidecar cannot hide a status decision SQLite committed."""
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    post = client.post(
+        f"/facts/{fid}/{action}", headers={"HX-Request": "true"}
+    )
+
+    assert post.status_code == 409
+    redirect = post.headers["HX-Redirect"]
+    assert redirect.startswith(
+        webapp.FACT_TERMS_UNAVAILABLE_PATH
+        + f"?decision_fact_id={fid}&decision_action={action}&decision_log_id="
+    )
+    assert client.app.state.store.get_fact(fid)["status"] == expected_status
+
+    halt = client.get(redirect)
+
+    assert halt.status_code == 409
+    body = " ".join(halt.text.split())
+    assert f"Your {action} decision was already saved in SQLite" in body
+    assert "facts.duckdb" in halt.text
+    assert "confirm the fact's current status" in body
+
+
+def test_committed_decision_notice_survives_an_app_restart(tmp_path):
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    post = client.post(f"/facts/{fid}/accept", headers={"HX-Request": "true"})
+
+    restarted = TestClient(create_app(client.app.state.cfg))
+    halt = restarted.get(post.headers["HX-Redirect"])
+
+    assert halt.status_code == 409
+    assert "Your accept decision was already saved in SQLite" in " ".join(
+        halt.text.split()
+    )
+
+
+def test_saved_decision_notice_rejects_forged_or_stale_redirect_state(tmp_path):
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path)
+    post = client.post(f"/facts/{fid}/accept", headers={"HX-Request": "true"})
+    redirect = post.headers["HX-Redirect"]
+
+    forged = client.get(redirect.replace("decision_action=accept", "decision_action=reject"))
+    assert "decision was already saved in SQLite" not in forged.text
+
+    client.app.state.store.toggle_review(fid)
+    stale = client.get(redirect)
+    assert "decision was already saved in SQLite" not in stale.text
+
+
+def test_non_htmx_committed_decision_renders_the_saved_notice_inline(tmp_path):
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    halt = client.post(f"/facts/{fid}/accept")
+
+    assert halt.status_code == 409
+    assert "Your accept decision was already saved in SQLite" in " ".join(
+        halt.text.split()
+    )
+
+
+def test_unchanged_decision_does_not_create_a_saved_notice(tmp_path):
+    client, fid, _token = _corrupt_sidecar_kb(tmp_path, status="confirmed")
+
+    post = client.post(f"/facts/{fid}/accept", headers={"HX-Request": "true"})
+
+    assert post.status_code == 409
+    assert post.headers["HX-Redirect"] == webapp.FACT_TERMS_UNAVAILABLE_PATH
+    halt = client.get(post.headers["HX-Redirect"])
+    assert "decision was already saved in SQLite" not in halt.text
+
+
+def test_generic_sidecar_halt_does_not_claim_a_decision_was_saved(tmp_path):
+    client, _fid, _token = _corrupt_sidecar_kb(tmp_path)
+
+    r = client.get(webapp.FACT_TERMS_UNAVAILABLE_PATH)
+
+    assert r.status_code == 409
+    assert "decision was already saved in SQLite" not in r.text
+
+
 def test_review_renders_normally_for_a_string_fact_on_a_healthy_sidecar(tmp_path):
     # False-positive guard: a legitimately string-typed fact must keep rendering
     # as kind="string" with a 200 -- only a genuine raise halts, never the

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1959,29 +1959,86 @@ class Store:
             ]
 
     def backfill_fact_terms(self) -> int:
-        """Backfill legacy SQLite-only fact rows into DuckDB as StringLit terms."""
+        """Backfill legacy SQLite-only fact rows into DuckDB as StringLit terms.
+
+        The token is part of the paired fact representation, so a backfilled
+        DuckDB row also repairs the legacy SQLite NULL token.  Keeping both
+        copies canonical makes a later unchanged amend a real replay rather
+        than an apparent divergence that needs an amend to self-heal.
+        """
+        from verinote.store.duckdb_fact_terms import fact_term_token
+
         with self._lock:
             rows = list(
                 self._conn.execute(
-                    "SELECT id, subject, relation, object FROM facts ORDER BY id"
+                    "SELECT id, subject, relation, object, status, term_token "
+                    "FROM facts ORDER BY id"
                 )
             )
-            existing = self.fact_terms.get_many_fact_terms(row["id"] for row in rows)
-            missing = [int(row["id"]) for row in rows if int(row["id"]) not in existing]
+            fact_terms = self.fact_terms
+            records = fact_terms.get_many_fact_term_records(row["id"] for row in rows)
+            missing = [int(row["id"]) for row in rows if int(row["id"]) not in records]
             if missing and self._has_fact_terms_marker():
                 raise _missing_fact_terms_error(missing)
-            written = 0
+
+            # A failed final SQLite commit can leave a just-backfilled DuckDB
+            # row ahead of its SQLite token. Recover that narrow window on the
+            # next backfill, but only when the sidecar still proves it encodes
+            # this legacy display triple as the same canonical StringLit tuple.
+            token_updates: list[tuple[int, str, str | None]] = []
             for row in rows:
                 fact_id = int(row["id"])
-                if fact_id in existing:
-                    continue
-                self.fact_terms.put_fact_terms(
-                    fact_id, row["subject"], row["relation"], row["object"]
+                token = fact_term_token(row["subject"], row["relation"], row["object"])
+                record = records.get(fact_id)
+                should_sync = record is None or (
+                    row["term_token"] is None
+                    and record.term_token == token
+                    and record.content_token == token
                 )
-                written += 1
+                # A superseded fact's content axis is immutable, including its
+                # token. It cannot reach amend's replay path, so leave that
+                # terminal legacy metadata untouched.
+                if should_sync and row["status"] != "superseded":
+                    sqlite_token = row["term_token"]
+                    if sqlite_token not in {None, token}:
+                        raise _stale_fact_terms_error([fact_id])
+                    if sqlite_token != token:
+                        token_updates.append((fact_id, token, sqlite_token))
+
+            written = 0
             if rows:
-                origin = "legacy_backfill" if written else "existing_sidecar"
-                self._record_fact_terms_marker_unlocked(origin=origin)
+                self._conn.execute("BEGIN")
+                try:
+                    for fact_id, token, sqlite_token in token_updates:
+                        cur = self._conn.execute(
+                            "UPDATE facts SET term_token = ? "
+                            "WHERE id = ? AND term_token IS ?",
+                            (token, fact_id, sqlite_token),
+                        )
+                        if cur.rowcount != 1:
+                            raise _stale_fact_terms_error([fact_id])
+                    for row in rows:
+                        fact_id = int(row["id"])
+                        if fact_id not in missing:
+                            continue
+                        token = fact_term_token(
+                            row["subject"], row["relation"], row["object"]
+                        )
+                        fact_terms.put_fact_terms(
+                            fact_id,
+                            row["subject"],
+                            row["relation"],
+                            row["object"],
+                            term_token=token,
+                        )
+                        written += 1
+                    if rows:
+                        origin = "legacy_backfill" if written else "existing_sidecar"
+                        self._record_fact_terms_marker_unlocked(origin=origin)
+                    self._conn.execute("COMMIT")
+                except BaseException:
+                    self._rollback_quietly()
+                    raise
             return written
 
     def get_fact(self, fact_id: int) -> sqlite3.Row | None:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -8,6 +8,7 @@ swaps a single row partial). No JS build step. The app owns one `Store` (SQLite)
 from __future__ import annotations
 
 from importlib import resources
+import json
 import logging
 from pathlib import Path
 import threading
@@ -127,6 +128,14 @@ FACT_TERMS_UNAVAILABLE_PATH = "/fact-terms-unavailable"
 # `_config_corrupt_handler`.
 CONFIG_UNAVAILABLE_PATH = "/config-unavailable"
 
+# The public action names are deliberately separate from the append-only audit
+# vocabulary. A halt redirect carries both forms through SQLite validation.
+_FACT_DECISION_LOG_ACTIONS = {
+    "toggle": "toggled",
+    "accept": "accepted",
+    "reject": "rejected",
+}
+
 
 def _matches(path: str, allowed: tuple[str, ...]) -> bool:
     return any(path == a or path.startswith(a + "/") for a in allowed)
@@ -196,22 +205,81 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     app.add_exception_handler(PolicyMissingError, _policy_missing_handler)
 
-    def _fact_terms_unavailable_page(request: Request):
+    def _fact_terms_unavailable_page(
+        request: Request, *, saved_decision: str | None = None
+    ):
         # Deliberately generic: DuckDBFactTermStoreError covers a corrupt/unopenable
         # sidecar but also stale/missing-term and malformed-input conditions, so the
         # copy must not diagnose one specific cause it cannot be sure of.
         return templates.TemplateResponse(
             request,
             "sidecar_unreadable.html",
-            {},
+            {"saved_decision": saved_decision},
             status_code=409,
         )
 
     @app.get(FACT_TERMS_UNAVAILABLE_PATH, response_class=HTMLResponse)
-    def fact_terms_unavailable(request: Request):
+    def fact_terms_unavailable(
+        request: Request,
+        decision_fact_id: str | None = None,
+        decision_action: str | None = None,
+        decision_log_id: str | None = None,
+    ):
         # The full-page halt and the HX-Redirect target below. It reads no fact
         # terms, so it still renders while the term store cannot be read.
-        return _fact_terms_unavailable_page(request)
+        saved_decision = _saved_fact_decision(
+            decision_fact_id, decision_action, decision_log_id
+        )
+        return _fact_terms_unavailable_page(request, saved_decision=saved_decision)
+
+    def _saved_fact_decision(
+        fact_id: object, action: object, log_id: object
+    ) -> str | None:
+        """Validate a halt notice against the durable SQLite decision audit.
+
+        The URL is deliberately self-contained so it survives an application
+        restart. It is not trusted: the referenced audit row must be the fact's
+        latest human decision and the current SQLite status must still be the
+        status that action committed. This keeps forged and stale URLs generic.
+        """
+        if not isinstance(action, str) or action not in _FACT_DECISION_LOG_ACTIONS:
+            return None
+        try:
+            parsed_fact_id = int(fact_id)
+            parsed_log_id = int(log_id)
+        except (TypeError, ValueError):
+            return None
+        if parsed_fact_id <= 0 or parsed_log_id <= 0:
+            return None
+
+        store = app.state.store
+        if store is None:
+            return None
+        fact = store.get_fact(parsed_fact_id)
+        log = store.fact_log(parsed_fact_id)
+        if fact is None or not log:
+            return None
+        latest = log[-1]
+        if (
+            int(latest["id"]) != parsed_log_id
+            or latest["action"] != _FACT_DECISION_LOG_ACTIONS[action]
+        ):
+            return None
+        matching_events = [
+            event
+            for event in store.fact_events(parsed_fact_id)
+            if event["event_type"] == _FACT_DECISION_LOG_ACTIONS[action]
+            and event["actor"] == "human"
+        ]
+        if not matching_events:
+            return None
+        try:
+            after = json.loads(matching_events[-1]["after_json"])
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(after, dict) or after.get("status") != fact["status"]:
+            return None
+        return action
 
     def _fact_terms_unreadable_handler(request: Request, exc: Exception):
         """One loud, non-lying halt for every surface that cannot read a fact's
@@ -228,9 +296,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         *before* it commits, so nothing was written; but `accept`/`reject`/`toggle`
         do a bare SQLite status UPDATE that autocommits immediately and only reach
         this handler on the follow-on row re-render, so for those the decision
-        already succeeded and merely could not be displayed. This page therefore
-        never claims the action was rejected -- only that the terms could not be
-        read.
+        already succeeded and merely could not be displayed. The decision routes
+        mark only a changed, committed decision on the request. That explicit
+        state adds a saved-decision notice here; all other halts stay generic.
 
         htmx will NOT swap a 4xx/5xx response into the DOM -- it fires
         `htmx:responseError` and swaps nothing -- so answering an htmx partial
@@ -240,12 +308,25 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         acts on HX-Redirect regardless of status, so the 409 stays honest.
         Full-page (non-htmx) requests render the halt page inline.
         """
+        saved_decision = _saved_fact_decision(
+            *getattr(request.state, "saved_fact_decision", (None, None, None))
+        )
         if request.headers.get("HX-Request") == "true":
+            redirect_path = FACT_TERMS_UNAVAILABLE_PATH
+            notice = getattr(request.state, "saved_fact_decision", None)
+            if saved_decision and notice is not None:
+                redirect_path += "?" + urlencode(
+                    {
+                        "decision_fact_id": notice[0],
+                        "decision_action": notice[1],
+                        "decision_log_id": notice[2],
+                    }
+                )
             return Response(
                 status_code=409,
-                headers={"HX-Redirect": FACT_TERMS_UNAVAILABLE_PATH},
+                headers={"HX-Redirect": redirect_path},
             )
-        return _fact_terms_unavailable_page(request)
+        return _fact_terms_unavailable_page(request, saved_decision=saved_decision)
 
     app.add_exception_handler(
         DuckDBFactTermStoreError, _fact_terms_unreadable_handler
@@ -516,6 +597,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if any(rec.fact_id != acted_fact_id for rec in applied):
             response.headers["HX-Refresh"] = "true"
         return response
+
+    def _mark_saved_fact_decision(request: Request, action: str, decision) -> None:
+        """Carry one committed review-log record to a later sidecar halt."""
+        if not decision.changed or decision.fact is None:
+            return
+        fact_id = int(decision.fact["id"])
+        log = _active_store().fact_log(fact_id)
+        if log and log[-1]["action"] == _FACT_DECISION_LOG_ACTIONS[action]:
+            request.state.saved_fact_decision = (fact_id, action, int(log[-1]["id"]))
 
     def _fact_edit_context(fact, *, error: str | None = None):
         kinds = {"subject": "string", "relation": "string", "object": "string"}
@@ -1347,6 +1437,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def toggle(request: Request, fact_id: int):
         _actionable_fact_or_error(fact_id)
         toggled = _active_store().toggle_review(fact_id)
+        _mark_saved_fact_decision(request, "toggle", toggled)
         # A demotion parks the fact in exactly the tier auto-accept promotes
         # from, so an unrestricted pass would undo the user's click inside their
         # own request. The demotion is the decision; the rule may act on the
@@ -1368,6 +1459,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def accept(request: Request, fact_id: int):
         _actionable_fact_or_error(fact_id)
         accepted = _active_store().accept_fact(fact_id)
+        _mark_saved_fact_decision(request, "accept", accepted)
         return _row_after_decision(
             request, accepted.fact, fact_id, decided=accepted.changed
         )
@@ -1379,6 +1471,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # keeping the trigger here matches the other decision routes.
         _actionable_fact_or_error(fact_id)
         rejected = _active_store().reject_fact(fact_id)
+        _mark_saved_fact_decision(request, "reject", rejected)
         return _row_after_decision(
             request, rejected.fact, fact_id, decided=rejected.changed
         )

--- a/verinote/web/templates/sidecar_unreadable.html
+++ b/verinote/web/templates/sidecar_unreadable.html
@@ -12,12 +12,19 @@
 
     {# Generic on purpose: the underlying error may be a corrupt/unopenable
        structural term store, a stale or missing term row, or malformed input.
-       verinote stops rather than render or change a fact whose logical terms it
-       cannot read, because falling back to the plain-text mirror would show a
-       structural fact as an ordinary string and invite a save that destroys it. #}
+       verinote stops rather than render a fact whose logical terms it cannot
+       read, because falling back to the plain-text mirror would show a structural
+       fact as an ordinary string and invite a save that destroys it. #}
     <p class="error" role="alert">The knowledge base could not read this fact's
-      logical terms, so it stopped instead of showing or changing the fact in a
-      way that might misrepresent it.</p>
+      logical terms, so it stopped instead of showing the fact or making further
+      changes in a way that might misrepresent it.</p>
+
+    {% if saved_decision %}
+    <p class="error" role="alert">Your {{ saved_decision }} decision was already
+      saved in SQLite before the result could be rendered. After restoring
+      <code>facts.duckdb</code>, return to Review to confirm the fact's current
+      status.</p>
+    {% endif %}
 
     <p class="muted">If the structural term store (<code>facts.duckdb</code>) was
       moved, replaced or damaged, restore it from a backup or version control. The


### PR DESCRIPTION
## Summary\n- show a verified persisted decision when fact-term rendering halts after a committed review action\n- synchronize legacy backfill SQLite term tokens with canonical DuckDB terms\n- cover durable halt notices and backfill failure recovery with synthetic regression tests\n\nCloses #346\n\n## Verification\n- .venv/bin/pytest -q tests/test_web.py tests/test_store_fact_terms.py tests/test_store.py