### PR TITLE
fix: resolve KB roots outside working trees

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,28 +14,38 @@ The active KB path is saved in a platform-native app config file:
 | macOS | `~/Library/Application Support/verinote/app.json` |
 | Linux/Unix | `${XDG_CONFIG_HOME:-~/.config}/verinote/app.json` |
 
-`VERINOTE_ROOT` overrides the saved active KB and is still useful for scripts,
-tests, and one-off launches:
+`VERINOTE_ROOT` overrides the saved active KB for the UI and is still useful for
+scripts, tests, and one-off launches:
 
 ```bash
 VERINOTE_ROOT=/path/to/kb verinote ui
 ```
 
-## Scaffolding a KB from the CLI
+## CLI KB roots
 
-`init` and `seed` are *local* commands: they never write to the saved active KB.
-They target the root you name, else `VERINOTE_ROOT`, else `./data` in the current
-directory.
+Every non-UI CLI command uses the same root resolver. Precedence is `--root`,
+then `VERINOTE_ROOT`, then a CWD-independent platform user-data default:
+
+| Platform | Default KB root |
+|---|---|
+| Windows | `%LOCALAPPDATA%\\verinote\\kb` |
+| macOS | `~/Library/Application Support/verinote/kb` |
+| Linux/Unix | `${XDG_DATA_HOME:-~/.local/share}/verinote/kb` |
+
+Explicit roots expand `~` but must be absolute; relative roots are rejected.
+`init` and `seed` retain an absolute positional root as a temporary compatibility
+alias, but it cannot be combined with `--root`.
 
 ```bash
-verinote init                 # ./data here (or $VERINOTE_ROOT if set)
-verinote init /path/to/kb     # a named root
-verinote seed /path/to/kb     # demo facts into an existing KB
+verinote init --root /path/to/kb
+verinote --root /path/to/kb status
+VERINOTE_ROOT=/path/to/kb verinote seed
+verinote init /path/to/kb     # temporary positional compatibility alias
 ```
 
-Creating a KB does not make it the active one. Every other command still reads the
-saved active KB, so to work with the KB you just created, either point
-`VERINOTE_ROOT` at it or select it in the UI:
+Creating a KB does not make it the active UI selection. The web UI still uses its
+saved active KB unless `VERINOTE_ROOT` or its own `--root` is provided. CLI
+commands continue to use the resolver above:
 
 ```bash
 VERINOTE_ROOT=/path/to/kb verinote status
@@ -46,6 +56,9 @@ data has to pass through human review like anything else.
 
 > Prefer a KB outside the working tree. See
 > [operations.md](operations.md#keep-the-kb-outside-the-working-tree).
+
+`init` and `seed` refuse targets inside normal and linked Git worktrees before
+creating any KB files, including nested or symlinked paths that resolve there.
 
 ## Providers
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -62,15 +62,17 @@ the marker exists and the refusal above applies.
 
 ## Keep the KB outside the working tree
 
-The default root (`./data`) is a convenience for a first run, not a safe home:
+The default root is a platform user-data directory, but an explicit absolute
+root makes automated operation unambiguous:
 
 ```bash
