### PR TITLE
fix: make the Claude CLI model field a dropdown, not a text box

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,15 +103,21 @@ silently swapped for one that is — the page reports your KB's real state.
 
 The `claude` binary has no listing command, so there is nothing to discover —
 its `--model` help documents three aliases and otherwise takes a full model id.
-Settings therefore offers a **datalist**: `fable`, `opus`, and `sonnet` appear as
-suggestions, and you can type past them.
+Settings offers those as a dropdown:
 
-The distinction the wording keeps is that these are the aliases *verinote*
-resolves — a claim about this code — not a report of what your account can
-reach, which verinote cannot see. An alias selects the latest model of that
-family; a full id such as `claude-opus-4-8` reaches the CLI unchanged and stays
-pinned to that version. A model that does not exist, or that your CLI cannot
-reach, surfaces as the CLI's own error rather than a silent substitution.
+| Option | Meaning |
+|---|---|
+| **CLI default (no --model)** | verinote passes no `--model`, so the CLI uses whatever it is configured for |
+| `fable` / `opus` / `sonnet` | the latest model of that family |
+| *(a pinned id, when one is saved)* | shown selected, so the list always reports what `config.json` says |
+
+Because that list is curated rather than discovered, it is not the set of models
+you can reach — it is the set of aliases *verinote* resolves, which is a claim
+about this code and not about your account. **Enter a model id** swaps the
+dropdown for a text box when you want to pin a version: a full id such as
+`claude-opus-4-8` reaches the CLI unchanged and stays on that version. A model
+that does not exist, or that your CLI cannot reach, surfaces as the CLI's own
+error rather than a silent substitution.
 
 Because the list cannot be verified against a server, **Test connection** is the
 check that matters here: it runs one real extraction through the `claude` binary

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4764,9 +4764,10 @@ def test_model_field_halts_under_a_corrupt_config(tmp_path):
 # --- the Claude CLI alias picker: suggestions you can type past ---
 
 
-def test_model_field_offers_cli_aliases_without_reaching_a_provider(tmp_path, monkeypatch):
-    """The CLI has no listing endpoint, so the suggestions are curated from the
-    adapter -- rendering them must not require (or attempt) a provider call."""
+def test_model_field_offers_cli_aliases_as_a_real_select(tmp_path, monkeypatch):
+    """Curated does not mean typed. The CLI has no listing endpoint, so the
+    options are curated from the adapter -- rendering them must not require (or
+    attempt) a provider call, and must still be a control you pick from."""
     monkeypatch.setattr(
         webapp, "get_client", lambda _cfg: pytest.fail("claudecli has nothing to enumerate")
     )
