### PR TITLE
feat: add manual app theme preference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,12 @@ The active KB path is saved in a platform-native app config file:
 | macOS | `~/Library/Application Support/verinote/app.json` |
 | Linux/Unix | `${XDG_CONFIG_HOME:-~/.config}/verinote/app.json` |
 
+The same app-level file stores the Settings theme preference: `system` (the
+default, following the operating system), `light`, or `dark`. It is independent
+of the active KB, so changing KBs does not change the selected theme. Theme
+changes are intentionally unavailable while a KB's logic policy is halted: the
+policy guard permits only writes that leave the halted KB.
+
 `VERINOTE_ROOT` overrides the saved active KB for the UI and is still useful for
 scripts, tests, and one-off launches:
 

--- a/tests/test_active_root.py
+++ b/tests/test_active_root.py
@@ -6,9 +6,11 @@ import os
 
 from verinote.config import (
     active_root,
+    app_theme,
     app_config_path,
     read_app_config,
     save_active_root,
+    save_app_theme,
 )
 
 _SENTINEL_NS = 1_000_000_000_000_000_000  # a fixed, unmistakably-old mtime
@@ -105,6 +107,33 @@ def test_save_active_root_keeps_unknown_keys_when_switching(tmp_path, monkeypatc
 
     # Switching KBs must not drop settings this version does not know about.
     assert read_app_config()["extra"] == "keep"
+
+
+def test_save_app_theme_keeps_active_root_and_unknown_keys(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    kb = _make_kb(tmp_path, "kb")
+    _seed_app_config(kb)
+
+    save_app_theme("dark")
+
+    assert read_app_config() == {
+        "active_root": str(kb),
+        "extra": "keep",
+        "theme": "dark",
+    }
+    assert active_root() == kb.resolve()
+    assert app_theme() == "dark"
+
+
+def test_app_theme_defaults_to_system_for_absent_or_unknown_values(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+
+    assert app_theme() == "system"
+    path = app_config_path()
+    path.parent.mkdir(parents=True)
+    path.write_text('{"theme": "synthetic-future-theme"}\n', encoding="utf-8")
+
+    assert app_theme() == "system"
 
 
 def test_save_active_root_writes_when_saved_value_is_empty(tmp_path, monkeypatch):

--- a/tests/test_sources_progress.py
+++ b/tests/test_sources_progress.py
@@ -487,7 +487,9 @@ def _terminal_progress_palette_tokens(css: str, palette: str) -> dict[str, str]:
     else:
         match = re.search(
             r"@media\s*\(\s*prefers-color-scheme\s*:\s*light\s*\)\s*"
-            r"\{\s*:root\s*\{(?P<body>[^{}]*)\}",
+            + r"\{\s*"
+            + re.escape(':root:not([data-theme="light"]):not([data-theme="dark"])')
+            + r"\s*\{(?P<body>[^{}]*)\}",
             css,
             re.DOTALL,
         )

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -44,7 +44,13 @@ CSS_PATH = WEB / "static" / "app.css"
 TEMPLATES = WEB / "templates"
 
 # Templates that link app.css directly (base.html covers every page that extends it).
-LINKING_TEMPLATES = ("base.html", "kb_select.html", "policy_halted.html")
+LINKING_TEMPLATES = (
+    "base.html",
+    "config_corrupt.html",
+    "kb_select.html",
+    "policy_halted.html",
+    "sidecar_unreadable.html",
+)
 
 CUSTOM_PROPERTY = re.compile(r"(--[A-Za-z0-9_-]+)\s*:")
 
@@ -121,6 +127,14 @@ def _light_palette_declarations(css: str) -> str:
     return inner
 
 
+def _explicit_light_palette_block(css: str) -> str:
+    """The manual-light override, which must beat an opposite OS preference."""
+    match = re.search(r'^:root\[data-theme="light"\]\s*\{', css, re.MULTILINE)
+    assert match, "app.css defines no explicit light theme override"
+    start, end = _block_at(css, match.start())
+    return css[start:end]
+
+
 def _strip_comments(css: str) -> str:
     """Drop /* ... */ comments.
 
@@ -132,8 +146,12 @@ def _strip_comments(css: str) -> str:
 
 
 def _rule_bodies(css: str) -> str:
-    """app.css with both palette blocks cut out -- everything that must use tokens."""
-    for block in (_light_media_block(css), _dark_root_block(css)):
+    """app.css with all palette blocks cut out -- everything else uses tokens."""
+    for block in (
+        _explicit_light_palette_block(css),
+        _light_media_block(css),
+        _dark_root_block(css),
+    ):
         css = css.replace(block, "", 1)
     return _strip_comments(css)
 
@@ -341,6 +359,22 @@ def test_light_palette_redefines_every_dark_token() -> None:
         f"the light palette never overrides {sorted(missing)}; those tokens would keep "
         "their dark values under (prefers-color-scheme: light)."
     )
+
+
+def test_manual_theme_overrides_have_the_same_light_palette() -> None:
+    """Light stays light even when the OS media query selects dark.
+
+    Dark needs no duplicate block: the base palette is dark and the media query
+    explicitly excludes `data-theme=dark`. System is the only value allowed to
+    enter that query, so it continues following the operating system.
+    """
+    css = _read_css()
+    media = _light_media_block(css)
+    explicit = _explicit_light_palette_block(css)
+
+    assert ':root:not([data-theme="light"]):not([data-theme="dark"])' in media
+    assert _palette_tokens(explicit) == _palette_tokens(_light_palette_declarations(css))
+    assert "color-scheme: light" in explicit
 
 
 def test_each_palette_declares_its_own_color_scheme() -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3649,6 +3649,51 @@ def test_settings_page_renders(tmp_path):
     assert 'href="/prompts"' in r.text
 
 
+def test_settings_saves_app_theme_across_kb_switches(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    c = _client(tmp_path)
+    other = tmp_path / "other-kb"
+
+    initial = c.get("/settings")
+    assert 'data-theme="system"' in initial.text
+    assert 'action="/settings/theme"' in initial.text
+    assert 'name="theme"' in initial.text
+
+    r = c.post("/settings/theme", data={"theme": "dark"}, follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/settings"
+    assert read_app_config()["theme"] == "dark"
+    assert 'data-theme="dark"' in c.get("/settings").text
+
+    assert c.post("/settings/root", data={"root": str(other)}).status_code == 200
+    assert read_app_config()["theme"] == "dark"
+    assert 'data-theme="dark"' in c.get("/settings").text
+
+
+def test_halted_kb_disables_and_refuses_app_theme_changes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    cfg, _, _ = _job_kb(tmp_path, with_policy=False)
+    c = TestClient(create_app(cfg))
+
+    settings = c.get("/settings")
+
+    assert settings.status_code == 200
+    assert 'action="/settings/theme"' in settings.text
+    assert 'name="theme" disabled' in settings.text
+    assert "Theme changes are unavailable while this KB's logic policy is halted." in settings.text
+
+    r = c.post("/settings/theme", data={"theme": "light"}, follow_redirects=False)
+
+    assert r.status_code == 409
+    assert "Verification halted" in r.text
+    assert read_app_config() == {}
+
+
 def test_prompts_page_renders_default_prompt(tmp_path):
     c = _client(tmp_path)
 

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -50,6 +50,7 @@ from verinote.prompts import render_prompt
 SETTINGS_FILENAME = "config.json"
 APP_CONFIG_FILENAME = "app.json"
 APP_NAME = "verinote"
+APP_THEMES = ("system", "light", "dark")
 
 _MODEL_DEFAULTS = {
     "anthropic": "claude-opus-4-8",
@@ -198,6 +199,27 @@ def save_active_root(root: Path) -> None:
     path = app_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {**existing, "active_root": str(resolved)}
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def app_theme() -> str:
+    """Return the app-wide colour preference, defaulting safely to the system."""
+    theme = read_app_config().get("theme")
+    return theme if theme in APP_THEMES else "system"
+
+
+def save_app_theme(theme: str) -> None:
+    """Persist an app-wide colour preference without disturbing other app settings."""
+    if theme not in APP_THEMES:
+        raise ValueError(f"unknown app theme: {theme}")
+    existing = read_app_config()
+    if existing.get("theme") == theme:
+        return
+    path = app_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {**existing, "theme": theme}
     path.write_text(
         json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -23,13 +23,16 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from verinote.config import (
+    APP_THEMES,
     PROVIDER_LABELS,
     PROVIDERS,
     TESTABLE_PROVIDERS,
     Config,
     ConfigCorruptError,
+    app_theme,
     assert_settings_intact,
     save_active_root,
+    save_app_theme,
     save_settings,
 )
 from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
@@ -163,17 +166,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         ensure_policy_marker(store, cfg.root)
         app.state.store = store
 
-    def _common_template_context(request: Request) -> dict[str, int]:
+    def _common_template_context(request: Request) -> dict[str, int | str]:
         """Values needed by shared templates, including the primary navigation."""
         store = request.app.state.store
         if store is None:
-            return {"review_count": 0}
+            return {"review_count": 0, "theme": app_theme()}
 
         status_counts = store.status_counts()
         return {
             "review_count": sum(
                 status_counts.get(status, 0) for status in review_statuses()
-            )
+            ),
+            "theme": app_theme(),
         }
 
     templates = Jinja2Templates(
@@ -1720,6 +1724,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         c = app.state.cfg
         if c is None:
             return _kb_select(request)
+        theme_editable = True
+        if app.state.store is not None:
+            try:
+                assert_writable(app.state.store)
+            except PolicyMissingError:
+                theme_editable = False
         return templates.TemplateResponse(
             request,
             "settings.html",
@@ -1745,6 +1755,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # above is the built-in default, NOT the user's saved choice, so
                 # warn instead of silently presenting it as chosen (#269).
                 "settings_error": c.settings_error,
+                "app_themes": APP_THEMES,
+                "theme_editable": theme_editable,
             },
             status_code=status_code,
         )
@@ -1814,6 +1826,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)
+        return RedirectResponse("/settings", status_code=303)
+
+    @app.post("/settings/theme", response_class=HTMLResponse)
+    def save_theme_route(request: Request, theme: str = Form(...)):
+        try:
+            save_app_theme(theme)
+        except ValueError as exc:
+            return _settings(request, error=str(exc), status_code=400)
         return RedirectResponse("/settings", status_code=303)
 
     @app.post("/settings/relation-aliases", response_class=HTMLResponse)

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -13,7 +13,7 @@
   --btn-active-filter: brightness(.95);
 }
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
     color-scheme: light;
     --bg: #f6f8fa; --panel: #ffffff; --line: #d0d7de; --fg: #1f2328;
     --muted: #59636e; --accent: #0969da; --ok: #116329; --warn: #7d4e00; --danger: #a40e26;
@@ -29,6 +29,21 @@
        show no brightness feedback at all -- only the translateY nudge. */
     --btn-active-filter: brightness(.90);
   }
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f6f8fa; --panel: #ffffff; --line: #d0d7de; --fg: #1f2328;
+  --muted: #59636e; --accent: #0969da; --ok: #116329; --warn: #7d4e00; --danger: #a40e26;
+  --progress-terminal-stripe: #ffffff;
+  --on-accent: #ffffff;
+  --editing-bg: rgba(9, 105, 218, .06);
+  --ok-bg: rgba(26, 127, 55, .10);
+  --warn-bg: rgba(154, 103, 0, .10);
+  --danger-bg: rgba(207, 34, 46, .08);
+  --term-bg: rgba(89, 99, 110, .10);
+  --btn-hover-filter: brightness(.95);
+  --btn-active-filter: brightness(.90);
 }
 * { box-sizing: border-box; }
 body { margin: 0; background: var(--bg); color: var(--fg);

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="{{ theme }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}verinote{% endblock %}</title>
   <script src="/static/htmx.min.js"></script>
-  <link rel="stylesheet" href="/static/app.css?v=4">
+  <link rel="stylesheet" href="/static/app.css?v=5">
 </head>
 <body>
   <header>

--- a/verinote/web/templates/config_corrupt.html
+++ b/verinote/web/templates/config_corrupt.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="{{ theme }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Config unreadable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=4">
+  <link rel="stylesheet" href="/static/app.css?v=5">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/kb_select.html
+++ b/verinote/web/templates/kb_select.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="{{ theme }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Select KB — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=4">
+  <link rel="stylesheet" href="/static/app.css?v=5">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/policy_halted.html
+++ b/verinote/web/templates/policy_halted.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="{{ theme }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Verification halted — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=4">
+  <link rel="stylesheet" href="/static/app.css?v=5">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -31,6 +31,23 @@
   <button class="btn ghost" type="submit">Save machine-wide active KB</button>
 </form>
 
+<h2>Appearance</h2>
+<form class="settings" action="/settings/theme" method="post">
+  <label>Theme
+    <select name="theme"{% if not theme_editable %} disabled{% endif %}>
+      {% for option in app_themes %}
+      <option value="{{ option }}" {{ 'selected' if option == theme else '' }}>
+        {{ option|capitalize }}
+      </option>
+      {% endfor %}
+    </select>
+  </label>
+  <button class="btn" type="submit"{% if not theme_editable %} disabled aria-disabled="true"{% endif %}>Save theme</button>
+</form>
+{% if not theme_editable %}
+<p class="warn" role="alert">Theme changes are unavailable while this KB's logic policy is halted. Restore the policy or open another KB before changing the app-wide theme.</p>
+{% endif %}
+
 <h2>LLM provider</h2>
 <form class="settings" action="/settings" method="post">
   <label>Provider

--- a/verinote/web/templates/sidecar_unreadable.html
+++ b/verinote/web/templates/sidecar_unreadable.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="{{ theme }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fact terms unavailable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=4">
+  <link rel="stylesheet" href="/static/app.css?v=5">
 </head>
 <body>
   <main class="chooser">


### PR DESCRIPTION
## Summary\n- persist an app-wide system/light/dark theme preference without custom JavaScript\n- let explicit light/dark override OS preference while system follows it\n- keep theme changes blocked when a KB policy is halted\n\nCloses #217\n\n## Verification\n- .venv/bin/pytest -q tests/test_theme.py tests/test_active_root.py tests/test_web.py\n  - 212 passed