### PR TITLE
ci: add scheduled provider contract lane

### DIFF
--- a/.github/workflows/provider-contract.yml
+++ b/.github/workflows/provider-contract.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MPL-2.0
+name: provider contract
+
+# Keep provider calls out of ordinary PR CI.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provider-contract
+  cancel-in-progress: false
+
+jobs:
+  openai:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: provider-contract
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: pip install -e ".[test,openai,wirelog]"
+      - run: tests/contract/run.sh
+        env:
+          VN_CONTRACT_PROVIDER: openai
+          VN_CONTRACT_MODEL: gpt-4o
+          VN_CONTRACT_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Summary:
- add a separate scheduled/manual OpenAI contract workflow
- keep ordinary pull-request CI provider-free
- restrict execution to main and scope the API key to the contract-test step

The `provider-contract` GitHub Environment must supply `OPENAI_API_KEY` before dispatched or scheduled live runs can succeed.

Verification:
- YAML parsing passed
- workflow security and contract collection independently reviewed
- `git diff --check`

Related to #270