@@ -4774,15 +4775,41 @@ def test_model_field_offers_cli_aliases_without_reaching_a_provider(tmp_path, mo
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=opus")
 
     assert r.status_code == 200
-    assert '<datalist id="model-aliases">' in r.text
-    assert '<input type="text" name="model" value="opus" list="model-aliases"' in r.text
-    assert "<select" not in r.text  # typing a full id must stay possible
+    assert '<select name="model">' in r.text
+    assert '<option value="opus" selected>opus — latest</option>' in unescape(r.text)
+    assert 'type="text" name="model"' not in r.text  # choosing costs a click, not typing
     assert 'hx-trigger="load"' not in r.text  # nothing to lazily fetch
 
 
-def test_model_field_alias_suggestions_match_what_the_adapter_resolves(tmp_path):
-    """A suggested alias the adapter did not recognise would be offered as a
-    choice and then silently mean something else.
+def test_model_field_keeps_the_cli_default_selectable(tmp_path):
+    """An empty model means "pass no --model, let the CLI decide" -- this KB's
+    shipped default. Without an option for it the browser auto-selects the first
+    alias, so merely opening Settings and pressing Save would switch the KB to
+    `fable` without anyone choosing it."""
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=")
+
+    assert '<option value="" selected>CLI default (no --model)</option>' in r.text
+    first_option = re.search(r"<option [^>]*>", r.text).group(0)
+    assert 'value=""' in first_option  # and it is the one a browser lands on
+
+
+def test_model_field_keeps_a_pinned_id_in_the_list_and_selected(tmp_path):
+    """A pin is not an alias, but it is still what config.json says. Dropping it
+    from the options would make the page report a model the KB is not using."""
+    r = _ollama_client(tmp_path).get(
+        "/settings/model-field?provider=claudecli&model=claude-opus-4-8"
+    )
+
+    assert (
+        '<option value="claude-opus-4-8" selected>claude-opus-4-8 — pinned</option>'
+        in unescape(r.text)
+    )
+    assert '<option value="" >CLI default (no --model)</option>' in r.text  # not selected
+
+
+def test_model_field_alias_options_match_what_the_adapter_resolves(tmp_path):
+    """A listed alias the adapter did not recognise would be offered as a choice
+    and then silently mean something else.
 
     `_cli_model(alias) == alias` is NOT the property to assert: unknown strings
     are passed through unchanged, so any invented alias satisfies it. What only
@@ -4792,22 +4819,62 @@ def test_model_field_alias_suggestions_match_what_the_adapter_resolves(tmp_path)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=")
 
-    offered = re.findall(r'<option value="([^"]+)"></option>', r.text)
-    assert offered == list(CLI_MODEL_ALIASES)  # rendered list cannot drift
-    for alias in offered:
+    offered = re.findall(r'<option value="([^"]*)"[^>]*>([^<]*) — latest</option>', r.text)
+    assert [value for value, _ in offered] == list(CLI_MODEL_ALIASES)
+    for alias, _ in offered:
         assert _cli_model(f"Claude {alias.title()} 9.9") == alias
 
 
-def test_model_field_tells_the_truth_about_pinning_a_full_id(tmp_path):
-    """The note promises a full id reaches the CLI unchanged; that promise is the
-    behaviour `_cli_model` now guarantees, so assert them together."""
-    from verinote.llm.claude_cli_adapter import _cli_model
+def test_model_field_swaps_to_a_text_input_for_a_full_id(tmp_path, monkeypatch):
+    """The escape hatch sits beside the control, not inside it: the list stays a
+    list, and a full id is still reachable in one click."""
+    monkeypatch.setattr(
+        webapp, "get_client", lambda _cfg: pytest.fail("claudecli has nothing to enumerate")
+    )
 
-    r = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=")
+    listed = _ollama_client(tmp_path).get("/settings/model-field?provider=claudecli&model=opus")
+    typed = _ollama_client(tmp_path).get(
+        "/settings/model-field?provider=claudecli&model=opus&custom=1"
+    )
 
-    assert "claude-opus-4-8" in r.text
-    assert "passed to the CLI unchanged" in r.text
-    assert _cli_model("claude-opus-4-8") == "claude-opus-4-8"
+    assert "Enter a model id" in listed.text
+    assert '<input type="text" name="model" value="opus"' in typed.text
+    assert "<select" not in typed.text
+    assert "passed to the CLI unchanged" in typed.text
+    assert "Back to the list" in typed.text  # and the swap is reversible
+
+
+def test_settings_page_renders_the_cli_picker_as_a_list(tmp_path):
+    """`custom` is a view state the partial owns; the page render must never
+    start in it. A Settings page that opened on a text input would put every
+    user back to typing -- the exact thing the select replaced."""
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="claudecli",
+        model="opus",
+        api_key=None,
+        base_url=None,
+    )
+
+    r = TestClient(create_app(cfg)).get("/settings")
+
+    assert '<select name="model">' in r.text
+    assert 'type="text" name="model"' not in r.text
+
+
+def test_model_field_custom_never_downgrades_the_discovered_picker(tmp_path, monkeypatch):
+    """A stray `custom=1` must not turn Ollama's discovered list into free text --
+    that list is evidence, and there is no reason to type past it."""
+    fake = _FakeOllama(models=["qwen3:8b"])
+    monkeypatch.setattr(webapp, "get_client", fake.factory)
+
+    r = _ollama_client(tmp_path).get(
+        "/settings/model-field?provider=ollama&model=qwen3:8b&custom=1"
+    )
+
+    assert '<select name="model">' in r.text
+    assert 'type="text" name="model"' not in r.text
 
 
 def test_model_field_keeps_aliases_off_the_ollama_picker(tmp_path, monkeypatch):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1733,7 +1733,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return templates.TemplateResponse(request, "analytics.html", {"a": compute(_active_cfg().db_path)})
 
     def _model_field_context(
-        *, provider: str, model: str, base_url: str, lazy: bool
+        *, provider: str, model: str, base_url: str, lazy: bool, custom: bool = False
     ) -> dict:
         """Resolve the Model field's state for one (provider, base URL) pair.
 
@@ -1752,12 +1752,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         `aliases` is the other kind of list, and stays a separate key on
         purpose: it is curated from the adapter, never read from a provider, so
         it can never stand in for `models` or be mistaken for discovery.
+        `custom` swaps that picker for a text input so a full model id can still
+        be entered — a view state, never persisted, so a reload returns to the
+        list showing whatever was actually saved.
         """
         listable = provider in MODEL_LISTING_PROVIDERS
         base = {
             "provider": provider,
             "model": model,
             "aliases": MODEL_ALIASES_BY_PROVIDER.get(provider, ()),
+            "custom": custom,
             # The URL actually dialled, not the literal "(default)" — so the
             # page names the same endpoint the adapter will use.
             "endpoint": (base_url.strip() or OLLAMA_DEFAULT_BASE_URL) if listable else "",
@@ -1786,6 +1790,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         provider: str = "",
         model: str = "",
         base_url: str = "",
+        custom: int = 0,
     ):
         if app.state.cfg is None:
             return _kb_select(request)
