### PR TITLE
feat: add a Windows launcher that provisions the venv and starts the app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# cmd.exe reads a batch file by byte offset as it executes it, so `goto`, labels
+# and multi-line `if (...)` blocks are the known-fragile constructs under LF line
+# endings — and scripts/run.cmd uses all three. Git for Windows defaults to
+# core.autocrlf=true, so this rule is insurance for the checkouts that default
+# does not cover (autocrlf=false, or a clone made from Linux/WSL), not a fix for
+# a bug seen in the wild.
+*.cmd text eol=crlf

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ pip install -e ".[anthropic,test]"   # pick the providers you use
 verinote ui                          # opens http://127.0.0.1:8731
 ```
 
+On Windows, `scripts\run.cmd` does both steps for you — it creates the virtual
+environment, installs verinote into it, and starts the app. Double-clicking it in
+Explorer works, and so does running it from a shell:
+
+```cmd
+scripts\run.cmd                 REM verinote ui
+scripts\run.cmd ui --port 9000  REM arguments are passed straight through
+scripts\run.cmd status
+```
+
+It re-installs only when `pyproject.toml` or your chosen extras change. Set
+`VERINOTE_EXTRAS` to pick different providers (`VERINOTE_EXTRAS=ingest` for a
+vendor-neutral install with Ollama or the Claude CLI), `PYTHON` to choose the
+interpreter, or `VERINOTE_DRY_RUN=1` to see what it would do without doing it.
+
 On first launch verinote asks you to pick a KB folder (creating `kb.sqlite` if
 needed) and remembers it for next time.
 

--- a/scripts/run.cmd
+++ b/scripts/run.cmd
@@ -1,0 +1,336 @@
+@echo off
+rem SPDX-License-Identifier: MPL-2.0
+rem
+rem Windows launcher: provision the virtual environment if it is missing, then
+rem run verinote. Double-clicking this file in Explorer is a supported way to
+rem start the app; so is `scripts\run.cmd` from a shell.
+rem
+rem   scripts\run.cmd                 -> verinote ui   (opens http://127.0.0.1:8731)
+rem   scripts\run.cmd ui --port 9000  -> verinote ui --port 9000
+rem   scripts\run.cmd status          -> verinote status
+rem
+rem Arguments are passed through verbatim. Only the no-argument case injects a
+rem subcommand, because `--version` and `--help` live on the top-level parser and
+rem a launcher that silently rewrote them into `verinote ui --version` would turn
+rem the two flags a new user is likeliest to try into an argparse error.
+rem
+rem Environment overrides (all optional):
+rem   PYTHON             interpreter to build the venv with; wins outright
+rem   VERINOTE_VENV      venv location            (default: <repo>\.venv)
+rem   VERINOTE_EXTRAS    pyproject extras         (default: anthropic,ingest)
+rem   VERINOTE_REINSTALL set to 1 to force the install step to run
+rem   VERINOTE_DRY_RUN   set to 1 to print the resolution and exit, changing nothing
+rem   VERINOTE_NO_PAUSE  set to 1 to never pause on failure (for scripted runs)
+rem
+rem This script deliberately never sets VERINOTE_ROOT. That variable takes
+rem precedence over the active KB saved by the browser picker (verinote/cli.py,
+rem `_config_for`), and the web app refuses to save an active KB while it is set
+rem — so a root defaulted here would shadow the user's own KB and lock them out
+rem of correcting it from the UI. An inherited VERINOTE_ROOT is passed through
+rem untouched. The platform default KB root is already outside this working tree
+rem (docs/configuration.md), which is where that constraint belongs.
+
+setlocal EnableExtensions
+
+rem Delayed expansion stays OFF so that a `!` in a path is not eaten; every
+rem read-after-write below is therefore structured with `call`/`goto` or with
+rem `if defined`, which is evaluated at run time rather than at parse time.
+
+rem A version probe must never install a Python behind the user's back: with
+rem this set, `py -3.12` can trigger a winget install. `endlocal` reverts it.
+set "PYLAUNCHER_ALLOW_INSTALL="
+
+rem `%~dp0` carries a trailing backslash, hence "%~dp0.." and not "%~dp0\..".
+for %%I in ("%~dp0..") do set "REPO=%%~fI"
+
+if not defined VERINOTE_VENV set "VERINOTE_VENV=%REPO%\.venv"
+set "VENV=%VERINOTE_VENV%"
+
+rem Explorer double-click runs us as `cmd /c "...run.cmd"`, and that window closes
+rem the instant we exit — so failures must pause to stay readable. `%cmdcmdline%`
+rem is the only signal batch has here, and it cannot tell a double-click from a
+rem deliberate `cmd /c run.cmd`: both carry `/c`. The cost of that ambiguity is
+rem one spurious line in a scripted run (`pause` returns immediately when stdin
+rem is not a console), and VERINOTE_NO_PAUSE=1 suppresses it outright.
+rem The quotes must be stripped before `%cmdcmdline%` is expanded into any
+rem command: `for %%C in (%cmdcmdline%)` and a bare `if` comparison both let the
+rem path's own `(`, `)` and `&` reach the parser, which aborts the script before
+rem anything runs. The double-click form is `cmd /c ""C:\...\run.cmd" "`, whose
+rem leading `""` closes immediately and leaves the rest bare — so an ordinary
+rem `C:\Program Files (x86)\...` or `C:\Repo (1)\...` install killed the launcher
+rem in exactly the case this probe exists to serve.
+rem
+rem This must stay above every `goto :bad_*`: a failure that jumps out before
+rem DBLCLICK is set cannot pause, and the window takes the message with it.
+set "CCL=%cmdcmdline:"=%"
+set "DBLCLICK="
+if not "%CCL%"=="%CCL: /c =%" set "DBLCLICK=1"
+if "%VERINOTE_NO_PAUSE%"=="1" set "DBLCLICK="
+
+if not defined VERINOTE_EXTRAS set "VERINOTE_EXTRAS=anthropic,ingest"
+rem Quotes are stripped first, and that is load-bearing rather than tidiness: a
+rem quote hides the character after it from the tests below, so `ingest"&"x`
+rem would pass the guard and then be executed — the guard failing *open*, with
+rem the run still reporting success. It is also the one character the tests
+rem cannot check for, since a `%EXTRAS:"=%` comparison is itself unbalanced.
+set "EXTRAS=%VERINOTE_EXTRAS:"=%"
+rem EXTRAS is expanded onto `echo` lines (the dry-run report, and the stamp
+rem write via WANT), so a metacharacter in it would be parsed as a command. The
+rem quiet failure is the one that matters: `&` truncates the stamp, HAVE never
+rem again equals WANT, and every launch silently reinstalls. Extras names are
+rem PEP 508 identifiers, so refusing anything outside this set costs nothing and
+rem is safer than trying to escape it.
+rem Each test removes one character and compares: a difference means it was
+rem present. Written out literally rather than looped over a character set,
+rem because substring replacement with a `for` variable needs delayed expansion,
+rem which this script deliberately runs without.
+set "BADX="
+if not "%EXTRAS%"=="%EXTRAS:&=%" set "BADX=1"
+if not "%EXTRAS%"=="%EXTRAS:|=%" set "BADX=1"
+if not "%EXTRAS%"=="%EXTRAS:>=%" set "BADX=1"
+if not "%EXTRAS%"=="%EXTRAS:<=%" set "BADX=1"
+if not "%EXTRAS%"=="%EXTRAS:^=%" set "BADX=1"
+if not "%EXTRAS%"=="%EXTRAS:(=%" set "BADX=1"
+if not "%EXTRAS%"=="%EXTRAS:)=%" set "BADX=1"
+if defined BADX goto :bad_extras
+rem `anthropic` matches the built-in default provider (verinote/config.py), so
+rem the common path works after one launch rather than two. It is not needed for
+rem a legible error: the adapter already turns a missing SDK into
+rem `LLMError: anthropic SDK not installed`, naming the remedy. `ingest` makes
+rem docx/pdf upload work. The `test` extra from requirements.txt is omitted: a
+rem launcher provisions the app, not a dev harness. Vendor-neutral users want
+rem VERINOTE_EXTRAS=ingest and an ollama or claudecli provider; neither adapter
+rem needs an SDK.
+
+set "STAMP=%VENV%\.verinote-install"
+set "VENVPY=%VENV%\Scripts\python.exe"
+
+rem An interrupted `python -m venv` leaves the directory but no interpreter, so
+rem the interpreter is the existence test, never the directory.
+if exist "%VENVPY%" goto :have_venv
+
+call :resolve_python
+if errorlevel 1 goto :no_python
+call :check_version
+if errorlevel 1 goto :done
+
+if "%VERINOTE_DRY_RUN%"=="1" goto :dry_run
+
+echo [verinote] Creating the virtual environment at "%VENV%".
+call "%PYEXE%" %PYARGS% -m venv "%VENV%"
+if errorlevel 1 goto :venv_failed
+if not exist "%VENVPY%" goto :venv_failed
+set "FRESH=1"
+goto :install_check
+
+:have_venv
+rem Steady state runs no interpreter discovery at all: a venv built with 3.12
+rem must never silently rebase onto whatever `py -3` resolves to today.
+if "%VERINOTE_DRY_RUN%"=="1" (
+    set "PYEXE=%VENVPY%"
+    set "PYARGS="
+    goto :dry_run
+)
+
+:install_check
+rem Reinstall only when the declared dependencies or the chosen extras actually
+rem changed. Signature is the content hash of pyproject.toml, not its timestamp:
+rem two edits inside the same minute share a timestamp, which would claim "fresh"
+rem when it is not. certutil is a Windows builtin, so this stays pure batch.
+set "PJSIG="
+for /f "skip=1 delims=" %%H in ('certutil -hashfile "%REPO%\pyproject.toml" SHA256 2^>nul') do (
+    if not defined PJSIG set "PJSIG=%%H"
+)
+set "PJSIG=%PJSIG: =%"
+rem certutil absent or refusing: fall back to the timestamp. Weaker, but it errs
+rem toward reinstalling rather than toward claiming a stale venv is current.
+if not defined PJSIG for %%I in ("%REPO%\pyproject.toml") do set "PJSIG=%%~tI"
+
+rem The separator must not be a cmd metacharacter: `%WANT%` is expanded on an
+rem `echo` line when the stamp is written, so a `|` here would be parsed as a
+rem pipe and cmd would try to run the extras list as a command.
+set "WANT=%PJSIG%~%EXTRAS%"
+set "HAVE="
+if exist "%STAMP%" for /f "usebackq delims=" %%S in ("%STAMP%") do if not defined HAVE set "HAVE=%%S"
+
+set "NEEDINSTALL="
+set "WHY=Dependencies changed"
+if not "%HAVE%"=="%WANT%" set "NEEDINSTALL=1"
+rem The console script is what `[project.scripts]` regenerates; its absence is
+rem the one way this script notices a `pip uninstall` done behind its back.
+if not exist "%VENV%\Scripts\verinote.exe" (
+    set "NEEDINSTALL=1"
+    set "WHY=The verinote command is missing from the environment"
+)
+if "%VERINOTE_REINSTALL%"=="1" (
+    set "NEEDINSTALL=1"
+    set "WHY=VERINOTE_REINSTALL is set"
+)
+
+if not defined NEEDINSTALL goto :run
+
+rem Say which of the three reasons actually triggered this, rather than blaming a
+rem dependency change for an install the caller forced.
+if defined FRESH (
+    echo [verinote] First run: installing verinote and its dependencies.
+) else (
+    echo [verinote] %WHY%: reinstalling verinote.
+)
+echo [verinote] This downloads packages and can take several minutes.
+"%VENVPY%" -m pip install -e "%REPO%[%EXTRAS%]"
+if errorlevel 1 goto :pip_failed
+> "%STAMP%" echo %WANT%
+
+:run
+if "%~1"=="" goto :run_ui
+"%VENV%\Scripts\verinote.exe" %*
+set "CODE=%ERRORLEVEL%"
+goto :done
+
+:run_ui
+"%VENV%\Scripts\verinote.exe" ui
+set "CODE=%ERRORLEVEL%"
+goto :done
+
+rem ---------------------------------------------------------------- subroutines
+
+:resolve_python
+rem The interpreter is kept as a program (PYEXE) plus its arguments (PYARGS)
+rem rather than one string, so PYEXE can be quoted at every use site. An
+rem unquotable single string cannot express both `py -3.12` and
+rem `C:\Program Files\Python312\python.exe` — and the latter is a default install
+rem location, so collapsing them rejected the interpreter the caller named.
+rem An explicit PYTHON wins outright and must not fall through to discovery:
+rem silently ignoring it would run a different interpreter than the one asked for.
+if defined PYTHON (
+    set "PYEXE=%PYTHON%"
+    set "PYARGS="
+    exit /b 0
+)
+rem Probe with `--version`, never bare: a bare `py -3.12` opens a REPL and the
+rem launcher would sit at `>>>` forever behind a double-clicked window.
+rem Newest CI-tested version first; keep in sync with the matrix in
+rem .github/workflows/ci.yml. A version the launcher does not have exits 103, and
+rem an absent `py` exits 9009 — both non-zero, so the ladder falls through.
+for %%V in (3.13 3.12 3.11) do (
+    if not defined PYEXE (
+        py -%%V --version >nul 2>&1 && call :set_py py -%%V
+    )
+)
+if not defined PYEXE py -3 --version >nul 2>&1 && call :set_py py -3
+if not defined PYEXE python --version >nul 2>&1 && call :set_py python
+if not defined PYEXE exit /b 1
+exit /b 0
+
+:set_py
+set "PYEXE=%~1"
+set "PYARGS=%~2"
+exit /b 0
+
+:check_version
+rem This runs inside a `call` frame, so it must report failure with `exit /b`
+rem and never `goto` out to a shared exit label: such a jump stays in the call
+rem frame, so the exit path would run once on the way out of the subroutine and
+rem again in the caller, popping `setlocal` early and pausing twice.
+set "PYMAJ="
+set "PYMIN="
+rem Invoked directly rather than through `for /f ('...')`: that form cannot quote
+rem a program whose path contains a space, and every attempt to quote inside it
+rem dies on the nested quotes. `call` is what lets a `.cmd` stand-in return here
+rem instead of replacing this script's context.
+set "VERFILE=%TEMP%\verinote-pyver-%RANDOM%.txt"
+call "%PYEXE%" %PYARGS% -c "import sys;print(sys.version_info[0], sys.version_info[1])" > "%VERFILE%" 2>nul
+rem No file at all means the redirect failed, not that the interpreter did:
+rem blaming a perfectly good `py -3.12` and sending the user off to set PYTHON
+rem would be a wrong diagnosis of an unwritable TEMP.
+if not exist "%VERFILE%" goto :cv_no_temp
+for /f "usebackq tokens=1,2" %%a in ("%VERFILE%") do (
+    set "PYMAJ=%%a"
+    set "PYMIN=%%b"
+)
+del "%VERFILE%" >nul 2>&1
+if not defined PYMIN goto :cv_not_runnable
+if %PYMAJ% LSS 3 goto :cv_too_old
+if %PYMAJ% EQU 3 if %PYMIN% LSS 11 goto :cv_too_old
+rem Above the tested ceiling we warn and continue rather than refuse:
+rem pyproject's `requires-python = ">=3.11"` has no upper bound, and a launcher
+rem must not enforce a stricter contract than the package it installs. The real
+rem failure mode is a dependency with no wheel for this version falling back to
+rem a source build, which the warning makes legible in advance.
+if %PYMAJ% EQU 3 if %PYMIN% GTR 13 (
+    echo [verinote] Warning: Python %PYMAJ%.%PYMIN% is newer than the versions this
+    echo [verinote] project tests ^(3.11-3.13^). If the install fails on a package
+    echo [verinote] with no matching wheel, set PYTHON to a 3.12 or 3.13 and retry.
+)
+exit /b 0
+
+:cv_no_temp
+echo [verinote] error: could not write a temporary file under "%TEMP%".
+echo [verinote] The interpreter was not the problem. Set TEMP to a writable
+echo [verinote] directory and run this script again.
+set "CODE=1"
+exit /b 1
+
+:cv_not_runnable
+echo [verinote] error: "%PYEXE%" could not report its version, so it is not usable.
+echo [verinote] Set PYTHON to a working Python 3.11+ interpreter.
+set "CODE=1"
+exit /b 1
+
+:cv_too_old
+echo [verinote] error: Python %PYMAJ%.%PYMIN% is too old; verinote requires 3.11 or newer.
+echo [verinote] Set PYTHON to a newer interpreter, e.g.
+echo [verinote]     set PYTHON=C:\Python312\python.exe
+set "CODE=1"
+exit /b 1
+
+rem --------------------------------------------------------------- exit handling
+
+:dry_run
+rem Quoted: an unquoted `echo` splits on a `&` in a path and executes the tail.
+echo [verinote] dry run - nothing was created or installed.
+echo   repo        "%REPO%"
+echo   venv        "%VENV%"
+echo   interpreter "%PYEXE%" %PYARGS%
+echo   extras      "%EXTRAS%"
+set "CODE=0"
+goto :done
+
+:no_python
+echo [verinote] error: no usable Python found.
+echo [verinote] Install Python 3.11 or newer from https://www.python.org/downloads/
+echo [verinote] or set PYTHON to the interpreter you want, e.g.
+echo [verinote]     set PYTHON=C:\Python312\python.exe
+set "CODE=1"
+goto :done
+
+:bad_extras
+echo [verinote] error: VERINOTE_EXTRAS contains characters that are not allowed.
+echo [verinote] Use a comma-separated list of extra names, e.g.
+echo [verinote]     set VERINOTE_EXTRAS=anthropic,ingest
+set "CODE=1"
+goto :done
+
+:venv_failed
+echo [verinote] error: could not create the virtual environment at "%VENV%".
+echo [verinote] Remove that folder and try again, or set VERINOTE_VENV elsewhere.
+set "CODE=1"
+goto :done
+
+:pip_failed
+echo [verinote] error: installing dependencies failed.
+echo [verinote] Check the pip output above. To start over, delete
+echo [verinote]     "%VENV%"
+echo [verinote] and run this script again.
+set "CODE=1"
+goto :done
+
+:done
+rem The app's own exit code reaches this pause too: the commonest repeat failure
+rem is a second launch hitting an in-use port or a locked KB, and that message
+rem must not vanish with the window.
+if defined DBLCLICK if not "%CODE%"=="0" (
+    echo.
+    pause
+)
+endlocal & exit /b %CODE%

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Execution tests for the Windows launcher, `scripts/run.cmd`.
+
+The wrapper in `tests/contract/run.sh` is tested by *running* it
+(`tests/contract/test_contract_meta.py`), added for #273 after tests that
+spawned `sys.executable` directly let a broken wrapper stay green. The same
+reasoning applies here, and more sharply: CI is ubuntu-only, so nothing else in
+this repository ever executes `run.cmd`. These tests skip on non-Windows exactly
+as `_shim_dir` does — the platform gate is the established pattern, not an
+excuse.
+
+Every case here is confined to two harmless branches: the ones that refuse
+before provisioning, and `VERINOTE_DRY_RUN=1`, which reports the resolution and
+exits. That confinement is deliberate. `run.cmd` derives the repository from its
+own location (`%~dp0..`), which no fixture can redirect, so a test that reached
+the install branch would run a real `pip install -e` into the developer's own
+`.venv` — minutes of network I/O and a mutation of a known-good environment, out
+of a unit test. `VERINOTE_VENV` is pointed at `tmp_path` besides, so even a
+regression that slipped past the dry-run gate could not touch it.
+
+What is deliberately *not* tested here: the venv-creation and install path
+itself. It cannot be exercised without the side effects above, so it is verified
+by hand on a Windows machine when the script changes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUN_CMD = REPO_ROOT / "scripts" / "run.cmd"
+
+windows_only = pytest.mark.skipif(
+    os.name != "nt", reason="run.cmd is a batch file; cmd.exe is not available on this platform"
+)
+
+
+def _run(tmp_path: Path, *args: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+    """Invoke run.cmd with a sandboxed venv location and no interactive pause."""
+    env = os.environ | {
+        "VERINOTE_VENV": str(tmp_path / "venv"),
+        "VERINOTE_NO_PAUSE": "1",
+    }
+    # A stale VERINOTE_ROOT from the ambient shell would not change the script's
+    # behaviour, but drop it so a failure here can never be blamed on one.
+    env.pop("VERINOTE_ROOT", None)
+    env.pop("PYTHON", None)
+    env.pop("VERINOTE_DRY_RUN", None)
+    env.pop("VERINOTE_EXTRAS", None)
+    env.update(overrides)
+    return subprocess.run(
+        [str(RUN_CMD), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def _shim(tmp_path: Path, name: str, body: str) -> Path:
+    """A fake interpreter that answers the script's version query and nothing else.
+
+    `run.cmd` asks for the version with `-c "import sys;print(...)"` and reads
+    two whitespace-separated tokens, so a batch file that echoes them is a
+    complete stand-in — and cannot accidentally build a virtualenv.
+    """
+    path = tmp_path / name
+    # CRLF: cmd.exe reads a batch file by byte offset as it executes it.
+    path.write_bytes(f"@echo off\r\n{body}\r\n".encode())
+    return path
+
+
+def test_script_never_assigns_verinote_root() -> None:
+    """The launcher must not default VERINOTE_ROOT.
+
+    That variable takes precedence over the active KB saved by the browser
+    picker (`verinote/cli.py`, `_config_for`), and `verinote/web/app.py` refuses
+    to save an active KB while it is set — so a root defaulted by a launcher
+    would shadow the user's KB *and* remove the UI's way of correcting it. The
+    failure is silent, which is why it is pinned here rather than left to review.
+
+    Matched anywhere in the line, not just at its start: the spelling a future
+    edit would most naturally reach for is the guarded one this script already
+    uses twice for its own variables, `if not defined X set "X=..."`. An
+    assertion anchored to the start of the line would miss exactly that.
+    """
+    assign = re.compile(r'\bsetx?\s+"?verinote_root\b', re.IGNORECASE)
+    text = RUN_CMD.read_text(encoding="utf-8")
+    assignments = [line.strip() for line in text.splitlines() if assign.search(line)]
+    assert assignments == []
+
+
+@windows_only
+def test_dry_run_resolves_an_interpreter(tmp_path: Path) -> None:
+    result = _run(tmp_path, VERINOTE_DRY_RUN="1")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "dry run" in result.stdout
+    # The resolution must name a concrete interpreter, not an empty variable.
+    interpreter = [ln for ln in result.stdout.splitlines() if ln.strip().startswith("interpreter")]
+    assert len(interpreter) == 1, result.stdout
+    assert interpreter[0].split(None, 1)[1].strip()
+
+
+@windows_only
+def test_refuses_python_below_the_floor(tmp_path: Path) -> None:
+    """3.10 is refused outright: pyproject requires >=3.11 and the install would fail anyway."""
+    shim = _shim(tmp_path, "py310.cmd", "echo 3 10")
+    result = _run(tmp_path, PYTHON=str(shim))
+    assert result.returncode != 0
+    assert "3.10" in result.stdout
+    assert "3.11" in result.stdout
+
+
+@windows_only
+def test_warns_but_proceeds_above_the_tested_ceiling(tmp_path: Path) -> None:
+    """Newer than the CI matrix warns; it must not refuse.
+
+    `requires-python = ">=3.11"` has no upper bound, so a launcher that refused
+    here would enforce a stricter contract than the package it installs.
+    """
+    shim = _shim(tmp_path, "py399.cmd", "echo 3 99")
+    result = _run(tmp_path, PYTHON=str(shim), VERINOTE_DRY_RUN="1")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Warning" in result.stdout
+    assert "3.99" in result.stdout
+
+
+@windows_only
+def test_rejects_an_interpreter_that_cannot_report_a_version(tmp_path: Path) -> None:
+    """An explicit PYTHON that answers nothing is an error, never a fall-through.
+
+    Silently discovering a different interpreter would run something other than
+    the one the caller named.
+    """
+    shim = _shim(tmp_path, "pymute.cmd", "rem answers nothing")
+    result = _run(tmp_path, PYTHON=str(shim), VERINOTE_DRY_RUN="1")
+    assert result.returncode != 0
+    assert "version" in result.stdout.lower()
+
+
+@windows_only
+def test_reports_when_no_python_is_available(tmp_path: Path) -> None:
+    """With no interpreter on PATH the script says so and names PYTHON as the way out.
+
+    The message itself is asserted, not just the word `PYTHON`: that substring
+    also appears in the "could not report its version" refusal, so matching it
+    alone could not tell the two failures apart.
+    """
+    result = _run(tmp_path, PATH=str(tmp_path / "empty"))
+    assert result.returncode != 0
+    assert "no usable Python found" in result.stdout
+    assert "PYTHON" in result.stdout
+
+
+@windows_only
+def test_existing_venv_short_circuits_discovery(tmp_path: Path) -> None:
+    """An existing venv is used as-is, without consulting the `py` launcher.
+
+    This is what stops a venv built with 3.12 from silently rebasing onto
+    whatever `py -3` resolves to later — on this project's own dev machine those
+    are different interpreters.
+    """
+    venv_python = tmp_path / "venv" / "Scripts" / "python.exe"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_bytes(b"")  # never executed: the dry run stops before use
+    result = _run(tmp_path, VERINOTE_DRY_RUN="1")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert str(venv_python) in result.stdout
+
+
+@windows_only
+def test_runs_from_a_path_containing_shell_metacharacters(tmp_path: Path) -> None:
+    """A parenthesised install path must not abort the script.
+
+    `C:\\Program Files (x86)\\...` and `...\\Repo (1)\\...` are ordinary paths.
+    The double-click probe expands `%cmdcmdline%`, so unstripped quotes let the
+    path's own `(`/`)` reach the parser, which aborted the launcher before
+    anything ran — in precisely the double-click case the probe exists for.
+    """
+    nasty = tmp_path / "Repo (1)" / "scripts"
+    nasty.mkdir(parents=True)
+    shutil.copy2(RUN_CMD, nasty / "run.cmd")
+    env = os.environ | {
+        "VERINOTE_VENV": str(tmp_path / "venv"),
+        "VERINOTE_NO_PAUSE": "1",
+        "VERINOTE_DRY_RUN": "1",
+    }
+    # Same ambient-variable pops as `_run`: an inherited VERINOTE_EXTRAS holding
+    # a metacharacter would fail this test for an entirely unrelated reason.
+    for name in ("VERINOTE_ROOT", "PYTHON", "VERINOTE_EXTRAS"):
+        env.pop(name, None)
+    # The double-click spelling specifically: `cmd /c ""<path>" "`.
+    result = subprocess.run(
+        f'cmd /c ""{nasty / "run.cmd"}" "',
+        capture_output=True,
+        text=True,
+        env=env,
+        shell=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "dry run" in result.stdout
+
+
+@windows_only
+def test_rejects_extras_containing_metacharacters(tmp_path: Path) -> None:
+    """A metacharacter in VERINOTE_EXTRAS is refused rather than executed.
+
+    It reaches an `echo` line and the stamp file, where `&` would truncate the
+    stamp so that no later launch could ever match it — silently reinstalling
+    on every single run.
+    """
+    result = _run(tmp_path, VERINOTE_EXTRAS="ingest&echo INJECTED", VERINOTE_DRY_RUN="1")
+    assert result.returncode != 0
+    assert "INJECTED" not in result.stdout
+    assert "VERINOTE_EXTRAS" in result.stdout


### PR DESCRIPTION
`scripts\run.cmd` is a double-clickable Windows entry point: it discovers a
Python, creates `.venv` if missing, installs verinote into it, and launches the
app.

```cmd
scripts\run.cmd                 REM verinote ui -> http://127.0.0.1:8731
scripts\run.cmd ui --port 9000
scripts\run.cmd status
```

## Design notes

**Arguments pass through verbatim.** Only the no-argument case injects `ui`.
Rewriting a leading `-` into `verinote ui ...` was considered and rejected:
`--version` lives on the top-level parser, so that heuristic turned one of the
two flags a new user tries first into an argparse error.

**It never sets `VERINOTE_ROOT`.** That variable takes precedence over the
active KB saved by the browser picker (`_config_for`), and the web app refuses
to save one while it is set — so a root defaulted here would shadow the user's
KB *and* remove the UI's way of correcting it. The platform default already
lives outside the working tree.

**Reinstalls are gated on a content hash**, not an mtime: the stamp holds
certutil's SHA256 of `pyproject.toml` plus the chosen extras, because two edits
inside one minute share a timestamp. An existing venv short-circuits
interpreter discovery entirely, so a venv built with 3.12 cannot silently
rebase onto whatever `py -3` resolves to later.

**Extras default to `anthropic,ingest`.** `anthropic` is the built-in default
provider, so the common path works after one launch instead of two. It is not
needed for a legible error — the adapter already raises
`LLMError: anthropic SDK not installed`. `VERINOTE_EXTRAS=ingest` is the
vendor-neutral install for ollama or claudecli.

## Bugs found by executing it

Each of these was reproduced against the script and then fixed. None would have
been caught by reading it:

- `for %%C in (%cmdcmdline%)` let a path's own `(`, `)` or `&` reach the
  parser, so an ordinary `C:\Program Files (x86)\...` aborted the launcher with
  exit 255 — in exactly the double-click case that probe exists to serve.
- A single unquotable `PY` string rejected `C:\Program Files\Python312\python.exe`
  as unusable. Split into `PYEXE` + `PYARGS`.
- `goto` from inside a `call` frame to a shared exit label ran the exit path
  twice, popping `setlocal` early and pausing twice.
- `|` as the stamp separator was parsed as a pipe when the stamp was written.
- A quote in `VERINOTE_EXTRAS` hid the next character from the metacharacter
  guard, which then failed **open** — the injected text ran and the script
  still exited 0.

## Testing

CI is ubuntu-only and can never execute a `.cmd`, so the tests skip on
non-Windows, mirroring `_shim_dir` in `tests/contract/test_contract_meta.py`.
Every case is confined to a refusal branch or `VERINOTE_DRY_RUN`, with
`VERINOTE_VENV` pointed at `tmp_path`, so no test can trigger a real install.

Verified by hand on Windows 11: fresh venv creation plus a real install; the
same via a real interpreter at a spaced path; the pip-failure branch against a
genuine `MAX_PATH` failure; stamp short-circuit (~780ms, no reinstall); all
three reinstall triggers; the 3.11 floor, above-ceiling warning, mute-interpreter
and no-Python refusals; HTTP 200 from a cwd outside the repo; and a
double-click from a `Repo (1)` path.

`ruff check` clean. Full suite compared against a clean `HEAD` worktree: the
`FAILED` name lists are byte-identical (pre-existing Windows/POSIX and cp949
failures on this machine, untouched by these paths), with exactly +9 passing —
the new tests.
