### PR TITLE
feat: add a macOS and Linux launcher beside the Windows one

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,9 @@
 # does not cover (autocrlf=false, or a clone made from Linux/WSL), not a fix for
 # a bug seen in the wild.
 *.cmd text eol=crlf
+
+# The mirror of the rule above, for the opposite failure. A CRLF checkout of a
+# shell script breaks at the shebang -- `/usr/bin/env bash\r` is not a program
+# -- and Git for Windows' default core.autocrlf=true would produce exactly that
+# in a clone someone then runs under WSL or shares onto a Mac.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -61,9 +61,19 @@ pip install -e ".[anthropic,test]"   # pick the providers you use
 verinote ui                          # opens http://127.0.0.1:8731
 ```
 
-On Windows, `scripts\run.cmd` does both steps for you — it creates the virtual
-environment, installs verinote into it, and starts the app. Double-clicking it in
-Explorer works, and so does running it from a shell:
+A launcher does both steps for you — it creates the virtual environment,
+installs verinote into it, and starts the app.
+
+On macOS and Linux:
+
+```bash
+scripts/run.sh                 # verinote ui
+scripts/run.sh ui --port 9000  # arguments are passed straight through
+scripts/run.sh status
+```
+
+On Windows, `scripts\run.cmd` is the same thing. Double-clicking it in Explorer
+works, and so does running it from a shell:
 
 ```cmd
 scripts\run.cmd                 REM verinote ui
