### PR TITLE
feat: group primary navigation and show review count

### DIFF
--- a/tests/test_nav_active_state.py
+++ b/tests/test_nav_active_state.py
@@ -19,6 +19,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from verinote.config import Config  # noqa: E402
+from verinote.store import db as store_db  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
 CSS_PATH = Path(__file__).resolve().parents[1] / "verinote" / "web" / "static" / "app.css"
@@ -124,6 +125,12 @@ def _current(html: str) -> list[str]:
     return [href for href, is_current in _nav_links(html) if is_current]
 
 
+def _review_link_body(html: str) -> str:
+    match = re.search(r'<a\b[^>]*href="/review"[^>]*>(.*?)</a>', html, re.S)
+    assert match, "the primary nav renders no Review link"
+    return match.group(1)
+
+
 def test_each_nav_destination_marks_its_own_link(tmp_path) -> None:
     client = _client(tmp_path)
     hrefs = [href for href, _ in _nav_links(client.get("/").text)]
@@ -164,11 +171,78 @@ def test_page_outside_the_nav_marks_nothing(tmp_path) -> None:
     assert _current(response.text) == []
 
 
+def test_primary_nav_groups_destinations_by_task(tmp_path) -> None:
+    client = _client(tmp_path)
+    header = HEADER_BLOCK.search(client.get("/").text)
+    assert header, "the page renders no header"
+
+    groups = dict(re.findall(
+        r'<div class="nav-group" role="group" aria-labelledby="nav-group-([^\"]+)">(.*?)</div>',
+        header.group(1),
+        re.S,
+    ))
+    assert set(groups) == {"manage", "review", "explore", "configure"}
+    assert "Dashboard" in groups["manage"]
+    assert "Sources" in groups["manage"]
+    assert "Review" in groups["review"]
+    assert "Workbench" in groups["review"]
+    assert "Ask" in groups["explore"]
+    assert "Analytics" in groups["explore"]
+    assert "Prompts" in groups["configure"]
+    assert "Settings" in groups["configure"]
+
+
+def test_review_nav_count_uses_the_runtime_review_tier(tmp_path, monkeypatch) -> None:
+    """The shared count follows `review_statuses()`, not a copied status list."""
+    client = _client(tmp_path)
+    client.app.state.store.add_fact(
+        "Synthetic accepted", "is_a", "Synthetic type", status="accepted", confidence=0.9
+    )
+    monkeypatch.setattr(store_db, "REVIEW_STATUSES", frozenset({"accepted"}))
+
+    body = _review_link_body(client.get("/sources").text)
+    assert '<span class="nav-count" aria-hidden="true">1</span>' in body
+    assert '<span class="visually-hidden"> 1 awaiting review</span>' in body
+
+
+def test_review_nav_count_is_hidden_when_the_queue_is_empty(tmp_path) -> None:
+    cfg = Config(
+        root=tmp_path, db_path=tmp_path / "kb.sqlite",
+        provider="anthropic", model="m", api_key=None, base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+
+    body = _review_link_body(client.get("/").text)
+    assert "nav-count" not in body
+    assert "awaiting review" not in body
+
+
+def test_common_nav_context_is_safe_without_an_active_kb(tmp_path, monkeypatch) -> None:
+    """Context processors run for kb_select.html too, where `store` is None."""
+    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    monkeypatch.chdir(tmp_path)
+
+    response = TestClient(create_app()).get("/")
+    assert response.status_code == 200
+    assert "Select a knowledge base" in response.text
+
+
 def test_stylesheet_styles_the_current_link() -> None:
     """Without a rule, the attribute is invisible to anyone not using a screen reader."""
     assert _rule_body(CURRENT_SELECTOR) is not None, (
         "app.css has no rule selecting the current nav link"
     )
+
+
+def test_nav_group_styles_are_scoped_to_the_header() -> None:
+    css = CSS_PATH.read_text(encoding="utf-8")
+    for selector in ("header nav", "header .nav-group", "header .nav-group-label", "header .nav-count"):
+        assert re.search(rf"(?:^|\n){re.escape(selector)}\s*\{{", css), (
+            f"app.css has no header-scoped rule for {selector}"
+        )
 
 
 def test_current_link_is_marked_off_a_non_colour_channel() -> None:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -161,7 +161,23 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         ensure_policy_marker(store, cfg.root)
         app.state.store = store
 
-    templates = Jinja2Templates(directory=str(_TEMPLATES))
+    def _common_template_context(request: Request) -> dict[str, int]:
+        """Values needed by shared templates, including the primary navigation."""
+        store = request.app.state.store
+        if store is None:
+            return {"review_count": 0}
+
+        status_counts = store.status_counts()
+        return {
+            "review_count": sum(
+                status_counts.get(status, 0) for status in review_statuses()
+            )
+        }
+
+    templates = Jinja2Templates(
+        directory=str(_TEMPLATES),
+        context_processors=[_common_template_context],
+    )
     app.mount("/static", StaticFiles(directory=str(_STATIC)), name="static")
 
     def _policy_halted(request: Request, message: str):
@@ -923,7 +939,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # "engine input" card must answer the same question as coverage
                 # and the Sources badge, from the same constant.
                 "engine_input": sum(counts.get(status, 0) for status in engine_statuses()),
-                "review_count": sum(counts.get(status, 0) for status in review_statuses()),
                 "all_fact_statuses": fact_status_order(),
                 "sources": store.sources(),
                 "coverage": coverage(store, root=cfg.root),

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -33,11 +33,30 @@
 * { box-sizing: border-box; }
 body { margin: 0; background: var(--bg); color: var(--fg);
   font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif; }
-header { display: flex; align-items: center; gap: 1.5rem;
+header { display: flex; align-items: flex-start; gap: .8rem 1.5rem; flex-wrap: wrap;
   padding: .8rem 1.4rem; border-bottom: 1px solid var(--line); background: var(--panel); }
 .brand { font-weight: 700; letter-spacing: .02em; color: var(--fg); text-decoration: none; }
 nav a { color: var(--muted); text-decoration: none; margin-right: 1rem; }
 nav a:hover { color: var(--fg); }
+/* Primary navigation groups task-oriented destinations without affecting the review
+   filters or pagination navs that share this document. */
+header nav { display: flex; flex: 1 1 42rem; flex-wrap: wrap; align-items: baseline;
+  gap: .45rem 1rem; min-width: 0; }
+header .nav-group { display: flex; align-items: baseline; gap: .45rem; padding-right: 1rem;
+  border-right: 1px solid var(--line); }
+header .nav-group:last-child { padding-right: 0; border-right: 0; }
+header .nav-group-label { color: var(--muted); font-size: .72rem; font-weight: 700;
+  text-transform: uppercase; }
+header nav a { margin-right: 0; white-space: nowrap; }
+header .nav-count { display: inline-flex; align-items: center; justify-content: center;
+  min-width: 1.35rem; padding: .02rem .3rem; border: 1px solid var(--accent);
+  border-radius: 999px; color: var(--fg); font-size: .75rem; font-variant-numeric: tabular-nums;
+  line-height: 1.25; vertical-align: .08em; }
+@media (max-width: 720px) {
+  header { align-items: stretch; }
+  header nav { flex-basis: 100%; }
+  header .nav-group { border-right: 0; padding-right: 0; }
+}
 /* The current page (#225). Colour alone would not carry it -- #226 -- so the
    weight and the underline mark it on a non-colour channel too. Scoped to the
    header nav: review.html's <nav class="filters"> marks its own active badge

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -10,25 +10,24 @@
 <body>
   <header>
     <a class="brand" href="/">verinote</a>
-    {% set nav_links = [
-      ("/", "Dashboard"),
-      ("/sources", "Sources"),
-      ("/review", "Review"),
-      ("/workbench", "Workbench"),
-      ("/ask", "Ask"),
-      ("/questions", "Questions"),
-      ("/report", "Report"),
-      ("/analytics", "Analytics"),
-      ("/prompts", "Prompts"),
-      ("/settings", "Settings"),
+    {% set nav_groups = [
+      ("Manage", "manage", [("/", "Dashboard"), ("/sources", "Sources")]),
+      ("Review", "review", [("/review", "Review"), ("/workbench", "Workbench")]),
+      ("Explore", "explore", [("/ask", "Ask"), ("/questions", "Questions"), ("/report", "Report"), ("/analytics", "Analytics")]),
+      ("Configure", "configure", [("/prompts", "Prompts"), ("/settings", "Settings")]),
     ] %}
     {# `/` matches exactly; a prefix match there would light Dashboard up on every
        page. Sub-paths (`/sources/…`) keep their section link current. Pages under
        no nav entry (e.g. a fact's provenance) leave every link inactive. #}
     {% set path = request.url.path %}
-    <nav>
-      {% for href, label in nav_links %}
-      <a href="{{ href }}"{% if path == href or (href != "/" and path.startswith(href ~ "/")) %} aria-current="page"{% endif %}>{{ label }}</a>
+    <nav aria-label="Primary">
+      {% for group_label, group_id, links in nav_groups %}
+      <div class="nav-group" role="group" aria-labelledby="nav-group-{{ group_id }}">
+        <span class="nav-group-label" id="nav-group-{{ group_id }}">{{ group_label }}</span>
+        {% for href, label in links %}
+        <a href="{{ href }}"{% if path == href or (href != "/" and path.startswith(href ~ "/")) %} aria-current="page"{% endif %}>{{ label }}{% if href == "/review" and review_count > 0 %} <span class="nav-count" aria-hidden="true">{{ review_count }}</span><span class="visually-hidden"> {{ review_count }} awaiting review</span>{% endif %}</a>
+        {% endfor %}
+      </div>
       {% endfor %}
     </nav>
   </header>


### PR DESCRIPTION
## Summary\n- group primary navigation by task while preserving current-page semantics\n- add a null-safe shared template context for runtime review counts\n- expose an accessible Review queue count and cover selected/no-KB paths\n\nCloses #225\n\n## Verification\n- .venv/bin/pytest -q tests/test_nav_active_state.py tests/test_base_template_assets.py tests/test_theme.py tests/test_web.py::test_dashboard_renders tests/test_web.py::test_no_active_kb_shows_selector