### PR TITLE
fix: require confirmation to persist web KB selection

### DIFF
--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -34,7 +34,7 @@ from env_sandbox import (
     session_home,
     snapshot,
 )
-from verinote.config import Config, active_root, app_config_dir, app_config_path
+from verinote.config import Config, app_config_dir, app_config_path
 from verinote.kb_location import user_data_kb_root
 
 # The web stack is the only thing here that needs FastAPI. Guarding just the one
@@ -91,6 +91,9 @@ def test_settings_switch_without_manual_isolation_stays_in_the_sandbox(tmp_path)
     )
     client = TestClient(create_app(cfg))
     other = tmp_path / "other-kb"
+    sandbox_config_path = app_config_path()
+
+    assert not sandbox_config_path.exists()
 
     r = client.post("/settings/root", data={"root": str(other)}, follow_redirects=False)
 
@@ -100,9 +103,11 @@ def test_settings_switch_without_manual_isolation_stays_in_the_sandbox(tmp_path)
     )
     home = sandbox_home()
     assert home is not None
-    assert home in app_config_path().parents
-    assert app_config_path().is_file()
-    assert active_root() == other.resolve()
+    assert home in sandbox_config_path.parents
+    assert not sandbox_config_path.exists(), "an ordinary KB switch persisted app.json"
+    assert client.app.state.cfg.root == other.resolve()
+    assert client.app.state.store.db_path == other.resolve() / "kb.sqlite"
+    assert (other / "kb.sqlite").is_file()
 
 
 def test_config_load_uses_the_sandboxed_user_data_root_not_the_cwd(tmp_path, monkeypatch):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -13,7 +13,13 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 import verinote.web.app as webapp  # noqa: E402
-from verinote.config import Config, ConfigCorruptError, save_settings  # noqa: E402
+from verinote.config import (  # noqa: E402
+    Config,
+    ConfigCorruptError,
+    app_config_path,
+    read_app_config,
+    save_settings,
+)
 from verinote.engine import CheckReport, DEFAULT_POLICY, FindingDetail  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.kb_location import KBRootSafetyError  # noqa: E402
@@ -359,6 +365,7 @@ def test_select_kb_activates_app(tmp_path, monkeypatch):
     assert (kb / "kb.sqlite").is_file()
     assert (kb / "policy" / "logic-policy.dl").is_file()
     assert c.app.state.cfg.root == kb.resolve()
+    assert not app_config_path().exists()
     assert "Knowledge base" in c.get("/").text
 
 
@@ -3927,6 +3934,7 @@ def test_settings_switches_active_kb_root(tmp_path, monkeypatch):
     assert c.app.state.cfg.root == other.resolve()
     assert c.app.state.store.db_path == other.resolve() / "kb.sqlite"
     assert (other / "kb.sqlite").is_file()
+    assert not app_config_path().exists()
     assert "Review queue is empty" in c.get("/review").text
     assert str(other.resolve()) in c.get("/").text
 
@@ -3938,6 +3946,125 @@ def test_settings_rejects_empty_kb_root(tmp_path):
 
     assert r.status_code == 400
     assert "KB directory is required" in r.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/kb/select", "/settings/root", "/settings/root/persist"],
