### PR TITLE
test: add Ollama contract fixtures

### DIFF
--- a/tests/fixtures/contract/ollama/extraction_acme_two_dates.json
+++ b/tests/fixtures/contract/ollama/extraction_acme_two_dates.json
@@ -1,0 +1,9 @@
+{
+  "provider": "ollama",
+  "model": "qwen3:30b-a3b",
+  "prompt_id": "extraction",
+  "captured_at": "2026-07-26",
+  "input": "Acme Robotics is a company. Acme Robotics was founded in 2020 according to its incorporation filing. A later press release states that Acme Robotics was established in 2021.",
+  "raw_response": "{\n  \"facts\": [\n    {\n      \"confidence\": 0.9,\n      \"note\": \"Acme Robotics was founded in 2020 according to its incorporation filing.\",\n      \"object\": {\n        \"kind\": \"term\",\n        \"value\": \"date(2020)\"\n      },\n      \"relation\": {\n        \"kind\": \"string\",\n        \"value\": \"founded\"\n      },\n      \"subject\": {\n        \"kind\": \"string\",\n        \"value\": \"Acme Robotics\"\n      }\n    },\n    {\n      \"confidence\": 0.8,\n      \"note\": \"A later press release states that Acme Robotics was established in 2021.\",\n      \"object\": {\n        \"kind\": \"term\",\n        \"value\": \"date(2021)\"\n      },\n      \"relation\": {\n        \"kind\": \"string\",\n        \"value\": \"established\"\n      },\n      \"subject\": {\n        \"kind\": \"string\",\n        \"value\": \"Acme Robotics\"\n      }\n    }\n  ]\n}",
+  "parse_error": null
+}

--- a/tests/fixtures/contract/ollama/query_intent_acme_ceo.json
+++ b/tests/fixtures/contract/ollama/query_intent_acme_ceo.json
@@ -1,0 +1,9 @@
+{
+  "provider": "ollama",
+  "model": "qwen3:30b-a3b",
+  "prompt_id": "query-intent",
+  "captured_at": "2026-07-26",
+  "input": "Who is the CEO of Acme Robotics?",
+  "raw_response": "{\n  \"answer_var\": null,\n  \"chain_hops\": null,\n  \"conditions\": null,\n  \"hops\": null,\n  \"kind\": \"lookup_object\",\n  \"object\": null,\n  \"operator\": null,\n  \"reason\": null,\n  \"relation\": {\n    \"kind\": \"relation\",\n    \"value\": \"CEO\"\n  },\n  \"relation_candidates\": [],\n  \"subject\": {\n    \"kind\": \"entity\",\n    \"value\": \"Acme Robotics\"\n  },\n  \"value\": null,\n  \"value_type\": null\n}",
+  "parse_error": null
+}


### PR DESCRIPTION
Summary:
- add a reviewed Ollama query-intent and extraction fixture pair
- capture adapter-boundary output from local `qwen3:30b-a3b`
- retain only synthetic Acme prompts and responses

Verification:
- `.venv/bin/python -m pytest -q tests/contract/test_contract_meta.py`
  - 50 passed
- provider-free replay nodes with `VN_CONTRACT_PROVIDER=replay`
  - 5 passed
- contract validation with `VN_CONTRACT_PROVIDER=ollama`
  - 54 passed
- `git diff --check`

Related to #271