@@ -1797,6 +1802,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 model=model,
                 base_url=base_url,
                 lazy=False,
+                custom=bool(custom),
             ),
         )
 

--- a/verinote/web/templates/partials/model_field.html
+++ b/verinote/web/templates/partials/model_field.html
@@ -15,10 +15,18 @@
    statement from "your server could not be reached".
 
    The Claude CLI has no listing to read -- its `--model` help documents three
-   aliases and otherwise takes a full model id -- so it gets a *datalist*, not a
-   select: suggestions you can also type past. The wording below says these are
-   the aliases verinote resolves, which is a claim about this code, not the
-   discovery claim the Ollama picker makes about a live server. #}
+   aliases and otherwise takes a full model id -- so its options are curated,
+   which the wording says plainly: these are the aliases verinote resolves, a
+   claim about this code rather than the discovery claim the Ollama picker makes
+   about a live server.
+
+   Curated does NOT mean it should be typed. This was a datalist first, on the
+   reasoning that a closed list would imply it was the complete set of valid
+   models; but a datalist renders as a bare text box in most browsers, so a
+   field whose whole point is choosing demanded typing instead. The escape hatch
+   belongs beside the control, not inside it: a real select, plus a button that
+   swaps in a text input for a full id. The list stays honest because the button
+   says so, and picking a model costs one click. #}
 <div id="model-field"{% if lazy %}
      hx-get="/settings/model-field"
      hx-trigger="load"
@@ -52,18 +60,43 @@
     <code>{{ model }}</code>, which is not installed on <code>{{ endpoint }}</code>.
     Pick an installed model, or run <code>ollama pull {{ model }}</code>.</p>
   {% endif %}
-  {% elif aliases %}
+  {% elif aliases and not custom %}
   <label>Model