-VERINOTE_ROOT=~/verinote-kb verinote init   # scaffold a KB outside the repo
-VERINOTE_ROOT=~/verinote-kb verinote ui
+verinote init --root ~/verinote-kb          # scaffold a KB outside the repo
+verinote --root ~/verinote-kb ui
 ```
 
-`VERINOTE_ROOT` selects the KB root for every command, so exporting it once in
-your shell profile keeps all of your data out of the working tree.
+`--root` wins over `VERINOTE_ROOT`, which wins over the platform default. `init`
+and `seed` reject targets inside normal or linked Git worktrees, including nested
+and symlinked paths resolving into one.
 
 ### A KB inside the repo tree gets committed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,12 @@
 
 `verinote.config.app_config_dir()` resolves through `HOME`/`USERPROFILE`/
 `XDG_CONFIG_HOME`/`APPDATA`/`LOCALAPPDATA` depending on the platform, and
-`active_root()` falls back to `./data` relative to the *current working
-directory*. A test that forgets to isolate either one can rewrite the
-developer's real `app.json` — repointing the active KB — or open the repo's own
-`data/kb.sqlite`. `Config.for_root()` also reads every `VERINOTE_*` variable
-env-first, so an ambient export in the developer's shell can change what a test
-sees.
+`Config.load()` resolves its default KB under `XDG_DATA_HOME` (or the platform
+equivalent), while `active_root()` reads the web UI's app config. A test that
+forgets to isolate either location can rewrite the developer's real `app.json`
+or open their real default KB. `Config.for_root()` also reads every
+`VERINOTE_*` variable env-first, so an ambient export in the developer's shell
+can change what a test sees.
 
 The sandbox is two-tier on purpose:
 
@@ -36,7 +36,14 @@ import pytest
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.query_intent import parse_query_intent
 
-HOME_VARS = ("HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA")
+HOME_VARS = (
+    "HOME",
+    "USERPROFILE",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "APPDATA",
+    "LOCALAPPDATA",
+)
 
 _session_patch: pytest.MonkeyPatch | None = None
 _session_tmp: str | None = None
@@ -89,9 +96,9 @@ def isolate_app_environment(monkeypatch, tmp_path_factory):
     pollute them. Every `VERINOTE_*` variable is dropped (`ROOT`, `PROVIDER`,
     `MODEL`, `BASE_URL`, `API_KEY`, `LLM_TIMEOUT`, the `EXTRACTION_*` knobs and
     `AUTO_ACCEPT_RECOMMENDATIONS` are all read env-first by `Config`), and the
-    CWD is moved off the repo so `active_root()`'s `./data` fallback cannot
-    reach the repo's own KB. Tests that set these vars themselves still win:
-    this runs first, their `setenv` runs after.
+    CWD is also moved off the repo to keep filesystem fixtures separate from the
+    checkout. Tests that set these vars themselves still win: this runs first,
+    their `setenv` runs after.
     """
     home = tmp_path_factory.mktemp("home")
     _sandbox_env(monkeypatch, home, tmp_path_factory.mktemp("cwd"))

--- a/tests/test_active_root.py
+++ b/tests/test_active_root.py
@@ -133,3 +133,13 @@ def test_save_active_root_creates_file_when_absent(tmp_path, monkeypatch):
 
     assert app_config_path().is_file()
     assert read_app_config()["active_root"] == str(kb.resolve())
+
+
+def test_active_root_does_not_fall_back_to_cwd_data(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.delenv("VERINOTE_ROOT", raising=False)
+    cwd_data = _make_kb(tmp_path, "data")
+    monkeypatch.chdir(tmp_path)
+
+    assert active_root() is None
+    assert cwd_data.is_dir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 import verinote.cli as cli
 from verinote import config
 from verinote.engine import DEFAULT_POLICY
+from verinote.kb_location import user_data_kb_root
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline.ingest import register_converter
 from verinote.pipeline.query_intent import parse_query_intent
@@ -1207,7 +1208,9 @@ def _isolated(monkeypatch, tmp_path):
     home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(home / ".config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(home / ".local" / "share"))
     monkeypatch.setenv("APPDATA", str(home / "AppData"))
+    monkeypatch.setenv("LOCALAPPDATA", str(home / "AppData" / "Local"))
     return home
 
 
@@ -1235,7 +1238,8 @@ def test_init_seed_in_empty_dir_ignores_saved_active_kb(tmp_path, monkeypatch, c
 
     assert cli.main(["init", "--seed"]) == 0
 
-    new_db = workdir / "data" / "kb.sqlite"
+    new_root = user_data_kb_root()
+    new_db = new_root / "kb.sqlite"
     assert new_db.is_file()
     # The saved KB is untouched, byte for byte.
     assert (existing / "kb.sqlite").read_bytes() == before
@@ -1245,7 +1249,7 @@ def test_init_seed_in_empty_dir_ignores_saved_active_kb(tmp_path, monkeypatch, c
     assert config.read_app_config()["active_root"] == str(existing)
 
     out = capsys.readouterr().out
-    assert f"initialised KB at {workdir / 'data'}" in out
+    assert f"initialised KB at {new_root}" in out
     assert str(existing) not in out
 
 
@@ -1391,7 +1395,7 @@ def test_init_rejects_a_root_that_is_an_existing_file(tmp_path, monkeypatch, cap
 
 
 def test_init_rejects_an_empty_root_argument(tmp_path, monkeypatch, capsys):
-    """An empty ROOT must fail, not silently fall back to ./data."""
+    """An empty ROOT must fail, not silently fall back to the default root."""
     _isolated(monkeypatch, tmp_path)
     workdir = tmp_path / "cwd"
     workdir.mkdir()
@@ -1904,13 +1908,15 @@ def test_status_on_absent_kb_refuses_and_creates_nothing(tmp_path, monkeypatch, 
     workdir = tmp_path / "empty"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
+    root = user_data_kb_root()
 
     assert cli.main(["status"]) == 1
 
-    assert not (workdir / "data").exists()  # no KB was created behind our back
+    assert not root.exists()  # no KB was created behind our back
+    assert not (workdir / "data").exists()  # CWD is never the implicit root
     err = capsys.readouterr().err
     assert "no KB" in err
-    assert str(workdir / "data") in err
+    assert str(root) in err
 
 
 def test_coverage_on_absent_kb_refuses_and_creates_nothing(tmp_path, monkeypatch, capsys):
@@ -1918,13 +1924,15 @@ def test_coverage_on_absent_kb_refuses_and_creates_nothing(tmp_path, monkeypatch
     workdir = tmp_path / "empty"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
+    root = user_data_kb_root()
 
     assert cli.main(["coverage"]) == 1
 
+    assert not root.exists()
     assert not (workdir / "data").exists()
     err = capsys.readouterr().err
     assert "no KB" in err
-    assert str(workdir / "data") in err
+    assert str(root) in err
 
 
 def test_status_rejects_an_empty_db_file_instead_of_creating_a_schema(
@@ -2501,39 +2509,57 @@ def test_sync_with_nothing_to_sync_creates_no_kb(tmp_path, monkeypatch, capsys):
 def test_sync_scaffolds_when_source_files_exist_without_a_kb(tmp_path, monkeypatch):
     # The workflow the guard must not break: drop files under sources/ and sync.
     # There IS work to do, so scaffolding the KB is legitimate.
+    from verinote.pipeline.extract import SyncResult
+
     _isolated(monkeypatch, tmp_path)
     workdir = tmp_path / "work"
-    sources = workdir / "data" / "sources"
+    workdir.mkdir()
+    root = user_data_kb_root()
+    sources = root / "sources"
     sources.mkdir(parents=True)
     (sources / "x.txt").write_text("body", encoding="utf-8")
     monkeypatch.chdir(workdir)
-    monkeypatch.setattr(
-        "verinote.llm.get_client",
-        lambda cfg: (_ for _ in ()).throw(LLMError("provider down")),
-    )
+    received = {}
 
-    cli.main(["sync"])
+    def sync_sources(store, client, source_pairs, **kwargs):
+        received["source_pairs"] = source_pairs
+        return SyncResult(run_id=1, per_source=[(path, 0) for path, _ in source_pairs])
 
-    # It got past the guard and opened the KB — that is what is being pinned.
-    assert (workdir / "data" / "kb.sqlite").is_file()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
+    monkeypatch.setattr("verinote.pipeline.sync_sources", sync_sources)
+
+    assert cli.main(["sync"]) == 0
+
+    assert (root / "kb.sqlite").is_file()
+    assert received["source_pairs"] == [("sources/x.txt", "body")]
+    assert not (workdir / "data").exists()
 
 
 def test_sync_with_a_path_argument_still_scaffolds(tmp_path, monkeypatch):
     # An explicit path is work by itself, so the guard must not fire on it.
+    from verinote.pipeline.extract import SyncResult
+
     _isolated(monkeypatch, tmp_path)
     workdir = tmp_path / "work"
     workdir.mkdir()
     monkeypatch.chdir(workdir)
     note = workdir / "note.txt"
     note.write_text("body", encoding="utf-8")
-    monkeypatch.setattr(
-        "verinote.llm.get_client",
-        lambda cfg: (_ for _ in ()).throw(LLMError("provider down")),
-    )
+    root = user_data_kb_root()
+    received = {}
 
-    cli.main(["sync", str(note)])
+    def sync_sources(store, client, source_pairs, **kwargs):
+        received["source_pairs"] = source_pairs
+        return SyncResult(run_id=1, per_source=[(path, 0) for path, _ in source_pairs])
 
-    assert (workdir / "data" / "kb.sqlite").is_file()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: object())
+    monkeypatch.setattr("verinote.pipeline.sync_sources", sync_sources)
+
+    assert cli.main(["sync", str(note)]) == 0
+
+    assert (root / "kb.sqlite").is_file()
+    assert received["source_pairs"] == [(str(note.resolve()), "body")]
+    assert not (workdir / "data").exists()
 
 
 def test_sync_on_an_existing_kb_with_no_sources_keeps_its_message(
@@ -2564,22 +2590,17 @@ def test_query_with_a_question_still_creates_a_kb(tmp_path, monkeypatch):
 
     cli.main(["query", "What is X?"])
 
-    db_path = workdir / "data" / "kb.sqlite"
+    db_path = user_data_kb_root() / "kb.sqlite"
     assert db_path.is_file()
     store = Store(db_path)
     assert [q["text"] for q in store.questions()] == ["What is X?"]
     store.close()
 
 
-def test_query_with_a_saved_active_kb_elsewhere_creates_nothing_in_cwd(
+def test_query_without_an_explicit_root_does_not_use_the_saved_active_kb(
     tmp_path, monkeypatch, capsys
 ):
-    """The guard judges the RESOLVED cfg.db_path, not the directory you stand in.
-
-    #185 adjacency: with no VERINOTE_ROOT and a saved active KB pointing
-    elsewhere, `verinote query` must work against that KB and leave the cwd
-    untouched — never scaffolding a stray `./data` beside the user.
-    """
+    """CLI commands use the canonical default, never the UI's saved KB."""
     _isolated(monkeypatch, tmp_path)
     existing = _existing_kb(tmp_path)
     workdir = tmp_path / "elsewhere"
@@ -2589,8 +2610,7 @@ def test_query_with_a_saved_active_kb_elsewhere_creates_nothing_in_cwd(
     assert cli.main(["query"]) == 1
 
     assert not (workdir / "data").exists()
-    # It reached the real (saved) KB rather than refusing it.
-    assert "no pending or failed questions" in capsys.readouterr().err
+    assert "no KB at" in capsys.readouterr().err
     assert (existing / "kb.sqlite").is_file()
 
 

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -5,9 +5,8 @@ The bug these guard against is not hypothetical. `POST /settings/root` calls
 `save_active_root()`, which writes the platform app config resolved from `HOME`
 (and friends); a web test that forgot to isolate `HOME` therefore rewrote the
 developer's *real* `app.json` and repointed their active KB at a temp directory
-that pytest then deleted. `active_root()` also falls back to `./data` relative
-to the CWD, so an unisolated test run from the repo root opens the repo's own
-`data/kb.sqlite`.
+that pytest then deleted. `Config.load()` also resolves a default KB under the
+user-data directory, so an unisolated test could open the developer's real KB.
 
 Every test below deliberately omits manual isolation and never requests the
 `isolate_app_environment` fixture by name — it must be the *autouse* fixture in
@@ -36,6 +35,7 @@ from env_sandbox import (
     snapshot,
 )
 from verinote.config import Config, active_root, app_config_dir, app_config_path
+from verinote.kb_location import user_data_kb_root
 
 # The web stack is the only thing here that needs FastAPI. Guarding just the one
 # test that uses it — rather than `importorskip`ing the whole module — keeps the
@@ -105,27 +105,17 @@ def test_settings_switch_without_manual_isolation_stays_in_the_sandbox(tmp_path)
     assert active_root() == other.resolve()
 
 
-def test_active_root_fallback_is_cwd_relative_and_the_sandbox_cwd_is_off_the_repo(
-    tmp_path, monkeypatch
-):
-    # Prove the CWD guard without relying on the repo's own `data/` (which is
-    # gitignored, so it does not exist on CI — asserting `active_root() is None`
-    # there would pass even with the chdir isolation deleted). Instead: plant a
-    # KB under a temp CWD and show the fallback follows the CWD, then show the
-    # sandbox CWD has no KB and is not the repo.
+def test_config_load_uses_the_sandboxed_user_data_root_not_the_cwd(tmp_path, monkeypatch):
+    expected = user_data_kb_root()
     planted = tmp_path / "data"
     planted.mkdir()
     (planted / "kb.sqlite").write_text("", encoding="utf-8")
 
     with monkeypatch.context() as m:
         m.chdir(tmp_path)
-        assert active_root() == planted.resolve(), "the `./data` fallback is CWD-relative"
+        assert Config.load().root == expected.resolve()
 
-    cwd = Path.cwd()
-
-    assert cwd != REPO_ROOT, "the test run must not sit in the repo root"
-    assert REPO_ROOT not in cwd.parents, "the test run must not sit inside the repo"
-    assert active_root() is None, "the sandbox CWD must hold no KB to fall back to"
+    assert REPO_ROOT not in Config.load().root.parents
 
 
 def test_module_scoped_fixtures_run_inside_the_sandbox(module_scoped_app_config_dir):
@@ -140,8 +130,8 @@ def test_module_scoped_fixtures_run_inside_the_sandbox(module_scoped_app_config_
 
 
 def test_module_scoped_config_load_stays_in_the_sandbox(module_scoped_config):
-    # `Config.load()` resolves the root through the real `app.json` *and* the
-    # CWD-relative `./data` fallback, so both tiers of the leak show up here.
+    # `Config.load()` resolves through the platform user-data root, so a
+    # module-scoped fixture must still stay under the session environment seal.
     root = module_scoped_config.root
 
     assert session_home() is not None, "the session-start environment seal is not installed"

--- a/tests/test_kb_location.py
+++ b/tests/test_kb_location.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MPL-2.0
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import verinote.cli as cli
+import verinote.kb_location as kb_location
+from verinote.store import Store
+
+
+def test_resolve_kb_root_precedence_and_cwd_invariance(tmp_path, monkeypatch):
+    data_home = tmp_path / "data-home"
+    env_root = tmp_path / "from-env"
+    explicit_root = tmp_path / "explicit"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    monkeypatch.setenv("VERINOTE_ROOT", str(env_root))
+    monkeypatch.setattr(kb_location.sys, "platform", "linux")
+
+    assert kb_location.resolve_kb_root() == env_root.resolve()
+    assert kb_location.resolve_kb_root(explicit_root) == explicit_root.resolve()
+
+    monkeypatch.delenv("VERINOTE_ROOT")
+    first = kb_location.resolve_kb_root()
+    other_cwd = tmp_path / "other-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    assert first == data_home / "verinote" / "kb"
+    assert kb_location.resolve_kb_root() == first
+
+
+def test_user_data_kb_root_uses_each_platform_convention(tmp_path, monkeypatch):
+    monkeypatch.setattr(kb_location.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    assert kb_location.user_data_kb_root() == (tmp_path / "xdg-data" / "verinote" / "kb")
+
+    monkeypatch.setattr(kb_location.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path / "mac-home"))
+    assert kb_location.user_data_kb_root() == (
+        tmp_path / "mac-home" / "Library" / "Application Support" / "verinote" / "kb"
+    )
+
+    monkeypatch.setattr(kb_location.sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local-app-data"))
+    assert kb_location.user_data_kb_root() == (
+        tmp_path / "local-app-data" / "verinote" / "kb"
+    )
+
+
+@pytest.mark.parametrize("root", ["relative-kb", "", "   "])
+def test_explicit_roots_must_be_nonempty_and_absolute(root):
+    with pytest.raises(kb_location.KBLocationError):
+        kb_location.resolve_kb_root(root)
+
+
+def test_explicit_root_expands_tilde_before_absolute_validation(tmp_path, monkeypatch):
+    home = tmp_path / "synthetic-home"
+    monkeypatch.setenv("HOME", str(home))
+
+    assert kb_location.resolve_kb_root("~/kb") == home / "kb"
+
+
+def test_relative_verinote_root_is_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_ROOT", "relative-kb")
+
+    with pytest.raises(kb_location.KBLocationError, match="VERINOTE_ROOT must be an absolute path"):
+        kb_location.resolve_kb_root()
+
+
+def test_cli_root_overrides_environment_for_normal_commands(tmp_path, monkeypatch, capsys):
+    env_root = tmp_path / "from-env"
+    explicit_root = tmp_path / "explicit"
+    monkeypatch.setenv("VERINOTE_ROOT", str(env_root))
+    store = Store(explicit_root / "kb.sqlite")
+    store.init_schema()
+    store.close()
+
+    assert cli.main(["status", "--root", str(explicit_root)]) == 0
+    assert f"KB: {explicit_root}" in capsys.readouterr().out
+    assert not env_root.exists()
+
+
+def test_ui_root_is_resolved_and_passed_to_the_app_factory(tmp_path, monkeypatch):
+    root = tmp_path / "ui-root"
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=lambda *args, **kwargs: calls.append(args)))
+    args = cli.build_parser().parse_args(["ui", "--root", str(root), "--no-browser"])
+    cfg = cli._config_for(args)
+
+    assert cfg is not None
+    assert cfg.root == root.resolve()
+    assert cli.cmd_ui(cfg, args) == 0
+    assert calls == [("verinote.web.app:_default",)]
+    assert os.environ["VERINOTE_ROOT"] == str(root.resolve())
+
+
+@pytest.mark.parametrize("argv", [["--root", "relative-kb", "init"], ["init", "relative-kb"]])
+def test_cli_rejects_relative_roots(argv, capsys):
+    assert cli.main(argv) == 1
+    assert "must be an absolute path" in capsys.readouterr().err
+
+
+def test_init_accepts_absolute_positional_alias_and_rejects_root_conflict(
+    tmp_path, capsys
+):
+    positional_root = tmp_path / "positional"
+    option_root = tmp_path / "option"
+
+    assert cli.main(["init", str(positional_root)]) == 0
+    assert (positional_root / "kb.sqlite").is_file()
+
+    assert cli.main(["init", str(positional_root), "--root", str(option_root)]) == 1
+    assert "cannot use ROOT and --root together" in capsys.readouterr().err
+    assert not option_root.exists()
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for worktree safety tests")
+@pytest.mark.parametrize("command", ["init", "seed"])
+@pytest.mark.parametrize("target_kind", ["nested", "symlink", "linked-worktree"])
+def test_init_and_seed_refuse_git_worktree_descendants_before_writing(
+    tmp_path, capsys, command, target_kind
+):
+    repo = _git_repository(tmp_path)
+    if target_kind == "nested":
+        target = repo / "synthetic-nested" / "kb"
+        expected = target
+    elif target_kind == "symlink":
+        alias = tmp_path / "repo-alias"
+        alias.symlink_to(repo, target_is_directory=True)
+        target = alias / "synthetic-nested" / "kb"
+        expected = repo / "synthetic-nested" / "kb"
+    else:
+        linked = tmp_path / "linked-worktree"
+        _git("-C", repo, "worktree", "add", "-b", "synthetic-linked", linked)
+        target = linked / "synthetic-nested" / "kb"
+        expected = target
+
+    assert cli.main(["--root", str(target), command]) == 1
+    assert "inside Git worktree" in capsys.readouterr().err
+    assert not expected.exists()
+
+
+def _git_repository(tmp_path: Path) -> Path:
+    repo = tmp_path / "synthetic-repository"
+    _git("init", repo)
+    _git("-C", repo, "config", "user.email", "synthetic@example.invalid")
+    _git("-C", repo, "config", "user.name", "Synthetic Fixture")
+    (repo / "fixture.txt").write_text("synthetic fixture\n", encoding="utf-8")
+    _git("-C", repo, "add", "fixture.txt")
+    _git("-C", repo, "commit", "-m", "synthetic fixture")
+    return repo
+
+
+def _git(*args: Path | str) -> None:
+    subprocess.run(
+        ["git", *(str(arg) for arg in args)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -16,6 +16,7 @@ import verinote.web.app as webapp  # noqa: E402
 from verinote.config import Config, ConfigCorruptError, save_settings  # noqa: E402
 from verinote.engine import CheckReport, DEFAULT_POLICY, FindingDetail  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
+from verinote.kb_location import KBRootSafetyError  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
 from verinote.pipeline import ChunkedExtractionResult, ExtractionJobBusyError  # noqa: E402
 from verinote.pipeline.verify import _with_unrecorded_policy_warning  # noqa: E402
@@ -359,6 +360,50 @@ def test_select_kb_activates_app(tmp_path, monkeypatch):
     assert (kb / "policy" / "logic-policy.dl").is_file()
     assert c.app.state.cfg.root == kb.resolve()
     assert "Knowledge base" in c.get("/").text
+
+
+def _unsafe_ui_root(tmp_path, kind):
+    worktree = tmp_path / "synthetic-worktree"
+    worktree.mkdir()
+    if kind == "linked-worktree":
+        (worktree / ".git").write_text("gitdir: synthetic\n", encoding="utf-8")
+    else:
+        (worktree / ".git").mkdir()
+    expected = worktree / "nested" / "kb"
+    if kind == "symlink":
+        alias = tmp_path / "synthetic-worktree-alias"
+        alias.symlink_to(worktree, target_is_directory=True)
+        return alias / "nested" / "kb", expected
+    return expected, expected
+
+
+@pytest.mark.parametrize("kind", ["normal-worktree", "linked-worktree", "symlink"])
+def test_ui_startup_refuses_worktree_descendant_before_initializing(tmp_path, kind):
+    root, expected = _unsafe_ui_root(tmp_path, kind)
+
+    with pytest.raises(KBRootSafetyError, match="inside Git worktree"):
+        create_app(Config.for_root(root))
+
+    assert not expected.exists()
+
+
+@pytest.mark.parametrize("path", ["/kb/select", "/settings/root"])
+@pytest.mark.parametrize("kind", ["normal-worktree", "linked-worktree", "symlink"])
+def test_ui_root_selection_refuses_worktree_descendant_before_initializing(
+    tmp_path, path, kind
+):
+    root, expected = _unsafe_ui_root(tmp_path, kind)
+    client = (
+        _client(tmp_path)
+        if path == "/settings/root"
+        else TestClient(create_app())
+    )
+
+    response = client.post(path, data={"root": str(root)}, follow_redirects=False)
+
+    assert response.status_code == 400
+    assert "inside Git worktree" in response.text
+    assert not expected.exists()
 
 
 def test_dashboard_shows_coverage_gap(tmp_path):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -5,20 +5,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 from dataclasses import dataclass, field
 import sys
 from pathlib import Path
 
 from verinote import __version__
-from verinote.config import Config, local_root
+from verinote.config import Config
+from verinote.kb_location import (
+    KBLocationError,
+    assert_kb_root_is_safe_to_create,
+    resolve_kb_root,
+)
 from verinote.pipeline.question_outcome import format_question_outcome
 from verinote.store import Store, engine_statuses, fact_status_order
 from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreLockedError
 from verinote.text import nfc
 
-# Local commands own their KB location: they never inherit the KB the web UI
-# last selected, so `verinote init` cannot scribble into somebody else's data.
 _LOCAL_ROOT_COMMANDS = frozenset({"init", "seed"})
 
 _DEMO_FACTS = [
@@ -1371,6 +1375,10 @@ def cmd_ui(cfg: Config | None, args: argparse.Namespace) -> int:
         print("uvicorn not installed; `pip install verinote`", file=sys.stderr)
         return 1
     url = f"http://{args.host}:{args.port}"
+    if args.root is not None and cfg is not None:
+        # Uvicorn imports the app factory separately, so carry the explicit CLI
+        # choice into that process without changing the saved UI selection.
+        os.environ["VERINOTE_ROOT"] = str(cfg.root)
     if cfg is None:
         print(f"verinote ui → {url}  (select a KB in the browser)")
     else:
@@ -1458,32 +1466,45 @@ def build_parser() -> argparse.ArgumentParser:
     """
     p = argparse.ArgumentParser(prog="verinote", description="Honest KB: LLM extracts, DuckDB verifies.")
     p.add_argument("--version", action="version", version=f"verinote {__version__}")
+    p.add_argument(
+        "--root",
+        metavar="PATH",
+        help="absolute KB root (overrides $VERINOTE_ROOT and the platform user-data default)",
+    )
     sub = p.add_subparsers(dest="command", required=True)
+    root_option = argparse.ArgumentParser(add_help=False)
+    root_option.add_argument("--root", metavar="PATH", default=argparse.SUPPRESS)
 
     init = sub.add_parser(
         "init",
-        help="scaffold a KB (SQLite) at ROOT (default: $VERINOTE_ROOT, else ./data in the current directory)",
+        parents=[root_option],
+        help="scaffold a KB (SQLite) at the resolved root",
     )
     init.add_argument(
-        "root",
+        "root_alias",
         nargs="?",
-        help="where to create the KB (default: $VERINOTE_ROOT, else ./data here)",
+        metavar="ROOT",
+        help="temporary compatibility alias for an absolute --root PATH",
     )
     init.add_argument("--seed", action="store_true", help="insert demo facts")
     init.set_defaults(func=cmd_init, halt_safe=False)
 
     seed = sub.add_parser(
         "seed",
-        help="insert demo facts into an existing KB at ROOT (default: $VERINOTE_ROOT, else ./data in the current directory)",
+        parents=[root_option],
+        help="insert demo facts into an existing KB at the resolved root",
     )
     seed.add_argument(
-        "root",
+        "root_alias",
         nargs="?",
-        help="an existing KB root (default: $VERINOTE_ROOT, else ./data here)",
+        metavar="ROOT",
+        help="temporary compatibility alias for an absolute --root PATH",
     )
     seed.set_defaults(func=cmd_seed, halt_safe=False)
 
-    sync = sub.add_parser("sync", help="extract candidate facts from sources via the LLM")
+    sync = sub.add_parser(
+        "sync", parents=[root_option], help="extract candidate facts from sources via the LLM"
+    )
     sync.add_argument(
         "path",
         nargs="?",
@@ -1503,14 +1524,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sync.set_defaults(func=cmd_sync, halt_safe=False)
 
-    ingest = sub.add_parser("ingest", help="register a source file (converting docx/pdf to text)")
+    ingest = sub.add_parser(
+        "ingest",
+        parents=[root_option],
+        help="register a source file (converting docx/pdf to text)",
+    )
     ingest.add_argument("path", help="a .txt/.md file, or a .docx/.pdf to convert")
     ingest.set_defaults(func=cmd_ingest, halt_safe=False)
 
-    sources = sub.add_parser("sources", help="inspect and repair registered sources")
+    sources = sub.add_parser(
+        "sources", parents=[root_option], help="inspect and repair registered sources"
+    )
     sources_sub = sources.add_subparsers(dest="sources_command", required=True)
     repair_identities = sources_sub.add_parser(
         "repair-identities",
+        parents=[root_option],
         help="scan NFC/NFD duplicate source identities; --apply repairs verified groups",
     )
     repair_identities.add_argument(
@@ -1520,14 +1548,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     repair_identities.set_defaults(func=cmd_sources_repair_identities, halt_safe=False)
 
-    query = sub.add_parser("query", help="translate pending NL questions to Datalog queries")
+    query = sub.add_parser(
+        "query", parents=[root_option], help="translate pending NL questions to Datalog queries"
+    )
     query.add_argument("question", nargs="?", help="a question to add before translating")
     query.set_defaults(func=cmd_query, halt_safe=False)
 
-    repair = sub.add_parser("repair", help="re-translate review_required questions (engine-gated)")
+    repair = sub.add_parser(
+        "repair", parents=[root_option], help="re-translate review_required questions (engine-gated)"
+    )
     repair.set_defaults(func=cmd_repair, halt_safe=False)
 
-    coverage = sub.add_parser("coverage", help="report per-source engine-fact coverage")
+    coverage = sub.add_parser(
+        "coverage", parents=[root_option], help="report per-source engine-fact coverage"
+    )
     coverage.add_argument(
         "--strict",
         action="store_true",
@@ -1539,13 +1573,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     coverage.set_defaults(func=cmd_coverage, halt_safe=True)
 
-    status = sub.add_parser("status", help="summarise KB state")
+    status = sub.add_parser("status", parents=[root_option], help="summarise KB state")
     status.set_defaults(func=cmd_status, halt_safe=True)
 
-    policy = sub.add_parser("policy", help="manage this KB's logic policy file")
+    policy = sub.add_parser(
+        "policy", parents=[root_option], help="manage this KB's logic policy file"
+    )
     policy_sub = policy.add_subparsers(dest="policy_command", required=True)
     policy_reset = policy_sub.add_parser(
-        "reset", help="re-create the default logic policy (explicit human gate)"
+        "reset",
+        parents=[root_option],
+        help="re-create the default logic policy (explicit human gate)",
     )
     policy_reset.add_argument(
         "--force",
@@ -1555,7 +1593,7 @@ def build_parser() -> argparse.ArgumentParser:
     # The one command that must run *on* a halted KB: it is how a halt is cleared.
     policy_reset.set_defaults(func=cmd_policy_reset, halt_safe=True)
 
-    ui = sub.add_parser("ui", help="launch the web app")
+    ui = sub.add_parser("ui", parents=[root_option], help="launch the web app")
     ui.add_argument("--host", default="127.0.0.1")
     ui.add_argument("--port", type=int, default=8731)
     ui.add_argument("--reload", action="store_true", help="auto-reload (dev)")
@@ -1564,7 +1602,7 @@ def build_parser() -> argparse.ArgumentParser:
     # blocks writes while still serving the /report page that explains the halt.
     # Refusing to start the server would strand the user with no way to diagnose it.
     ui.set_defaults(func=cmd_ui, halt_safe=True)
-    sub.add_parser("serve", help="alias for ui").set_defaults(
+    sub.add_parser("serve", parents=[root_option], help="alias for ui").set_defaults(
         func=cmd_ui, halt_safe=True, host="127.0.0.1", port=8731, reload=False, no_browser=True
     )
 
@@ -1573,17 +1611,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _config_for(args: argparse.Namespace) -> Config | None:
     if args.command in {"ui", "serve"}:
+        if args.root is not None or "VERINOTE_ROOT" in os.environ:
+            return Config.for_root(resolve_kb_root(args.root))
         return Config.load_for_ui()
     if args.command in _LOCAL_ROOT_COMMANDS:
-        return Config.for_root(local_root(args.root))
-    return Config.load()
+        if args.root is not None and args.root_alias is not None:
+            raise KBLocationError("cannot use ROOT and --root together; choose one KB root")
+        root = resolve_kb_root(args.root if args.root is not None else args.root_alias)
+        assert_kb_root_is_safe_to_create(root)
+        return Config.for_root(root)
+    return Config.for_root(resolve_kb_root(args.root))
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         cfg = _config_for(args)
-    except ValueError as exc:  # e.g. a blank explicit KB root
+    except KBLocationError as exc:
         print(str(exc), file=sys.stderr)
         return 1
     # The single CLI enforcement point for a halted KB. It sits here, before

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -28,10 +28,12 @@ value. `null` means "unset" only where `save_settings` can write it —
 `base_url` and the optional extraction settings — and counts as unusable in
 `provider` and `model`.
 
-The active KB root is stored in a platform-native app config file when the web
-UI selects one: Windows uses `%APPDATA%`, macOS uses `~/Library/Application
-Support`, and Unix uses `${XDG_CONFIG_HOME:-~/.config}`. `VERINOTE_ROOT` still
-overrides this for scripts and tests.
+CLI and non-UI runtime paths resolve their KB root consistently: an explicit
+root (the CLI's `--root`) wins, then `VERINOTE_ROOT`, then a CWD-independent
+platform user-data location. The web UI's separately selected active KB remains
+stored in a platform-native app config file: Windows uses `%APPDATA%`, macOS
+uses `~/Library/Application Support`, and Unix uses
+`${XDG_CONFIG_HOME:-~/.config}`.
 """
 
 from __future__ import annotations
@@ -42,6 +44,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from verinote.kb_location import resolve_kb_root
 from verinote.prompts import render_prompt
 
 SETTINGS_FILENAME = "config.json"
@@ -72,37 +75,13 @@ def normalize_provider(provider: str | None) -> str:
     return key
 
 
-def _default_root() -> Path:
-    return Path("./data").expanduser().resolve()
-
-
 def _root() -> Path:
-    root = active_root()
-    return root if root is not None else _default_root()
+    return resolve_kb_root()
 
 
 def local_root(explicit: Path | str | None = None) -> Path:
-    """Resolve the KB root for *local* commands that must never target a saved KB.
-
-    Commands like `init` and `seed` act on a location the caller names, not on
-    whatever KB the web UI last selected. Precedence (highest first): the
-    explicit argument, `VERINOTE_ROOT`, then `./data` relative to the current
-    working directory. The saved app config (`active_root()`) is deliberately
-    **not** consulted — otherwise `verinote init` in an empty directory would
-    write into somebody else's KB.
-
-    A blank explicit root raises `ValueError`: falling back would write the KB
-    somewhere the caller never named, which is exactly what these commands
-    promise not to do.
-    """
-    if explicit is not None:
-        if isinstance(explicit, str) and not explicit.strip():
-            raise ValueError("KB root must be a path, not an empty string")
-        return Path(explicit).expanduser().resolve()
-    env_root = os.environ.get("VERINOTE_ROOT")
-    if env_root:
-        return Path(env_root).expanduser().resolve()
-    return _default_root()
+    """Backward-compatible name for the single CLI/config KB root resolver."""
+    return resolve_kb_root(explicit)
 
 
 def app_config_dir() -> Path:
@@ -233,10 +212,6 @@ def active_root() -> Path | None:
     saved = _saved_root(read_app_config())
     if saved is not None and (saved / "kb.sqlite").is_file():
         return saved
-
-    default = _default_root()
-    if (default / "kb.sqlite").is_file():
-        return default
     return None
 
 

--- a/verinote/kb_location.py
+++ b/verinote/kb_location.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MPL-2.0
+"""KB location resolution and safeguards for commands that create KB files."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+APP_NAME = "verinote"
+
+
+class KBLocationError(ValueError):
+    """Raised when a requested KB location is not an unambiguous absolute path."""
+
+
+class KBRootSafetyError(KBLocationError):
+    """Raised when creating a KB at a target could modify a Git worktree."""
+
+
+def _canonical_absolute_path(value: Path | str, *, source: str) -> Path:
+    raw = os.fspath(value)
+    if not raw.strip():
+        raise KBLocationError(f"{source} must be a path, not an empty string")
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        raise KBLocationError(
+            f"{source} must be an absolute path; relative KB roots are not supported"
+        )
+    try:
+        return path.resolve()
+    except OSError as exc:
+        raise KBLocationError(f"could not resolve {source} {path}: {exc}") from exc
+    except RuntimeError as exc:
+        raise KBLocationError(f"could not resolve {source} {path}: symlink loop") from exc
+
+
+def user_data_kb_root() -> Path:
+    """Return the CWD-independent default KB root for the current platform."""
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            candidate = Path(base).expanduser()
+            if candidate.is_absolute():
+                return (candidate / APP_NAME / "kb").resolve()
+        return (Path.home() / "AppData" / "Local" / APP_NAME / "kb").resolve()
+    if sys.platform == "darwin":
+        return (Path.home() / "Library" / "Application Support" / APP_NAME / "kb").resolve()
+
+    base = os.environ.get("XDG_DATA_HOME")
+    if base:
+        candidate = Path(base).expanduser()
+        if candidate.is_absolute():
+            return (candidate / APP_NAME / "kb").resolve()
+    return (Path.home() / ".local" / "share" / APP_NAME / "kb").resolve()
+
+
+def resolve_kb_root(explicit: Path | str | None = None) -> Path:
+    """Resolve CLI/config KB location: explicit root, environment, then user data."""
+    if explicit is not None:
+        return _canonical_absolute_path(explicit, source="KB root")
+
+    env_root = os.environ.get("VERINOTE_ROOT")
+    if env_root is not None:
+        return _canonical_absolute_path(env_root, source="VERINOTE_ROOT")
+    return user_data_kb_root()
+
+
+def assert_kb_root_is_safe_to_create(root: Path | str) -> None:
+    """Refuse a root inside a normal or linked Git worktree before writes begin.
+
+    `resolve()` follows existing symlink components even when the final target
+    does not exist. Walking its ancestors therefore covers direct, nested, and
+    symlinked descendants of both normal worktrees (`.git` directory) and linked
+    worktrees (`.git` file).
+    """
+    target = _canonical_absolute_path(root, source="KB root")
+    if target.exists() and not target.is_dir():
+        # Let `cmd_init` issue its more specific existing-file diagnostic.
+        return
+    for directory in (target, *target.parents):
+        marker = directory / ".git"
+        try:
+            marker.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise KBRootSafetyError(
+                f"cannot inspect {marker} before creating a KB: {exc}"
+            ) from exc
+        raise KBRootSafetyError(
+            f"refusing to create a KB inside Git worktree {directory} (found {marker})"
+        )

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -32,6 +32,7 @@ from verinote.config import (
     save_active_root,
     save_settings,
 )
+from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
 from verinote.llm import LLMError, get_client
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
@@ -156,6 +157,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     app.state.repair_scheduler_lock = Lock()
     app.state.repair_scheduled = set()
     if cfg is not None:
+        assert_kb_root_is_safe_to_create(cfg.root)
         store = Store(cfg.db_path)
         store.init_schema()
         ensure_policy_marker(store, cfg.root)
@@ -485,6 +487,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _open_root(root: Path) -> None:
         """Point this running app at a KB root, creating it if needed."""
         root = root.expanduser().resolve()
+        assert_kb_root_is_safe_to_create(root)
         root.mkdir(parents=True, exist_ok=True)
         next_cfg = Config.for_root(root)
         # Refuse BEFORE installing: transiently swapping in a corrupt cfg would let
@@ -1269,7 +1272,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def select_kb(request: Request, root: str = Form(...)):
         try:
             _open_root(Path(root))
-        except OSError as e:
+        except (KBLocationError, OSError) as e:
             return _kb_select(request, error=f"could not open KB: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
 
@@ -1835,7 +1838,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 error=f"refused to open KB — its config.json is corrupt: {e}",
                 status_code=400,
             )
-        except OSError as e:
+        except (KBLocationError, OSError) as e:
             return _settings(request, error=f"could not open KB directory: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
 


### PR DESCRIPTION
## Summary\n- resolve CLI roots from --root, VERINOTE_ROOT, or a CWD-independent user-data default\n- reject relative roots and prevent init, seed, and UI creation paths from writing inside Git worktrees\n- remove the UI CWD data fallback and document the new location contract\n\nCloses #416\n\n## Verification\n- .venv/bin/pytest -q tests/test_kb_location.py tests/test_config.py tests/test_env_isolation.py tests/test_active_root.py tests/test_web.py tests/test_cli.py\n  - 436 passed