### PR TITLE
feat: offer the Claude CLI's model aliases, and let the choice be tested

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,9 +99,27 @@ type a model id and save. And a model named in `config.json` that the server
 does not have stays selected, marked `— not installed`, rather than being
 silently swapped for one that is — the page reports your KB's real state.
 
-Every other provider keeps the free-text field. A cloud catalogue is not a
-property of the endpoint you point at, and `claudecli` has nothing to enumerate,
-so there is no list either could answer truthfully.
+### Picking a Claude CLI model
+
+The `claude` binary has no listing command, so there is nothing to discover —
+its `--model` help documents three aliases and otherwise takes a full model id.
+Settings therefore offers a **datalist**: `fable`, `opus`, and `sonnet` appear as
+suggestions, and you can type past them.
+
+The distinction the wording keeps is that these are the aliases *verinote*
+resolves — a claim about this code — not a report of what your account can
+reach, which verinote cannot see. An alias selects the latest model of that
+family; a full id such as `claude-opus-4-8` reaches the CLI unchanged and stays
+pinned to that version. A model that does not exist, or that your CLI cannot
+reach, surfaces as the CLI's own error rather than a silent substitution.
+
+Because the list cannot be verified against a server, **Test connection** is the
+check that matters here: it runs one real extraction through the `claude` binary
+with the model you chose.
+
+The cloud providers keep the plain free-text field — a vendor catalogue is not a
+property of the endpoint you point at, so there is no list they could answer
+truthfully either.
 
 ## Auto-accept
 

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -166,3 +166,91 @@ def test_claude_cli_prompt_validation_error_is_llm_error(tmp_path):
 
     with pytest.raises(LLMError, match="\\{schema_json\\}"):
         ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="x")
+
+
+# --- a pinned model id must survive to the CLI, not collapse to "latest" ---
+
+
+def _record_commands(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0, stdout='{"facts":[]}', stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return commands
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-8",
+        "claude-fable-5",
+        "claude-sonnet-5",
+        "claude-haiku-4-5",
+        "claude-3-opus-20240229",
+    ],
+)
+def test_claude_cli_passes_a_canonical_model_id_through_unchanged(tmp_path, monkeypatch, model):
+    """The CLI accepts these verbatim. Rewriting `claude-opus-4-8` to `opus` ran
+    whatever is newest instead, so config.json named one model and the CLI ran
+    another -- a lost pin with no error to notice it by."""
+    commands = _record_commands(monkeypatch)
+
+    ClaudeCliAdapter(_cfg(tmp_path, model=model)).extract_facts(source_text="x")
+
+    assert commands[0][0:3] == ["claude", "--model", model]
+
+
+def test_claude_cli_keeps_a_pin_that_differs_only_in_capitalisation(tmp_path, monkeypatch):
+    """Capitalisation is not a reason to lose a pin: fold it to the canonical id
+    rather than letting the alias path claim it."""
+    commands = _record_commands(monkeypatch)
+
+    ClaudeCliAdapter(_cfg(tmp_path, model="CLAUDE-OPUS-4-8")).extract_facts(source_text="x")
+
+    assert commands[0][0:3] == ["claude", "--model", "claude-opus-4-8"]
+
+
+def test_claude_cli_pins_the_id_for_every_call_shape(tmp_path, monkeypatch):
+    """`--model` is assembled separately in the JSON-schema and plain-text paths;
+    a pin that survived only one of them would still be lost on the other."""
+    commands = _record_commands(monkeypatch)
+    adapter = ClaudeCliAdapter(_cfg(tmp_path, model="claude-opus-4-8"))
+
+    adapter.extract_facts(source_text="x")  # --json-schema path
+    adapter.answer_question(question="Who?", context="c")  # plain-text path
+
+    assert [c[0:3] for c in commands] == [["claude", "--model", "claude-opus-4-8"]] * 2
+
+
+@pytest.mark.parametrize(
+    ("display", "expected"),
+    [("Opus 4.8", "opus"), ("Claude Opus", "opus"), ("claude-opus", "opus"), ("SONNET", "sonnet")],
+)
+def test_claude_cli_still_collapses_loose_display_names(tmp_path, monkeypatch, display, expected):
+    """The looseness stays for names that are not ids -- only canonical ids are
+    exempt, so pinning is not bought by breaking the display-name convenience."""
+    commands = _record_commands(monkeypatch)
+
+    ClaudeCliAdapter(_cfg(tmp_path, model=display)).extract_facts(source_text="x")
+
+    assert commands[0][0:3] == ["claude", "--model", expected]
+
+
+def test_claude_cli_surfaces_an_unknown_model_id_instead_of_substituting_one(tmp_path, monkeypatch):
+    """Passing an id through means a wrong one reaches the CLI, which exits 1 with
+    its own message. That loud failure is the point: the alternative was quietly
+    running a model the user never chose."""
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="There's an issue with the selected model (claude-nonexistent-9).",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(LLMError, match="claude-nonexistent-9"):
+        ClaudeCliAdapter(_cfg(tmp_path, model="claude-nonexistent-9")).extract_facts(source_text="x")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -188,8 +188,19 @@ def test_extraction_settings_round_trip_and_env_override(tmp_path, monkeypatch):
 
 def test_claude_cli_provider_is_available():
     assert "claudecli" in PROVIDERS