-    <input type="text" name="model" value="{{ model }}" list="model-aliases"
-           placeholder="alias or model id">
+    <select name="model">
+      {# An empty model means "pass no --model and let the CLI use its own
+         default" -- a real choice, and this KB's shipped one. Without an option
+         for it the browser would auto-select the first alias, silently turning
+         that default into `fable` the next time Save is pressed. #}
+      <option value="" {{ 'selected' if not model else '' }}>CLI default (no --model)</option>
+      {% for alias in aliases %}
+      <option value="{{ alias }}" {{ 'selected' if alias == model else '' }}>{{ alias }} — latest</option>
+      {% endfor %}
+      {% if model and model not in aliases %}
+      {# A pinned id belongs in the list, selected, so choosing stays a choice
+         and the page keeps reporting what config.json actually says. #}
+      <option value="{{ model }}" selected>{{ model }} — pinned</option>
+      {% endif %}
+    </select>
   </label>
-  <datalist id="model-aliases">
-    {% for alias in aliases %}<option value="{{ alias }}"></option>{% endfor %}
-  </datalist>
   <p class="muted field-note">
-    {{ aliases|join(', ') }} select the latest model of that family. A full id
-    such as <code>claude-opus-4-8</code> is passed to the CLI unchanged, so it
-    stays pinned to that version.
+    An alias tracks the latest model of that family. These are the aliases
+    verinote resolves, not a list of what your CLI can reach — <strong>Test
+    connection</strong> below is what confirms a choice works.
+    <button class="btn ghost" type="button"
+            hx-get="/settings/model-field?custom=1"
+            hx-include="[name='provider'], [name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">Enter a model id</button>
+  </p>
+  {% elif aliases and custom %}
+  <label>Model
+    <input type="text" name="model" value="{{ model }}" placeholder="claude-opus-4-8">
+  </label>
+  <p class="muted field-note">
+    A full id is passed to the CLI unchanged, so it stays pinned to that version.
+    <button class="btn ghost" type="button"
+            hx-get="/settings/model-field"
+            hx-include="[name='provider'], [name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">Back to the list</button>
   </p>
   {% else %}
   <label>Model


### PR DESCRIPTION
Follow-up to #426. The Claude CLI model field shipped as a **datalist**, on the
reasoning that a closed list would imply it was the complete set of valid
models. That reasoning was protecting a true claim with the wrong control: a
datalist renders as a bare text box in most browsers, so a field whose entire
job is *choosing* demanded typing — you had to know an alias by heart and spell
it right.

It is now a real `<select>`. The honesty the datalist bought comes instead from
putting the escape hatch **beside** the control rather than inside it.

## What you get

| Option | Meaning |
|---|---|
| **CLI default (no --model)** | pass no `--model`; the CLI uses whatever it is configured for |
| `fable` / `opus` / `sonnet` | the latest model of that family |
| *(pinned id, when saved)* | listed and selected, e.g. `claude-opus-4-8 — pinned` |

**Enter a model id** swaps the dropdown for a text input (and **Back to the
list** returns), so pinning a version stays one click away. The note says
outright that these are the aliases verinote resolves, not what your CLI can
reach, and points at Test connection as the thing that confirms a choice works.

## Two options that keep the select from changing state by being looked at

- **The CLI default needs its own option.** An empty model — pass no `--model`
  — is this KB's shipped default. Without an option for it, the browser
  auto-selects the first alias, so *opening Settings and pressing Save* would
  switch the KB to `fable` with nobody choosing it. It is first in the list and
  selected when the model is empty.
- **A pinned id is listed and selected.** It is not an alias, but it is what
  `config.json` says; dropping it would make the page report a model the KB is
  not using.

`custom` is a view state the partial owns — the page render never starts in it,
so a reload returns to the list showing what was actually saved.

## Verification

- Full suite **2217 passed, 10 skipped**; `ruff@0.15.18 check` (CI's exact
  invocation) passes.
- **6 mutation probes, all caught**: dropping the CLI-default option, moving it
  after the aliases (so the browser lands on `fable`), dropping the pinned-id
  option, ignoring `custom`, letting `custom` leak into the Ollama branch, and
  persisting `custom` into the page render.
- Two probes initially reported "17 passed" because bash mangled the Jinja
  quoting and the mutation **never applied** — a non-result, not evidence. Re-run
  through a JSON spec file; both then failed as they should.
- One probe found a real gap rather than confirming a guard: the
  "not persisted" test was checking the partial route, so persisting `custom`
  into `_settings` went unnoticed. Retargeted at `GET /settings`.
- Driven live: a saved `claude-opus-4-8` renders selected as `— pinned`,
  **Enter a model id** returns the text input, and picking `sonnet` round-trips
  into `config.json`.
