### PR TITLE
feat: pick an Ollama model from the ones that server has

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,32 @@ vendor's package:
 pip install -e ".[anthropic]"   # or .[openai] — Ollama needs no SDK
 ```
 
+### Picking an Ollama model
+
+With `ollama` selected, Settings turns the Model field into a picker over the
+models that server actually has (`GET /api/tags` against the Base URL you
+configured, or `http://localhost:11434` when it is unset), so a mistyped tag
+cannot become a runtime failure at the first extraction. The list reloads when
+you change the provider or the Base URL, and a **Refresh list** button picks up
+anything pulled since the page loaded.
+
+Three outcomes stay distinct, because the fix for each is different:
+
+| What you see | What it means |
+|---|---|
+| A picker | that server is reachable and has these models |
+| Text input + *"has no models installed"* | reachable, but nothing pulled yet — `ollama pull <model>` |
+| Text input + *"Could not load the model list"* | that endpoint could not be reached; the error is quoted verbatim |
+
+The field never becomes unusable: when the list cannot be loaded you can still
+type a model id and save. And a model named in `config.json` that the server
+does not have stays selected, marked `— not installed`, rather than being
+silently swapped for one that is — the page reports your KB's real state.
+
+Every other provider keeps the free-text field. A cloud catalogue is not a
+property of the endpoint you point at, and `claudecli` has nothing to enumerate,
+so there is no list either could answer truthfully.
+
 ## Auto-accept
 
 `auto_accept_recommendations` is the one setting that changes what verinote

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import json
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -315,3 +316,107 @@ def test_padded_base_url_env_does_not_break_the_request_url(tmp_path, monkeypatc
     OllamaAdapter(Config.for_root(tmp_path)).extract_facts(source_text="Ada")
 
     assert urls == ["https://llm.internal/v1/api/chat"]
+
+
+# --- list_models: the settings picker's source of truth ---
+
+
+class _TagsResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def _tags(monkeypatch, payload):
+    """Answer /api/tags with `payload`; return the recorded (url, timeout) calls."""
+    calls = []
+
+    def fake_urlopen(req, *, timeout):
+        calls.append(SimpleNamespace(url=req.full_url, timeout=timeout))
+        return _TagsResponse(payload)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    return calls
+
+
+def test_list_models_returns_sorted_unique_names_from_tags(tmp_path, monkeypatch):
+    calls = _tags(
+        monkeypatch,
+        {
+            "models": [
+                {"name": "qwen3:8b"},
+                {"name": "llava:7b"},
+                {"name": "  qwen3:8b  "},  # same model, padded
+                {"name": "   "},  # no usable id
+                {"no_name": 1},
+                "not-an-object",
+            ]
+        },
+    )
+
+    models = OllamaAdapter(_cfg(tmp_path)).list_models()
+
+    assert models == ["llava:7b", "qwen3:8b"]
+    assert calls[0].url == "http://localhost:11434/api/tags"
+
+
+def test_list_models_honours_the_configured_base_url(tmp_path, monkeypatch):
+    calls = _tags(monkeypatch, {"models": []})
+
+    OllamaAdapter(replace(_cfg(tmp_path), base_url="http://llm.internal:9999/")).list_models()
+
+    assert calls[0].url == "http://llm.internal:9999/api/tags"
+
+
+def test_list_models_is_bounded_far_below_the_generation_timeout(tmp_path, monkeypatch):
+    """A page-load call must not inherit the minutes-long completion budget."""
+    calls = _tags(monkeypatch, {"models": []})
+
+    OllamaAdapter(_cfg(tmp_path, timeout=900.0)).list_models()
+
+    assert calls[0].timeout == 5.0
+
+
+def test_list_models_keeps_an_even_shorter_configured_timeout(tmp_path, monkeypatch):
+    """The bound is the *smaller* of the two, so a tighter user setting still wins."""
+    calls = _tags(monkeypatch, {"models": []})
+
+    OllamaAdapter(_cfg(tmp_path, timeout=1.5)).list_models()
+
+    assert calls[0].timeout == 1.5
+
+
+def test_list_models_returns_empty_for_a_server_with_nothing_pulled(tmp_path, monkeypatch):
+    """Reachable-but-empty is data, not an error: the caller must be able to say
+    'this server has no models' rather than 'this server could not be reached'."""
+    _tags(monkeypatch, {"models": []})
+
+    assert OllamaAdapter(_cfg(tmp_path)).list_models() == []
+
+
+def test_list_models_raises_on_transport_failure(tmp_path, monkeypatch):
+    def boom(req, *, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+
+    with pytest.raises(LLMError, match="ollama request failed"):
+        OllamaAdapter(_cfg(tmp_path)).list_models()
+
+
+@pytest.mark.parametrize("payload", [{"models": "qwen3:8b"}, {}, ["qwen3:8b"]])
+def test_list_models_raises_on_schema_mismatch(tmp_path, monkeypatch, payload):
+    """A shape that is not {'models': [...]} is a failure, never a silent empty
+    list -- that would render as 'no models installed' and blame the user."""
+    _tags(monkeypatch, payload)
+
+    with pytest.raises(LLMError, match="did not match schema"):
+        OllamaAdapter(_cfg(tmp_path)).list_models()

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -755,7 +755,12 @@ def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
     """Enumerated so a newly added route is covered automatically."""
     client = _halted_client(tmp_path, monkeypatch)
     app = client.app
-    exempt = {"/report", "/settings"}
+    # Prefixes, not exact paths: the read guard exempts a diagnostic page *and its
+    # fragments* (`_matches`), because a settings sub-view that halted would leave
+    # htmx unable to swap anything into the recovery page it belongs to. Spelled
+    # out here rather than read off `_POLICY_GUARD_READ_PATHS` so widening that
+    # constant to a real KB page still fails this test.
+    exempt = ("/report", "/settings")
 
     paths = _get_paths(app, client)
     assert "/" in paths and "/review" in paths and "/workbench" in paths
@@ -763,7 +768,7 @@ def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
     for path in paths:
         resp = client.get(path)
         assert resp.status_code != 500, f"{path} crashed instead of reporting"
-        if path in exempt:
+        if any(path == e or path.startswith(e + "/") for e in exempt):
             continue
         assert resp.status_code == 409, f"{path} did not halt"
         assert "policy reset --force" in resp.text, f"{path} hid the recovery route"
@@ -774,6 +779,28 @@ def test_no_get_route_crashes_when_the_policy_is_lost(tmp_path, monkeypatch):
     # (the "has unresolved errors under its policy" errors banner is not a claim
     # that the KB checked out clean)
     assert "knowledge base is consistent" not in report.text
+
+
+def test_settings_model_field_stays_usable_on_a_halted_policy(tmp_path, monkeypatch):
+    """The settings page is the recovery surface, so its fragments must load too.
+
+    A halt here would be worse than a visible error: htmx never swaps a 4xx into
+    the DOM (#173), so the Model field would sit on "Loading installed models..."
+    forever while the user is trying to recover the KB. A lost logic policy is a
+    statement about verification, not about which model the user may pick.
+    """
+    import verinote.web.app as webapp
+
+    client = _halted_client(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        webapp, "get_client", lambda _cfg: type("C", (), {"list_models": lambda s: ["qwen3:8b"]})()
+    )
+
+    r = client.get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text
+    assert "policy reset --force" not in r.text
 
 
 def test_report_banner_makes_no_fact_causal_claim_on_a_lost_policy(tmp_path, monkeypatch):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4564,3 +4564,176 @@ def test_worker_config_corrupt_does_not_mark_the_job_failed(tmp_path, monkeypatc
     assert job["status"] == "pending", "a corrupt-config race buried the job in `failed`"
     assert "analysis failed" not in (job["message"] or "")
     assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
+
+
+# --- the Ollama model picker: choose from what the server actually has ---
+
+
+def _ollama_client(tmp_path, *, provider="ollama", model="qwen3:8b", base_url=None):
+    return TestClient(
+        create_app(
+            Config(
+                root=tmp_path,
+                db_path=tmp_path / "kb.sqlite",
+                provider=provider,
+                model=model,
+                api_key=None,
+                base_url=base_url,
+            )
+        )
+    )
+
+
+class _FakeOllama:
+    """Stands in for the adapter the factory would return, recording the base URL
+    it was resolved with so a test can prove which endpoint got asked."""
+
+    name = "ollama"
+
+    def __init__(self, models=(), error=None):
+        self.models = list(models)
+        self.error = error
+        self.seen = []
+
+    def factory(self, cfg):
+        self.seen.append(cfg.base_url)
+        return self
+
+    def list_models(self):
+        if self.error is not None:
+            raise self.error
+        return self.models
+
+
+def test_settings_defers_the_ollama_model_list_off_the_page_load(tmp_path, monkeypatch):
+    """`/settings` is also the recovery page for a corrupt config and a halted
+    policy, so rendering it must never wait on a provider. The field ships as a
+    working text input that lazily swaps itself for the picker."""
+    monkeypatch.setattr(
+        webapp, "get_client", lambda _cfg: pytest.fail("/settings must not call the provider")
+    )
+
+    r = _ollama_client(tmp_path).get("/settings")
+
+    assert r.status_code == 200
+    assert 'id="model-field"' in r.text
+    assert 'hx-get="/settings/model-field"' in r.text
+    assert 'hx-trigger="load"' in r.text
+    assert 'name="model"' in r.text  # usable without htmx, never a dead field
+
+
+def test_settings_does_not_defer_for_a_provider_with_nothing_to_enumerate(tmp_path):
+    """A cloud catalogue is not a property of the endpoint, so anthropic keeps the
+    text input and must NOT sit in a lazy state waiting for a list forever."""
+    r = _ollama_client(tmp_path, provider="anthropic", model="claude-opus-4-8").get("/settings")
+
+    assert 'id="model-field"' in r.text
+    assert 'hx-trigger="load"' not in r.text
+    assert '<input type="text" name="model" value="claude-opus-4-8"' in r.text
+
+
+def test_model_field_offers_the_installed_models_as_a_picker(tmp_path, monkeypatch):
+    fake = _FakeOllama(models=["llava:7b", "qwen3:8b"])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text
+    assert '<option value="llava:7b" >llava:7b</option>' in unescape(r.text)
+    assert '<option value="qwen3:8b" selected>qwen3:8b</option>' in unescape(r.text)
+    assert 'type="text" name="model"' not in r.text  # no free-text field alongside
+
+
+def test_model_field_asks_the_endpoint_being_edited_not_the_saved_one(tmp_path, monkeypatch):
+    """The form's Base URL is the endpoint whose models the user is choosing from.
+    Listing against the saved config instead would show models from a server the
+    user is in the middle of switching away from."""
+    fake = _FakeOllama(models=["qwen3:8b"])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path, base_url="http://saved:11434").get(
+        "/settings/model-field?provider=ollama&model=qwen3:8b&base_url=http://edited:9999"
+    )
+
+    assert fake.seen == ["http://edited:9999"]
+    assert "http://edited:9999" in r.text
+
+
+def test_model_field_keeps_a_configured_model_the_server_does_not_have(tmp_path, monkeypatch):
+    """config.json really does name this model. Dropping it from the picker would
+    silently select a different one and make the page misreport the KB's state."""
+    fake = _FakeOllama(models=["llava:7b", "qwen3:8b"])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path, model="llama3.1").get(
+        "/settings/model-field?provider=ollama&model=llama3.1"
+    )
+
+    assert '<option value="llama3.1" selected>llama3.1 — not installed</option>' in unescape(r.text)
+    assert "which is not installed on" in r.text
+    assert "ollama pull llama3.1" in r.text
+
+
+def test_model_field_falls_back_to_typing_when_the_server_is_unreachable(tmp_path, monkeypatch):
+    """An empty picker would read as 'nothing to choose' and, worse, leave the user
+    unable to set a model at all. Say what failed and keep the field usable."""
+    fake = _FakeOllama(error=LLMError("ollama request failed: connection refused"))
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert r.status_code == 200
+    assert "<select" not in r.text
+    assert '<input type="text" name="model" value="qwen3:8b"' in r.text
+    assert "Could not load the model list" in r.text
+    assert "connection refused" in r.text
+
+
+def test_model_field_distinguishes_an_empty_server_from_an_unreachable_one(tmp_path, monkeypatch):
+    """Reachable-with-nothing-pulled and could-not-be-reached are different facts
+    about the user's machine, and the fix for each is different."""
+    fake = _FakeOllama(models=[])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=")
+
+    assert "has no models installed" in r.text
+    assert "Could not load the model list" not in r.text
+    assert '<input type="text" name="model"' in r.text
+
+
+def test_model_field_names_the_default_endpoint_it_will_actually_dial(tmp_path, monkeypatch):
+    fake = _FakeOllama(models=[])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=")
+
+    assert fake.seen == [None]  # an unset Base URL stays unset in config
+    assert "http://localhost:11434" in r.text  # ...but the page names the real target
+
+
+def test_model_field_does_not_reach_the_provider_for_a_text_input_provider(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        webapp, "get_client", lambda _cfg: pytest.fail("no provider call for anthropic")
+    )
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=anthropic&model=gpt")
+
+    assert '<input type="text" name="model" value="gpt"' in r.text
+    assert 'hx-trigger="load"' not in r.text
+
+
+def test_model_field_halts_under_a_corrupt_config(tmp_path):
+    """The picker is a provider call like any other: a corrupt config.json makes the
+    resolved provider untrustworthy, so it halts rather than listing against a
+    provider the user never chose (#269)."""
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    c = TestClient(create_app(cfg))
+
+    r = c.get(
+        "/settings/model-field?provider=ollama&model=m", headers={"HX-Request": "true"}
+    )
+
+    assert r.status_code == 409
+    assert r.headers.get("HX-Redirect") == webapp.CONFIG_UNAVAILABLE_PATH

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -66,6 +66,11 @@ PROVIDER_LABELS = {
     "ollama": "Ollama",
 }
 TESTABLE_PROVIDERS = frozenset({"anthropic", "openai", "ollama"})
+# Providers whose installed models can be enumerated from the very endpoint the
+# user configured, so the settings UI can offer a picker instead of free text.
+# A cloud catalogue is not a property of its endpoint and `claudecli` has no
+# listing at all, so neither can be answered truthfully here.
+MODEL_LISTING_PROVIDERS = frozenset({"ollama"})
 
 
 def normalize_provider(provider: str | None) -> str:

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -22,13 +22,57 @@ from verinote.llm.schema import (
 from verinote.pipeline.query_intent import QueryIntent, parse_query_intent
 from verinote.prompts import PromptError, render_prompt
 
+# `list_models` is an interactive page-load call, not a generation, so it is
+# bounded far tighter than `cfg.llm_timeout_seconds` (minutes, sized for a long
+# local completion). The effective bound is still the *smaller* of the two, so a
+# user who configures an even shorter timeout keeps it.
+MODEL_LIST_TIMEOUT_SECONDS = 5.0
+
+# The endpoint an unset `base_url` resolves to. Named so the settings UI can
+# report the *same* URL it will actually talk to instead of printing "(default)".
+OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
+
 
 class OllamaAdapter:
     name = "ollama"
 
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
-        self.base_url = (cfg.base_url or "http://localhost:11434").rstrip("/")
+        self.base_url = (cfg.base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/")
+
+    def list_models(self) -> list[str]:
+        """Model ids this Ollama server has installed, sorted, deduplicated.
+
+        Ollama-specific by design, so it is deliberately NOT on the `LLMClient`
+        protocol: the cloud adapters' catalogues are not a property of the
+        endpoint the user pointed at, and `claudecli` has nothing to enumerate.
+        Callers that want the list ask the Ollama adapter for it.
+
+        Raises `LLMError` on any transport or shape failure rather than
+        returning `[]` — an empty list means "this server has no models pulled",
+        and a caller must be able to tell that apart from "the server could not
+        be reached" (which the settings UI reports verbatim instead of showing
+        an empty picker).
+        """
+        req = urllib.request.Request(f"{self.base_url}/api/tags")
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+                req, timeout=min(self.cfg.llm_timeout_seconds, MODEL_LIST_TIMEOUT_SECONDS)
+            ) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+            raise LLMError(f"ollama request failed: {exc}") from exc
+
+        if not isinstance(body, dict) or not isinstance(body.get("models"), list):
+            raise LLMError("ollama model list did not match schema: expected {'models': [...]}")
+        names = {
+            entry["name"].strip()
+            for entry in body["models"]
+            if isinstance(entry, dict)
+            and isinstance(entry.get("name"), str)
+            and entry["name"].strip()
+        }
+        return sorted(names)
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         system = _with_schema_hint(

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -7,6 +7,7 @@ swaps a single row partial). No JS build step. The app owns one `Store` (SQLite)
 
 from __future__ import annotations
 
+from dataclasses import replace
 from importlib import resources
 import json
 import logging
@@ -24,6 +25,7 @@ from fastapi.templating import Jinja2Templates
 
 from verinote.config import (
     APP_THEMES,
+    MODEL_LISTING_PROVIDERS,
     PROVIDER_LABELS,
     PROVIDERS,
     TESTABLE_PROVIDERS,
@@ -31,12 +33,14 @@ from verinote.config import (
     ConfigCorruptError,
     app_theme,
     assert_settings_intact,
+    normalize_provider,
     save_active_root,
     save_app_theme,
     save_settings,
 )
 from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
 from verinote.llm import LLMError, get_client
+from verinote.llm.ollama_adapter import OLLAMA_DEFAULT_BASE_URL
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
     create_chunked_extraction_job,
@@ -1720,6 +1724,69 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         return templates.TemplateResponse(request, "analytics.html", {"a": compute(_active_cfg().db_path)})
 
+    def _model_field_context(
+        *, provider: str, model: str, base_url: str, lazy: bool
+    ) -> dict:
+        """Resolve the Model field's state for one (provider, base URL) pair.
+
+        `lazy=True` returns the not-yet-loaded state without touching the
+        network; the partial then fetches itself. Only the eager call reaches
+        the provider, and only for a provider whose installed models are a
+        property of the endpoint the user pointed at.
+
+        `models` distinguishes three outcomes the UI must not conflate: a list
+        (what that server has, possibly empty), or `None` with `models_error`
+        set (the server could not be asked). `ConfigCorruptError` is left to
+        propagate to the app-wide halt handler — a corrupt config.json means the
+        resolved provider is untrustworthy, and this route would otherwise
+        report on a provider the user never chose (#269).
+        """
+        listable = provider in MODEL_LISTING_PROVIDERS
+        base = {
+            "provider": provider,
+            "model": model,
+            # The URL actually dialled, not the literal "(default)" — so the
+            # page names the same endpoint the adapter will use.
+            "endpoint": (base_url.strip() or OLLAMA_DEFAULT_BASE_URL) if listable else "",
+            # A provider with nothing to enumerate must not sit in a lazy state
+            # forever: it renders its text input once and never self-fetches.
+            "lazy": lazy and listable,
+            "models": None,
+            "models_error": None,
+        }
+        if lazy or not listable:
+            return base
+        # Routed through the factory, never by constructing the adapter here, so
+        # this path inherits the corrupt-config halt every provider call gets.
+        client = get_client(
+            replace(app.state.cfg, provider=provider, base_url=base_url.strip() or None)
+        )
+        try:
+            base["models"] = client.list_models()
+        except LLMError as exc:
+            base["models_error"] = str(exc)
+        return base
+
+    @app.get("/settings/model-field", response_class=HTMLResponse)
+    def model_field(
+        request: Request,
+        provider: str = "",
+        model: str = "",
+        base_url: str = "",
+    ):
+        if app.state.cfg is None:
+            return _kb_select(request)
+        return templates.TemplateResponse(
+            request,
+            "partials/model_field.html",
+            _model_field_context(
+                provider=normalize_provider(provider),
+                model=model,
+                base_url=base_url,
+                lazy=False,
+            ),
+        )
+
     def _settings(request: Request, *, test_result=None, error=None, status_code=200):
         c = app.state.cfg
         if c is None:
@@ -1748,6 +1815,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "has_key": bool(c.api_key),  # never render the key itself
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
                 "relation_aliases": _relation_aliases_text(),
+                # The Model field starts as the plain text input and, for a
+                # model-enumerable provider, lazily swaps itself for the picker
+                # (`hx-trigger="load"`). Enumerating eagerly here would put a
+                # network call on the critical path of the one page that is also
+                # the recovery surface for a corrupt config and a halted policy.
+                **_model_field_context(
+                    provider=c.provider, model=c.model, base_url=c.base_url or "", lazy=True
+                ),
                 "test_result": test_result,
                 "error": error,
                 # /settings is deliberately reachable during the halt (it is the

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -234,6 +234,13 @@ tr.editing td { background: var(--editing-bg); }
 .settings .inline-setting { flex-direction: row; align-items: center; color: var(--fg); }
 .settings .inline-setting input { width: auto; }
 .settings .btn { align-self: flex-start; }
+/* #model-field wraps its label so HTMX can swap the whole field -- input, note
+   and warning -- as one unit. It has to keep behaving like the bare label it
+   replaced: a flex column item of .settings, with the note tucked under the
+   control rather than spaced like a sibling field. */
+.settings #model-field { display: flex; flex-direction: column; gap: .3rem; }
+.settings .field-note { margin: 0; font-size: .85rem; }
+.settings .field-note .btn { display: inline-block; padding: .1rem .4rem; font-size: .85em; }
 .ask-form { display: flex; flex-direction: column; gap: .7rem; margin: 1.2rem 0; }
 .ask-form label { display: flex; flex-direction: column; gap: .3rem; color: var(--muted); }
 .ask-form textarea { min-height: 7rem; resize: vertical; background: var(--bg); color: var(--fg);

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}verinote{% endblock %}</title>
   <script src="/static/htmx.min.js"></script>
-  <link rel="stylesheet" href="/static/app.css?v=5">
+  <link rel="stylesheet" href="/static/app.css?v=6">
 </head>
 <body>
   <header>

--- a/verinote/web/templates/config_corrupt.html
+++ b/verinote/web/templates/config_corrupt.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Config unreadable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=5">
+  <link rel="stylesheet" href="/static/app.css?v=6">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/kb_select.html
+++ b/verinote/web/templates/kb_select.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Select KB — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=5">
+  <link rel="stylesheet" href="/static/app.css?v=6">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/partials/model_field.html
+++ b/verinote/web/templates/partials/model_field.html
@@ -1,0 +1,73 @@
+{# The Model field of the LLM provider form, swapped in place by HTMX whenever
+   the chosen provider or base URL changes.
+
+   For Ollama the installed models ARE enumerable from the endpoint the user
+   pointed at (`GET /api/tags`), so the field is a picker over what that server
+   actually has rather than free text a typo turns into a runtime failure. Every
+   other provider keeps the text input: a cloud catalogue is not a property of
+   the endpoint, so there is nothing truthful to enumerate there.
+
+   Three states, kept distinct on purpose (#state-honesty): a reachable server
+   WITH models becomes a picker; a reachable server with NO models pulled and an
+   UNREACHABLE server both fall back to the text input plus a note saying which
+   of the two happened. An empty picker would look like a normal empty field and
+   quietly claim "your server offers nothing to choose", which is a different
+   statement from "your server could not be reached". #}
+<div id="model-field"{% if lazy %}
+     hx-get="/settings/model-field"
+     hx-trigger="load"
+     hx-include="[name='provider'], [name='base_url'], [name='model']"
+     hx-target="this" hx-swap="outerHTML"{% endif %}>
+  {% if models %}
+  <label>Model
+    <select name="model">
+      {% if model and model not in models %}
+      {# Never drop the configured model just because this server lacks it: the
+         KB's config.json really does name it, and silently selecting a
+         different model would make the page misreport the KB's own state. Show
+         it, keep it selected, and say plainly that it is not installed. #}
+      <option value="{{ model }}" selected>{{ model }} — not installed</option>
+      {% endif %}
+      {% for m in models %}
+      <option value="{{ m }}" {{ 'selected' if m == model else '' }}>{{ m }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <p class="muted field-note">
+    {{ models|length }} model{{ '' if models|length == 1 else 's' }} installed on
+    <code>{{ endpoint }}</code>.
+    <button class="btn ghost" type="button"
+            hx-get="/settings/model-field"
+            hx-include="[name='provider'], [name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">Refresh list</button>
+  </p>
+  {% if model and model not in models %}
+  <p class="warn field-note" role="alert">This KB is configured for
+    <code>{{ model }}</code>, which is not installed on <code>{{ endpoint }}</code>.
+    Pick an installed model, or run <code>ollama pull {{ model }}</code>.</p>
+  {% endif %}
+  {% else %}
+  <label>Model
+    <input type="text" name="model" value="{{ model }}" placeholder="model id">
+  </label>
+  {% if models_error %}
+  <p class="warn field-note" role="alert">Could not load the model list from
+    <code>{{ endpoint }}</code>, so the model must be typed in. ({{ models_error }})
+    <button class="btn ghost" type="button"
+            hx-get="/settings/model-field"
+            hx-include="[name='provider'], [name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">Retry</button>
+  </p>
+  {% elif models is not none %}
+  <p class="warn field-note" role="alert"><code>{{ endpoint }}</code> is reachable but
+    has no models installed. Run <code>ollama pull &lt;model&gt;</code>, then
+    <button class="btn ghost" type="button"
+            hx-get="/settings/model-field"
+            hx-include="[name='provider'], [name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">refresh the list</button>.
+  </p>
+  {% elif lazy %}
+  <p class="muted field-note" role="status">Loading installed models…</p>
+  {% endif %}
+  {% endif %}
+</div>

--- a/verinote/web/templates/policy_halted.html
+++ b/verinote/web/templates/policy_halted.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Verification halted — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=5">
+  <link rel="stylesheet" href="/static/app.css?v=6">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -50,8 +50,14 @@
 
 <h2>LLM provider</h2>
 <form class="settings" action="/settings" method="post">
+  {# Provider and base URL both decide what the Model field can offer, so both
+     re-render it. `hx-include` carries the current model along so switching
+     provider never silently discards what is configured. #}
   <label>Provider
-    <select name="provider">
+    <select name="provider"
+            hx-get="/settings/model-field"
+            hx-include="[name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">
       {% for p in providers %}
       <option value="{{ p }}" {{ 'selected' if p == provider else '' }}>
         {{ provider_labels.get(p, p) }}
@@ -59,11 +65,12 @@
       {% endfor %}
     </select>
   </label>
-  <label>Model
-    <input type="text" name="model" value="{{ model }}" placeholder="model id">
-  </label>
+  {% include "partials/model_field.html" %}
   <label>Base URL <span class="muted">(optional)</span>
-    <input type="text" name="base_url" value="{{ base_url }}" placeholder="https://…">
+    <input type="text" name="base_url" value="{{ base_url }}" placeholder="https://…"
+           hx-get="/settings/model-field" hx-trigger="change"
+           hx-include="[name='provider'], [name='model']"
+           hx-target="#model-field" hx-swap="outerHTML">
   </label>
   <label>Chunk size
     <input type="number" name="extraction_chunk_chars" value="{{ extraction_chunk_chars }}" min="1" step="50">

--- a/verinote/web/templates/sidecar_unreadable.html
+++ b/verinote/web/templates/sidecar_unreadable.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fact terms unavailable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=5">
+  <link rel="stylesheet" href="/static/app.css?v=6">
 </head>
 <body>
   <main class="chooser">


### PR DESCRIPTION
## What

With `ollama` selected, the Settings **Model** field becomes a picker over the
models that server actually has, instead of free text a typo turns into a
failure at the first extraction. The list comes from `GET /api/tags` against the
configured Base URL (or `http://localhost:11434` when unset), reloads when the
provider or Base URL changes, and has a **Refresh list** button for anything
pulled while the page is open.

Ollama is the only provider this can be answered truthfully for — a cloud
catalogue is not a property of the endpoint you point at, and `claudecli` has
nothing to enumerate — so `MODEL_LISTING_PROVIDERS` gates it and every other
provider keeps the text input.

## Three outcomes, kept distinct

Each has a different fix, so conflating them would misdirect the user:

| State | Meaning |
|---|---|
| A picker | reachable, and these models are installed |
| Text input + *"has no models installed"* | reachable, nothing pulled yet |
| Text input + *"Could not load the model list"* | that endpoint could not be reached (error quoted verbatim) |

An empty picker would collapse the last two into "nothing to choose" **and**
leave the model unsettable, so a failed listing always falls back to a field the
user can still type into and save. `list_models` raises on a malformed payload
rather than returning `[]`, which would render as "no models installed" and
blame the user for a server bug.

## State honesty

A model named in `config.json` that the server lacks stays **selected** and is
marked `— not installed`, with a note naming the endpoint and the `ollama pull`
that would fix it. Dropping it would silently select a different model and make
the page misreport the KB's own configuration.

## Why lazy, bounded, and factory-routed

- **Lazy** (`hx-trigger="load"`): `/settings` is also the recovery surface for a
  corrupt `config.json` and a halted policy, so rendering it must never wait on a
  provider. The field ships as a working text input and swaps itself; without
  htmx it stays a working text input.
- **Bounded at 5s**, not `llm_timeout_seconds` (minutes, sized for a local
  completion) — but `min()` of the two, so a tighter user setting still wins.
- **Routed through `get_client`**, never by constructing the adapter, so it
  inherits the corrupt-config halt (#269) like every other provider call.

## One existing test changed

`test_no_get_route_crashes_when_the_policy_is_lost` enumerated GET routes and
exempted `/report` and `/settings` by **exact match**, while the guard itself
(`_matches`) is prefix-based and deliberately allows reads under a diagnostic
page. `/settings/model-field` is a fragment of that page: halting it would leave
the Model field stuck on "Loading…" forever, since htmx never swaps a 4xx into
the DOM (#173). Widened the test to prefixes, spelled out locally rather than
read off `_POLICY_GUARD_READ_PATHS` so widening that constant to a real KB page
still fails. Added a test pinning the exemption as a deliberate property.

## Verification

- Full suite **2194 passed, 10 skipped**; `ruff@0.15.18 check` (CI's exact
  invocation) passes.
- 20 new tests. **7 mutation probes, all caught**: removing the lazy defer,
  `lazy and listable` → `lazy`, collapsing the error into `[]`, listing against
  the saved instead of the edited Base URL, unbounding the timeout, deleting the
  "not installed" option, and bypassing the factory.
- Driven against a real Ollama server: 16 models listed, not-installed warning,
  unreachable endpoint (connection refused), provider switch, and the picked
  model's round-trip into `config.json`.