+)
+def test_web_root_selection_errors_leave_active_root_and_app_config_unchanged(
+    tmp_path, path
+):
+    c = _client(tmp_path)
+    before_root = c.app.state.cfg.root
+    config_path = app_config_path()
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '{"active_root": "/synthetic/saved-kb", "extra": "keep"}\n',
+        encoding="utf-8",
+    )
+    before_config = config_path.read_bytes()
+
+    r = c.post(
+        path,
+        data={"root": "relative-kb", "confirm_persistence": "on"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert "absolute path" in r.text
+    assert c.app.state.cfg.root == before_root
+    assert config_path.read_bytes() == before_config
+
+
+@pytest.mark.parametrize("path", ["/kb/select", "/settings/root"])
+def test_reopening_selected_kb_does_not_modify_saved_active_root(tmp_path, path):
+    c = _client(tmp_path)
+    config_path = app_config_path()
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '{"active_root": "/synthetic/saved-kb", "extra": "keep"}\n',
+        encoding="utf-8",
+    )
+    before = config_path.read_bytes()
+
+    r = c.post(path, data={"root": str(tmp_path.resolve())}, follow_redirects=False)
+
+    assert r.status_code == 303
+    assert c.app.state.cfg.root == tmp_path.resolve()
+    assert config_path.read_bytes() == before
+
+
+def test_settings_renders_explicit_machine_wide_kb_confirmation(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.get("/settings")
+
+    assert r.status_code == 200
+    assert 'action="/settings/root/persist"' in r.text
+    assert 'name="confirm_persistence"' in r.text
+    assert str(tmp_path.resolve()) in r.text
+    assert "future verinote web processes" in r.text
+
+
+def test_settings_persist_active_kb_requires_confirmation(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/root/persist",
+        data={"root": str(tmp_path.resolve())},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert "Confirm the machine-wide KB change" in r.text
+    assert not app_config_path().exists()
+
+
+def test_settings_persist_active_kb_after_explicit_confirmation(tmp_path):
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/root/persist",
+        data={"root": str(tmp_path.resolve()), "confirm_persistence": "on"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/settings"
+    assert read_app_config()["active_root"] == str(tmp_path.resolve())
+
+
+def test_settings_persist_refuses_unsafe_root_without_touching_app_config(tmp_path):
+    c = _client(tmp_path)
+    root, expected = _unsafe_ui_root(tmp_path, "normal-worktree")
+
+    r = c.post(
+        "/settings/root/persist",
+        data={"root": str(root), "confirm_persistence": "on"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert "inside Git worktree" in r.text
+    assert c.app.state.cfg.root == tmp_path.resolve()
+    assert not expected.exists()
+    assert not app_config_path().exists()
+
+
+def test_settings_persist_refuses_when_verinote_root_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings/root/persist",
+        data={"root": str(tmp_path.resolve()), "confirm_persistence": "on"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert "VERINOTE_ROOT controls this process" in r.text
+    assert not app_config_path().exists()
 
 
 def test_settings_never_renders_api_key(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from importlib import resources
 import json
 import logging
+import os
 from pathlib import Path
 import threading
 from threading import Lock
@@ -27,7 +28,6 @@ from verinote.config import (
     TESTABLE_PROVIDERS,
     Config,
     ConfigCorruptError,
-    app_config_path,
     assert_settings_intact,
     save_active_root,
     save_settings,
@@ -486,8 +486,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     def _open_root(root: Path) -> None:
         """Point this running app at a KB root, creating it if needed."""
-        root = root.expanduser().resolve()
         assert_kb_root_is_safe_to_create(root)
+        root = root.expanduser().resolve()
         root.mkdir(parents=True, exist_ok=True)
         next_cfg = Config.for_root(root)
         # Refuse BEFORE installing: transiently swapping in a corrupt cfg would let
@@ -505,7 +505,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if resolve_policy(next_store).status is PolicyStatus.UNRECORDED_DEFAULT:
             write_default_policy(next_store, root, origin="scaffold")
 
-        save_active_root(root)
         old_store = app.state.store
         if old_store is not None:
             old_store.close()
@@ -516,7 +515,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return templates.TemplateResponse(
             request,
             "kb_select.html",
-            {"error": error, "config_path": app_config_path()},
+            {"error": error},
             status_code=status_code,
         )
 
@@ -1270,8 +1269,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/kb/select", response_class=HTMLResponse)
     def select_kb(request: Request, root: str = Form(...)):
+        path = root.strip()
+        if not path:
+            return _kb_select(request, error="KB directory is required", status_code=400)
         try:
-            _open_root(Path(root))
+            _open_root(Path(path))
+        except ConfigCorruptError as e:
+            return _kb_select(
+                request,
+                error=f"refused to open KB — its config.json is corrupt: {e}",
+                status_code=400,
+            )
         except (KBLocationError, OSError) as e:
             return _kb_select(request, error=f"could not open KB: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
@@ -1841,6 +1849,59 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         except (KBLocationError, OSError) as e:
             return _settings(request, error=f"could not open KB directory: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
+
+    @app.post("/settings/root/persist", response_class=HTMLResponse)
+    def persist_root(
+        request: Request,
+        root: str = Form(...),
+        confirm_persistence: str | None = Form(None),
+    ):
+        """Persist the current KB only after an explicit, path-bound confirmation."""
+        cfg = app.state.cfg
+        if cfg is None:
+            return _kb_select(request)
+        if os.environ.get("VERINOTE_ROOT") is not None:
+            return _settings(
+                request,
+                error="VERINOTE_ROOT controls this process, so its KB cannot be saved as the machine-wide active KB.",
+                status_code=400,
+            )
+
+        path = root.strip()
+        if not path:
+            return _settings(request, error="KB directory is required", status_code=400)
+        try:
+            # Validate the submitted path independently of the active config. This
+            # keeps a forged persistence form from recording a worktree descendant.
+            assert_kb_root_is_safe_to_create(path)
+            target = Path(path).expanduser().resolve()
+        except (KBLocationError, OSError) as e:
+            return _settings(
+                request,
+                error=f"could not save KB directory: {e}",
+                status_code=400,
+            )
+        if target != cfg.root:
+            return _settings(
+                request,
+                error="Open this KB before saving it as the machine-wide active KB.",
+                status_code=400,
+            )
+        if confirm_persistence != "on":
+            return _settings(
+                request,
+                error="Confirm the machine-wide KB change before saving it.",
+                status_code=400,
+            )
+        try:
+            save_active_root(target)
+        except OSError as e:
+            return _settings(
+                request,
+                error=f"could not save KB directory: {e}",
+                status_code=400,
+            )
+        return RedirectResponse("/settings", status_code=303)
 
     @app.post("/settings/test", response_class=HTMLResponse)
     def test_connection(request: Request):

--- a/verinote/web/templates/kb_select.html
+++ b/verinote/web/templates/kb_select.html
@@ -9,20 +9,21 @@
 <body>
   <main class="chooser">
     <h1>Select a knowledge base</h1>
-    <p class="muted">Choose a KB folder to open. If it does not exist yet,
-      verinote will create it and initialise <code>kb.sqlite</code>.</p>
+    <p class="muted">Choose an absolute KB folder to open in this web process. If it
+      does not exist yet, verinote will create it and initialise <code>kb.sqlite</code>.</p>
 
     {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 
     <form class="settings" action="/kb/select" method="post">
       <label>KB folder
-        <input type="text" name="root" value="./data" placeholder="/path/to/verinote-kb" required>
+        <input type="text" name="root" placeholder="/absolute/path/to/verinote-kb" required>
       </label>
       <button class="btn" type="submit">Open KB</button>
     </form>
 
-    <p class="muted">The active KB path is saved in
-      <code>{{ config_path }}</code>. <code>VERINOTE_ROOT</code> overrides it.</p>
+    <p class="muted">Opening a KB does not change the machine-wide active KB. You can
+      explicitly save an opened KB as the future web default in Settings.
+      <code>VERINOTE_ROOT</code> overrides the saved choice.</p>
   </main>
 </body>
 </html>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -19,7 +19,16 @@
   <label>Directory
     <input type="text" name="root" value="{{ root }}" placeholder="/path/to/kb">
   </label>
-  <button class="btn" type="submit">Open KB</button>
+  <button class="btn" type="submit">Open in this web process</button>
+</form>
+<p class="muted">Opening a KB changes only this web process.</p>
+<form class="settings" action="/settings/root/persist" method="post">
+  <input type="hidden" name="root" value="{{ root }}">
+  <label class="inline-setting">
+    <input type="checkbox" name="confirm_persistence" value="on" required>
+    Save <code>{{ root }}</code> as this machine's active KB for future verinote web processes
+  </label>
+  <button class="btn ghost" type="submit">Save machine-wide active KB</button>
 </form>
 
 <h2>LLM provider</h2>


### PR DESCRIPTION
## Summary\n- make ordinary web KB opens process-local\n- require a path-bound confirmation before saving the machine-wide active KB\n- reject relative, unsafe, and VERINOTE_ROOT-overridden persistence paths\n\nCloses #418\n\n## Verification\n- .venv/bin/pytest -q tests/test_web.py tests/test_active_root.py tests/test_config.py tests/test_kb_location.py\n  - 326 passed