-    assert "claudecli" not in TESTABLE_PROVIDERS
     assert "ollama" in TESTABLE_PROVIDERS
+
+
+def test_every_shipped_provider_can_be_connection_tested():
+    """`claudecli` was excluded as a "non-API" provider, but the test is one real
+    extraction, which the CLI serves as well as an HTTP endpoint does. It is also
+    the provider that needs it most: its models cannot be enumerated, so running
+    the chosen one is the only evidence available that the choice works.
+
+    Asserted over PROVIDERS rather than as a claudecli special case, so a new
+    provider has to make the same decision deliberately.
+    """
+    assert set(PROVIDERS) <= TESTABLE_PROVIDERS
 
 
 def test_legacy_claude_provider_normalizes_to_claudecli(tmp_path):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3911,11 +3911,14 @@ def test_settings_save_changes_active_provider(tmp_path, monkeypatch):
     assert (tmp_path / "config.json").is_file()
 
 
-def test_settings_disables_connection_test_for_non_api_provider(tmp_path):
+def test_settings_disables_connection_test_for_untestable_provider(tmp_path):
+    """Every provider verinote ships can be connection-tested, so the disabled
+    state is reached by a `config.json` naming one it does not -- the case where
+    running the test would mean resolving a provider that has no adapter."""
     cfg = Config(
         root=tmp_path,
         db_path=tmp_path / "kb.sqlite",
-        provider="claudecli",
+        provider="madeup",
         model="",
         api_key=None,
         base_url=None,
@@ -3924,17 +3927,16 @@ def test_settings_disables_connection_test_for_non_api_provider(tmp_path):
 
     r = client.get("/settings")
 
-    assert "ClaudeCLI" in r.text
     assert "Test connection" in r.text
     assert 'aria-disabled="true"' in r.text
     assert "Connection test is not available for this provider." not in r.text
 
 
-def test_test_connection_rejects_non_api_provider(tmp_path):
+def test_test_connection_rejects_untestable_provider(tmp_path):
     cfg = Config(
         root=tmp_path,
         db_path=tmp_path / "kb.sqlite",
-        provider="claudecli",
+        provider="madeup",
         model="",
         api_key=None,
         base_url=None,
@@ -3945,6 +3947,26 @@ def test_test_connection_rejects_non_api_provider(tmp_path):
 
     assert r.status_code == 400
     assert "Connection test is not available for this provider." in r.text
+
+
+def test_settings_enables_connection_test_for_claude_cli(tmp_path):
+    """The CLI's models cannot be listed, so actually running the chosen one is
+    the only evidence available that it works -- the button matters most here."""
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="claudecli",
+        model="opus",
+        api_key=None,
+        base_url=None,
+    )
+    client = TestClient(create_app(cfg))
+
+    r = client.get("/settings")
+
+    assert "ClaudeCLI" in r.text
+    assert "Test connection" in r.text
+    assert 'aria-disabled="true"' not in r.text
 
 
 def test_settings_enables_connection_test_for_ollama(tmp_path):
@@ -4737,3 +4759,72 @@ def test_model_field_halts_under_a_corrupt_config(tmp_path):
 
     assert r.status_code == 409
     assert r.headers.get("HX-Redirect") == webapp.CONFIG_UNAVAILABLE_PATH
+
+
+# --- the Claude CLI alias picker: suggestions you can type past ---
+
+
+def test_model_field_offers_cli_aliases_without_reaching_a_provider(tmp_path, monkeypatch):
+    """The CLI has no listing endpoint, so the suggestions are curated from the
+    adapter -- rendering them must not require (or attempt) a provider call."""
+    monkeypatch.setattr(
+        webapp, "get_client", lambda _cfg: pytest.fail("claudecli has nothing to enumerate")
+    )
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=opus")
+
+    assert r.status_code == 200
+    assert '<datalist id="model-aliases">' in r.text
+    assert '<input type="text" name="model" value="opus" list="model-aliases"' in r.text
+    assert "<select" not in r.text  # typing a full id must stay possible
+    assert 'hx-trigger="load"' not in r.text  # nothing to lazily fetch
+
+
+def test_model_field_alias_suggestions_match_what_the_adapter_resolves(tmp_path):
+    """A suggested alias the adapter did not recognise would be offered as a
+    choice and then silently mean something else.
+
+    `_cli_model(alias) == alias` is NOT the property to assert: unknown strings
+    are passed through unchanged, so any invented alias satisfies it. What only
+    a real alias satisfies is absorbing a decorated display name of its family.
+    """
+    from verinote.llm.claude_cli_adapter import CLI_MODEL_ALIASES, _cli_model
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=")
+
+    offered = re.findall(r'<option value="([^"]+)"></option>', r.text)
+    assert offered == list(CLI_MODEL_ALIASES)  # rendered list cannot drift
+    for alias in offered:
+        assert _cli_model(f"Claude {alias.title()} 9.9") == alias
+
+
+def test_model_field_tells_the_truth_about_pinning_a_full_id(tmp_path):
+    """The note promises a full id reaches the CLI unchanged; that promise is the
+    behaviour `_cli_model` now guarantees, so assert them together."""
+    from verinote.llm.claude_cli_adapter import _cli_model
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=")
+
+    assert "claude-opus-4-8" in r.text
+    assert "passed to the CLI unchanged" in r.text
+    assert _cli_model("claude-opus-4-8") == "claude-opus-4-8"
+
+
+def test_model_field_keeps_aliases_off_the_ollama_picker(tmp_path, monkeypatch):
+    """Curated aliases and a discovered list are different claims; the Ollama
+    field must never quietly gain entries no server reported."""
+    fake = _FakeOllama(models=["qwen3:8b"])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert "<datalist" not in r.text
+    for alias in ("fable", "sonnet"):
+        assert f'value="{alias}"' not in r.text
+
+
+def test_model_field_gives_no_aliases_to_a_plain_text_provider(tmp_path):
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=anthropic&model=claude")
+
+    assert "<datalist" not in r.text
+    assert '<input type="text" name="model" value="claude" placeholder="model id">' in r.text

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -65,7 +65,11 @@ PROVIDER_LABELS = {
     "openai": "OpenAI",
     "ollama": "Ollama",
 }
-TESTABLE_PROVIDERS = frozenset({"anthropic", "openai", "ollama"})
+# Providers whose configuration can be checked by actually running it. `claudecli`
+# belongs here for the same reason the others do -- the check is one real
+# extraction -- and it matters most there: its installed models cannot be
+# enumerated, so running the chosen one is the only way to learn it works.
+TESTABLE_PROVIDERS = frozenset({"anthropic", "claudecli", "openai", "ollama"})
 # Providers whose installed models can be enumerated from the very endpoint the
 # user configured, so the settings UI can offer a picker instead of free text.
 # A cloud catalogue is not a property of its endpoint and `claudecli` has no

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -27,6 +27,17 @@ _MODEL_ALIASES = {
     "opus": "opus",
     "sonnet": "sonnet",
 }
+# The aliases the CLI's own `--model` help documents, in its order. Exported so
+# the settings UI offers exactly what `_cli_model` recognises: a picker that
+# listed an alias this adapter cannot resolve would be advertising a choice that
+# silently does something else.
+CLI_MODEL_ALIASES = tuple(_MODEL_ALIASES)
+
+# A canonical model id -- lowercase, hyphen-separated, at least three segments
+# (`claude-opus-4-8`, `claude-haiku-4-5`, `claude-3-opus-20240229`). The CLI
+# accepts these verbatim, so they must reach it unchanged; only looser *display*
+# names ("Opus 4.8", "Claude Opus") are collapsed to an alias.
+_CANONICAL_MODEL_ID = re.compile(r"^claude-[a-z0-9]+(?:-[a-z0-9]+)+$")
 
 
 class ClaudeCliAdapter:
@@ -182,9 +193,26 @@ def _render_prompt(root, prompt_id: str, **values: object) -> str:
 
 
 def _cli_model(model: str) -> str:
-    """Convert UI/display model names to Claude CLI aliases."""
+    """Convert UI/display model names to Claude CLI aliases.
+
+    A *canonical* model id is passed through untouched. The substring match
+    below is deliberately loose so "Opus 4.8" resolves to `opus`, but that same
+    looseness silently rewrote `claude-opus-4-8` -- a pinned id the CLI accepts
+    verbatim -- into `opus`, i.e. whatever is newest. The KB's config.json then
+    named one model while the CLI ran another, and the pin was lost with no
+    error. Canonical ids are recognised first so a pin stays a pin; an id that
+    turns out not to exist is the CLI's own loud `exit 1`, not a silent
+    downgrade to a model the user did not choose.
+    """
+    stripped = model.strip()
+    # Canonical ids are lowercase by definition, but a typed-in `CLAUDE-OPUS-4-8`
+    # is still unambiguously that pin -- fold the case rather than sending it
+    # down the alias path, which would drop the pin over capitalisation alone.
+    folded = stripped.casefold()
+    if _CANONICAL_MODEL_ID.match(folded):
+        return folded
     normalized = re.sub(r"[^a-z0-9]+", "", model.casefold())
     for key, value in _MODEL_ALIASES.items():
         if key in normalized:
             return value
-    return model.strip()
+    return stripped

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -40,6 +40,7 @@ from verinote.config import (
 )
 from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
 from verinote.llm import LLMError, get_client
+from verinote.llm.claude_cli_adapter import CLI_MODEL_ALIASES
 from verinote.llm.ollama_adapter import OLLAMA_DEFAULT_BASE_URL
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
@@ -125,6 +126,13 @@ _STATIC = resources.files("verinote.web").joinpath("static")
 # a change made while this KB's rules are not being applied.
 _POLICY_GUARD_READ_PATHS = ("/report", "/settings", "/static")
 _POLICY_GUARD_WRITE_PATHS = ("/kb/select", "/settings/root")
+
+# Providers whose Model field offers a *curated* list rather than a discovered
+# one, keyed to the adapter constant so the two cannot drift: every suggestion
+# here is an alias that adapter actually resolves. Deliberately not a set in
+# `config` alongside MODEL_LISTING_PROVIDERS -- the values come from the adapter
+# modules, which import `config`, so this is the layer that can name both.
+MODEL_ALIASES_BY_PROVIDER = {"claudecli": CLI_MODEL_ALIASES}
 
 # Full-page halt shown when a fact's logical terms cannot be read. htmx partial
 # swaps are redirected here (HX-Redirect) because htmx will not swap an error
@@ -1740,11 +1748,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         propagate to the app-wide halt handler — a corrupt config.json means the
         resolved provider is untrustworthy, and this route would otherwise
         report on a provider the user never chose (#269).
+
+        `aliases` is the other kind of list, and stays a separate key on
+        purpose: it is curated from the adapter, never read from a provider, so
+        it can never stand in for `models` or be mistaken for discovery.
         """
         listable = provider in MODEL_LISTING_PROVIDERS
         base = {
             "provider": provider,
             "model": model,
+            "aliases": MODEL_ALIASES_BY_PROVIDER.get(provider, ()),
             # The URL actually dialled, not the literal "(default)" — so the
             # page names the same endpoint the adapter will use.
             "endpoint": (base_url.strip() or OLLAMA_DEFAULT_BASE_URL) if listable else "",

--- a/verinote/web/templates/partials/model_field.html
+++ b/verinote/web/templates/partials/model_field.html
@@ -12,7 +12,13 @@
    UNREACHABLE server both fall back to the text input plus a note saying which
    of the two happened. An empty picker would look like a normal empty field and
    quietly claim "your server offers nothing to choose", which is a different
-   statement from "your server could not be reached". #}
+   statement from "your server could not be reached".
+
+   The Claude CLI has no listing to read -- its `--model` help documents three
+   aliases and otherwise takes a full model id -- so it gets a *datalist*, not a
+   select: suggestions you can also type past. The wording below says these are
+   the aliases verinote resolves, which is a claim about this code, not the
+   discovery claim the Ollama picker makes about a live server. #}
 <div id="model-field"{% if lazy %}
      hx-get="/settings/model-field"
      hx-trigger="load"
@@ -46,6 +52,19 @@
     <code>{{ model }}</code>, which is not installed on <code>{{ endpoint }}</code>.
     Pick an installed model, or run <code>ollama pull {{ model }}</code>.</p>
   {% endif %}
+  {% elif aliases %}
+  <label>Model
+    <input type="text" name="model" value="{{ model }}" list="model-aliases"
+           placeholder="alias or model id">
+  </label>
+  <datalist id="model-aliases">
+    {% for alias in aliases %}<option value="{{ alias }}"></option>{% endfor %}
+  </datalist>
+  <p class="muted field-note">
+    {{ aliases|join(', ') }} select the latest model of that family. A full id
+    such as <code>claude-opus-4-8</code> is passed to the CLI unchanged, so it
+    stays pinned to that version.
+  </p>
   {% else %}
   <label>Model
     <input type="text" name="model" value="{{ model }}" placeholder="model id">


### PR DESCRIPTION
Follow-up to #425, which gave Ollama a model picker. The obvious next question
is whether `claudecli` can have the same thing. **It cannot** — and the two
commits here are what it can honestly have instead.

## Why the Ollama mechanism does not transfer

The `claude` binary has no listing command (`agents, auth, auto-mode, doctor,
gateway, install, mcp, plugin, project, setup-token, ultrareview, update`).
Its `--model` help documents three aliases and otherwise takes a full model id.

Ollama's list is a fact about the endpoint the user configured. There is no
equivalent to ask here, so anything shown is a curated constant — a different
claim, and the UI must not blur them. `GET /v1/models` exists but needs an API
key, and `claudecli` users are precisely those authenticating through the CLI's
own credentials; listing what `VERINOTE_API_KEY` can see and labelling it "your
Claude CLI models" would report a different account's catalogue as this one's.

## Commit 1 — a pinned model id no longer collapses to "latest"

Found while checking whether a picker could offer full ids. `_cli_model`
matched aliases as substrings:

```
'claude-opus-4-8'   -> --model 'opus'          ← the pin, silently dropped
'claude-sonnet-5'   -> --model 'sonnet'
'claude-haiku-4-5'  -> --model 'claude-haiku-4-5'   ← only haiku survived
```

`config.json` named one model while the CLI ran another, with nothing to notice
it by — and inconsistently, since only ids *containing* an alias name lost their
pin. Canonical ids are now recognised first and passed through (case folded, so
capitalisation alone does not drop a pin); "Opus 4.8" and "Claude Opus" still
resolve to `opus`.

Verified against the real binary before changing anything: `--model
claude-opus-4-8` exits 0, `--model claude-nonexistent-9` exits 1 with *"It may
not exist or you may not have access to it"*. So passing ids through means a
wrong one produces the CLI's own loud error rather than a silent downgrade.

## Commit 2 — a datalist, plus the check that actually verifies it

A **datalist**, not a select: `fable`/`opus`/`sonnet` as suggestions you can
type past, because the curated list is not the set of valid choices. The
suggestions are keyed to the adapter's alias table so a picker entry is always
something `_cli_model` resolves, and `aliases` is a separate context key from
`models` so curated can never render through the discovered path.

Since that list cannot be checked against anything, `claudecli` joins
`TESTABLE_PROVIDERS`. Running the chosen model is the only evidence available
that it works — so the connection test matters *more* here than for providers
that already had it. The test is one real extraction, which the CLI serves as
well as an HTTP endpoint does; the "non-API provider" exclusion was about
transport, not about whether the check is meaningful.

## Verification

- Full suite **2213 passed, 10 skipped**; `ruff@0.15.18 check` (CI's exact
  invocation) passes.
- **7 mutation probes, all caught**: reverting the canonical-id guard, loosening
  it to 2 segments, dropping its `claude-` anchor, removing the case fold,
  handing aliases to every provider, turning the datalist into a closed select,
  and dropping `claudecli` from `TESTABLE_PROVIDERS`.
- One probe initially **survived** and the test was wrong, not the code: the
  drift guard asserted `_cli_model(alias) == alias`, which any invented alias
  satisfies since unknown strings pass through. Re-pinned on the property only a
  real alias has — absorbing a decorated display name of its family — plus an
  exact match against the adapter constant.
- Driven end to end against the real binary: **"ClaudeCLI answered with 1
  fact(s) from claude-opus-4-8"** — note it reports the pinned id, which before
  commit 1 would have run `--model opus`.

## Two existing tests changed

`test_settings_disables_connection_test_for_non_api_provider` and
`test_test_connection_rejects_non_api_provider` used `claudecli` for the
disabled path. That branch is still reachable — a `config.json` naming a
provider with no adapter — so both now use an unknown provider rather than
being deleted. `test_claude_cli_provider_is_available` asserted the old
exclusion; the replacement asserts coverage over `PROVIDERS`, so a new provider
has to make the decision deliberately instead of inheriting it.