@@ -71,7 +81,7 @@ scripts\run.cmd ui --port 9000  REM arguments are passed straight through
 scripts\run.cmd status
 ```
 
-It re-installs only when `pyproject.toml` or your chosen extras change. Set
+Both re-install only when `pyproject.toml` or your chosen extras change. Set
 `VERINOTE_EXTRAS` to pick different providers (`VERINOTE_EXTRAS=ingest` for a
 vendor-neutral install with Ollama or the Claude CLI), `PYTHON` to choose the
 interpreter, or `VERINOTE_DRY_RUN=1` to see what it would do without doing it.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# macOS/Linux launcher: provision the virtual environment if it is missing, then
+# run verinote. The POSIX counterpart of scripts/run.cmd.
+#
+#   scripts/run.sh                 -> verinote ui   (opens http://127.0.0.1:8731)
+#   scripts/run.sh ui --port 9000  -> verinote ui --port 9000
+#   scripts/run.sh status          -> verinote status
+#
+# Arguments are passed through verbatim. Only the no-argument case injects a
+# subcommand, because `--version` and `--help` live on the top-level parser and
+# a launcher that silently rewrote them into `verinote ui --version` would turn
+# the two flags a new user is likeliest to try into an argparse error.
+#
+# Environment overrides (all optional):
+#   PYTHON             interpreter to build the venv with; wins outright
+#   VERINOTE_VENV      venv location            (default: <repo>/.venv)
+#   VERINOTE_EXTRAS    pyproject extras         (default: anthropic,ingest)
+#   VERINOTE_REINSTALL set to 1 to force the install step to run
+#   VERINOTE_DRY_RUN   set to 1 to print the resolution and exit, changing nothing
+#
+# run.cmd's VERINOTE_NO_PAUSE has no counterpart here, and neither does the
+# double-click probe that guards it. Explorer closes a .cmd window the instant
+# the script exits, so a failure message would vanish with it; Terminal.app
+# defaults to "Close if the shell exited cleanly", so the same message already
+# survives a failed run. A `pause` equivalent here would instead hang every
+# scripted run that left stdin attached to a terminal.
+#
+# This script deliberately never sets VERINOTE_ROOT. That variable takes
+# precedence over the active KB saved by the browser picker (verinote/cli.py,
+# `_config_for`), and the web app refuses to save an active KB while it is set
+# — so a root defaulted here would shadow the user's own KB and lock them out
+# of correcting it from the UI. An inherited VERINOTE_ROOT is passed through
+# untouched. The platform default KB root is already outside this working tree
+# (docs/configuration.md), which is where that constraint belongs.
+#
+# Targets bash 3.2: that is what macOS ships, and it has neither associative
+# arrays nor `${x^^}`. `set -e` is deliberately not used — every failure below
+# is reported with its own remedy, which a bare exit-on-error would replace with
+# silence.
+
+set -u
+
+say() { printf '[verinote] %s\n' "$*"; }
+
+# Diagnostics go to stderr, progress and the dry-run report to stdout, so a
+# caller can capture the report without the errors bleeding into it.
+fail() {
+  for _line in "$@"; do
+    printf '[verinote] %s\n' "$_line" >&2
+  done
+  exit 1
+}
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Every path below is derived from `repo`, and the ways it can come out wrong
+# are all silent: `dirname` missing from a pinned PATH makes the substitution
+# empty, so `cd /..` lands on `/` and succeeds. The install would then run as
+# `pip install -e "/[anthropic,ingest]"` and fail talking about a requirement
+# the user never typed. Checking for the file that must be there names the real
+# problem instead, and guarantees it exists for the hash below.
+[ -f "$repo/pyproject.toml" ] || fail \
+  "error: could not locate the verinote repository from \"${BASH_SOURCE[0]}\"." \
+  "Expected to find pyproject.toml in \"$repo\"." \
+  'Run this script from its place in a verinote checkout.'
+
+venv="${VERINOTE_VENV:-$repo/.venv}"
+# An interrupted `python -m venv` leaves the directory but no interpreter, so
+# the interpreter is the existence test, never the directory.
+venvpy="$venv/bin/python"
+stamp="$venv/.verinote-install"
+extras="${VERINOTE_EXTRAS:-anthropic,ingest}"
+
+# `anthropic` matches the built-in default provider (verinote/config.py), so the
+# common path works after one launch rather than two. `ingest` makes docx/pdf
+# upload work. The `test` extra from requirements.txt is omitted: a launcher
+# provisions the app, not a dev harness. Vendor-neutral users want
+# VERINOTE_EXTRAS=ingest and an ollama or claudecli provider; neither adapter
+# needs an SDK.
+#
+# Unlike run.cmd's guard, this one is not about command injection: `$extras` is
+# only ever used inside a quoted expansion, and the shell does not re-parse the
+# result of one, so the cmd.exe failure mode (a `&` truncating the stamp write
+# and silently reinstalling on every launch) cannot occur here. What remains is
+# a validity check. Extras are PEP 508 identifiers, so anything outside this set
+# is a typo, and refusing it names the mistake instead of letting pip fail with
+# a message about a requirement the user never typed.
+case "$extras" in
+  *[!A-Za-z0-9._,-]*)
+    fail 'error: VERINOTE_EXTRAS contains characters that are not allowed.' \
+         'Use a comma-separated list of extra names, e.g.' \
+         '    VERINOTE_EXTRAS=anthropic,ingest' ;;
+esac
+
+dry_run() {
+  say 'dry run - nothing was created or installed.'
+  printf '  repo        "%s"\n' "$repo"
+  printf '  venv        "%s"\n' "$venv"
+  printf '  interpreter "%s"\n' "$py"
+  printf '  extras      "%s"\n' "$extras"
+  exit 0
+}
+
+resolve_python() {
+  # An explicit PYTHON wins outright and must not fall through to discovery:
+  # silently ignoring it would run a different interpreter than the one asked
+  # for.
+  if [ -n "${PYTHON:-}" ]; then
+    py="$PYTHON"
+    return 0
+  fi
+  # Newest CI-tested version first; keep in sync with the matrix in
+  # .github/workflows/ci.yml. The bare `python3`/`python` tail is the fallback
+  # for the systems that expose no versioned name at all: `python3` is the only
+  # spelling on many machines, while activated virtualenvs and older images
+  # expose `python` alone, so hard-coding either name breaks half of them.
+  for _cand in python3.13 python3.12 python3.11 python3 python; do
+    if command -v "$_cand" >/dev/null 2>&1; then
+      py="$_cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_version() {
+  _ver="$("$py" -c 'import sys; print(sys.version_info[0], sys.version_info[1])' 2>/dev/null)" || _ver=''
+  # Deliberately unquoted: the two fields are split on whitespace. This runs in
+  # a function, so it rewrites the function's positional parameters and leaves
+  # the script's own "$@" — the user's verinote arguments — untouched.
+  set -- $_ver
+  _major="${1:-}"
+  _minor="${2:-}"
+  # Non-numeric output would make the comparisons below a shell error rather
+  # than a diagnosis, and an interpreter that cannot answer is not usable.
+  case "${_major}.${_minor}" in
+    ''|*[!0-9.]*|.*|*.)
+      fail "error: \"$py\" could not report its version, so it is not usable." \
+           'Set PYTHON to a working Python 3.11+ interpreter.' ;;
+  esac
+  if [ "$_major" -lt 3 ] || { [ "$_major" -eq 3 ] && [ "$_minor" -lt 11 ]; }; then
+    fail "error: Python $_major.$_minor is too old; verinote requires 3.11 or newer." \
+         'Set PYTHON to a newer interpreter, e.g.' \
+         '    PYTHON=/opt/homebrew/bin/python3.12 scripts/run.sh'
+  fi
+  # Above the tested ceiling we warn and continue rather than refuse:
+  # pyproject's `requires-python = ">=3.11"` has no upper bound, and a launcher
+  # must not enforce a stricter contract than the package it installs. The real
+  # failure mode is a dependency with no wheel for this version falling back to
+  # a source build, which the warning makes legible in advance.
+  if [ "$_major" -eq 3 ] && [ "$_minor" -gt 13 ]; then
+    printf '[verinote] %s\n' \
+      "Warning: Python $_major.$_minor is newer than the versions this" \
+      'project tests (3.11-3.13). If the install fails on a package' \
+      'with no matching wheel, set PYTHON to a 3.12 or 3.13 and retry.' >&2
+  fi
+}
+
+fresh=''
+if [ ! -x "$venvpy" ]; then
+  resolve_python || fail \
+    'error: no usable Python found.' \
+    'Install Python 3.11 or newer from https://www.python.org/downloads/' \
+    '(or `brew install python@3.12`), or set PYTHON to the interpreter you' \
+    'want, e.g.' \
+    '    PYTHON=/opt/homebrew/bin/python3.12 scripts/run.sh'
+  # Checked before the dry run so that `VERINOTE_DRY_RUN=1` still reports an
+  # unusable interpreter rather than printing it as if it would work.
+  check_version
+
+  [ "${VERINOTE_DRY_RUN:-}" = '1' ] && dry_run
+
+  say "Creating the virtual environment at \"$venv\"."
+  "$py" -m venv "$venv" || fail \
+    "error: could not create the virtual environment at \"$venv\"." \
+    'Remove that directory and try again, or set VERINOTE_VENV elsewhere.'
+  [ -x "$venvpy" ] || fail \
+    "error: could not create the virtual environment at \"$venv\"." \
+    'Remove that directory and try again, or set VERINOTE_VENV elsewhere.'
+  fresh=1
+else
+  # Steady state runs no interpreter discovery at all: a venv built with 3.12
+  # must never silently rebase onto whatever `python3` resolves to today.
+  if [ "${VERINOTE_DRY_RUN:-}" = '1' ]; then
+    py="$venvpy"
+    dry_run
+  fi
+fi
+
+# Reinstall only when the declared dependencies or the chosen extras actually
+# changed. The signature is the content hash of pyproject.toml, not its
+# timestamp: two edits inside the same minute share a timestamp, which would
+# claim "fresh" when it is not. The hash is taken with the venv interpreter,
+# which is guaranteed to exist by this point, rather than with sha256sum or
+# shasum -- those are spelled differently on macOS and Linux, and picking one
+# would make the launcher's behaviour depend on which coreutils is installed.
+pjsig="$("$venvpy" -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$repo/pyproject.toml" 2>/dev/null)" || pjsig=''
+# Both inputs were checked above -- pyproject.toml exists, and venvpy is
+# executable -- so an empty hash here is a real fault (an unreadable file, a
+# broken interpreter), not a platform the launcher should route around. Saying
+# so beats substituting a placeholder that would compare unequal forever and
+# reinstall on every single launch while looking like it worked.
+[ -n "$pjsig" ] || fail \
+  "error: could not hash \"$repo/pyproject.toml\"." \
+  'Check that the file is readable and that the interpreter at' \
+  "    \"$venvpy\"" \
+  'still runs.'
+
+want="$pjsig~$extras"
+have=''
+if [ -f "$stamp" ]; then
+  read -r have < "$stamp" || have=''
+fi
+
+needinstall=''
+why='Dependencies changed'
+[ "$have" = "$want" ] || needinstall=1
+# The console script is what `[project.scripts]` regenerates; its absence is the
+# one way this script notices a `pip uninstall` done behind its back.
+if [ ! -x "$venv/bin/verinote" ]; then
+  needinstall=1
+  why='The verinote command is missing from the environment'
+fi
+if [ "${VERINOTE_REINSTALL:-}" = '1' ]; then
+  needinstall=1
+  why='VERINOTE_REINSTALL is set'
+fi
+
+if [ -n "$needinstall" ]; then
+  # Say which of the three reasons actually triggered this, rather than blaming
+  # a dependency change for an install the caller forced.
+  if [ -n "$fresh" ]; then
+    say 'First run: installing verinote and its dependencies.'
+  else
+    say "$why: reinstalling verinote."
+  fi
+  say 'This downloads packages and can take several minutes.'
+  "$venvpy" -m pip install -e "$repo[$extras]" || fail \
+    'error: installing dependencies failed.' \
+    'Check the pip output above. To start over, delete' \
+    "    \"$venv\"" \
+    'and run this script again.'
+  printf '%s\n' "$want" > "$stamp"
+fi
+
+# `exec` hands the app the terminal and makes its exit code this script's own,
+# which is the whole of run.cmd's %ERRORLEVEL% plumbing.
+if [ "$#" -eq 0 ]; then
+  exec "$venv/bin/verinote" ui
+fi
+exec "$venv/bin/verinote" "$@"

--- a/tests/test_run_sh.py
+++ b/tests/test_run_sh.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Execution tests for the macOS/Linux launcher, `scripts/run.sh`.
+
+The mirror of `tests/test_run_cmd.py`, with one difference that changes what
+these tests are worth: CI is ubuntu-only (`.github/workflows/ci.yml`), so
+`run.cmd`'s suite skips wholesale on every machine that runs it, while this one
+actually executes. The precedent for running a shell launcher for real rather
+than re-implementing its logic in Python is
+`tests/contract/test_contract_meta.py` (issue #273), which caught a broken
+wrapper that every test spawning `sys.executable` directly had let stay green.
+
+Every case here is confined to the same two harmless branches as the Windows
+suite: the ones that refuse before provisioning, and `VERINOTE_DRY_RUN=1`, which
+reports the resolution and exits. That confinement is deliberate. `run.sh`
+derives the repository from its own location, which no fixture can redirect, so
+a test that reached the install branch would run a real `pip install -e` into
+the developer's own `.venv` -- minutes of network I/O and a mutation of a
+known-good environment, out of a unit test. `VERINOTE_VENV` is pointed at
+`tmp_path` besides, so even a regression that slipped past the dry-run gate
+could not touch it.
+
+What is deliberately *not* tested here: the venv-creation and install path
+itself, and the argument passthrough that follows it, since both are reachable
+only through the side effects above.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUN_SH = REPO_ROOT / "scripts" / "run.sh"
+
+# The externals `run.sh` needs before it has found an interpreter: `bash` for
+# the `/usr/bin/env bash` shebang, and `dirname` to locate the repository. Kept
+# in step with `WRAPPER_TOOLS` in tests/contract/test_contract_meta.py, which
+# pins PATH the same way for the same reason.
+LAUNCHER_TOOLS = ("bash", "dirname")
+
+posix_only = pytest.mark.skipif(
+    os.name == "nt", reason="run.sh is a POSIX shell script; bash is not assumed on Windows"
+)
+
+
+def _run(tmp_path: Path, *args: str, **overrides: str) -> subprocess.CompletedProcess[str]:
+    """Invoke run.sh with a sandboxed venv location."""
+    env = os.environ | {"VERINOTE_VENV": str(tmp_path / "venv")}
+    # A stale VERINOTE_ROOT from the ambient shell would not change the script's
+    # behaviour, but drop it so a failure here can never be blamed on one.
+    for name in ("VERINOTE_ROOT", "PYTHON", "VERINOTE_DRY_RUN", "VERINOTE_EXTRAS",
+                 "VERINOTE_REINSTALL"):
+        env.pop(name, None)
+    env.update(overrides)
+    return subprocess.run(
+        [str(RUN_SH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def _output(result: subprocess.CompletedProcess[str]) -> str:
+    """Both streams. Diagnostics go to stderr, the dry-run report to stdout."""
+    return result.stdout + result.stderr
+
+
+def _shim(tmp_path: Path, name: str, body: str) -> Path:
+    """A fake interpreter that answers the script's version query and nothing else.
+
+    `run.sh` asks for the version with `-c "import sys; print(...)"` and reads
+    two whitespace-separated tokens, so a shell script that echoes them is a
+    complete stand-in -- and cannot accidentally build a virtualenv.
+    """
+    path = tmp_path / name
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _toolsdir(tmp_path: Path) -> Path:
+    """A PATH directory exposing the launcher's externals and *no* interpreter.
+
+    Pinning PATH to this is what makes the discovery cases hold everywhere: the
+    ambient PATH on any dev machine has a `python3`, so a test that relied on it
+    could not distinguish "discovery worked" from "discovery was never needed".
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    for tool in LAUNCHER_TOOLS:
+        real = shutil.which(tool)
+        if real is None:
+            pytest.skip(f"{tool} is not available; run.sh cannot run on this platform")
+        (bin_dir / tool).symlink_to(real)
+    return bin_dir
+
+
+def test_script_never_assigns_verinote_root() -> None:
+    """The launcher must not default VERINOTE_ROOT.
+
+    That variable takes precedence over the active KB saved by the browser
+    picker (`verinote/cli.py`, `_config_for`), and `verinote/web/app.py` refuses
+    to save an active KB while it is set -- so a root defaulted by a launcher
+    would shadow the user's KB *and* remove the UI's way of correcting it. The
+    failure is silent, which is why it is pinned here rather than left to
+    review. The Windows launcher carries the identical guard.
+
+    Both spellings are matched: a bare assignment and an `export`, since either
+    would leak the variable into the app the script goes on to exec.
+    """
+    assign = re.compile(r"^\s*(export\s+)?VERINOTE_ROOT=", re.MULTILINE)
+    text = RUN_SH.read_text(encoding="utf-8")
+    assert assign.search(text) is None
+
+
+def test_script_is_executable() -> None:
+    """The mode bit is part of the deliverable.
+
+    `scripts/run.sh` is documented as being run directly, so a checkout where
+    git recorded 100644 turns the README's own command into "permission
+    denied". Nothing else in the suite would notice: every case here invokes the
+    script as itself, which is exactly the invocation that breaks.
+    """
+    assert os.access(RUN_SH, os.X_OK)
+
+
+@posix_only
+def test_dry_run_resolves_an_interpreter(tmp_path: Path) -> None:
+    result = _run(tmp_path, VERINOTE_DRY_RUN="1")
+    assert result.returncode == 0, _output(result)
+    assert "dry run" in result.stdout
+    # The resolution must name a concrete interpreter, not an empty variable.
+    interpreter = [ln for ln in result.stdout.splitlines() if ln.strip().startswith("interpreter")]
+    assert len(interpreter) == 1, result.stdout
+    assert interpreter[0].split(None, 1)[1].strip(' "')
+
+
+@posix_only
+def test_refuses_python_below_the_floor(tmp_path: Path) -> None:
+    """3.10 is refused outright: pyproject requires >=3.11 and the install would fail anyway."""
+    shim = _shim(tmp_path, "py310", "echo 3 10")
+    result = _run(tmp_path, PYTHON=str(shim))
+    assert result.returncode != 0
+    assert "3.10" in _output(result)
+    assert "3.11" in _output(result)
+
+
+@posix_only
+def test_warns_but_proceeds_above_the_tested_ceiling(tmp_path: Path) -> None:
+    """Newer than the CI matrix warns; it must not refuse.
+
+    `requires-python = ">=3.11"` has no upper bound, so a launcher that refused
+    here would enforce a stricter contract than the package it installs.
+    """
+    shim = _shim(tmp_path, "py399", "echo 3 99")
+    result = _run(tmp_path, PYTHON=str(shim), VERINOTE_DRY_RUN="1")
+    assert result.returncode == 0, _output(result)
+    assert "Warning" in _output(result)
+    assert "3.99" in _output(result)
+
+
+@posix_only
+def test_rejects_an_interpreter_that_cannot_report_a_version(tmp_path: Path) -> None:
+    """An explicit PYTHON that answers nothing is an error, never a fall-through.
+
+    Silently discovering a different interpreter would run something other than
+    the one the caller named.
+    """
+    shim = _shim(tmp_path, "pymute", ": answers nothing")
+    result = _run(tmp_path, PYTHON=str(shim), VERINOTE_DRY_RUN="1")
+    assert result.returncode != 0
+    assert "version" in _output(result).lower()
+
+
+@posix_only
+def test_reports_when_no_python_is_available(tmp_path: Path) -> None:
+    """With no interpreter on PATH the script says so and names PYTHON as the way out.
+
+    The message itself is asserted, not just the word `PYTHON`: that substring
+    also appears in the "could not report its version" refusal, so matching it
+    alone could not tell the two failures apart.
+    """
+    result = _run(tmp_path, PATH=str(_toolsdir(tmp_path)))
+    assert result.returncode != 0
+    assert "no usable Python found" in _output(result)
+    assert "PYTHON" in _output(result)
+
+
+@posix_only
+def test_honours_an_explicit_python_override(tmp_path: Path) -> None:
+    """PYTHON must win over discovery.
+
+    PATH here holds *no* interpreter at all, so the run can only succeed via the
+    override -- if it were ignored, discovery would have nothing to fall back on
+    and this would go red rather than pass by luck.
+    """
+    result = _run(
+        tmp_path,
+        PATH=str(_toolsdir(tmp_path)),
+        PYTHON=sys.executable,
+        VERINOTE_DRY_RUN="1",
+    )
+    assert result.returncode == 0, _output(result)
+    assert sys.executable in result.stdout
+
+
+@posix_only
+def test_existing_venv_short_circuits_discovery(tmp_path: Path) -> None:
+    """An existing venv is used as-is, without consulting PATH.
+
+    This is what stops a venv built with 3.12 from silently rebasing onto
+    whatever `python3` resolves to later -- on this project's own dev machine
+    those are different interpreters. PATH is pinned bare to prove the point:
+    discovery could not have supplied this answer.
+    """
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_bytes(b"")  # never executed: the dry run stops before use
+    venv_python.chmod(venv_python.stat().st_mode | stat.S_IXUSR)
+    result = _run(tmp_path, PATH=str(_toolsdir(tmp_path)), VERINOTE_DRY_RUN="1")
+    assert result.returncode == 0, _output(result)
+    assert str(venv_python) in result.stdout
+
+
+@posix_only
+def test_directory_without_an_interpreter_is_not_mistaken_for_a_venv(tmp_path: Path) -> None:
+    """An interrupted `python -m venv` leaves the directory but no interpreter.
+
+    The existence test is therefore the interpreter, never the directory. If it
+    were the directory, this run would skip provisioning and go on to exec a
+    `verinote` that was never installed.
+    """
+    (tmp_path / "venv" / "bin").mkdir(parents=True)
+    result = _run(tmp_path, PATH=str(_toolsdir(tmp_path)))
+    assert result.returncode != 0
+    assert "no usable Python found" in _output(result)
+
+
+@posix_only
+def test_runs_from_a_path_containing_shell_metacharacters(tmp_path: Path) -> None:
+    """A parenthesised, spaced install path must not derail the script.
+
+    `~/Downloads/verinote (1)/` is what an unzip of a second copy produces, and
+    every path the script derives from its own location flows from there into a
+    command line.
+    """
+    nasty = tmp_path / "Repo (1) & co" / "scripts"
+    nasty.mkdir(parents=True)
+    shutil.copy2(RUN_SH, nasty / "run.sh")
+    # The script now refuses a location with no pyproject.toml beside it, which
+    # is the point of the guard -- so the copy needs one to get as far as the
+    # resolution this test is actually about.
+    (nasty.parent / "pyproject.toml").write_text("", encoding="utf-8")
+    env = os.environ | {"VERINOTE_VENV": str(tmp_path / "venv"), "VERINOTE_DRY_RUN": "1"}
+    # Same ambient-variable pops as `_run`: an inherited VERINOTE_EXTRAS holding
+    # a metacharacter would fail this test for an entirely unrelated reason.
+    for name in ("VERINOTE_ROOT", "PYTHON", "VERINOTE_EXTRAS", "VERINOTE_REINSTALL"):
+        env.pop(name, None)
+    result = subprocess.run(
+        [str(nasty / "run.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "dry run" in result.stdout
+    assert str(nasty.parent) in result.stdout
+
+
+@posix_only
+def test_refuses_when_the_repository_cannot_be_located(tmp_path: Path) -> None:
+    """A mis-derived repository root is named, not acted on.
+
+    Everything the launcher does is built from that root, and each way it can
+    come out wrong is silent: with `dirname` absent from PATH the substitution
+    is empty, so `cd /..` lands on `/` and succeeds. Without this guard the run
+    reaches `pip install -e "/[anthropic,ingest]"` and fails talking about a
+    requirement the user never typed.
+    """
+    stray = tmp_path / "not-a-checkout" / "scripts"
+    stray.mkdir(parents=True)
+    shutil.copy2(RUN_SH, stray / "run.sh")
+    result = subprocess.run(
+        [str(stray / "run.sh")],
+        capture_output=True,
+        text=True,
+        env=os.environ | {"VERINOTE_VENV": str(tmp_path / "venv"), "VERINOTE_DRY_RUN": "1"},
+        timeout=120,
+    )
+    assert result.returncode != 0
+    assert "pyproject.toml" in _output(result)
+
+
+@posix_only
+def test_rejects_extras_that_are_not_extra_names(tmp_path: Path) -> None:
+    """A metacharacter in VERINOTE_EXTRAS is refused rather than passed to pip.
+
+    Unlike the Windows launcher, this is not an injection guard: `$extras` is
+    only ever used inside a quoted expansion, and the shell does not re-parse
+    the result of one. It is a validity check -- extras are PEP 508 identifiers,
+    so this names the typo instead of letting pip fail with a message about a
+    requirement the user never typed.
+    """
+    result = _run(tmp_path, VERINOTE_EXTRAS="ingest&echo INJECTED", VERINOTE_DRY_RUN="1")
+    assert result.returncode != 0
+    assert "INJECTED" not in _output(result)
+    assert "VERINOTE_EXTRAS" in _output(result)


### PR DESCRIPTION
`scripts/run.sh` is the POSIX counterpart of `scripts/run.cmd`: it discovers a Python, creates `.venv` if missing, installs verinote into it, and launches the app. macOS and Linux had no launcher — the Quickstart only documented the Windows one.

The contract is the one `run.cmd` documents. `PYTHON` wins outright over discovery; an existing venv short-circuits discovery entirely, so a venv built with 3.12 cannot rebase onto whatever `python3` resolves to later; the 3.11 floor refuses while anything above the 3.13 CI ceiling only warns; only the no-argument case injects `ui`, so `--version` still reaches the top-level parser. It never sets `VERINOTE_ROOT`, for the reason `run.cmd` gives, and the same static test pins that.

## Deliberate deviations from run.cmd

These are ported decisions, not transliterations, and each carries its reasoning in the script rather than inheriting the Windows one.

**The double-click probe and `VERINOTE_NO_PAUSE` are gone.** `run.cmd` needs them because Explorer closes the window the instant the script exits, taking the error with it. Terminal.app defaults to leaving a failed run's window open, so the message already survives. A `pause` equivalent would instead hang every scripted run that left stdin attached to a terminal.

**`pyproject.toml` is hashed with the venv's own interpreter and `hashlib`,** not `sha256sum` or `shasum`. Those are spelled differently on macOS and Linux, and picking either would make reinstall behaviour depend on which coreutils happens to be installed. The interpreter is guaranteed to exist wherever the hash is taken, so this costs nothing.

**The `VERINOTE_EXTRAS` guard is an allowlist justified as a validity check.** `run.cmd`'s blacklist exists because the value reaches an `echo` line which cmd re-parses — that is how a `&` truncated the stamp and made every launch reinstall while still reporting success. The shell does not re-parse the result of a quoted expansion, so that failure cannot occur here. Copying the injection rationale across would have been false. What remains is that extras are PEP 508 identifiers, so refusing anything else names the typo instead of letting pip fail about a requirement the user never typed.

`*.sh text eol=lf` mirrors the existing `.cmd` rule for the opposite failure: Git for Windows defaults to `core.autocrlf=true`, and a CRLF checkout of a shell script breaks at the shebang, since `/usr/bin/env bash\r` is not a program.

## Hazards found by running it

- With `dirname` absent from a pinned `PATH` the substitution is empty, so `cd /..` lands on `/` and *succeeds*. The run then reached `pip install -e "/[anthropic,ingest]"` and failed talking about a requirement nobody typed. The derived root is now checked for its own `pyproject.toml`, which also guarantees the input to the hash above.
- An unhashable `pyproject.toml` was first papered over with a placeholder signature. That compares unequal forever, so it would have reinstalled on every launch while looking like it worked. It is a hard failure now.

## Testing

Unlike the `.cmd` suite — which skips wholesale, since CI is ubuntu-only and can never run a batch file — **these tests actually execute in CI.** They stay confined to the refusal branches and `VERINOTE_DRY_RUN` so they can never trigger a real install, and `PATH` is pinned to a directory holding no interpreter at all, so the discovery cases cannot pass vacuously. That PATH-pinning follows the `tests/contract/test_contract_meta.py` precedent from #273.

The suite was mutation-tested to confirm it is not vacuous: lowering the version floor, swapping the interpreter check for a directory check, and disabling the `PYTHON` override each turned it red, and it went green again on restore.

The provisioning and install path is unreachable without the side effects above, so — as `run.cmd`'s suite says it does on Windows — it was verified by hand, into a throwaway venv: cold install, `status` propagating its own exit code, `--version` passing through, and each of the four reinstall triggers firing with its own distinct reason. Also verified under macOS's actual bash 3.2.

## Reviewer notes

Two things worth a second pair of eyes:

- **The review was not independent of the author.** The intended independent review pass could not run in the authoring environment, so both hazards above were found by self-review — which is exactly the check self-review is weakest at. The shell script is where I would start.
- **The broad suite was not run.** The authoring environment has no provisioned venv, and the bare interpreter lacks `fastapi`/`starlette`; the identical collection errors reproduce at the base commit in a clean worktree, so they predate this change. CI will be the first full run.

Argument passthrough is covered by the hand-run above, not by an automated test.
