### PR TITLE
Add OpenRouter: keys in Settings, a catalogue-backed model picker, and a keyless listing seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ Three things set verinote apart:
    which adapter *and endpoint* you configure decides what leaves your machine:
    document text and your questions go to whatever endpoint that adapter is
    pointed at. By default that is Anthropic's or OpenAI's API for those
-   adapters, and a server on your own machine for Ollama — but `VERINOTE_BASE_URL`
-   redirects any of the three, in either direction. The Claude CLI adapter is the
-   exception: it shells out to the `claude` binary, so it goes wherever that CLI
-   is configured to talk to — Anthropic unless your environment redirects it. No
-   lock-in either way; that is a design principle, not a missing feature.
+   adapters, `https://openrouter.ai/api/v1` for OpenRouter, and a server on your
+   own machine for Ollama — but `VERINOTE_BASE_URL` redirects any of the four,
+   in either direction. The Claude CLI adapter is the exception: it shells out
+   to the `claude` binary, so it goes wherever that CLI is configured to talk to
+   — Anthropic unless your environment redirects it. No lock-in either way; that
+   is a design principle, not a missing feature.
 
 When you ask a question, the answer arrives labeled with how much you can trust
 it: **`VERIFIED — engine`** when the Datalog engine proved it from facts you
@@ -99,7 +100,7 @@ that mapping and the rest of the query path are in
 | Concern | Decision |
 |---|---|
 | Logic engine | **DuckDB-backed Datalog.** Confirmed rows load into in-memory DuckDB; non-recursive policy/query rules compile to SQL. |
-| LLM | **Hand-rolled `LLMClient` adapters** (Anthropic / Claude CLI / OpenAI / Ollama). No vendor lock-in. |
+| LLM | **Hand-rolled `LLMClient` adapters** (Anthropic / Claude CLI / OpenAI / OpenRouter / Ollama). No vendor lock-in. |
 | Web | **FastAPI + HTMX + Jinja** — server-rendered partials, no JS build step. |
 | Storage | **SQLite** owns KB metadata, source/run provenance, review lifecycle, the audit log, and the text display mirrors. **DuckDB** owns the canonical logical fact terms, runs verification, and attaches SQLite read-only for metadata analytics. `.dl` policy/query files stay editable inputs. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,13 +69,20 @@ creating any KB files, including nested or symlinked paths that resolve there.
 ## Providers
 
 Provider choice lives in `config.json` (or `VERINOTE_PROVIDER`), and one adapter
-is selected from it: `anthropic`, `claudecli`, `openai`, or `ollama`. Install only
-the SDK you need — the LLM extras exist so the app installs without any single
-vendor's package:
+is selected from it: `anthropic`, `claudecli`, `openai`, `openrouter`, or
+`ollama`. Install only the SDK you need — the LLM extras exist so the app
+installs without any single vendor's package:
 
 ```bash
 pip install -e ".[anthropic]"   # or .[openai] — Ollama needs no SDK
 ```
+
+OpenRouter speaks the OpenAI wire protocol and inherits that adapter's request
+paths, so it uses the same `.[openai]` extra; there is no separate `openrouter`
+extra. What it does not inherit is the endpoint: an unset Base URL resolves to
+`https://openrouter.ai/api/v1` rather than to OpenAI's API, so clearing the field
+cannot send your documents to a vendor you did not select. A Base URL you do set
+still overrides it.
 
 ### Picking an Ollama model
 
@@ -98,6 +105,58 @@ The field never becomes unusable: when the list cannot be loaded you can still
 type a model id and save. And a model named in `config.json` that the server
 does not have stays selected, marked `— not installed`, rather than being
 silently swapped for one that is — the page reports your KB's real state.
+
+### Picking an OpenRouter model
+
+With `openrouter` selected, Settings turns the Model field into a picker too, but
+over a different kind of list: the catalogue the endpoint you configured
+publishes (`GET {base_url}/models` against your Base URL, or
+`https://openrouter.ai/api/v1` when it is unset). That request carries **no API
+key**, so what comes back is the catalogue that endpoint publishes — not a list
+of what your account can reach. A model in the dropdown is one the catalogue lists,
+not one verinote has confirmed your key can call: **Test connection** runs one
+real extraction with the provider and model you chose, and that is what confirms
+a choice works.
+
+The options are split into two groups, **Advertises structured output** and
+**Does not advertise structured output**, built from what each catalogue entry
+declares in its `supported_parameters`. The split matters because verinote asks
+for a JSON-schema `response_format` on every call that has to come back as JSON —
+extraction, query translation, query intent — so picking from the second group
+means asking a model for something its own entry does not advertise. Both groups
+render even when one is empty, and neither is a measurement: verinote has not run
+these models, it is repeating what the catalogue says about them.
+
+As with Ollama, the list reloads when you change the provider or the Base URL, a
+**Refresh list** button re-reads it, and the field never becomes unusable — when
+the catalogue cannot be loaded you can still type a model id and save. The same
+three outcomes stay distinct:
+
+| What you see | What it means |
+|---|---|
+| A grouped picker | that endpoint is reachable and lists these models |
+| Text input + *"is reachable but listed no models"* | reachable, but the catalogue came back empty |
+| Text input + *"Could not load the model list"* | that endpoint could not be reached; the error is quoted verbatim |
+
+A model named in `config.json` that the catalogue does not list stays selected,
+marked `— not in this catalogue`, rather than being silently swapped — the page
+reports your KB's real state. Leave the model blank and the built-in default
+applies: `openai/gpt-oss-20b:free`, a concrete free model rather than the
+`openrouter/free` router. A router picks a different model per request, so one
+**Test connection** could not stand for the next call, and the settings banner
+would name a model that did not answer. This one was chosen because every
+endpoint serving it advertises structured output — which holds because it has
+exactly one endpoint, not because a fleet of them was surveyed. And again,
+*advertises*: whether an endpoint honours `strict` is only knowable by running
+it.
+
+Switching the provider select **to** OpenRouter clears the Base URL field,
+because that field's only job is to point verinote at a different endpoint and
+the endpoint you are leaving belongs to the provider you are leaving —
+`http://localhost:11434` is not an OpenRouter endpoint. Only OpenRouter does
+this. The clear is announced, not silent: a note names the value that was
+discarded and what would be dialled instead, nothing is written until you press
+**Save**, and typing the old value back in keeps it.
 
 ### Picking a Claude CLI model
 
@@ -123,9 +182,71 @@ Because the list cannot be verified against a server, **Test connection** is the
 check that matters here: it runs one real extraction through the `claude` binary
 with the model you chose.
 
-The cloud providers keep the plain free-text field — a vendor catalogue is not a
-property of the endpoint you point at, so there is no list they could answer
-truthfully either.
+Anthropic and OpenAI keep the plain free-text field — a vendor's own catalogue is
+not a property of the endpoint you point at, so there is no list they could
+answer truthfully either. OpenRouter is the exception among the cloud providers,
+and it does not generalise: there, the endpoint you are configuring is itself
+what serves the catalogue.
+
+## API keys
+
+`anthropic`, `openai`, and `openrouter` authenticate with an API key. The other
+two never read one at all — `claudecli` shells out to the `claude` binary and
+`ollama` talks to a local endpoint — so Settings lists them as *no API key
+needed*.
+
+Settings has an **API keys** section with one small form per key-using provider —
+its own form, so a key can never ride along with a provider/model save. All five
+providers get a row; the two that need no key get no form. The field is a
+password input and is never rendered back with a value, so submitting it empty
+means *leave the current key alone*; **Remove saved key** is the separate action
+that clears one.
+
+Saved keys are written to `credentials.json` in the same app config directory as
+`app.json` — never inside a KB, so a KB stays safe to copy or share — with file
+mode `0600`, and each provider's key is stored separately so a key saved for one
+is never sent to another. One caveat to that first claim: a key shorter than
+the app's redaction threshold is accepted (a self-hosted gateway's token can
+legitimately be that short) but Settings warns when you save one, because
+redaction of a provider's error text only covers secrets at least that long,
+and those error messages *are* stored in the KB.
+
+A provider-scoped environment variable wins. For each provider, the key is
+resolved in this order:
+
+| Source | Notes |
+|---|---|
+| `VERINOTE_<PROVIDER>_API_KEY` | provider-scoped, e.g. `VERINOTE_OPENROUTER_API_KEY`, `VERINOTE_ANTHROPIC_API_KEY`, `VERINOTE_OPENAI_API_KEY` |
+| the key saved in Settings | per provider |
+| `VERINOTE_API_KEY` | legacy, provider-agnostic — applies to whichever provider got this far |
+
+The saved key sits above the legacy variable on purpose: `VERINOTE_API_KEY` names
+no provider, so ranking it first would take a key you saved *for OpenAI* and
+replace it with whatever single value happens to be exported. The scoped variable
+keeps env-first available without that ambiguity. Settings shows which of these
+each provider's key is actually coming from, and warns when a saved key is being
+shadowed by the environment.
+
+An unreadable `credentials.json` is a halt, not an absence. If the file is there
+but cannot be read or understood, and it is what would have decided the selected
+provider's key, verinote refuses provider calls. That check sits at the one
+place every provider call is built, before the provider is even chosen, so it
+covers every path that calls one by construction — extraction, question repair,
+asking a question, translating questions, the model list, and **Test
+connection** are examples of what stops, not the full set — rather than
+proceeding as though no key were saved and calling a provider unauthenticated. A
+provider whose key comes from either environment variable is unaffected, because
+the file could not have changed the outcome. Settings says which of those two
+situations you are in, and `/credentials-unavailable` names the file and the
+ways out — restore it from a backup, delete it, export the scoped variable for
+the provider you are using, or switch to a provider that needs no key. Saving a
+key stays refused until then: a save merges into the other providers' entries,
+so writing over a file it cannot read would silently discard them.
+
+verinote does not fall back to a vendor SDK's own `OPENAI_API_KEY` or
+`ANTHROPIC_API_KEY`: a request that authenticated with a credential verinote
+never resolved could not be redacted from an error message, so a missing key is
+an error instead.
 
 ## Auto-accept
 
@@ -149,7 +270,7 @@ Set it in the Settings UI, in `config.json`, or via
 
 | Extra | What it installs |
 |---|---|
-| `anthropic`, `openai` | the vendor SDK for that provider |
+| `anthropic`, `openai` | the vendor SDK for that provider (OpenRouter uses `openai` — see [Providers](#providers)) |
 | `ingest` | `python-docx` + `pypdf`, for binary source ingestion (docx/pdf → text) |
 | `test` | the test dependencies |
 | `analytics` | nothing — a **compatibility no-op**. DuckDB is a core dependency because it powers verification, and analytics uses that same dependency. |

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -9,6 +9,7 @@ or that the deterministic suite would otherwise paper over:
 | `test_query_intent_contract.py` | #237 | A role question the deterministic parser hands off must yield a valid intent through the live provider and the production parse boundary. |
 | `test_extraction_contract.py` | #238 | A founding-date fact the extractor produces must normalise into the policy's *functional* relation vocabulary, so a two-date contradiction is catchable. |
 | `test_sync_rc_contract.py` | #239 | `verinote sync` must not report success when every extraction chunk fails. |
+| `test_openrouter_catalogue_contract.py` | — | OpenRouter's model catalogue must still carry the `id` and `supported_parameters` fields the settings Model picker is built from, and still declare `structured_outputs`. Needs no key or client; reads the live endpoint. |
 | `test_contract_meta.py` | — | Meta guards on the harness itself (marker registered, fixtures carry provenance, every module has a guard, the skipped-run guard bites). Runs in the default suite. |
 
 ## Running

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -20,9 +20,12 @@ Two gates share it:
   provider is unreachable (e.g. the ``claude`` binary is missing) it *fails*,
   never skips — a provider you asked to exercise but that cannot run is a real
   failure, not an absence of coverage (issue #234).
-* :func:`require_opt_in` gates the deterministic contract tests (replay and the
-  sync exit-code guard). They need no live provider but must still stay out of
-  the default suite, so they skip on the same unset gate.
+* :func:`require_opt_in` gates the guards that build no provider client: the
+  replays, the sync exit-code guard, and the OpenRouter catalogue guard. The
+  first two are deterministic; the last reads a live, unauthenticated HTTP
+  endpoint. What they share is that none of them needs a provider client or a
+  key — and that all of them must stay out of the default suite, so they skip on
+  the same unset gate.
 
 :func:`pytest_sessionfinish` closes the harness's worst failure mode: asking for
 contract tests and getting a green run that exercised nothing. Whenever a run
@@ -265,7 +268,13 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
 @pytest.fixture
 def require_opt_in() -> str:
-    """Skip unless the opt-in gate is set. For deterministic contract tests."""
+    """Skip unless the opt-in gate is set. For contract tests needing no client.
+
+    Which provider the gate names is not read here: these guards build no
+    provider client, so any set gate means "run the opt-in tests". Not every one
+    of them is offline — the OpenRouter catalogue guard reads a live endpoint —
+    so this is not a promise that nothing touches the network.
+    """
     provider = contract_provider()
     if not provider:
         pytest.skip(GATE_HINT)

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -58,6 +58,7 @@ CONTRACT_MODULES = (
     "test_query_intent_contract.py",
     "test_extraction_contract.py",
     "test_sync_rc_contract.py",
+    "test_openrouter_catalogue_contract.py",
 )
 # A module whose contract tests are *all* gated, so an ungated run executes none
 # of them.

--- a/tests/contract/test_openrouter_catalogue_contract.py
+++ b/tests/contract/test_openrouter_catalogue_contract.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Contract guard for the OpenRouter catalogue the settings Model picker reads.
+
+The picker is built from two things `GET {base_url}/models` returns: a string
+``id`` per entry, and a ``supported_parameters`` list carrying
+``structured_outputs`` for the entries that advertise it. Both are OpenRouter's
+schema, not verinote's, so a rename upstream is invisible to the deterministic
+suite -- which stubs the response and would stay green while every real user's
+picker either failed to load or filed all 300-odd models under "does not
+advertise structured output".
+
+Two guards, because the two ways it can rot fail differently:
+
+* a missing or retyped ``id`` / ``supported_parameters`` makes
+  :func:`~verinote.llm.openrouter_adapter.list_models` raise, and the picker
+  degrades to a text input with an error -- loud, but only for users.
+* a renamed ``structured_outputs`` value raises nothing at all. The listing
+  still parses; the grouping just silently becomes "none of them". That one
+  needs a positive assertion that the string is still in the live data, which is
+  why the second guard exists and does not simply re-run the first.
+
+Both guards read one fetched snapshot, and the module makes exactly one request:
+they assert about the same catalogue, and a comparison between them cannot fail
+merely because OpenRouter edited its listing between two calls.
+
+Gated opt-in like every other module here, so the default suite never reaches
+the network; the scheduled provider lane is what runs it. It needs no API key
+and builds no client -- the catalogue endpoint answers unauthenticated, which is
+the property that lets the settings seam list models without holding a key.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+import pytest
+
+from verinote.llm.openrouter_adapter import (
+    OPENROUTER_DEFAULT_BASE_URL,
+    _STRUCTURED_OUTPUTS_PARAMETER,
+    list_models,
+)
+
+_TIMEOUT_SECONDS = 30.0
+_raw_catalogue: dict | None = None
+
+
+def _live_catalogue() -> dict:
+    """The decoded catalogue body. The only request this module makes, once.
+
+    Memoised rather than a module-scoped fixture: the gate is a function-scoped
+    fixture, and a module-scoped one could not depend on it -- so the fetch would
+    move above the gate and the default suite would hit the network on collection.
+    """
+    global _raw_catalogue
+    if _raw_catalogue is None:
+        req = urllib.request.Request(f"{OPENROUTER_DEFAULT_BASE_URL}/models")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS) as resp:  # noqa: S310
+            _raw_catalogue = json.loads(resp.read().decode("utf-8"))
+    return _raw_catalogue
+
+
+def _listing_from_the_fetched_catalogue(monkeypatch):
+    """The production parse, run over the body `_live_catalogue` already fetched.
+
+    `list_models` fetches and parses in one function, so handing its transport
+    the snapshot is the only way to reach the parse with the same bytes the raw
+    assertions were made against. Calling it plainly would dial the endpoint a
+    second time, and two responses need not agree: OpenRouter edits the
+    catalogue continuously and serves it from more than one backend, so
+    comparing a parse of snapshot B against ids read out of snapshot A reddens
+    the scheduled lane for an ordinary upstream edit with no contract broken.
+
+    Only the second *request* is stubbed. The bytes are the live ones, and every
+    line of `list_models` that reads them -- the schema checks, the id
+    normalisation, the `supported_parameters` split -- runs unchanged, which is
+    what these guards are here to exercise.
+    """
+    body = _live_catalogue()
+
+    class _Snapshot:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def read(self):
+            return json.dumps(body).encode("utf-8")
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, *, timeout: _Snapshot())
+    return list_models(None, _TIMEOUT_SECONDS)
+
+
+@pytest.mark.contract
+def test_live_catalogue_entries_carry_an_id_and_supported_parameters(require_opt_in):
+    """Every entry must still have the two fields the picker is built from.
+
+    Asserted against the raw body, not through `list_models`: the adapter raises
+    on the first bad entry, so a partial rename would surface as one opaque
+    error instead of a count. Here it names how many entries broke and which.
+    """
+    body = _live_catalogue()
+    assert isinstance(body, dict) and isinstance(body.get("data"), list), (
+        f"the catalogue is no longer {{'data': [...]}}: {sorted(body)[:8]}"
+    )
+    entries = body["data"]
+    assert entries, "the live catalogue listed no models at all"
+    malformed = [
+        entry.get("id", entry)
+        for entry in entries
+        if not isinstance(entry, dict)
+        or not isinstance(entry.get("id"), str)
+        or not isinstance(entry.get("supported_parameters"), list)
+    ]
+    assert not malformed, (
+        f"{len(malformed)}/{len(entries)} catalogue entries lack a string `id` or a "
+        f"`supported_parameters` list: {malformed[:5]}"
+    )
+
+
+@pytest.mark.contract
+def test_live_catalogue_still_declares_structured_outputs_and_splits_in_two(
+    require_opt_in, monkeypatch
+):
+    """The grouping value must still appear, and must still split the catalogue.
+
+    A rename of `structured_outputs` raises nothing -- the listing parses and
+    every model quietly lands in "does not advertise structured output" -- so the
+    presence of the string is asserted positively. Both groups are then required
+    to be non-empty through the production `list_models`, because a picker whose
+    second group is always empty renders a heading that never means anything, and
+    one whose first group is empty is the silent-rename failure itself.
+
+    Both halves read the one fetched snapshot, so the equality below compares a
+    parse against the very bytes it parsed rather than against a second, possibly
+    newer response -- see `_listing_from_the_fetched_catalogue`.
+    """
+    entries = _live_catalogue()["data"]
+    declaring = [
+        entry["id"]
+        for entry in entries
+        if _STRUCTURED_OUTPUTS_PARAMETER in entry.get("supported_parameters", [])
+    ]
+    assert declaring, (
+        f"no live catalogue entry lists {_STRUCTURED_OUTPUTS_PARAMETER!r} in its "
+        "`supported_parameters`; either OpenRouter renamed it or nothing advertises "
+        "it any more, and the settings picker's grouping now says the same thing "
+        "about every model"
+    )
+
+    listing = _listing_from_the_fetched_catalogue(monkeypatch)
+
+    assert listing.structured_output_ids is not None
+    assert set(listing.structured_output_ids) == set(declaring)
+    assert set(listing.models) - set(listing.structured_output_ids), (
+        "every live model advertises structured output, so the picker's second "
+        "group is empty; the split is no longer telling a user anything"
+    )

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -8,6 +8,7 @@ from verinote.config import Config, save_settings
 from verinote.llm.anthropic_adapter import AnthropicAdapter
 from verinote.llm.base import LLMError
 from verinote.llm.openai_adapter import OpenAIAdapter
+from verinote.llm.openrouter_adapter import OpenRouterAdapter
 from verinote.prompts import save_prompt_override
 
 
@@ -253,6 +254,17 @@ _CLOUD_ADAPTERS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _configured_key(monkeypatch):
+    """The base_url tests below resolve their Config from the environment, and a
+    cloud adapter now refuses to run without a key rather than letting the vendor
+    SDK fall back to its own env var. They are about base_url plumbing, so give
+    them a key. Tests that exercise key handling build their Config directly and
+    are unaffected by this.
+    """
+    monkeypatch.setenv("VERINOTE_API_KEY", "configured-test-key")
+
+
 @pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
 def test_empty_base_url_env_reaches_cloud_client_as_none(tmp_path, monkeypatch, provider):
     # `is None`, not falsy: an empty string is falsy too, so a truthiness check
@@ -315,3 +327,88 @@ def test_padded_base_url_reaches_cloud_client_trimmed(tmp_path, monkeypatch, pro
     adapter_cls(Config.for_root(tmp_path)).extract_facts(source_text="x")
 
     assert recorded["base_url"] == "https://llm.internal/v1"
+
+
+# --- a provider's 401 body can echo the key it rejected ---
+
+_LONG_KEY = "sk-test-DEADBEEFDEADBEEF"
+
+
+def _raising_sdk(monkeypatch, provider: str, exc: Exception) -> None:
+    """Stub the vendor SDK so the request path raises inside the adapter's try."""
+
+    class _Raises:
+        def create(self, **kwargs):
+            raise exc
+
+    if provider in ("openai", "openrouter"):
+        client = SimpleNamespace(chat=SimpleNamespace(completions=_Raises()))
+        monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=lambda **k: client))
+    else:
+        client = SimpleNamespace(messages=_Raises())
+        monkeypatch.setitem(
+            sys.modules, "anthropic", SimpleNamespace(Anthropic=lambda **k: client)
+        )
+
+
+def _keyed_cfg(tmp_path, provider: str, key: str | None) -> Config:
+    return Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider=provider,
+        model="model",
+        api_key=key,
+        base_url=None,
+    )
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+@pytest.mark.parametrize("provider", sorted(_CLOUD_ADAPTERS))
+def test_provider_error_never_carries_the_key(tmp_path, monkeypatch, method, provider):
+    """This string is persisted into `source_chunks.error` and rendered on three
+    pages, so a key echoed back by a 401 would come to rest inside the KB — the
+    one place the key is supposed never to reach. Every method is covered because
+    each raise site is its own chance to bypass the redacting constructor."""
+    adapter_cls = _CLOUD_ADAPTERS[provider][1]
+    _raising_sdk(monkeypatch, provider, RuntimeError(f"401 invalid key {_LONG_KEY}"))
+
+    with pytest.raises(LLMError) as exc:
+        _INVOCATIONS[method](adapter_cls(_keyed_cfg(tmp_path, provider, _LONG_KEY)))
+
+    assert _LONG_KEY not in str(exc.value)
+    assert "***" in str(exc.value)
+
+
+def test_a_short_key_leaves_the_message_intact(tmp_path, monkeypatch):
+    """Redacting a short string mangles ordinary diagnostics — `api_key="key"` is
+    live in this file and would turn "invalid api key" into "invalid api ***".
+    Message text that varies with the key's content is its own small oracle."""
+    _raising_sdk(monkeypatch, "openai", RuntimeError("invalid api key here"))
+
+    with pytest.raises(LLMError, match="invalid api key here"):
+        OpenAIAdapter(_keyed_cfg(tmp_path, "openai", "key")).extract_facts(source_text="x")
+
+
+# OpenRouter inherits both guards from OpenAIAdapter, so it is listed explicitly
+# rather than left to transitive coverage: it is the provider most likely to be
+# pointed at a caller-supplied endpoint, which is where an unredactable key hurts.
+_KEYED_ADAPTERS = {"openai": OpenAIAdapter, "anthropic": AnthropicAdapter,
+                   "openrouter": OpenRouterAdapter}
+
+
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_no_key_refuses_instead_of_falling_back_to_the_vendor_env_var(
+    tmp_path, monkeypatch, provider
+):
+    """Both SDKs read their own OPENAI_API_KEY/ANTHROPIC_API_KEY when handed
+    `api_key=None`, so the request would authenticate with a credential this
+    process never resolved — one `redact_secret` cannot match, whose echo in a
+    4xx body is persisted verbatim into `source_chunks.error`. The env vars are
+    set here so the test fails if the fallback is ever restored."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-FALLBACK-SECRET-0001")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env-FALLBACK-SECRET-0001")
+    adapter_cls = _KEYED_ADAPTERS[provider]
+    _raising_sdk(monkeypatch, provider, RuntimeError("unreachable"))
+
+    with pytest.raises(LLMError, match="requires an API key"):
+        adapter_cls(_keyed_cfg(tmp_path, provider, None)).extract_facts(source_text="x")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -873,3 +873,47 @@ def test_replace_preserves_the_api_key():
     )
 
     assert replace(cfg, provider="openrouter").api_key == "sk-test-DEADBEEFDEADBEEF"
+
+
+# --- app.json survives a failed write instead of being truncated ---
+
+
+def test_a_failed_app_config_write_leaves_the_previous_file_intact(tmp_path, monkeypatch):
+    """`write_text` truncates in place, so a crash mid-write left JSON the reader
+    silently turns into `{}` — the app forgetting the active KB and the theme
+    without reporting it. Asserts byte-identity, not merely that the file parses."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    config_module.save_app_theme("dark")
+    path = config_module.app_config_path()
+    before = path.read_bytes()
+
+    real_replace = config_module.os.replace
+    monkeypatch.setattr(
+        config_module.os, "replace", lambda *a, **k: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    with pytest.raises(OSError):
+        config_module.save_active_root(tmp_path / "kb")
+    monkeypatch.setattr(config_module.os, "replace", real_replace)
+
+    assert path.read_bytes() == before
+    assert config_module.app_theme() == "dark"
+
+
+def test_a_failed_write_leaves_no_temp_file_behind(tmp_path, monkeypatch):
+    """A sibling temp file that outlived its failed write would accumulate in the
+    user's config directory forever."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+    config_module.save_app_theme("dark")
+    directory = config_module.app_config_dir()
+
+    monkeypatch.setattr(
+        config_module.os, "replace", lambda *a, **k: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    with pytest.raises(OSError):
+        config_module.save_app_theme("light")
+
+    assert [p.name for p in directory.iterdir()] == ["app.json"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import json
+import os
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -917,3 +918,29 @@ def test_a_failed_write_leaves_no_temp_file_behind(tmp_path, monkeypatch):
         config_module.save_app_theme("light")
 
     assert [p.name for p in directory.iterdir()] == ["app.json"]
+
+
+@pytest.mark.skipif(not hasattr(os, "fchmod"), reason="POSIX file modes only")
+def test_app_config_is_written_owner_only(tmp_path, monkeypatch):
+    """Switching to the atomic writer tightened this from the 0o644 `write_text`
+    produced. That is intended — the directory is per-user and is about to hold a
+    secrets file beside it — so it is pinned rather than left to `mkstemp`."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+
+    config_module.save_app_theme("dark")
+
+    assert config_module.app_config_path().stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.skipif(not hasattr(os, "fchmod"), reason="POSIX file modes only")
+def test_the_atomic_writer_honours_a_requested_mode(tmp_path):
+    """The mode must be applied, not inherited. `mkstemp` already creates 0o600,
+    so asking for 0o600 here would pass with the chmod deleted — the assertion
+    has to request a mode the temp file does not already have."""
+    target = tmp_path / "other.json"
+
+    config_module._write_json_atomic(target, {"k": "v"}, mode=0o640)
+
+    assert target.stat().st_mode & 0o777 == 0o640

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -860,20 +860,36 @@ def test_api_key_is_not_in_the_config_repr():
     assert cfg.api_key == "sk-test-DEADBEEFDEADBEEF"  # still readable by callers
 
 
-def test_replace_preserves_the_api_key():
-    """`_model_field_context` rebuilds the Config with `dataclasses.replace` to
-    list models against the endpoint being edited; dropping the key there would
-    silently unauthenticate every provider call made through that path."""
+def test_replace_carries_the_saved_providers_key_to_a_different_provider():
+    """A sharp edge, pinned so it stays visible rather than rediscovered.
+
+    `for_root` resolves `api_key` once, for the provider it resolved, and
+    `dataclasses.replace(provider=...)` does not recompute it. So a Config
+    switched to another provider still holds the FIRST provider's key — an
+    Anthropic key on a Config that says `openrouter`.
+
+    That is fine for generation, where the provider is the saved one. It is why
+    the settings model picker must never be handed a Config at all: it dials a
+    URL taken from a query string, so a listing routine that read `cfg.api_key`
+    — which nothing stopped it from doing — would have sent this key to a
+    caller-named host in a single request. `_MODEL_LISTERS` takes
+    `(base_url, timeout)` for exactly this reason. This test asserts the
+    carry-over EXISTS; it is not a licence to route a caller-supplied endpoint
+    through a Config.
+    """
     cfg = Config(
         root=Path("/kb"),
         db_path=Path("/kb/kb.sqlite"),
-        provider="openai",
+        provider="anthropic",
         model="m",
         api_key="sk-test-DEADBEEFDEADBEEF",
         base_url=None,
     )
 
-    assert replace(cfg, provider="openrouter").api_key == "sk-test-DEADBEEFDEADBEEF"
+    switched = replace(cfg, provider="openrouter", base_url="http://caller.example")
+
+    assert switched.provider == "openrouter"
+    assert switched.api_key == "sk-test-DEADBEEFDEADBEEF"
 
 
 # --- app.json survives a failed write instead of being truncated ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -211,7 +211,7 @@ def test_legacy_claude_provider_normalizes_to_claudecli(tmp_path):
     assert Config.for_root(tmp_path).provider == "claudecli"
 
 
-def test_api_key_only_from_env_never_persisted(tmp_path, monkeypatch):
+def test_api_key_is_never_persisted_into_the_kb(tmp_path, monkeypatch):
     monkeypatch.setenv("VERINOTE_API_KEY", "supersecret")
     save_settings(tmp_path, provider="anthropic", model="m")
     cfg = Config.for_root(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -838,3 +839,37 @@ def test_saved_routing_values_still_go_through_the_trim_normalisation(
     _write_settings(tmp_path, _valid_settings(**{key: f"  {expected}  "}))
 
     assert getattr(Config.for_root(tmp_path), attr) == expected
+
+
+def test_api_key_is_not_in_the_config_repr():
+    """A stray `logger.exception` with locals, or a pytest assertion diff on two
+    Configs, would otherwise print the credential. Asserts the *value* is absent
+    from every stringification, not merely that the field name is missing."""
+    cfg = Config(
+        root=Path("/kb"),
+        db_path=Path("/kb/kb.sqlite"),
+        provider="openai",
+        model="m",
+        api_key="sk-test-DEADBEEFDEADBEEF",
+        base_url=None,
+    )
+
+    for rendered in (repr(cfg), str(cfg), f"{cfg}"):
+        assert "sk-test-DEADBEEFDEADBEEF" not in rendered
+    assert cfg.api_key == "sk-test-DEADBEEFDEADBEEF"  # still readable by callers
+
+
+def test_replace_preserves_the_api_key():
+    """`_model_field_context` rebuilds the Config with `dataclasses.replace` to
+    list models against the endpoint being edited; dropping the key there would
+    silently unauthenticate every provider call made through that path."""
+    cfg = Config(
+        root=Path("/kb"),
+        db_path=Path("/kb/kb.sqlite"),
+        provider="openai",
+        model="m",
+        api_key="sk-test-DEADBEEFDEADBEEF",
+        base_url=None,
+    )
+
+    assert replace(cfg, provider="openrouter").api_key == "sk-test-DEADBEEFDEADBEEF"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Stored API keys: where they live, which one wins, and what a broken file does.
+
+The precedence tests are written in pairs on purpose. "A stored key resolves"
+passes for an implementation that only ever reads the store, and "the env var
+resolves" passes for one that only ever reads the environment — neither says
+anything about the ordering, which is the whole point of the design.
+"""
+
+import json
+import os
+
+import pytest
+
+from verinote.config import (
+    PROVIDERS,
+    PROVIDERS_REQUIRING_KEY,
+    Config,
+    CredentialsCorruptError,
+    assert_credentials_intact,
+    credentials_path,
+    delete_credential,
+    provider_key_env_var,
+    resolve_api_key,
+    save_credential,
+    save_settings,
+)
+
+_STORED = "sk-stored-openai-DEADBEEF"
+_SCOPED = "sk-scoped-openai-DEADBEEF"
+_GLOBAL = "sk-global-anthropic-DEADBEEF"
+
+
+@pytest.fixture
+def isolated_app_config(isolate_app_environment):
+    """These tests write to a real filesystem path. The session-wide conftest
+    fixture already gives every test its own home — and therefore its own
+    `app_config_dir()` — so this only names the dependency the tests rely on.
+    """
+    return isolate_app_environment
+
+
+@pytest.fixture(autouse=True)
+def _clean_key_env(monkeypatch):
+    monkeypatch.delenv("VERINOTE_API_KEY", raising=False)
+    for provider in PROVIDERS:
+        monkeypatch.delenv(provider_key_env_var(provider), raising=False)
+
+
+# --- precedence: a key must never reach a provider it was not meant for ---
+
+
+def test_a_stored_key_beats_the_provider_agnostic_env_var(tmp_path, monkeypatch):
+    """The C1 case. `VERINOTE_API_KEY` names no provider, so ranking it above a
+    key saved *for OpenAI* would send whatever is exported — commonly an
+    Anthropic key — to api.openai.com."""
+    monkeypatch.setenv("VERINOTE_API_KEY", _GLOBAL)
+
+    assert resolve_api_key("openai", {"openai": _STORED}) == _STORED
+
+
+def test_the_env_var_still_resolves_when_nothing_is_stored(tmp_path, monkeypatch):
+    """Pairs with the test above: demoting the legacy variable must not break the
+    only way keys worked before this existed."""
+    monkeypatch.setenv("VERINOTE_API_KEY", _GLOBAL)
+
+    assert resolve_api_key("anthropic", {}) == _GLOBAL
+
+
+def test_the_provider_scoped_env_var_beats_a_stored_key(monkeypatch):
+    """Env-first stays available — it just has to name the provider to get it."""
+    monkeypatch.setenv(provider_key_env_var("openai"), _SCOPED)
+
+    assert resolve_api_key("openai", {"openai": _STORED}) == _SCOPED
+
+
+def test_a_scoped_var_does_not_leak_across_providers(monkeypatch):
+    monkeypatch.setenv(provider_key_env_var("openai"), _SCOPED)
+
+    assert resolve_api_key("anthropic", {}) is None
+
+
+@pytest.mark.parametrize(
+    "provider", sorted(set(PROVIDERS) - PROVIDERS_REQUIRING_KEY)
+)
+def test_a_keyless_provider_resolves_nothing_from_any_source(provider, monkeypatch):
+    """These adapters never read `cfg.api_key`, so a resolved value could only be
+    something to leak. All three sources are populated so the test fails if any
+    tier is consulted."""
+    monkeypatch.setenv("VERINOTE_API_KEY", _GLOBAL)
+    monkeypatch.setenv(provider_key_env_var(provider), _SCOPED)
+
+    assert resolve_api_key(provider, {provider: _STORED}) is None
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_stored_key_falls_through(blank, monkeypatch):
+    monkeypatch.setenv("VERINOTE_API_KEY", _GLOBAL)
+
+    assert resolve_api_key("openai", {"openai": blank}) == _GLOBAL
+
+
+def test_a_padded_stored_key_is_trimmed():
+    assert resolve_api_key("openai", {"openai": f"  {_STORED}  "}) == _STORED
+
+
+# --- the file: where it is, what it is not, and how it is written ---
+
+
+def test_saving_a_key_keeps_it_out_of_the_kb(tmp_path, isolated_app_config):
+    """A KB is user data that gets synced and shared; the app config directory is
+    machine-local. This is the invariant the whole storage choice exists for, so
+    it is asserted over every file the KB contains — and `save_settings` is
+    called first, because a KB with no config.json satisfies a config.json-only
+    check without proving anything.
+    """
+    save_settings(tmp_path, provider="openai", model="m")
+    save_credential("openai", _STORED)
+    Config.for_root(tmp_path)
+
+    assert _STORED in credentials_path().read_text(encoding="utf-8")
+    assert (tmp_path / "config.json").exists()
+    leaked = [
+        path
+        for path in tmp_path.rglob("*")
+        if path.is_file() and _STORED in path.read_bytes().decode("utf-8", "replace")
+    ]
+    assert leaked == []
+
+
+@pytest.mark.skipif(not hasattr(os, "fchmod"), reason="POSIX file modes only")
+def test_the_credentials_file_is_owner_only(isolated_app_config):
+    save_credential("openai", _STORED)
+
+    assert credentials_path().stat().st_mode & 0o777 == 0o600
+
+
+def test_saving_one_provider_leaves_the_others_untouched(isolated_app_config):
+    """A save is a merge. Rewriting the file from scratch would silently discard
+    every other provider's key."""
+    save_credential("openai", _STORED)
+    save_credential("anthropic", _GLOBAL)
+
+    keys = json.loads(credentials_path().read_text(encoding="utf-8"))["keys"]
+    assert keys == {"openai": _STORED, "anthropic": _GLOBAL}
+
+
+def test_deleting_reports_whether_anything_was_removed(isolated_app_config):
+    """A Remove that says "removed" when nothing was stored would tell the user
+    their key is gone while it never existed."""
+    save_credential("openai", _STORED)
+
+    assert delete_credential("openai") is True
+    assert delete_credential("openai") is False
+    assert resolve_api_key("openai", _stored_keys()) is None
+
+
+def test_a_keyless_provider_cannot_acquire_a_stored_key(isolated_app_config):
+    with pytest.raises(ValueError):
+        save_credential("ollama", _STORED)
+
+
+def test_the_config_directory_gets_a_gitignore(isolated_app_config):
+    """`XDG_CONFIG_HOME` is routinely a dotfiles repo, and a subdirectory
+    .gitignore is honoured by a repo rooted anywhere above it."""
+    save_credential("openai", _STORED)
+
+    assert (credentials_path().parent / ".gitignore").read_text(encoding="utf-8") == "*\n"
+
+
+def test_an_existing_gitignore_is_not_overwritten(isolated_app_config):
+    path = credentials_path().parent
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".gitignore").write_text("mine\n", encoding="utf-8")
+
+    save_credential("openai", _STORED)
+
+    assert (path / ".gitignore").read_text(encoding="utf-8") == "mine\n"
+
+
+# --- an unreadable file must not read as "no key" ---
+
+
+def _stored_keys() -> dict:
+    from verinote.config import _read_credentials
+
+    return _read_credentials()[0]
+
+
+def _corrupt(text: str = "{not json") -> None:
+    credentials_path().parent.mkdir(parents=True, exist_ok=True)
+    credentials_path().write_text(text, encoding="utf-8")
+
+
+def test_a_missing_file_is_not_an_error(tmp_path, isolated_app_config, monkeypatch):
+    """The normal state before anyone saves a key."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+
+    assert Config.for_root(tmp_path).credentials_error is None
+
+
+def test_an_unreadable_file_halts_instead_of_resolving_to_no_key(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt()
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.credentials_error is not None
+    assert cfg.api_key is None
+    with pytest.raises(CredentialsCorruptError):
+        assert_credentials_intact(cfg)
+
+
+@pytest.mark.parametrize(
+    ("provider", "env"),
+    [("ollama", None), ("openai", "scoped"), ("openai", "global")],
+)
+def test_an_unreadable_file_does_not_halt_when_it_could_not_decide_the_key(
+    tmp_path, isolated_app_config, monkeypatch, provider, env
+):
+    """Scoping matters as much as the halt: bricking an Ollama user, or one whose
+    key comes from the environment, over a file that changes nothing for them
+    would be its own misreport."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", provider)
+    if env == "scoped":
+        monkeypatch.setenv(provider_key_env_var(provider), _SCOPED)
+    elif env == "global":
+        monkeypatch.setenv("VERINOTE_API_KEY", _GLOBAL)
+    _corrupt()
+
+    assert Config.for_root(tmp_path).credentials_error is None
+
+
+@pytest.mark.parametrize("payload", ['{"version": 1, "keys": []}', '{"keys": {"openai": 5}}'])
+def test_a_non_string_key_is_refused_not_coerced(
+    tmp_path, isolated_app_config, monkeypatch, payload
+):
+    """`str()` on an object would invent a credential out of a structure a future
+    version meant as something else."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt(payload)
+
+    assert Config.for_root(tmp_path).credentials_error is not None
+
+
+def test_a_write_into_an_unreadable_file_refuses_and_changes_nothing(isolated_app_config):
+    """A save merges into the other providers' entries, so writing a fresh file
+    over an unreadable one would silently discard them."""
+    _corrupt()
+    before = credentials_path().read_bytes()
+
+    with pytest.raises(CredentialsCorruptError):
+        save_credential("openai", _STORED)
+
+    assert credentials_path().read_bytes() == before
+
+
+def test_an_undecodable_file_is_an_error_not_an_empty_store(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """Bad JSON and bad *bytes* reach the reader through different branches. Only
+    the first was covered, so a regression in the decode branch would have made an
+    unreadable file resolve to "no keys stored" — the misreport this design
+    exists to prevent — with a green suite."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    credentials_path().parent.mkdir(parents=True, exist_ok=True)
+    credentials_path().write_bytes(b'{"version": 1, "keys": {"openai": "\xff\xfe"}}')
+
+    cfg = Config.for_root(tmp_path)
+
+    assert cfg.credentials_error is not None
+    assert cfg.api_key is None
+
+
+# --- the web halt surface ---
+
+
+def _web_client(tmp_path):
+    from fastapi.testclient import TestClient
+
+    from verinote.web import create_app
+
+    cfg = Config.for_root(tmp_path)
+    return TestClient(create_app(cfg), raise_server_exceptions=False)
+
+
+def test_the_halt_page_names_the_credentials_file_not_config_json(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """A separate page from the config.json halt is the whole reason this error is
+    its own type: that one names a KB's config.json and tells the user to re-save
+    a provider, which does not touch this file."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt()
+
+    r = _web_client(tmp_path).get("/credentials-unavailable")
+
+    assert r.status_code == 409
+    assert str(credentials_path()) in r.text
+    assert "config.json" not in r.text
+    assert _STORED not in r.text
+
+
+def test_an_htmx_request_is_redirected_rather_than_swapped(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """htmx never swaps a 4xx into the DOM (#173), so answering one with an inline
+    body would be a silent no-op instead of a halt."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt()
+    client = _web_client(tmp_path)
+
+    r = client.post("/settings/test", headers={"HX-Request": "true"})
+
+    assert r.status_code == 409
+    assert r.headers.get("HX-Redirect") == "/credentials-unavailable"
+
+
+def test_settings_says_unknown_rather_than_not_set(tmp_path, isolated_app_config, monkeypatch):
+    """"not set" asserts the user has no key stored. When the file cannot be read
+    the app does not know that — it knows only that it cannot tell."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt()
+
+    r = _web_client(tmp_path).get("/settings")
+
+    assert r.status_code == 200  # the recovery page must stay reachable
+    assert "API key: not set" not in r.text
+    assert "unknown" in r.text
+
+
+def test_a_provider_classified_nowhere_is_rejected():
+    """The guard a subset check could not give: adding a provider without
+    deciding whether it needs a key would otherwise resolve to None for it
+    silently, and the provider would be called unauthenticated."""
+    from verinote.config import _check_every_provider_is_classified
+
+    with pytest.raises(RuntimeError, match="gemini"):
+        _check_every_provider_is_classified(
+            ("openai", "ollama", "gemini"), {"openai"}, {"ollama"}
+        )
+
+
+def test_a_provider_classified_on_both_sides_is_rejected():
+    from verinote.config import _check_every_provider_is_classified
+
+    with pytest.raises(RuntimeError, match="openai"):
+        _check_every_provider_is_classified(("openai",), {"openai"}, {"openai"})
+
+
+def test_a_corrupt_credentials_file_does_not_block_opening_a_kb(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """The per-KB reasoning behind refusing a switch on a corrupt `config.json`
+    does not transfer: this file is machine-wide and identical before and after
+    the switch, so refusing prevents no provider call that is not already gated —
+    while making every KB unopenable, including one whose provider needs no key.
+    """
+    from fastapi.testclient import TestClient
+
+    from verinote.web import create_app
+
+    _corrupt()
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    client = TestClient(create_app(None), raise_server_exceptions=False)
+
+    r = client.post("/kb/select", data={"root": str(kb)}, follow_redirects=False)
+
+    assert r.status_code == 303
+
+
+def test_no_surface_blames_config_json_for_a_credentials_failure(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """"refused to open KB — its config.json is corrupt: .../credentials.json is
+    not valid JSON" contradicted itself in one line and pointed at a fix that
+    does not touch the failing file."""
+    from fastapi.testclient import TestClient
+
+    from verinote.web import create_app
+
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt()
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    client = TestClient(create_app(None), raise_server_exceptions=False)
+
+    body = client.post("/kb/select", data={"root": str(kb)}, follow_redirects=True).text
+
+    assert "config.json is corrupt" not in body
+
+
+def test_settings_links_the_recovery_page(tmp_path, isolated_app_config, monkeypatch):
+    """The halt page carries the only correct recovery text, so the page a halted
+    user actually lands on has to reach it."""
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openai")
+    _corrupt()
+
+    r = _web_client(tmp_path).get("/settings")
+
+    assert "/credentials-unavailable" in r.text

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -402,3 +402,263 @@ def test_settings_links_the_recovery_page(tmp_path, isolated_app_config, monkeyp
     r = _web_client(tmp_path).get("/settings")
 
     assert "/credentials-unavailable" in r.text
+
+
+# --- entering a key in the web page ---
+
+
+def _settings_client(tmp_path, provider="openai"):
+    from fastapi.testclient import TestClient
+
+    from verinote.web import create_app
+
+    # The provider is persisted, not just constructed: every credentials route
+    # rebuilds `app.state.cfg` with `Config.for_root`, which re-resolves the
+    # provider from disk. A client whose provider existed only in memory would
+    # silently become the default on the first save.
+    save_settings(tmp_path, provider=provider, model="m")
+    return TestClient(create_app(Config.for_root(tmp_path)), raise_server_exceptions=False)
+
+
+def test_saving_a_key_takes_effect_without_a_restart(tmp_path, isolated_app_config):
+    """`app.state.cfg` is a snapshot. Without rebuilding it the badge would read
+    the new key from disk while every provider call kept using the old one — the
+    user would save a key and watch Test connection still say none is set."""
+    client = _settings_client(tmp_path)
+
+    client.post("/settings/credentials", data={"provider": "openai", "api_key": _STORED})
+
+    assert client.app.state.cfg.api_key == _STORED
+
+
+def test_the_page_never_echoes_a_saved_key_back(tmp_path, isolated_app_config):
+    """An input that prefilled `value=` would put the secret in the DOM of a page
+    that is also reachable while other things are broken."""
+    client = _settings_client(tmp_path)
+    client.post("/settings/credentials", data={"provider": "openai", "api_key": _STORED})
+
+    body = client.get("/settings").text
+
+    assert _STORED not in body
+    assert "saved in this app" in body
+
+
+def test_an_empty_submit_leaves_the_saved_key_alone(tmp_path, isolated_app_config):
+    """The field renders empty on every load, so an empty POST cannot be told
+    apart from "did not touch it". Treating it as a clear would silently unset a
+    working key."""
+    client = _settings_client(tmp_path)
+    client.post("/settings/credentials", data={"provider": "openai", "api_key": _STORED})
+
+    r = client.post("/settings/credentials", data={"provider": "openai", "api_key": ""})
+
+    assert client.app.state.cfg.api_key == _STORED
+    # The storage layer refuses an empty key either way, so surviving is not the
+    # property under test — not being told off for touching nothing is.
+    assert r.status_code == 200
+    assert "API key is empty" not in r.text
+
+
+def test_removing_says_when_an_environment_key_still_applies(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """A bare "removed" reads as "this provider has no key now", which is false
+    while the environment still supplies one."""
+    client = _settings_client(tmp_path)
+    client.post("/settings/credentials", data={"provider": "openai", "api_key": _STORED})
+    monkeypatch.setenv("VERINOTE_API_KEY", _GLOBAL)
+
+    body = client.post(
+        "/settings/credentials/remove", data={"provider": "openai"}, follow_redirects=True
+    ).text
+
+    assert "still supplies a key" in body
+
+
+def test_removing_nothing_does_not_claim_a_removal(tmp_path, isolated_app_config):
+    client = _settings_client(tmp_path)
+
+    body = client.post(
+        "/settings/credentials/remove", data={"provider": "openai"}, follow_redirects=True
+    ).text
+
+    assert "No saved key to remove" in body
+
+
+def test_a_shadowed_saved_key_is_reported(tmp_path, isolated_app_config, monkeypatch):
+    """"set from the environment" alone would hide that the key the user saved is
+    being overridden — they would edit it and see nothing change."""
+    client = _settings_client(tmp_path)
+    client.post("/settings/credentials", data={"provider": "openai", "api_key": _STORED})
+    monkeypatch.setenv(provider_key_env_var("openai"), _SCOPED)
+
+    body = client.get("/settings").text
+
+    assert "takes precedence" in body
+
+
+def test_a_keyless_provider_gets_no_input(tmp_path, isolated_app_config):
+    """A key field for Ollama would be a control that does nothing. Asserting the
+    label alone proves nothing — every provider gets a row on every settings
+    page — so this scopes to Ollama's row and asserts the input is absent."""
+    import re
+
+    body = _settings_client(tmp_path, provider="ollama").get("/settings").text
+    rows = re.findall(r'<div class="key-row">.*?</div>', body, re.S)
+    ollama = [r for r in rows if "Ollama" in r]
+
+    assert len(ollama) == 1
+    assert "no API key needed" in ollama[0]
+    assert 'name="api_key"' not in ollama[0]
+
+
+def test_a_short_key_is_stored_but_flagged_as_unredactable(tmp_path, isolated_app_config):
+    """Not rejected — a self-hosted gateway token can legitimately be short — but
+    it will not be redacted from provider errors, which are persisted into the KB."""
+    client = _settings_client(tmp_path)
+
+    body = client.post(
+        "/settings/credentials", data={"provider": "openai", "api_key": "short"}
+    ).text
+
+    assert client.app.state.cfg.api_key == "short"
+    assert "cannot be redacted" in body
+
+
+def test_a_provider_name_is_canonicalised_before_storing(tmp_path, isolated_app_config):
+    """The form posts a raw string. Stored under a non-canonical id the key would
+    be written successfully and then resolve for nobody — asserting a *refusal*
+    proves nothing, because an unnormalised id is refused anyway."""
+    client = _settings_client(tmp_path)
+
+    r = client.post(
+        "/settings/credentials", data={"provider": "OpenAI", "api_key": _STORED}
+    )
+
+    assert r.status_code == 200
+    assert _stored_keys() == {"openai": _STORED}
+    assert client.app.state.cfg.api_key == _STORED
+
+
+def test_a_halted_policy_disables_and_refuses_a_key_write(tmp_path, isolated_app_config):
+    """Correct today, and nothing would say if it stopped being: adding these
+    paths to the policy guard's write allowlist would un-gate key writes on a
+    halted KB with a fully green suite. Asserts the disabled control AND the
+    refusal AND that no file was written — the shape the theme test already uses.
+    """
+    from fastapi.testclient import TestClient
+
+    from verinote.engine import DEFAULT_POLICY
+    from verinote.pipeline.policy_state import POLICY_RELPATH, policy_sha256
+    from verinote.store import Store
+    from verinote.web import create_app
+
+    save_settings(tmp_path, provider="openai", model="m")
+    with Store(tmp_path / "kb.sqlite") as store:
+        store.init_schema()
+        policy = tmp_path / POLICY_RELPATH
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+    (tmp_path / POLICY_RELPATH).unlink()
+    client = TestClient(create_app(Config.for_root(tmp_path)), raise_server_exceptions=False)
+
+    assert "Saving keys is unavailable" in client.get("/settings").text
+    r = client.post("/settings/credentials", data={"provider": "openai", "api_key": _STORED})
+
+    assert r.status_code == 409
+    assert not credentials_path().exists()
+
+
+@pytest.mark.parametrize("path", ["/settings/credentials", "/settings/credentials/remove"])
+def test_a_cross_origin_key_write_is_refused(tmp_path, isolated_app_config, path):
+    """Gated by method rather than by a path list, so these were covered the
+    moment they existed — pinned because a key write is the highest-value thing
+    that gate protects."""
+    client = _settings_client(tmp_path)
+
+    r = client.post(
+        path,
+        data={"provider": "openai", "api_key": _STORED},
+        headers={"Origin": "http://evil.example"},
+    )
+
+    assert r.status_code == 403
+    assert not credentials_path().exists()
+
+
+def test_removing_a_provider_that_cannot_own_a_key_is_refused(tmp_path, isolated_app_config):
+    """Save refuses a bogus id; remove used to answer "nothing to remove" for the
+    same input, reflecting caller-supplied text back as a provider label."""
+    client = _settings_client(tmp_path)
+
+    r = client.post("/settings/credentials/remove", data={"provider": "ollama"})
+
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize("path", ["/settings/credentials", "/settings/credentials/remove"])
+def test_a_filesystem_failure_is_reported_not_a_500(
+    tmp_path, isolated_app_config, monkeypatch, path
+):
+    """The write reaches mkdir, a lock file and an atomic replace — all OSError.
+    A bare 500 gives the user nothing to act on, and the failing frame's locals
+    hold the plaintext key, which is one locals-rendering handler from exposure.
+    """
+    import verinote.web.app as webapp
+
+    client = _settings_client(tmp_path)
+    for name in ("save_credential", "delete_credential"):
+        monkeypatch.setattr(
+            webapp, name, lambda *a, **k: (_ for _ in ()).throw(OSError("no space left"))
+        )
+
+    r = client.post(path, data={"provider": "openai", "api_key": _STORED})
+
+    assert r.status_code == 400
+    assert "no space left" in r.text
+
+
+def test_no_refusal_is_claimed_while_the_environment_supplies_the_key(
+    tmp_path, isolated_app_config, monkeypatch
+):
+    """An unreadable file only halts a provider whose key it would have decided.
+    Claiming "verinote refuses provider calls" on a setup running fine from an
+    environment variable is a red alert about nothing — and `any(unknown)` says
+    exactly that, because the *other* providers' rows are unknown."""
+    monkeypatch.setenv(provider_key_env_var("openai"), _SCOPED)
+    client = _settings_client(tmp_path)
+    _corrupt()
+
+    body = client.get("/settings").text
+
+    assert "refuses provider calls" not in body
+    assert "could not be read" in body  # the file is still broken; say so
+
+
+def test_a_refusal_is_claimed_when_the_active_provider_really_is_halted(
+    tmp_path, isolated_app_config
+):
+    """Pairs with the test above: narrowing the claim must not silence it."""
+    client = _settings_client(tmp_path)
+    _corrupt()
+
+    assert "refuses provider calls" in client.get("/settings").text
+
+
+@pytest.mark.parametrize("path", ["/settings/credentials", "/settings/credentials/remove"])
+def test_a_write_with_no_active_kb_does_not_report_success_as_a_server_error(
+    tmp_path, isolated_app_config, path
+):
+    """The snapshot rebuild runs after the write. `_active_cfg()` raises when no
+    KB is selected, so the key would be stored (or deleted) and the response
+    would still be a 500."""
+    from fastapi.testclient import TestClient
+
+    from verinote.web import create_app
+
+    client = TestClient(create_app(None), raise_server_exceptions=False)
+
+    r = client.post(path, data={"provider": "openai", "api_key": _STORED})
+
+    assert r.status_code != 500

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 import json
-from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -8,7 +7,7 @@ import pytest
 from verinote.config import Config, save_settings
 from verinote.engine.terms import Compound, NumberLit
 from verinote.llm.base import LLMError
-from verinote.llm.ollama_adapter import OllamaAdapter
+from verinote.llm.ollama_adapter import OllamaAdapter, list_models
 from verinote.llm.schema import FACT_ARRAY_SCHEMA
 from verinote.pipeline import extract_source
 from verinote.prompts import save_prompt_override
@@ -362,61 +361,66 @@ def test_list_models_returns_sorted_unique_names_from_tags(tmp_path, monkeypatch
         },
     )
 
-    models = OllamaAdapter(_cfg(tmp_path)).list_models()
+    models = list_models(None, 5.0)
 
     assert models == ["llava:7b", "qwen3:8b"]
     assert calls[0].url == "http://localhost:11434/api/tags"
 
 
-def test_list_models_honours_the_configured_base_url(tmp_path, monkeypatch):
+def test_list_models_honours_the_supplied_base_url(monkeypatch):
     calls = _tags(monkeypatch, {"models": []})
 
-    OllamaAdapter(replace(_cfg(tmp_path), base_url="http://llm.internal:9999/")).list_models()
+    list_models("http://llm.internal:9999/", 5.0)
 
     assert calls[0].url == "http://llm.internal:9999/api/tags"
 
 
-def test_list_models_is_bounded_far_below_the_generation_timeout(tmp_path, monkeypatch):
-    """A page-load call must not inherit the minutes-long completion budget."""
+def test_list_models_passes_the_supplied_timeout_through(monkeypatch):
+    """The clamp against the generation budget belongs to the caller that still
+    holds a Config; this function must not silently re-derive or override it."""
     calls = _tags(monkeypatch, {"models": []})
 
-    OllamaAdapter(_cfg(tmp_path, timeout=900.0)).list_models()
-
-    assert calls[0].timeout == 5.0
-
-
-def test_list_models_keeps_an_even_shorter_configured_timeout(tmp_path, monkeypatch):
-    """The bound is the *smaller* of the two, so a tighter user setting still wins."""
-    calls = _tags(monkeypatch, {"models": []})
-
-    OllamaAdapter(_cfg(tmp_path, timeout=1.5)).list_models()
+    list_models(None, 1.5)
 
     assert calls[0].timeout == 1.5
 
 
-def test_list_models_returns_empty_for_a_server_with_nothing_pulled(tmp_path, monkeypatch):
+def test_list_models_takes_no_config_so_it_cannot_be_handed_a_key(monkeypatch):
+    """The settings picker dials a caller-supplied URL, so a listing routine that
+    could reach `cfg.api_key` would be one edit away from exfiltrating it. Taking
+    no `Config` means no key is handed in, which is what this pins for Ollama's
+    lister. It is not a guarantee that no key is reachable: a body can still go
+    fetch one. `_check_every_listable_provider_has_a_keyless_lister` applies the
+    same shape rule at import to every lister in the web layer's shipped table."""
+    import inspect
+
+    assert tuple(inspect.signature(list_models).parameters) == ("base_url", "timeout")
+    assert not hasattr(OllamaAdapter, "list_models")
+
+
+def test_list_models_returns_empty_for_a_server_with_nothing_pulled(monkeypatch):
     """Reachable-but-empty is data, not an error: the caller must be able to say
     'this server has no models' rather than 'this server could not be reached'."""
     _tags(monkeypatch, {"models": []})
 
-    assert OllamaAdapter(_cfg(tmp_path)).list_models() == []
+    assert list_models(None, 5.0) == []
 
 
-def test_list_models_raises_on_transport_failure(tmp_path, monkeypatch):
+def test_list_models_raises_on_transport_failure(monkeypatch):
     def boom(req, *, timeout):
         raise OSError("connection refused")
 
     monkeypatch.setattr("urllib.request.urlopen", boom)
 
     with pytest.raises(LLMError, match="ollama request failed"):
-        OllamaAdapter(_cfg(tmp_path)).list_models()
+        list_models(None, 5.0)
 
 
 @pytest.mark.parametrize("payload", [{"models": "qwen3:8b"}, {}, ["qwen3:8b"]])
-def test_list_models_raises_on_schema_mismatch(tmp_path, monkeypatch, payload):
+def test_list_models_raises_on_schema_mismatch(monkeypatch, payload):
     """A shape that is not {'models': [...]} is a failure, never a silent empty
     list -- that would render as 'no models installed' and blame the user."""
     _tags(monkeypatch, payload)
 
     with pytest.raises(LLMError, match="did not match schema"):
-        OllamaAdapter(_cfg(tmp_path)).list_models()
+        list_models(None, 5.0)

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -361,9 +361,9 @@ def test_list_models_returns_sorted_unique_names_from_tags(tmp_path, monkeypatch
         },
     )
 
-    models = list_models(None, 5.0)
+    listing = list_models(None, 5.0)
 
-    assert models == ["llava:7b", "qwen3:8b"]
+    assert listing.models == ("llava:7b", "qwen3:8b")
     assert calls[0].url == "http://localhost:11434/api/tags"
 
 
@@ -403,7 +403,23 @@ def test_list_models_returns_empty_for_a_server_with_nothing_pulled(monkeypatch)
     'this server has no models' rather than 'this server could not be reached'."""
     _tags(monkeypatch, {"models": []})
 
-    assert list_models(None, 5.0) == []
+    assert list_models(None, 5.0).models == ()
+
+
+def test_list_models_reports_no_structured_output_opinion_at_all(monkeypatch):
+    """`/api/tags` says nothing about capabilities, so this listing must not
+    answer for it. `None` is 'this listing does not say'; the empty frozenset a
+    listing that does report the property would return means 'it says none'.
+
+    Mutation: return `frozenset()` here instead of `None` and the settings picker
+    files every installed model under 'Does not advertise structured output' — a
+    heading claiming the Ollama server declared something it never mentioned.
+    """
+    _tags(monkeypatch, {"models": [{"name": "qwen3:8b"}]})
+
+    listing = list_models(None, 5.0)
+
+    assert listing.structured_output_ids is None
 
 
 def test_list_models_raises_on_transport_failure(monkeypatch):

--- a/tests/test_openrouter_adapter.py
+++ b/tests/test_openrouter_adapter.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: MPL-2.0
+"""OpenRouter reuses every OpenAI generation path, so the tests here cover only
+what is NOT inherited: which endpoint gets dialled, and which provider a failure
+names. Re-testing the four inherited methods against a stub would pass with the
+endpoint binding deleted, which is the whole point of having this provider.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from verinote.config import PROVIDERS, Config, ConfigCorruptError
+from verinote.llm import factory
+from verinote.llm.base import LLMError
+from verinote.llm.openai_adapter import OpenAIAdapter
+from verinote.llm.openrouter_adapter import OPENROUTER_DEFAULT_BASE_URL, OpenRouterAdapter
+
+_DATALOG = 'answer_q1(V) :- relation(V, "is_a", "x").'
+_INTENT = {
+    "kind": "unknown_or_unsupported",
+    "subject": None,
+    "relation": None,
+    "object": None,
+    "relation_candidates": None,
+    "operator": None,
+    "value_type": None,
+    "value": None,
+    "reason": "unsupported",
+}
+
+# Each method builds its own client, so a single-method test would leave three
+# construction sites unguarded.
+_INVOCATIONS = {
+    "extract_facts": lambda a: a.extract_facts(source_text="x"),
+    "translate_query": lambda a: a.translate_query(question="Who?", qid=1),
+    "extract_query_intent": lambda a: a.extract_query_intent(question="What?"),
+    "answer_question": lambda a: a.answer_question(question="Who?", context="c"),
+}
+
+
+def _cfg(tmp_path, *, provider="openrouter", base_url=None, model="m") -> Config:
+    return Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider=provider,
+        model=model,
+        api_key="key",
+        base_url=base_url,
+    )
+
+
+def _content(method: str):
+    import json
+
+    return {
+        "extract_facts": json.dumps({"facts": []}),
+        "translate_query": json.dumps({"datalog": _DATALOG}),
+        "extract_query_intent": json.dumps(_INTENT),
+        "answer_question": "ok",
+    }[method]
+
+
+def _record_client(monkeypatch, method: str, *, raises: Exception | None = None) -> dict:
+    """Stub the openai SDK and return the kwargs the client was built with."""
+    recorded: dict = {}
+    content = _content(method)
+
+    class _Completions:
+        def create(self, **kwargs):
+            if raises is not None:
+                raise raises
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+            )
+
+    def _factory(**kwargs):
+        recorded.update(kwargs)
+        return SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=_factory))
+    return recorded
+
+
+# --- the endpoint is bound to the provider, not to a blank-able field ---
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_unset_base_url_dials_openrouter_not_openai(tmp_path, monkeypatch, method):
+    """The reason this provider exists. Under `openai` + base_url, clearing the
+    field sends documents to api.openai.com — a vendor the user did not choose.
+    Asserted on the constructor argument, because a request-level assertion
+    would pass against a stub that never looks at the endpoint.
+    """
+    recorded = _record_client(monkeypatch, method)
+
+    _INVOCATIONS[method](OpenRouterAdapter(_cfg(tmp_path)))
+
+    assert recorded["base_url"] == OPENROUTER_DEFAULT_BASE_URL
+    # `LLMClient` makes applying the configured timeout a MUST for every adapter.
+    # Inheritance satisfies it today; a future `_client` override here would
+    # break that contract silently, and this adapter is in no other suite that
+    # enumerates cloud providers.
+    assert recorded["timeout"] == 600.0
+
+
+def test_explicit_base_url_still_wins(tmp_path, monkeypatch):
+    """A default, not a forced override — an OpenRouter-compatible proxy or a
+    regional endpoint must remain reachable."""
+    recorded = _record_client(monkeypatch, "extract_facts")
+
+    OpenRouterAdapter(_cfg(tmp_path, base_url="https://proxy.internal/v1")).extract_facts(
+        source_text="x"
+    )
+
+    assert recorded["base_url"] == "https://proxy.internal/v1"
+
+
+def test_openai_provider_keeps_the_sdk_default_endpoint(tmp_path, monkeypatch):
+    """The hook must not leak the OpenRouter endpoint into the openai provider."""
+    recorded = _record_client(monkeypatch, "extract_facts")
+
+    OpenAIAdapter(_cfg(tmp_path, provider="openai")).extract_facts(source_text="x")
+
+    assert recorded["base_url"] is None
+
+
+# --- a failure names the provider that failed ---
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_failure_names_openrouter_not_openai(tmp_path, monkeypatch, method):
+    """This string is the settings banner and the persisted chunk error. Naming
+    `openai` there would point a user at the wrong provider."""
+    _record_client(monkeypatch, method, raises=RuntimeError("boom"))
+
+    with pytest.raises(LLMError, match=r"^openrouter request failed"):
+        _INVOCATIONS[method](OpenRouterAdapter(_cfg(tmp_path)))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_openai_failure_still_names_openai(tmp_path, monkeypatch, method):
+    """Deriving the prefix from `name` must not have renamed the existing one."""
+    _record_client(monkeypatch, method, raises=RuntimeError("boom"))
+
+    with pytest.raises(LLMError, match=r"^openai request failed"):
+        _INVOCATIONS[method](OpenAIAdapter(_cfg(tmp_path, provider="openai")))
+
+
+# --- dispatch and the corrupt-config halt ---
+
+
+def test_factory_selects_the_openrouter_adapter(tmp_path):
+    assert isinstance(factory.get_client(_cfg(tmp_path)), OpenRouterAdapter)
+
+
+def test_corrupt_config_halts_before_the_adapter_is_constructed(tmp_path, monkeypatch):
+    """A corrupt config.json makes the resolved provider untrustworthy. Asserting
+    only that an error was raised would pass even if the adapter had already been
+    built and dialled — so count constructions instead (#269)."""
+    built = []
+    monkeypatch.setattr(
+        OpenRouterAdapter, "__init__", lambda self, cfg: built.append(cfg) or None
+    )
+    corrupt = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="openrouter",
+        model="m",
+        api_key="key",
+        base_url=None,
+        settings_error="config.json is not valid JSON",
+    )
+
+    with pytest.raises(ConfigCorruptError):
+        factory.get_client(corrupt)
+
+    assert built == []
+
+
+def test_unknown_provider_message_lists_every_provider(tmp_path):
+    """Spelled out by hand this went stale the moment a provider was added, and
+    it is what tells a user with a typo what they were allowed to write."""
+    with pytest.raises(LLMError) as exc:
+        factory.get_client(_cfg(tmp_path, provider="madeup"))
+
+    for provider in PROVIDERS:
+        assert provider in str(exc.value)
+
+
+# --- the default model is a model, not a router ---
+
+
+def test_default_model_is_a_concrete_model_not_a_router(tmp_path, monkeypatch):
+    """`openrouter/free` picks a different model per request, so the settings
+    banner's "answered ... from <model>" and a captured fixture's recorded model
+    would both name something that did not answer."""
+    monkeypatch.delenv("VERINOTE_MODEL", raising=False)
+    monkeypatch.setenv("VERINOTE_PROVIDER", "openrouter")
+
+    # The equality is the whole assertion; a separate `not startswith("openrouter/")`
+    # check would be implied by it and could never fail on its own.
+    assert Config.for_root(tmp_path).model == "openai/gpt-oss-20b:free"

--- a/tests/test_openrouter_adapter.py
+++ b/tests/test_openrouter_adapter.py
@@ -5,6 +5,8 @@ names. Re-testing the four inherited methods against a stub would pass with the
 endpoint binding deleted, which is the whole point of having this provider.
 """
 
+import inspect
+import json
 import sys
 from types import SimpleNamespace
 
@@ -14,7 +16,11 @@ from verinote.config import PROVIDERS, Config, ConfigCorruptError
 from verinote.llm import factory
 from verinote.llm.base import LLMError
 from verinote.llm.openai_adapter import OpenAIAdapter
-from verinote.llm.openrouter_adapter import OPENROUTER_DEFAULT_BASE_URL, OpenRouterAdapter
+from verinote.llm.openrouter_adapter import (
+    OPENROUTER_DEFAULT_BASE_URL,
+    OpenRouterAdapter,
+    list_models,
+)
 
 _DATALOG = 'answer_q1(V) :- relation(V, "is_a", "x").'
 _INTENT = {
@@ -201,3 +207,168 @@ def test_default_model_is_a_concrete_model_not_a_router(tmp_path, monkeypatch):
     # The equality is the whole assertion; a separate `not startswith("openrouter/")`
     # check would be implied by it and could never fail on its own.
     assert Config.for_root(tmp_path).model == "openai/gpt-oss-20b:free"
+
+
+# --- list_models: the settings picker's source of truth ---
+
+
+class _CatalogueResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def _catalogue(monkeypatch, payload):
+    """Answer /models with `payload`; return the recorded requests."""
+    calls = []
+
+    def fake_urlopen(req, *, timeout):
+        calls.append(SimpleNamespace(url=req.full_url, timeout=timeout, headers=req.header_items()))
+        return _CatalogueResponse(payload)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    return calls
+
+
+def _entry(model_id, *, structured=True, extra_parameters=("temperature",)):
+    parameters = list(extra_parameters) + (["structured_outputs"] if structured else [])
+    return {"id": model_id, "supported_parameters": parameters}
+
+
+def test_list_models_groups_the_catalogue_by_what_each_entry_advertises(monkeypatch):
+    """The picker's two groups are exactly this split, so both halves have to be
+    reported: the ids, and which of them listed `structured_outputs`.
+
+    Mutation: return every id in `structured_output_ids` (or none of them) and
+    the settings picker files a model under a heading its catalogue entry
+    contradicts.
+    """
+    calls = _catalogue(
+        monkeypatch,
+        {
+            "data": [
+                _entry("z/schema-model"),
+                _entry("a/plain-model", structured=False),
+                _entry("  z/schema-model  "),  # same id, padded
+            ]
+        },
+    )
+
+    listing = list_models(None, 5.0)
+
+    assert listing.models == ("a/plain-model", "z/schema-model")
+    assert listing.structured_output_ids == frozenset({"z/schema-model"})
+    assert calls[0].url == "https://openrouter.ai/api/v1/models"
+
+
+def test_list_models_sends_no_authorization_header(monkeypatch):
+    """The catalogue answers unauthenticated, so there is nothing to trade for
+    the omission -- and this lister is dialled at a URL the caller supplied in a
+    query string, where a key must never go.
+
+    The request is asserted to carry NO headers at all rather than to lack an
+    `Authorization` one specifically: a credential can be spelled `X-Api-Key`, or
+    ride in any header a later edit adds, and an empty list is the only assertion
+    that does not have to enumerate the spellings. Mutation: add any header here
+    and this fails, which is the intended review prompt.
+
+    The end-to-end egress proof lives in `tests/test_web.py`'s
+    `test_openrouter_model_field_puts_no_api_key_on_the_wire`; this one pins the
+    adapter in isolation.
+    """
+    calls = _catalogue(monkeypatch, {"data": []})
+
+    list_models(None, 5.0)
+
+    assert calls[0].headers == []
+
+
+def test_list_models_honours_the_supplied_base_url(monkeypatch):
+    """A proxy or gateway is configured with Base URL, and the catalogue must be
+    read from the endpoint that will actually serve the generation."""
+    calls = _catalogue(monkeypatch, {"data": []})
+
+    list_models("https://proxy.internal/v1/", 5.0)
+
+    assert calls[0].url == "https://proxy.internal/v1/models"
+
+
+def test_list_models_passes_the_supplied_timeout_through(monkeypatch):
+    """The clamp against the generation budget belongs to the caller that still
+    holds a Config; this function must not silently re-derive or override it."""
+    calls = _catalogue(monkeypatch, {"data": []})
+
+    list_models(None, 1.5)
+
+    assert calls[0].timeout == 1.5
+
+
+def test_list_models_takes_no_config_so_it_cannot_be_handed_a_key(monkeypatch):
+    """`openrouter` IS a key-holding provider, so unlike Ollama's lister there is
+    a real key to leak here. Taking no `Config` means none is handed in; it is not
+    a guarantee that none is reachable, which is why the web layer applies the
+    same shape rule at import to every lister in its shipped table."""
+    assert tuple(inspect.signature(list_models).parameters) == ("base_url", "timeout")
+    assert not hasattr(OpenRouterAdapter, "list_models")
+
+
+def test_list_models_returns_empty_for_a_catalogue_that_lists_nothing(monkeypatch):
+    """Reachable-but-empty is data, not an error: the caller must be able to say
+    'this endpoint listed nothing' rather than 'it could not be reached'."""
+    _catalogue(monkeypatch, {"data": []})
+
+    listing = list_models(None, 5.0)
+
+    assert listing.models == ()
+    # Reported and empty -- NOT `None`, which would mean "this listing does not
+    # report the property at all". The picker renders the two differently.
+    assert listing.structured_output_ids == frozenset()
+
+
+def test_list_models_raises_on_transport_failure(monkeypatch):
+    """Never `[]` on error: 'reachable but empty' and 'could not be reached' are
+    different facts, and the settings page renders each differently."""
+
+    def boom(req, *, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+
+    with pytest.raises(LLMError, match="openrouter request failed"):
+        list_models(None, 5.0)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"data": "gpt"},
+        {},
+        ["gpt"],
+        {"data": [{"supported_parameters": []}]},
+        {"data": [{"id": "  ", "supported_parameters": []}]},
+        {"data": ["not-an-object"]},
+        {"data": [{"id": "a/b"}]},
+        {"data": [{"id": "a/b", "supported_parameters": None}]},
+    ],
+)
+def test_list_models_raises_on_schema_mismatch(monkeypatch, payload):
+    """A shape that is not `{'data': [{id, supported_parameters}, ...]}` is a
+    failure, never a silent empty or half-read list.
+
+    The per-entry cases are the load-bearing ones: an entry that cannot be
+    classified must not be swept into 'does not advertise structured output',
+    which would report a claim the catalogue never made. Mutation: skip such
+    entries (or default them to non-advertising) and these stop raising.
+    """
+    _catalogue(monkeypatch, payload)
+
+    with pytest.raises(LLMError, match="did not match schema"):
+        list_models(None, 5.0)

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -10,6 +10,7 @@ import verinote.cli as cli
 import verinote.pipeline.acceptance as acceptance
 import verinote.store.db as store_db
 from verinote.engine import CheckReport, DEFAULT_POLICY
+from verinote.llm.base import ModelListing
 from verinote.pipeline.acceptance import AcceptRecommendation
 from verinote.pipeline.corroboration import store_functional_relations
 from verinote.pipeline.policy_state import (
@@ -785,7 +786,7 @@ def test_settings_model_field_stays_usable_on_a_halted_policy(tmp_path, monkeypa
     """The settings page is the recovery surface, so its fragments must load too.
 
     A halt here would be worse than a visible error: htmx never swaps a 4xx into
-    the DOM (#173), so the Model field would sit on "Loading installed models..."
+    the DOM (#173), so the Model field would sit on "Loading the model list..."
     forever while the user is trying to recover the KB. A lost logic policy is a
     statement about verification, not about which model the user may pick.
     """
@@ -793,7 +794,9 @@ def test_settings_model_field_stays_usable_on_a_halted_policy(tmp_path, monkeypa
 
     client = _halted_client(tmp_path, monkeypatch)
     monkeypatch.setitem(
-        webapp._MODEL_LISTERS, "ollama", lambda base_url, timeout: ["qwen3:8b"]
+        webapp._MODEL_LISTERS,
+        "ollama",
+        lambda base_url, timeout: ModelListing(models=("qwen3:8b",)),
     )
 
     r = client.get("/settings/model-field?provider=ollama&model=qwen3:8b")

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -792,8 +792,8 @@ def test_settings_model_field_stays_usable_on_a_halted_policy(tmp_path, monkeypa
     import verinote.web.app as webapp
 
     client = _halted_client(tmp_path, monkeypatch)
-    monkeypatch.setattr(
-        webapp, "get_client", lambda _cfg: type("C", (), {"list_models": lambda s: ["qwen3:8b"]})()
+    monkeypatch.setitem(
+        webapp._MODEL_LISTERS, "ollama", lambda base_url, timeout: ["qwen3:8b"]
     )
 
     r = client.get("/settings/model-field?provider=ollama&model=qwen3:8b")

--- a/tests/test_same_origin_guard.py
+++ b/tests/test_same_origin_guard.py
@@ -156,9 +156,17 @@ def test_cross_origin_reads_are_not_gated(tmp_path, path):
 
 
 def test_the_model_field_get_is_gated_because_it_dials_a_caller_url(tmp_path):
-    """`?base_url=` becomes a client. Keyless today, because only Ollama is
-    listable; one keyed provider in MODEL_LISTING_PROVIDERS turns this into
-    single-request key exfiltration with no form and no interaction."""
+    """`?base_url=` names a host this GET will dial. What this guard stops is
+    another site provoking that SSRF probe with no form and no interaction.
+
+    It is not what keeps the probe keyless: `_MODEL_LISTERS` does that, by giving
+    the listing seam a `(base_url, timeout)` signature that is handed no API key,
+    and by building no client that holds one. That is narrower than "no way to
+    hold a key" -- an import-time shape rule cannot stop a lister body from going
+    and fetching one -- but the two are still independent controls over the same
+    path and neither substitutes for the other: a keyless probe an attacker can
+    still trigger is a real finding, and so is a same-origin-only request that
+    could carry a key."""
     c = _client(tmp_path)
     url = "/settings/model-field?provider=ollama&base_url=http://evil.example"
 

--- a/tests/test_same_origin_guard.py
+++ b/tests/test_same_origin_guard.py
@@ -8,6 +8,9 @@ browser would, and the allow cases exist so a gate that simply refuses anything
 carrying an `Origin` — which would break every real browser — cannot pass.
 """
 
+import re
+from urllib.parse import urlsplit
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -172,6 +175,39 @@ def test_the_model_field_get_is_gated_because_it_dials_a_caller_url(tmp_path):
 
     assert c.get(url, headers={"Origin": "http://evil.example"}).status_code == 403
     assert c.get(url, headers={"Sec-Fetch-Site": "same-origin"}).status_code == 200
+
+
+def test_the_provider_change_url_the_page_actually_uses_is_gated(tmp_path):
+    """The provider select's URL renders Model *plus* Base URL, and dials
+    `?base_url=` exactly as the plain variant does -- so it has to be a query
+    parameter on the listed path, not a route of its own. Read out of the shipped
+    page rather than written here, because the mutation this must catch is a
+    sibling route: `_ORIGIN_GUARD_GET_PATHS` matches on exact path or
+    `path + "/"`, so `/settings/provider-fields` would sit outside it, and a
+    hardcoded `/settings/model-field?provider_changed=1` in this test would go on
+    passing while nothing in the browser used it.
+
+    Mutation: serve the wrapper from a new ungated route -- the predicate goes
+    False and the 403 becomes a 200, an ungated caller-URL dialer.
+
+    The element is matched first and its `hx-get` read out of it, rather than one
+    pattern spanning both: an attribute pattern anchored to `name="provider"`
+    would go None the moment someone reorders the attributes in `settings.html`,
+    which fails closed on the assert below but reports a template tidy-up as a
+    guard failure.
+    """
+    c = _client(tmp_path)
+    page = c.get("/settings").text
+    select = re.search(r'<select\b[^>]*\bname="provider"[^>]*>', page)
+
+    assert select is not None, "the settings page no longer has a provider select"
+    hx_get = re.search(r'\bhx-get="([^"]+)"', select.group(0))
+    assert hx_get is not None, "the provider select no longer has an hx-get to check"
+    url = hx_get.group(1)
+    assert webapp._origin_guard_applies("GET", urlsplit(url).path)
+    probe = f"{url}{'&' if '?' in url else '?'}provider=ollama&base_url=http://evil.example"
+    assert c.get(probe, headers={"Origin": "http://evil.example"}).status_code == 403
+    assert c.get(probe, headers={"Sec-Fetch-Site": "same-origin"}).status_code == 200
 
 
 # --- ordering, and what the reject path is allowed to touch ---

--- a/tests/test_same_origin_guard.py
+++ b/tests/test_same_origin_guard.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The same-origin gate on state-changing requests.
+
+`TestClient` sends neither `Origin` nor `Sec-Fetch-Site`, so every other test in
+this suite lands in the fail-open branch and would pass with the middleware
+deleted. Nothing here may rely on the bare client: each case sets the headers a
+browser would, and the allow cases exist so a gate that simply refuses anything
+carrying an `Origin` — which would break every real browser — cannot pass.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+import verinote.web.app as webapp  # noqa: E402
+from verinote.config import Config  # noqa: E402
+from verinote.engine import DEFAULT_POLICY  # noqa: E402
+from verinote.pipeline.policy_state import POLICY_RELPATH, policy_sha256  # noqa: E402
+from verinote.store import Store  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+_SETTINGS_FORM = {
+    "provider": "ollama",
+    "model": "llama3.1",
+    "base_url": "",
+    "extraction_chunk_chars": "300",
+    "extraction_chunk_overlap_chars": "40",
+    "extraction_max_facts_per_chunk": "8",
+}
+
+
+def _client(tmp_path, *, with_policy: bool = True) -> TestClient:
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        store.add_fact("A", "is_a", "B", status="needs_review", confidence=0.9)
+        policy = tmp_path / POLICY_RELPATH
+        policy.parent.mkdir(parents=True, exist_ok=True)
+        policy.write_text(DEFAULT_POLICY, encoding="utf-8")
+        store.record_policy_marker(policy_sha256(DEFAULT_POLICY), origin="scaffold")
+    if not with_policy:
+        (tmp_path / POLICY_RELPATH).unlink()
+    return TestClient(create_app(cfg), raise_server_exceptions=False)
+
+
+# --- the attack this exists for ---
+
+
+def test_cross_origin_post_is_refused_and_changes_nothing(tmp_path):
+    """`POST /settings` stores an unvalidated base_url that `POST /settings/test`
+    then dials carrying the API key. Refusing is only half of it — assert the
+    write did not land, since a 403 rendered after the route ran would be worse
+    than useless."""
+    c = _client(tmp_path)
+    before = c.app.state.cfg.provider
+
+    r = c.post("/settings", data=_SETTINGS_FORM, headers={"Origin": "http://evil.example"})
+
+    assert r.status_code == 403
+    assert "cross-origin request refused" in r.text
+    assert c.app.state.cfg.provider == before
+
+
+def test_same_origin_post_still_works(tmp_path):
+    """Pairs with the test above. Without this, "refuse anything with an Origin"
+    would pass — and that breaks every real browser, which always sends one."""
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings",
+        data=_SETTINGS_FORM,
+        headers={"Origin": "http://testserver"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 303
+    assert c.app.state.cfg.provider == "ollama"
+
+
+def test_the_gate_is_not_specific_to_settings(tmp_path):
+    """Keyed on the method, not on a list of interesting paths — a fact decision
+    taken by a page the user is not on is the same forgery."""
+    c = _client(tmp_path)
+    with Store(tmp_path / "kb.sqlite") as store:
+        fact_id = store.facts()[0]["id"]
+
+    r = c.post(f"/facts/{fact_id}/accept", headers={"Origin": "http://evil.example"})
+
+    assert r.status_code == 403
+    with Store(tmp_path / "kb.sqlite") as store:
+        assert store.get_fact(fact_id)["status"] == "needs_review"
+
+
+# --- the header decision table ---
+
+
+@pytest.mark.parametrize(
+    ("site", "allowed"),
+    [("same-origin", True), ("none", True), ("cross-site", False), ("same-site", False)],
+)
+def test_sec_fetch_site_decides_when_origin_is_absent(tmp_path, site, allowed):
+    """`same-site` is refused deliberately: for an IP host every loopback port is
+    same-site but cross-origin, so allowing it would let any other local dev
+    server drive verinote."""
+    c = _client(tmp_path)
+
+    r = c.post(
+        "/settings",
+        data=_SETTINGS_FORM,
+        headers={"Sec-Fetch-Site": site},
+        follow_redirects=False,
+    )
+
+    assert (r.status_code != 403) is allowed
+
+
+def test_opaque_origin_is_refused(tmp_path):
+    """A sandboxed iframe sends `Origin: null`, which has no netloc and must not
+    be allowed to match a missing or empty Host."""
+    c = _client(tmp_path)
+
+    r = c.post("/settings", data=_SETTINGS_FORM, headers={"Origin": "null"})
+
+    assert r.status_code == 403
+
+
+def test_a_client_sending_neither_header_is_allowed(tmp_path):
+    """Documented as intentional, not an oversight: no browser page can omit both
+    on a state-changing request, so this is curl or a script — which carries no
+    ambient authority for the gate to protect."""
+    c = _client(tmp_path)
+
+    r = c.post("/settings", data=_SETTINGS_FORM, follow_redirects=False)
+
+    assert r.status_code == 303
+
+
+# --- reads, and the one GET that dials a caller-supplied endpoint ---
+
+
+@pytest.mark.parametrize("path", ["/", "/review", "/settings"])
+def test_cross_origin_reads_are_not_gated(tmp_path, path):
+    """No CORS header is set anywhere, so a cross-origin GET is issued but
+    unreadable. Gating it would 403 an ordinary inbound link for nothing."""
+    c = _client(tmp_path)
+
+    assert c.get(path, headers={"Origin": "http://evil.example"}).status_code == 200
+
+
+def test_the_model_field_get_is_gated_because_it_dials_a_caller_url(tmp_path):
+    """`?base_url=` becomes a client. Keyless today, because only Ollama is
+    listable; one keyed provider in MODEL_LISTING_PROVIDERS turns this into
+    single-request key exfiltration with no form and no interaction."""
+    c = _client(tmp_path)
+    url = "/settings/model-field?provider=ollama&base_url=http://evil.example"
+
+    assert c.get(url, headers={"Origin": "http://evil.example"}).status_code == 403
+    assert c.get(url, headers={"Sec-Fetch-Site": "same-origin"}).status_code == 200
+
+
+# --- ordering, and what the reject path is allowed to touch ---
+
+
+def test_the_gate_runs_before_the_policy_guard(tmp_path):
+    """Middleware defined later runs first, which a reorder silently inverts. An
+    unattributable request must not reach the policy guard: that reads the store
+    and renders a 409, i.e. an attacker-triggerable oracle for the KB's state."""
+    c = _client(tmp_path, with_policy=False)
+
+    r = c.post("/settings", data=_SETTINGS_FORM, headers={"Origin": "http://evil.example"})
+
+    assert r.status_code == 403  # not 409, the policy-halt page
+
+
+def test_the_reject_path_reads_no_store(tmp_path, monkeypatch):
+    """Rendering any template runs the shared context processor, which queries the
+    store for a request already judged untrustworthy."""
+    c = _client(tmp_path)
+    monkeypatch.setattr(
+        webapp.Store, "status_counts", lambda self: pytest.fail("store read on reject")
+    )
+
+    r = c.post("/settings", data=_SETTINGS_FORM, headers={"Origin": "http://evil.example"})
+
+    assert r.status_code == 403
+
+
+def test_an_opaque_origin_cannot_match_a_missing_host():
+    """`urlsplit("null").netloc` is `""`, and a request with no Host header
+    compares against `""` too — so without the emptiness guard the two would
+    match and an opaque origin would be treated as same-origin. TestClient always
+    sends a Host, so this branch is only reachable at the predicate."""
+    from types import SimpleNamespace
+
+    no_host = SimpleNamespace(headers={"origin": "null"})
+
+    assert webapp._is_same_origin(no_host) is False
+
+
+def test_a_different_port_on_the_same_host_is_cross_origin(tmp_path):
+    """The load-bearing half of the `same-site` argument. Comparing hostnames
+    instead of host:port is a natural "simplification" that would let any other
+    local dev server drive verinote, and every other test here survives it."""
+    c = _client(tmp_path)
+
+    r = c.post("/settings", data=_SETTINGS_FORM, headers={"Origin": "http://testserver:9999"})
+
+    assert r.status_code == 403

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -47,6 +47,7 @@ TEMPLATES = WEB / "templates"
 LINKING_TEMPLATES = (
     "base.html",
     "config_corrupt.html",
+    "credentials_corrupt.html",
     "kb_select.html",
     "policy_halted.html",
     "sidecar_unreadable.html",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2,8 +2,10 @@
 import builtins
 from dataclasses import replace
 import functools
+import importlib.resources
 import importlib.util
 import inspect
+import json
 import logging
 import re
 import sys
@@ -18,6 +20,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
 import verinote.config  # noqa: E402
+import verinote.llm.openrouter_adapter  # noqa: E402
 import verinote.web.app as webapp  # noqa: E402
 from verinote.config import (  # noqa: E402
     Config,
@@ -30,7 +33,7 @@ from verinote.engine import CheckReport, DEFAULT_POLICY, FindingDetail  # noqa: 
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.kb_location import KBRootSafetyError  # noqa: E402
 from verinote.llm.anthropic_adapter import AnthropicAdapter  # noqa: E402
-from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
+from verinote.llm.base import ExtractedFact, LLMError, ModelListing  # noqa: E402
 from verinote.llm.claude_cli_adapter import ClaudeCliAdapter  # noqa: E402
 from verinote.llm.ollama_adapter import OllamaAdapter  # noqa: E402
 from verinote.llm.openai_adapter import OpenAIAdapter  # noqa: E402
@@ -4610,6 +4613,7 @@ def _ollama_client(
     provider="ollama",
     model="qwen3:8b",
     base_url=None,
+    api_key=None,
     llm_timeout_seconds=None,
 ):
     # No default of its own: an unset timeout must be Config's own default, so
@@ -4624,7 +4628,7 @@ def _ollama_client(
                 db_path=tmp_path / "kb.sqlite",
                 provider=provider,
                 model=model,
-                api_key=None,
+                api_key=api_key,
                 base_url=base_url,
                 **timeout,
             )
@@ -4632,17 +4636,24 @@ def _ollama_client(
     )
 
 
-class _FakeOllama:
+class _FakeLister:
     """Stands in for the keyless lister, recording the base URL and timeout it was
     called with so a test can prove which endpoint got asked, and how patiently.
 
     Installed over `webapp._MODEL_LISTERS` rather than over `webapp.get_client`:
     the listing path deliberately no longer builds a client, and a fake wired to
     the factory would sit unused while the real endpoint was dialled for real.
+
+    `structured_output_ids` defaults to `None` -- what a listing that does not
+    report the property returns, which is Ollama's case and the one most of these
+    tests are about. A listing that does report it passes a frozenset, including
+    an empty one, because "reported and none" is a different fact from "not
+    reported" and the picker renders the two differently.
     """
 
-    def __init__(self, models=(), error=None):
-        self.models = list(models)
+    def __init__(self, models=(), error=None, structured_output_ids=None):
+        self.models = tuple(models)
+        self.structured_output_ids = structured_output_ids
         self.error = error
         self.seen = []
         self.timeouts = []
@@ -4656,7 +4667,9 @@ class _FakeOllama:
         self.timeouts.append(timeout)
         if self.error is not None:
             raise self.error
-        return self.models
+        return ModelListing(
+            models=self.models, structured_output_ids=self.structured_output_ids
+        )
 
 
 def test_settings_defers_the_ollama_model_list_off_the_page_load(tmp_path, monkeypatch):
@@ -4689,7 +4702,7 @@ def test_settings_does_not_defer_for_a_provider_with_nothing_to_enumerate(tmp_pa
 
 
 def test_model_field_offers_the_installed_models_as_a_picker(tmp_path, monkeypatch):
-    _FakeOllama(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
+    _FakeLister(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 
@@ -4704,7 +4717,7 @@ def test_model_field_asks_the_endpoint_being_edited_not_the_saved_one(tmp_path, 
     """The form's Base URL is the endpoint whose models the user is choosing from.
     Listing against the saved config instead would show models from a server the
     user is in the middle of switching away from."""
-    fake = _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
+    fake = _FakeLister(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path, base_url="http://saved:11434").get(
         "/settings/model-field?provider=ollama&model=qwen3:8b&base_url=http://edited:9999"
@@ -4717,7 +4730,7 @@ def test_model_field_asks_the_endpoint_being_edited_not_the_saved_one(tmp_path, 
 def test_model_field_keeps_a_configured_model_the_server_does_not_have(tmp_path, monkeypatch):
     """config.json really does name this model. Dropping it from the picker would
     silently select a different one and make the page misreport the KB's state."""
-    _FakeOllama(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
+    _FakeLister(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path, model="llama3.1").get(
         "/settings/model-field?provider=ollama&model=llama3.1"
@@ -4731,7 +4744,7 @@ def test_model_field_keeps_a_configured_model_the_server_does_not_have(tmp_path,
 def test_model_field_falls_back_to_typing_when_the_server_is_unreachable(tmp_path, monkeypatch):
     """An empty picker would read as 'nothing to choose' and, worse, leave the user
     unable to set a model at all. Say what failed and keep the field usable."""
-    _FakeOllama(error=LLMError("ollama request failed: connection refused")).install(monkeypatch)
+    _FakeLister(error=LLMError("ollama request failed: connection refused")).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 
@@ -4745,7 +4758,7 @@ def test_model_field_falls_back_to_typing_when_the_server_is_unreachable(tmp_pat
 def test_model_field_distinguishes_an_empty_server_from_an_unreachable_one(tmp_path, monkeypatch):
     """Reachable-with-nothing-pulled and could-not-be-reached are different facts
     about the user's machine, and the fix for each is different."""
-    _FakeOllama(models=[]).install(monkeypatch)
+    _FakeLister(models=[]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=")
 
@@ -4755,12 +4768,16 @@ def test_model_field_distinguishes_an_empty_server_from_an_unreachable_one(tmp_p
 
 
 def test_model_field_names_the_default_endpoint_it_will_actually_dial(tmp_path, monkeypatch):
-    fake = _FakeOllama(models=[]).install(monkeypatch)
+    fake = _FakeLister(models=[]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=")
 
     assert fake.seen == [None]  # an unset Base URL stays unset in config
     assert "http://localhost:11434" in r.text  # ...but the page names the real target
+    # Ollama's entry in the default-endpoint map, not just *some* entry: a map
+    # whose two values were swapped would otherwise satisfy the openrouter test
+    # and this one both, while telling every user the wrong host.
+    assert "openrouter.ai" not in r.text
 
 
 def test_model_field_does_not_reach_the_provider_for_a_text_input_provider(tmp_path, monkeypatch):
@@ -4826,6 +4843,34 @@ def test_model_field_halts_under_unreadable_credentials(tmp_path, monkeypatch):
     assert r.headers.get("HX-Redirect") == webapp.CREDENTIALS_UNAVAILABLE_PATH
 
 
+def test_model_field_halts_on_config_first_when_both_errors_are_set(tmp_path, monkeypatch):
+    """Config-first order: settings_error must win when both halts apply.
+
+    A corrupt config.json falls back to the built-in cloud provider, which
+    requires a key, so credentials_error can be set alongside settings_error
+    on the very same Config. `_list_models_for` hand-writes the same
+    settings-then-credentials order `get_client` centralises; nothing keeps
+    the two surfaces agreeing. Swapping the two assert lines produces zero
+    failures elsewhere in the suite -- this is the one test that would catch it.
+    """
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    monkeypatch.setattr(
+        webapp,
+        "_MODEL_LISTERS",
+        {"ollama": lambda base_url, timeout: pytest.fail("dialled despite the halt")},
+    )
+    c = TestClient(
+        create_app(replace(cfg, credentials_error="credentials.json is not valid JSON"))
+    )
+
+    r = c.get(
+        "/settings/model-field?provider=ollama&model=m", headers={"HX-Request": "true"}
+    )
+
+    assert r.status_code == 409
+    assert r.headers.get("HX-Redirect") == webapp.CONFIG_UNAVAILABLE_PATH
+
+
 def test_model_field_never_constructs_a_provider_adapter(tmp_path, monkeypatch):
     """The load-bearing test for the keyless listing seam.
 
@@ -4850,7 +4895,7 @@ def test_model_field_never_constructs_a_provider_adapter(tmp_path, monkeypatch):
     monkeypatch.setattr(
         webapp, "get_client", lambda _cfg: pytest.fail("the listing path built a client")
     )
-    fake = _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
+    fake = _FakeLister(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 
@@ -4866,7 +4911,7 @@ def test_model_field_listing_clamps_the_page_load_timeout(tmp_path, monkeypatch)
     The clamp moved here with the seam: the lister takes a float and cannot
     re-derive it, so this is the only place left that can get it wrong.
     """
-    fake = _FakeOllama(models=[]).install(monkeypatch)
+    fake = _FakeLister(models=[]).install(monkeypatch)
 
     _ollama_client(tmp_path, llm_timeout_seconds=900.0).get(
         "/settings/model-field?provider=ollama&model="
@@ -4878,7 +4923,7 @@ def test_model_field_listing_clamps_the_page_load_timeout(tmp_path, monkeypatch)
 def test_model_field_listing_keeps_an_even_shorter_configured_timeout(tmp_path, monkeypatch):
     """The bound is the *smaller* of the two, so a tighter user setting still wins.
     Without this, clamping to a flat 5.0 would pass the test above."""
-    fake = _FakeOllama(models=[]).install(monkeypatch)
+    fake = _FakeLister(models=[]).install(monkeypatch)
 
     _ollama_client(tmp_path, llm_timeout_seconds=1.5).get(
         "/settings/model-field?provider=ollama&model="
@@ -5151,7 +5196,7 @@ def test_settings_page_renders_the_cli_picker_as_a_list(tmp_path):
 def test_model_field_custom_never_downgrades_the_discovered_picker(tmp_path, monkeypatch):
     """A stray `custom=1` must not turn Ollama's discovered list into free text --
     that list is evidence, and there is no reason to type past it."""
-    _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
+    _FakeLister(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get(
         "/settings/model-field?provider=ollama&model=qwen3:8b&custom=1"
@@ -5164,7 +5209,7 @@ def test_model_field_custom_never_downgrades_the_discovered_picker(tmp_path, mon
 def test_model_field_keeps_aliases_off_the_ollama_picker(tmp_path, monkeypatch):
     """Curated aliases and a discovered list are different claims; the Ollama
     field must never quietly gain entries no server reported."""
-    _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
+    _FakeLister(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 
@@ -5178,3 +5223,752 @@ def test_model_field_gives_no_aliases_to_a_plain_text_provider(tmp_path):
 
     assert "<datalist" not in r.text
     assert '<input type="text" name="model" value="claude" placeholder="model id">' in r.text
+
+
+# --- the OpenRouter catalogue picker: grouped by what each entry advertises ---
+
+
+_CATALOGUE = {
+    "schema": ("openai/gpt-oss-20b:free", "z/vendor-schema"),
+    "plain": ("a/vendor-plain",),
+}
+
+
+def _openrouter_lister(monkeypatch, **kwargs):
+    """A stub OpenRouter catalogue: two advertising entries and one that is not."""
+    models = _CATALOGUE["schema"] + _CATALOGUE["plain"]
+    defaults = {
+        "models": sorted(models),
+        "structured_output_ids": frozenset(_CATALOGUE["schema"]),
+    }
+    defaults.update(kwargs)
+    return _FakeLister(**defaults).install(monkeypatch, provider="openrouter")
+
+
+def _optgroups(text: str) -> list[str]:
+    return re.findall(r'<optgroup label="([^"]*)">', text)
+
+
+def test_settings_defers_the_openrouter_catalogue_off_the_page_load(tmp_path, monkeypatch):
+    """OpenRouter is listable now, so its Model field must behave like Ollama's:
+    a working text input that lazily swaps itself for the picker, never a network
+    call on the critical path of the page that also recovers a corrupt config."""
+    monkeypatch.setitem(
+        webapp._MODEL_LISTERS,
+        "openrouter",
+        lambda base_url, timeout: pytest.fail("/settings must not call the provider"),
+    )
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings"
+    )
+
+    assert r.status_code == 200
+    assert 'hx-trigger="load"' in r.text
+    assert 'name="model"' in r.text
+
+
+def test_openrouter_model_field_groups_the_catalogue_by_advertised_structured_output(
+    tmp_path, monkeypatch
+):
+    """The catalogue says which entries advertise structured output, and verinote
+    always asks for a JSON-schema `response_format` -- so which group a model is
+    in is the one thing about it that predicts a failure, and it has to be visible
+    while choosing.
+
+    Mutation: render the ids flat (drop the `structured_output_ids is none`
+    branch's else arm) and the two `<optgroup>`s disappear while every option
+    stays, so a user picks a non-advertising model with nothing said about it.
+    """
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text
+    assert _optgroups(r.text) == [
+        "Advertises structured output",
+        "Does not advertise structured output",
+    ]
+    advertising, unadvertising = r.text.split('<optgroup label="Does not advertise')
+    for model in _CATALOGUE["schema"]:
+        assert f'value="{model}"' in advertising
+    for model in _CATALOGUE["plain"]:
+        assert f'value="{model}"' in unadvertising
+        assert f'value="{model}"' not in advertising
+
+
+def test_ollama_model_field_stays_flat_because_its_listing_reports_no_capability(
+    tmp_path, monkeypatch
+):
+    """`/api/tags` says nothing about structured output, so grouping Ollama's
+    models would attribute a claim to a server that never made it.
+
+    Mutation: collapse the two in `_model_field_context`
+    (`listing.structured_output_ids or frozenset()`), which is the one-character
+    version of treating "does not report it" as "reports none" -- every installed
+    model then lands under "Does not advertise structured output".
+    """
+    _FakeLister(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert '<select name="model">' in r.text
+    assert _optgroups(r.text) == []
+    assert "advertise" not in r.text
+
+
+def test_openrouter_model_field_groups_a_catalogue_where_nothing_advertises(
+    tmp_path, monkeypatch
+):
+    """A listing that reports the property and finds nothing advertising it is not
+    a listing that does not report the property: the first is a catalogue saying
+    "none of these", the second (Ollama) is silence. Both groups render whenever
+    the property IS reported, so an empty "Advertises structured output" heading
+    is itself the honest answer -- and this state is reachable, being exactly what
+    OpenRouter renaming `structured_outputs` would produce.
+
+    Mutation: `{% if structured_output_ids is none %}` -> `{% if not
+    structured_output_ids %}` in `model_field.html`, which folds the empty
+    frozenset into the `None` case; the picker goes flat and every model loses the
+    heading that says its own entry does not advertise what verinote will ask it
+    for. The two sibling grouping tests miss it -- OpenRouter's set is non-empty
+    there and Ollama's is `None`, so neither tells truthiness from `is none`.
+    """
+    models = sorted(_CATALOGUE["schema"] + _CATALOGUE["plain"])
+    _FakeLister(models=models, structured_output_ids=frozenset()).install(
+        monkeypatch, provider="openrouter"
+    )
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text
+    assert _optgroups(r.text) == [
+        "Advertises structured output",
+        "Does not advertise structured output",
+    ]
+    advertising, unadvertising = r.text.split('<optgroup label="Does not advertise')
+    for model in models:
+        assert f'value="{model}"' in unadvertising
+        assert f'value="{model}"' not in advertising
+
+
+def test_openrouter_model_field_groups_a_catalogue_where_everything_advertises(
+    tmp_path, monkeypatch
+):
+    """The mirror of the sibling above, for the other empty group.
+
+    "Both groups are rendered whenever the property IS reported, even if one is
+    empty" is a claim about either group, and only one half of it was pinned. A
+    catalogue in which every entry advertises structured output leaves the SECOND
+    group empty, and its heading still has to appear: dropping it would turn the
+    remaining heading into an unlabelled section over the whole list, so a user
+    reading it has no way to know a "does not advertise" group exists at all --
+    and the next entry to land in it would arrive under a heading that had never
+    been shown.
+
+    Mutation: wrap either `<optgroup>` in a non-empty guard (for this one,
+    `{% if models | reject('in', structured_output_ids) | list %}`). The sibling
+    above catches that guard on the first group only, because its first group is
+    the empty one; this catches it on the second. Neither of the two grouping
+    tests with a mixed catalogue sees either, since both of their groups are
+    non-empty.
+    """
+    models = sorted(_CATALOGUE["schema"] + _CATALOGUE["plain"])
+    _FakeLister(models=models, structured_output_ids=frozenset(models)).install(
+        monkeypatch, provider="openrouter"
+    )
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text
+    assert _optgroups(r.text) == [
+        "Advertises structured output",
+        "Does not advertise structured output",
+    ]
+    advertising, unadvertising = r.text.split('<optgroup label="Does not advertise')
+    for model in models:
+        assert f'value="{model}"' in advertising
+        assert f'value="{model}"' not in unadvertising
+
+
+def test_openrouter_model_field_names_openrouters_endpoint_not_ollamas(tmp_path, monkeypatch):
+    """With a second listable provider, a hardcoded `OLLAMA_DEFAULT_BASE_URL`
+    would tell an OpenRouter user the page dialled `http://localhost:11434`.
+
+    Mutation: drop `_LISTABLE_DEFAULT_ENDPOINTS` and go back to the Ollama
+    constant -- the positive assertion is what catches it, since the note would
+    still render, just naming a host nothing here ever contacted.
+    """
+    fake = _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert fake.seen == [None]  # an unset Base URL stays unset in config
+    assert "https://openrouter.ai/api/v1" in r.text
+    assert "localhost:11434" not in r.text
+
+
+def test_openrouter_model_field_note_makes_no_ollama_claim(tmp_path, monkeypatch):
+    """The note under the picker is what stops the catalogue reading as account
+    entitlement and the two groups reading as a measurement. Both claims are
+    OpenRouter-specific and both are load-bearing: the request carried no key, so
+    this is what the endpoint publishes rather than what this account may call,
+    and the groups repeat `supported_parameters` rather than reporting a run.
+
+    Mutation: the note's `{% if provider == 'ollama' %}` -> `{% if 1 %}`, one
+    token no other test sees; the page then tells an OpenRouter user that N models
+    are "installed on" `https://openrouter.ai/api/v1` and the entire keyless
+    caveat disappears.
+    """
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert "3 models listed by" in r.text
+    assert "answered without an API key" in r.text
+    assert "not a list of what your account can reach" in r.text
+    # The sentence that keeps the grouping a repetition rather than a measurement.
+    assert "has not run any of them" in r.text
+    assert "installed on" not in r.text
+    assert "ollama pull" not in r.text
+
+
+def test_ollama_model_field_note_makes_no_openrouter_claim(tmp_path, monkeypatch):
+    """The other half of that branch, so an inversion fails in both directions.
+    Ollama's list is what is installed on a machine the user controls, where a
+    missing model is fixed with `ollama pull`; the catalogue copy would tell that
+    user their own server "answered without an API key" and that what it reported
+    is a published list rather than what they pulled.
+
+    Mutation: invert the note's `{% if provider == 'ollama' %}` the other way (to
+    `{% if 0 %}`, or swap the two arms) -- the OpenRouter sibling above still
+    passes, and only this catches it.
+    """
+    _FakeLister(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert "2 models installed on" in r.text
+    assert "http://localhost:11434" in r.text
+    assert "answered without an API key" not in r.text
+    assert "your account can reach" not in r.text
+    assert "listed by" not in r.text
+
+
+def test_openrouter_model_field_names_a_configured_proxy_not_the_literal_default(
+    tmp_path, monkeypatch
+):
+    """The note must interpolate the endpoint actually dialled. Hardcoding
+    `openrouter.ai` into the copy would pass the test above and then misreport
+    every gateway or proxy deployment.
+
+    Mutation: write the literal URL into `model_field.html` instead of
+    `{{ endpoint }}` -- that mutation is invisible to the sibling test and fails
+    only here.
+    """
+    fake = _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+        "&base_url=https://proxy.internal/v1"
+    )
+
+    assert fake.seen == ["https://proxy.internal/v1"]
+    assert "proxy.internal" in r.text
+    assert "openrouter.ai" not in r.text
+
+
+def test_openrouter_model_field_keeps_a_configured_model_absent_from_the_catalogue(
+    tmp_path, monkeypatch
+):
+    """config.json really does name this model, and the catalogue is a published
+    list, not a verdict on the id. Dropping it would silently select a different
+    model and make the page misreport the KB's own state.
+
+    Mutation: drop the "keep the configured model" branch and the option vanishes
+    while the picker still renders -- the browser then selects the first entry,
+    so the field shows a model this KB is not configured for. Mutation 2: leave
+    the label at Ollama's `— not installed` and an OpenRouter user is told a
+    catalogue entry is an installation.
+    """
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="vendor/private-model").get(
+        "/settings/model-field?provider=openrouter&model=vendor/private-model"
+    )
+
+    assert (
+        '<option value="vendor/private-model" selected>vendor/private-model'
+        " — not in this catalogue</option>" in unescape(r.text)
+    )
+    assert "did not list" in r.text
+    assert "not installed" not in r.text
+    assert "ollama pull" not in r.text
+
+
+def test_openrouter_model_field_falls_back_to_typing_when_the_catalogue_fails(
+    tmp_path, monkeypatch
+):
+    """An empty picker would read as "the catalogue offers nothing" and leave the
+    user unable to set a model at all.
+
+    The real lister runs here, against an `urlopen` that refuses, rather than a
+    stub raising `LLMError`: the mutation this exists for lives in the adapter.
+    Mutation: return an empty `ModelListing` from
+    `openrouter_adapter.list_models` on a transport error instead of raising --
+    the page then renders the empty-catalogue copy, blaming OpenRouter for
+    listing nothing when it was never reached. A stubbed lister would pass that
+    mutation, since the stub is what raises.
+    """
+
+    def refuse(req, *, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", refuse)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert r.status_code == 200
+    assert "<select" not in r.text
+    assert '<input type="text" name="model" value="openai/gpt-oss-20b:free"' in r.text
+    assert "Could not load the model list" in r.text
+    assert "connection refused" in r.text
+    assert "is reachable but" not in r.text
+
+
+def test_openrouter_empty_catalogue_copy_is_not_ollamas(tmp_path, monkeypatch):
+    """`ollama pull` fires for any listable provider whose listing came back
+    empty, so the moment OpenRouter joined, this state told an OpenRouter user to
+    run a command for a program they may not have installed.
+
+    Mutation: reuse Ollama's string for both and `ollama pull` appears here.
+    """
+    _FakeLister(models=[], structured_output_ids=frozenset()).install(
+        monkeypatch, provider="openrouter"
+    )
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="").get(
+        "/settings/model-field?provider=openrouter&model="
+    )
+
+    assert "ollama pull" not in r.text
+    assert "installed" not in r.text
+    assert "listed no models" in r.text
+    assert "https://openrouter.ai/api/v1" in r.text
+    assert '<input type="text" name="model"' in r.text
+
+
+def test_openrouter_model_field_offers_no_blank_option(tmp_path, monkeypatch):
+    """Unlike the CLI picker, a blank model here is not "no model": it falls
+    through to `_MODEL_DEFAULTS['openrouter']`, so an option labelled as an
+    absence would misreport the model this KB would actually use."""
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
+        "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
+    )
+
+    assert 'value=""' not in r.text
+
+
+def test_openrouter_model_field_puts_no_api_key_on_the_wire(tmp_path, monkeypatch):
+    """The egress site itself, not a proxy for it.
+
+    `test_model_field_never_constructs_a_provider_adapter` counts constructions,
+    which is one step removed: a lister body that read a key directly would build
+    nothing and still ship it. This runs the real `openrouter_adapter.list_models`
+    against an intercepted `urlopen` with a key in `app.state.cfg`, and asserts the
+    sentinel appears in none of the three places a request can carry it.
+
+    Mutation: add `Authorization: Bearer {cfg.api_key}` anywhere on that path --
+    which requires handing the lister a Config, so the import-time shape check is
+    the other half of this -- and the header assertion fails.
+    """
+    sentinel = "sk-or-v1-SENTINEL-DO-NOT-SEND-0123456789"
+    requests = []
+
+    class _Catalogue:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def read(self):
+            entry = {"id": "a/b", "supported_parameters": ["structured_outputs"]}
+            return json.dumps({"data": [entry]}).encode("utf-8")
+
+    def fake_urlopen(req, *, timeout):
+        requests.append(req)
+        return _Catalogue()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    client = _ollama_client(
+        tmp_path, provider="openrouter", model="a/b", api_key=sentinel
+    )
+    # The premise: the app really is holding the key while this request runs.
+    assert client.app.state.cfg.api_key == sentinel
+
+    r = client.get("/settings/model-field?provider=openrouter&model=a/b")
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text  # it really did render the picker
+    assert len(requests) == 1  # ...and really did dial the catalogue
+    req = requests[0]
+    assert sentinel not in req.full_url
+    assert not [item for item in req.header_items() if sentinel in str(item)]
+    assert req.data is None or sentinel.encode("utf-8") not in req.data
+
+
+# --- the default-endpoint map is checked at import, like the lister table ---
+
+
+@pytest.mark.parametrize(
+    "providers, endpoints, expected",
+    [
+        ({"ollama", "openrouter"}, {"ollama": "http://localhost:11434"}, "openrouter"),
+        (
+            {"ollama"},
+            {"ollama": "http://localhost:11434", "openrouter": "https://openrouter.ai/api/v1"},
+            "openrouter",
+        ),
+    ],
+)
+def test_the_check_rejects_a_listable_provider_without_a_default_endpoint(
+    providers, endpoints, expected
+):
+    """Both directions. A listable provider with no default endpoint would print
+    some other provider's host as the one that answered; an endpoint for a
+    provider that is not listable is an unused URL the next edit adopts without
+    anyone re-checking it.
+
+    Mutation: make the check a subset test (`set(providers) - set(endpoints)`)
+    and the second case stops raising.
+    """
+    with pytest.raises(RuntimeError, match=expected):
+        webapp._check_every_listable_provider_names_its_default_endpoint(providers, endpoints)
+
+
+def test_the_check_rejects_a_blank_default_endpoint():
+    """A present-but-empty entry passes the membership clause and then renders as
+    `<code></code>` under the picker -- a name for the dialled host that names
+    nothing.
+
+    Mutation: drop the blank clause and this stops raising.
+    """
+    with pytest.raises(RuntimeError, match="ollama"):
+        webapp._check_every_listable_provider_names_its_default_endpoint(
+            {"ollama"}, {"ollama": "   "}
+        )
+
+
+def test_the_module_body_runs_the_default_endpoint_check(monkeypatch):
+    """The predicate is only a gate if the module body calls it, and the tests
+    above call it themselves -- so deleting the module-level call leaves them all
+    green (`sys.modules` cached the real import long before they ran).
+
+    Blanking the adapter constant rather than adding a provider is what isolates
+    THIS check: an unknown listable provider is rejected by the lister check
+    first, so it could never prove this one runs. A fresh module object rather
+    than `importlib.reload`, for the reason its sibling states.
+    """
+    monkeypatch.setattr(
+        verinote.llm.openrouter_adapter, "OPENROUTER_DEFAULT_BASE_URL", ""
+    )
+    name = "verinote_web_app_endpoint_check_under_test"
+    spec = importlib.util.spec_from_file_location(name, webapp.__file__)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+
+    with pytest.raises(RuntimeError, match="openrouter"):
+        spec.loader.exec_module(module)
+
+
+# --- the Model field's per-provider copy is checked at import too ---
+
+
+_ONE_CHAIN = "{% if provider == 'ollama' %}a{% elif provider == 'openrouter' %}b{% endif %}"
+
+
+@pytest.mark.parametrize(
+    "providers, source, expected",
+    [
+        ({"ollama", "openrouter"}, "{% if provider == 'ollama' %}a{% endif %}", "openrouter"),
+        ({"ollama"}, _ONE_CHAIN, "openrouter"),
+    ],
+)
+def test_the_check_rejects_a_listable_provider_without_model_field_copy(
+    providers, source, expected
+):
+    """Both directions. A listable provider with no arm gets whatever the chain's
+    catch-all says -- which is another provider's copy, the failure this replaces
+    -- or, with no catch-all, nothing at all. An arm for a provider that is not
+    listable is copy no render reaches, and the next edit to
+    `MODEL_LISTING_PROVIDERS` would adopt it without anyone re-reading it.
+
+    Mutation: drop the `unlistable` clause and the second case stops raising;
+    drop `missing` and the first does.
+    """
+    with pytest.raises(RuntimeError, match=expected):
+        webapp._check_every_listable_provider_has_model_field_copy(providers, source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # Lopsided: `openrouter` appears fewer times than `ollama` overall.
+        _ONE_CHAIN + "{% if provider == 'ollama' %}c{% endif %}",
+        # Balanced: three arms each across the file, and still one chain that
+        # renders `openrouter` nothing, paid for by a duplicate arm elsewhere
+        # that no render can reach.
+        _ONE_CHAIN
+        + "{% if provider == 'ollama' %}c{% endif %}"
+        + "{% if provider == 'ollama' %}d{% elif provider == 'openrouter' %}e"
+        "{% elif provider == 'openrouter' %}f{% endif %}",
+    ],
+)
+def test_the_check_rejects_copy_written_at_only_some_of_the_branch_sites(source):
+    """Membership alone would pass copy written at one chain and forgotten at the
+    rest, which is the likely shape of the mistake: the template branches on the
+    provider in four separate places, and a new provider needs an arm in each.
+
+    The second source is why membership per chain is the rule rather than equal
+    totals: the totals balance at three apiece, so a check that counted names
+    across the whole file would pass it while the second chain rendered
+    `openrouter` nothing at all.
+
+    Mutation: compare totals per name instead of membership per chain -- the
+    shape this check had -- and the second source stops raising.
+    """
+    with pytest.raises(RuntimeError, match="openrouter"):
+        webapp._check_every_listable_provider_has_model_field_copy(
+            {"ollama", "openrouter"}, source
+        )
+
+
+def test_the_check_rejects_a_template_with_no_provider_chain_left_in_it():
+    """A per-chain rule says nothing about a file with no chains: flatten every
+    arm back into shared prose and there is no chain left to be missing a
+    provider, so the loop would pass a template that tells every provider's users
+    the same sentence -- the exact misreport this check exists for.
+
+    Mutation: delete the empty-`chains` guard and this stops raising.
+    """
+    source = "<p>{{ models|length }} models installed on {{ endpoint }}.</p>"
+
+    with pytest.raises(RuntimeError, match="no longer branches on `provider`"):
+        webapp._check_every_listable_provider_has_model_field_copy(
+            {"ollama", "openrouter"}, source
+        )
+
+
+def test_the_check_rejects_a_second_arm_for_the_same_provider_in_one_chain():
+    """"Exactly one arm" is the rule, and the second half of it is its own clause:
+    a chain that tests the same provider twice has a second arm no render can
+    reach, so the copy in it is never seen and never re-read. Membership alone
+    would pass this -- both names are present -- which is why the counts inside
+    the chain are checked as well as the names.
+
+    Mutation: stop collecting `repeated` and this stops raising, while a
+    maintainer could write a new sentence into a dead arm and see nothing.
+    """
+    source = (
+        "{% if provider == 'ollama' %}a{% elif provider == 'openrouter' %}b"
+        "{% elif provider == 'ollama' %}c{% endif %}"
+    )
+
+    with pytest.raises(RuntimeError, match=r"duplicate arms \['ollama'\]"):
+        webapp._check_every_listable_provider_has_model_field_copy(
+            {"ollama", "openrouter"}, source
+        )
+
+
+def test_the_check_does_not_count_a_provider_named_only_in_a_comment():
+    """The header comment above the markup discusses these arms at length, so a
+    name can appear there with no arm anywhere. Reading the file as text, four
+    such mentions look exactly like four arms; parsing drops `{# ... #}` in the
+    lexer, so they are not arms and the missing copy is still reported.
+
+    Mutation: find the arms with `re.findall(r"provider == '([^']*)'")` over the
+    source -- the shape this check had -- and this stops raising, because
+    `newguy` then "appears" in all four chains without a line of copy written for
+    it anywhere.
+    """
+    shipped = webapp._TEMPLATES.joinpath(webapp._MODEL_FIELD_TEMPLATE).read_text(
+        encoding="utf-8"
+    )
+    source = shipped.replace(
+        "#}",
+        "\n   e.g. provider == 'newguy', provider == 'newguy',\n"
+        "   provider == 'newguy', provider == 'newguy' #}",
+        1,
+    )
+    assert source != shipped, "the header comment's closing `#}` moved"
+
+    with pytest.raises(RuntimeError, match=r"missing \['newguy'\]"):
+        webapp._check_every_listable_provider_has_model_field_copy(
+            {"ollama", "openrouter", "newguy"}, source
+        )
+
+
+def test_a_comment_that_illustrates_an_arm_does_not_brick_the_check():
+    """The other direction of the same property, and the live one: the header
+    comment invites quoting one of these tests to explain it, and doing so must
+    not stop the app from starting.
+
+    Mutation: find the arms with `re.findall(r"provider == '([^']*)'")` over the
+    source and this raises -- `ollama` then "appears" five times to
+    `openrouter`'s four, so the app refuses to start and the error names
+    `openrouter`, whose four arms are all present and correct.
+    """
+    shipped = webapp._TEMPLATES.joinpath(webapp._MODEL_FIELD_TEMPLATE).read_text(
+        encoding="utf-8"
+    )
+    source = shipped.replace(
+        "#}", "\n   Each chain opens with provider == 'ollama'. #}", 1
+    )
+    assert source != shipped, "the header comment's closing `#}` moved"
+
+    webapp._check_every_listable_provider_has_model_field_copy(
+        {"ollama", "openrouter"}, source
+    )
+
+
+def test_the_check_catches_reverting_the_shipped_arms_to_a_catch_all_else():
+    """The realistic regression, run against the shipped file rather than a
+    fixture: someone folds `{% elif provider == 'openrouter' %}` back into
+    `{% else %}` because two providers make the elif look redundant. Every chain
+    then hands Ollama's copy -- "installed", "ollama pull" -- to whatever joins
+    next, which is the failure the whole check exists to stop.
+
+    Mutation: return early from the check when a chain has any arm at all, rather
+    than requiring each listable provider to have one, and this stops raising.
+    """
+    shipped = webapp._TEMPLATES.joinpath(webapp._MODEL_FIELD_TEMPLATE).read_text(
+        encoding="utf-8"
+    )
+    source = shipped.replace("{% elif provider == 'openrouter' %}", "{% else %}")
+    assert source != shipped, "the shipped arms no longer read `elif provider == ...`"
+
+    with pytest.raises(RuntimeError, match=r"missing \['openrouter'\]"):
+        webapp._check_every_listable_provider_has_model_field_copy(
+            {"ollama", "openrouter"}, source
+        )
+
+
+def test_the_check_finds_the_inline_chain_inside_the_option_tag():
+    """Four chains, not three. One of them is inline in an `<option>` tag rather
+    than a block of its own, and it carries the sentence that says why a
+    configured model is absent -- "not installed" versus "not in this catalogue".
+    A walk that only found block-level chains would let that one drift.
+
+    Mutation: skip `nodes.If` whose body is not a block and this returns three
+    chains, so the inline arms could be reverted to an `{% else %}` unnoticed.
+    """
+    shipped = webapp._TEMPLATES.joinpath(webapp._MODEL_FIELD_TEMPLATE).read_text(
+        encoding="utf-8"
+    )
+    anchor = "{% if provider == 'ollama' %} — not installed"
+    inline_lineno = shipped[: shipped.index(anchor)].count("\n") + 1
+
+    chains = webapp._model_field_provider_chains(shipped)
+
+    assert [names for _, names in chains] == [["ollama", "openrouter"]] * 4
+    assert inline_lineno in [lineno for lineno, _ in chains]
+
+
+def test_the_walk_ignores_chains_that_do_not_test_the_provider():
+    """Only chains that branch on `provider` are places a provider needs an arm.
+    The template's `{% if models %}` and `{% if structured_output_ids is none %}`
+    are not, and dragging them in would demand arms where the distinction being
+    made is not per-provider at all.
+
+    Mutation: treat every `nodes.If` as a provider chain and this returns extra
+    entries with no names, which the check would then report as missing both
+    providers -- the shipped template would not import.
+    """
+    source = "{% if models %}x{% endif %}" + _ONE_CHAIN
+
+    assert webapp._model_field_provider_chains(source) == [(1, ["ollama", "openrouter"])]
+
+
+def test_a_compound_guard_still_counts_as_that_providers_arm():
+    """`_provider_names_compared` walks every `Compare` node inside the test, not
+    just the test node itself, so an arm guarded by `provider == 'x' and models`
+    -- rather than a bare `provider == 'x'` -- is still `x`'s arm, not a chain
+    the walk fails to recognise.
+
+    One test rather than two: the chain-level assertion pins that `openrouter`
+    is attributed to *that* arm specifically (not merely that something passed),
+    and the check-level call is the positive-acceptance case the surrounding
+    tests lack -- every other guard test here asserts a raise, which a walk that
+    cannot see the compound arm would still produce (a chain missing an arm
+    always raises), so a rejection test cannot tell a correctly-attributed
+    compound arm apart from an invisible one. Passing is the only outcome a
+    narrowed walk cannot fake, and both assertions are cheap enough on one
+    `source` that splitting them would only duplicate the fixture.
+
+    Mutation: narrow the walk in `_provider_names_compared` to
+    `for node in (test,):` and the compound `openrouter` arm goes unseen, so the
+    chain reads as `['ollama']` -- missing `openrouter` -- and both assertions
+    fail: the chain list no longer matches, and the check raises.
+    """
+    source = (
+        "{% if provider == 'ollama' %}a"
+        "{% elif provider == 'openrouter' and models %}b"
+        "{% endif %}"
+    )
+
+    assert webapp._model_field_provider_chains(source) == [(1, ["ollama", "openrouter"])]
+    webapp._check_every_listable_provider_has_model_field_copy(
+        {"ollama", "openrouter"}, source
+    )
+
+
+def test_the_module_body_runs_the_model_field_copy_check(tmp_path, monkeypatch):
+    """The predicate is only a gate if the module body calls it; the tests above
+    call it themselves, so deleting the module-level call leaves them green.
+
+    Doctoring a copy of the shipped template is what isolates THIS check: it is
+    the only import-time check that reads that file, so nothing else can raise
+    first. `resources.files` is redirected rather than the repo's template being
+    edited, so the real one is never touched and a crashed run cannot leave it
+    mutated. A fresh module object rather than `importlib.reload`, for the reason
+    its sibling states.
+    """
+    shipped = webapp._TEMPLATES.joinpath(webapp._MODEL_FIELD_TEMPLATE).read_text(
+        encoding="utf-8"
+    )
+    partials = tmp_path / "templates" / "partials"
+    partials.mkdir(parents=True)
+    (partials / "model_field.html").write_text(
+        shipped.replace("provider == 'openrouter'", "provider == 'ollama'"), encoding="utf-8"
+    )
+    real_files = importlib.resources.files
+    monkeypatch.setattr(
+        importlib.resources,
+        "files",
+        lambda package: tmp_path if package == "verinote.web" else real_files(package),
+    )
+    name = "verinote_web_app_copy_check_under_test"
+    spec = importlib.util.spec_from_file_location(name, webapp.__file__)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+
+    with pytest.raises(RuntimeError, match="openrouter"):
+        spec.loader.exec_module(module)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4142,7 +4142,10 @@ def test_settings_never_renders_api_key(tmp_path):
     client = TestClient(create_app(cfg))
     r = client.get("/settings")
     assert "supersecret" not in r.text
-    assert "API key: set" in r.text
+    # `"API keys"` alone would be the unconditional <h2> and would pass whatever
+    # the rows said. Assert the row's actual state for the configured provider.
+    assert "Anthropic" in r.text
+    assert "not set" in r.text
 
 
 def test_test_connection_reports_adapter(tmp_path, monkeypatch, fake_client):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+from dataclasses import replace
+import functools
+import importlib.util
+import inspect
 import logging
 import re
+import sys
 import threading
 import time
 import unicodedata
@@ -12,6 +17,7 @@ import pytest
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
+import verinote.config  # noqa: E402
 import verinote.web.app as webapp  # noqa: E402
 from verinote.config import (  # noqa: E402
     Config,
@@ -23,7 +29,11 @@ from verinote.config import (  # noqa: E402
 from verinote.engine import CheckReport, DEFAULT_POLICY, FindingDetail  # noqa: E402
 from verinote.engine.terms import Atom, Compound, StringLit  # noqa: E402
 from verinote.kb_location import KBRootSafetyError  # noqa: E402
+from verinote.llm.anthropic_adapter import AnthropicAdapter  # noqa: E402
 from verinote.llm.base import ExtractedFact, LLMError  # noqa: E402
+from verinote.llm.claude_cli_adapter import ClaudeCliAdapter  # noqa: E402
+from verinote.llm.ollama_adapter import OllamaAdapter  # noqa: E402
+from verinote.llm.openai_adapter import OpenAIAdapter  # noqa: E402
 from verinote.pipeline import ChunkedExtractionResult, ExtractionJobBusyError  # noqa: E402
 from verinote.pipeline.verify import _with_unrecorded_policy_warning  # noqa: E402
 from verinote.pipeline.policy_state import (  # noqa: E402
@@ -4594,7 +4604,19 @@ def test_worker_config_corrupt_does_not_mark_the_job_failed(tmp_path, monkeypatc
 # --- the Ollama model picker: choose from what the server actually has ---
 
 
-def _ollama_client(tmp_path, *, provider="ollama", model="qwen3:8b", base_url=None):
+def _ollama_client(
+    tmp_path,
+    *,
+    provider="ollama",
+    model="qwen3:8b",
+    base_url=None,
+    llm_timeout_seconds=None,
+):
+    # No default of its own: an unset timeout must be Config's own default, so
+    # this helper cannot silently retune every test that uses it.
+    timeout = (
+        {} if llm_timeout_seconds is None else {"llm_timeout_seconds": llm_timeout_seconds}
+    )
     return TestClient(
         create_app(
             Config(
@@ -4604,27 +4626,34 @@ def _ollama_client(tmp_path, *, provider="ollama", model="qwen3:8b", base_url=No
                 model=model,
                 api_key=None,
                 base_url=base_url,
+                **timeout,
             )
         )
     )
 
 
 class _FakeOllama:
-    """Stands in for the adapter the factory would return, recording the base URL
-    it was resolved with so a test can prove which endpoint got asked."""
+    """Stands in for the keyless lister, recording the base URL and timeout it was
+    called with so a test can prove which endpoint got asked, and how patiently.
 
-    name = "ollama"
+    Installed over `webapp._MODEL_LISTERS` rather than over `webapp.get_client`:
+    the listing path deliberately no longer builds a client, and a fake wired to
+    the factory would sit unused while the real endpoint was dialled for real.
+    """
 
     def __init__(self, models=(), error=None):
         self.models = list(models)
         self.error = error
         self.seen = []
+        self.timeouts = []
 
-    def factory(self, cfg):
-        self.seen.append(cfg.base_url)
+    def install(self, monkeypatch, provider="ollama"):
+        monkeypatch.setitem(webapp._MODEL_LISTERS, provider, self.lister)
         return self
 
-    def list_models(self):
+    def lister(self, base_url, timeout):
+        self.seen.append(base_url)
+        self.timeouts.append(timeout)
         if self.error is not None:
             raise self.error
         return self.models
@@ -4634,8 +4663,10 @@ def test_settings_defers_the_ollama_model_list_off_the_page_load(tmp_path, monke
     """`/settings` is also the recovery page for a corrupt config and a halted
     policy, so rendering it must never wait on a provider. The field ships as a
     working text input that lazily swaps itself for the picker."""
-    monkeypatch.setattr(
-        webapp, "get_client", lambda _cfg: pytest.fail("/settings must not call the provider")
+    monkeypatch.setitem(
+        webapp._MODEL_LISTERS,
+        "ollama",
+        lambda base_url, timeout: pytest.fail("/settings must not call the provider"),
     )
 
     r = _ollama_client(tmp_path).get("/settings")
@@ -4658,8 +4689,7 @@ def test_settings_does_not_defer_for_a_provider_with_nothing_to_enumerate(tmp_pa
 
 
 def test_model_field_offers_the_installed_models_as_a_picker(tmp_path, monkeypatch):
-    fake = _FakeOllama(models=["llava:7b", "qwen3:8b"])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    _FakeOllama(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 
@@ -4674,8 +4704,7 @@ def test_model_field_asks_the_endpoint_being_edited_not_the_saved_one(tmp_path, 
     """The form's Base URL is the endpoint whose models the user is choosing from.
     Listing against the saved config instead would show models from a server the
     user is in the middle of switching away from."""
-    fake = _FakeOllama(models=["qwen3:8b"])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    fake = _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path, base_url="http://saved:11434").get(
         "/settings/model-field?provider=ollama&model=qwen3:8b&base_url=http://edited:9999"
@@ -4688,8 +4717,7 @@ def test_model_field_asks_the_endpoint_being_edited_not_the_saved_one(tmp_path, 
 def test_model_field_keeps_a_configured_model_the_server_does_not_have(tmp_path, monkeypatch):
     """config.json really does name this model. Dropping it from the picker would
     silently select a different one and make the page misreport the KB's state."""
-    fake = _FakeOllama(models=["llava:7b", "qwen3:8b"])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    _FakeOllama(models=["llava:7b", "qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path, model="llama3.1").get(
         "/settings/model-field?provider=ollama&model=llama3.1"
@@ -4703,8 +4731,7 @@ def test_model_field_keeps_a_configured_model_the_server_does_not_have(tmp_path,
 def test_model_field_falls_back_to_typing_when_the_server_is_unreachable(tmp_path, monkeypatch):
     """An empty picker would read as 'nothing to choose' and, worse, leave the user
     unable to set a model at all. Say what failed and keep the field usable."""
-    fake = _FakeOllama(error=LLMError("ollama request failed: connection refused"))
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    _FakeOllama(error=LLMError("ollama request failed: connection refused")).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 
@@ -4718,8 +4745,7 @@ def test_model_field_falls_back_to_typing_when_the_server_is_unreachable(tmp_pat
 def test_model_field_distinguishes_an_empty_server_from_an_unreachable_one(tmp_path, monkeypatch):
     """Reachable-with-nothing-pulled and could-not-be-reached are different facts
     about the user's machine, and the fix for each is different."""
-    fake = _FakeOllama(models=[])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    _FakeOllama(models=[]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=")
 
@@ -4729,8 +4755,7 @@ def test_model_field_distinguishes_an_empty_server_from_an_unreachable_one(tmp_p
 
 
 def test_model_field_names_the_default_endpoint_it_will_actually_dial(tmp_path, monkeypatch):
-    fake = _FakeOllama(models=[])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    fake = _FakeOllama(models=[]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=")
 
@@ -4740,7 +4765,9 @@ def test_model_field_names_the_default_endpoint_it_will_actually_dial(tmp_path, 
 
 def test_model_field_does_not_reach_the_provider_for_a_text_input_provider(tmp_path, monkeypatch):
     monkeypatch.setattr(
-        webapp, "get_client", lambda _cfg: pytest.fail("no provider call for anthropic")
+        webapp,
+        "_list_models_for",
+        lambda *a, **k: pytest.fail("no provider call for anthropic"),
     )
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=anthropic&model=gpt")
@@ -4749,11 +4776,22 @@ def test_model_field_does_not_reach_the_provider_for_a_text_input_provider(tmp_p
     assert 'hx-trigger="load"' not in r.text
 
 
-def test_model_field_halts_under_a_corrupt_config(tmp_path):
+def test_model_field_halts_under_a_corrupt_config(tmp_path, monkeypatch):
     """The picker is a provider call like any other: a corrupt config.json makes the
     resolved provider untrustworthy, so it halts rather than listing against a
-    provider the user never chose (#269)."""
+    provider the user never chose (#269).
+
+    The lister is replaced with a tripwire for the same reason its credentials-halt
+    sibling does it: a regressed halt would otherwise dial localhost:11434 for real
+    on any dev box running Ollama, and the assertions below would still pass or
+    fail on the status code alone without saying that happened.
+    """
     cfg, _, _ = _config_web_kb(tmp_path, corrupt=True)
+    monkeypatch.setattr(
+        webapp,
+        "_MODEL_LISTERS",
+        {"ollama": lambda base_url, timeout: pytest.fail("dialled despite the halt")},
+    )
     c = TestClient(create_app(cfg))
 
     r = c.get(
@@ -4762,6 +4800,250 @@ def test_model_field_halts_under_a_corrupt_config(tmp_path):
 
     assert r.status_code == 409
     assert r.headers.get("HX-Redirect") == webapp.CONFIG_UNAVAILABLE_PATH
+
+
+def test_model_field_halts_under_unreadable_credentials(tmp_path, monkeypatch):
+    """The other halt `get_client` used to supply for free on this path.
+
+    Dropping the factory call is what puts the API key out of the listing's
+    reach, but it also removed both halts, so each is now a hand-written line
+    with nothing else guarding it. Without this test `assert_credentials_intact`
+    could be deleted from `_list_models_for` and everything else stays green.
+    """
+    cfg, _, _ = _config_web_kb(tmp_path, corrupt=False)
+    monkeypatch.setattr(
+        webapp,
+        "_MODEL_LISTERS",
+        {"ollama": lambda base_url, timeout: pytest.fail("dialled despite the halt")},
+    )
+    c = TestClient(create_app(replace(cfg, credentials_error="credentials.json is not valid JSON")))
+
+    r = c.get(
+        "/settings/model-field?provider=ollama&model=m", headers={"HX-Request": "true"}
+    )
+
+    assert r.status_code == 409
+    assert r.headers.get("HX-Redirect") == webapp.CREDENTIALS_UNAVAILABLE_PATH
+
+
+def test_model_field_never_constructs_a_provider_adapter(tmp_path, monkeypatch):
+    """The load-bearing test for the keyless listing seam.
+
+    A `Config` carries a resolved `api_key` — and, after `replace(provider=...)`,
+    the *saved* provider's key. So the guarantee is not "the lister happens not
+    to read it" but "no object holding it is ever built on this path". Counting
+    constructions, rather than asserting an error, is what keeps this true
+    against a future edit that gives some adapter a `list_models` again.
+
+    `OpenAIAdapter.__init__` is patched rather than `OpenRouterAdapter`'s, which
+    it inherits; patching the subclass would miss a listing routed through the base.
+    `ClaudeCliAdapter` never reads `cfg.api_key`, but it still stores the whole
+    `Config` (`self.cfg = cfg`), so constructing one here would put an object
+    holding the saved provider's key on this path. All four are checked because
+    the name says *no* adapter and that has to be literally what is checked.
+    """
+    built = []
+    for cls in (OllamaAdapter, OpenAIAdapter, AnthropicAdapter, ClaudeCliAdapter):
+        monkeypatch.setattr(
+            cls, "__init__", lambda self, cfg, _n=cls.__name__: built.append(_n)
+        )
+    monkeypatch.setattr(
+        webapp, "get_client", lambda _cfg: pytest.fail("the listing path built a client")
+    )
+    fake = _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
+
+    r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
+
+    assert r.status_code == 200
+    assert '<select name="model">' in r.text  # it really did render the picker
+    assert fake.seen == [None]  # ...and really did go through the lister
+    assert built == []
+
+
+def test_model_field_listing_clamps_the_page_load_timeout(tmp_path, monkeypatch):
+    """A page-load call must not inherit the minutes-long completion budget.
+
+    The clamp moved here with the seam: the lister takes a float and cannot
+    re-derive it, so this is the only place left that can get it wrong.
+    """
+    fake = _FakeOllama(models=[]).install(monkeypatch)
+
+    _ollama_client(tmp_path, llm_timeout_seconds=900.0).get(
+        "/settings/model-field?provider=ollama&model="
+    )
+
+    assert fake.timeouts == [5.0]
+
+
+def test_model_field_listing_keeps_an_even_shorter_configured_timeout(tmp_path, monkeypatch):
+    """The bound is the *smaller* of the two, so a tighter user setting still wins.
+    Without this, clamping to a flat 5.0 would pass the test above."""
+    fake = _FakeOllama(models=[]).install(monkeypatch)
+
+    _ollama_client(tmp_path, llm_timeout_seconds=1.5).get(
+        "/settings/model-field?provider=ollama&model="
+    )
+
+    assert fake.timeouts == [1.5]
+
+
+@pytest.mark.parametrize(
+    "providers, listers, expected",
+    [
+        ({"ollama", "openai"}, {"ollama": lambda base_url, timeout: []}, "openai"),
+        ({"ollama"}, {"ollama": lambda base_url, timeout: [], "openai": None}, "openai"),
+    ],
+)
+def test_the_check_rejects_a_provider_set_and_lister_table_that_disagree(
+    providers, listers, expected
+):
+    """Both directions: a picker that can never fill, and dead code a later edit
+    could wire up without passing this gate."""
+    with pytest.raises(RuntimeError, match=expected):
+        webapp._check_every_listable_provider_has_a_keyless_lister(providers, listers)
+
+
+def test_the_check_rejects_a_lister_that_could_be_handed_a_config():
+    """Set equality alone would accept this. The parameter-name clause is what
+    keeps 'keyless' a fact about the code rather than a claim in a comment.
+
+    Mutation: delete the `_LISTER_SIGNATURE` clause and this no longer raises --
+    a plain non-closing lambda passes every other clause.
+    """
+    with pytest.raises(RuntimeError, match="cannot be handed an API key"):
+        webapp._check_every_listable_provider_has_a_keyless_lister(
+            {"ollama"}, {"ollama": lambda cfg, base_url, timeout: []}
+        )
+
+
+# The next three are the shapes that satisfy the parameter names *while already
+# carrying a Config*, which is what makes the names alone insufficient. Each was
+# accepted by the check before the `isfunction` and `__closure__` clauses existed.
+
+
+def test_the_check_rejects_a_partial_that_has_already_bound_a_config():
+    """`functools.partial` hides the bound first argument from `signature`, so a
+    keyed lister with `cfg` pre-filled reports exactly ('base_url', 'timeout').
+
+    Mutation: delete the `inspect.isfunction` clause and this stops raising the
+    RuntimeError asserted here -- the check falls through to `fn.__closure__`,
+    which a partial does not have at all.
+    """
+    def keyed_lister(cfg, base_url, timeout):
+        return [cfg.api_key]
+
+    bound = functools.partial(keyed_lister, object())
+    # The premise: it looks exactly like a conforming lister.
+    assert tuple(inspect.signature(bound).parameters) == webapp._LISTER_SIGNATURE
+
+    with pytest.raises(RuntimeError, match="must be a plain function"):
+        webapp._check_every_listable_provider_has_a_keyless_lister(
+            {"ollama"}, {"ollama": bound}
+        )
+
+
+def test_the_check_rejects_a_closure_over_a_captured_config():
+    """A closure cell holds the Config, and no parameter ever mentions it. This is
+    the shape a maintainer reaches for most naturally -- defining a lister inside
+    a factory that already has the config in scope.
+
+    Mutation: delete the `fn.__closure__` clause and this stops raising -- a
+    closure is a plain function with the right parameter names.
+    """
+    cfg = object()
+
+    def lister(base_url, timeout):
+        return [cfg]
+
+    # The premise: it looks exactly like a conforming lister.
+    assert tuple(inspect.signature(lister).parameters) == webapp._LISTER_SIGNATURE
+    assert lister.__closure__ is not None
+
+    with pytest.raises(RuntimeError, match="must not close over anything"):
+        webapp._check_every_listable_provider_has_a_keyless_lister(
+            {"ollama"}, {"ollama": lister}
+        )
+
+
+def test_the_check_rejects_a_callable_object_holding_a_config():
+    """`__call__(self, base_url, timeout)` presents the right parameters (`signature`
+    drops `self`) while the instance carries the Config as an attribute.
+
+    Mutation: delete the `inspect.isfunction` clause and this stops raising the
+    RuntimeError asserted here -- the check falls through to `fn.__closure__`,
+    which an instance does not have.
+    """
+    class KeyedLister:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def __call__(self, base_url, timeout):
+            return [self.cfg]
+
+    lister = KeyedLister(object())
+    # The premise: it looks exactly like a conforming lister.
+    assert tuple(inspect.signature(lister).parameters) == webapp._LISTER_SIGNATURE
+
+    with pytest.raises(RuntimeError, match="must be a plain function"):
+        webapp._check_every_listable_provider_has_a_keyless_lister(
+            {"ollama"}, {"ollama": lister}
+        )
+
+
+# And the names themselves are read off the function rather than trusted from
+# `inspect.signature`'s default view, because a lister can lie about them without
+# taking any of the three shapes above.
+
+
+def test_the_check_rejects_a_lister_whose_wrapped_attribute_hides_a_config():
+    """`inspect.signature` follows `__wrapped__`, so a plain, non-closing function
+    that really takes `(cfg, base_url, timeout)` can report the conforming two by
+    pointing that attribute at a decoy.
+
+    Mutation: drop `follow_wrapped=False` from the parameter-name clause and this
+    stops raising -- the decoy's names are then what the check sees, and every
+    other clause already passes.
+    """
+    def decoy(base_url, timeout):
+        return []
+
+    def keyed_lister(cfg, base_url, timeout):
+        return [cfg.api_key]
+
+    keyed_lister.__wrapped__ = decoy
+    # The premise: under the default it looks exactly like a conforming lister.
+    assert tuple(inspect.signature(keyed_lister).parameters) == webapp._LISTER_SIGNATURE
+
+    with pytest.raises(RuntimeError, match="cannot be handed an API key"):
+        webapp._check_every_listable_provider_has_a_keyless_lister(
+            {"ollama"}, {"ollama": keyed_lister}
+        )
+
+
+def test_the_module_body_runs_the_check(monkeypatch):
+    """The predicate is only a gate if the module body actually calls it.
+
+    The tests above call it themselves, and `sys.modules` caching means
+    the real import already happened before any of them ran -- so deleting the
+    module-level call leaves every one of them green. This re-executes
+    `app.py`'s body into a fresh module object with a provider set the shipped
+    `_MODEL_LISTERS` cannot satisfy, which raises only if that call site exists.
+
+    A separate module object rather than `importlib.reload`: reloading the live
+    `verinote.web.app` would swap out the identity of `Config`-facing handlers
+    and helper objects every other test in this session imported, and a reload
+    that raises part-way (which is the point here) leaves it half-rebuilt.
+    """
+    monkeypatch.setattr(
+        verinote.config, "MODEL_LISTING_PROVIDERS", frozenset({"ollama", "anthropic"})
+    )
+    name = "verinote_web_app_under_test"
+    spec = importlib.util.spec_from_file_location(name, webapp.__file__)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+
+    with pytest.raises(RuntimeError, match="anthropic"):
+        spec.loader.exec_module(module)
 
 
 # --- the Claude CLI alias picker: suggestions you can type past ---
@@ -4869,8 +5151,7 @@ def test_settings_page_renders_the_cli_picker_as_a_list(tmp_path):
 def test_model_field_custom_never_downgrades_the_discovered_picker(tmp_path, monkeypatch):
     """A stray `custom=1` must not turn Ollama's discovered list into free text --
     that list is evidence, and there is no reason to type past it."""
-    fake = _FakeOllama(models=["qwen3:8b"])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get(
         "/settings/model-field?provider=ollama&model=qwen3:8b&custom=1"
@@ -4883,8 +5164,7 @@ def test_model_field_custom_never_downgrades_the_discovered_picker(tmp_path, mon
 def test_model_field_keeps_aliases_off_the_ollama_picker(tmp_path, monkeypatch):
     """Curated aliases and a discovered list are different claims; the Ollama
     field must never quietly gain entries no server reported."""
-    fake = _FakeOllama(models=["qwen3:8b"])
-    monkeypatch.setattr(webapp, "get_client", fake.factory)
+    _FakeOllama(models=["qwen3:8b"]).install(monkeypatch)
 
     r = _ollama_client(tmp_path).get("/settings/model-field?provider=ollama&model=qwen3:8b")
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4142,7 +4142,7 @@ def test_settings_never_renders_api_key(tmp_path):
     client = TestClient(create_app(cfg))
     r = client.get("/settings")
     assert "supersecret" not in r.text
-    assert "set (from environment)" in r.text
+    assert "API key: set" in r.text
 
 
 def test_test_connection_reports_adapter(tmp_path, monkeypatch, fake_client):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -5074,20 +5074,32 @@ def test_the_module_body_runs_the_check(monkeypatch):
     `app.py`'s body into a fresh module object with a provider set the shipped
     `_MODEL_LISTERS` cannot satisfy, which raises only if that call site exists.
 
+    The match names the check, not just the provider, and that is what makes the
+    sentence above true: an unsatisfiable provider set fails the default-endpoint
+    check too, so matching on `anthropic` alone passed with THIS call site
+    deleted -- the sibling's error standing in for it.
+
     A separate module object rather than `importlib.reload`: reloading the live
     `verinote.web.app` would swap out the identity of `Config`-facing handlers
     and helper objects every other test in this session imported, and a reload
     that raises part-way (which is the point here) leaves it half-rebuilt.
+
+    The set ADDS to the shipped one rather than replacing it, so this stays a
+    test of the lister call site: dropping `openrouter` from listable would make
+    the clearing-set check -- which runs before this one -- raise first, about a
+    provider that clears the Base URL with no endpoint to name.
     """
     monkeypatch.setattr(
-        verinote.config, "MODEL_LISTING_PROVIDERS", frozenset({"ollama", "anthropic"})
+        verinote.config,
+        "MODEL_LISTING_PROVIDERS",
+        frozenset({"ollama", "openrouter", "anthropic"}),
     )
     name = "verinote_web_app_under_test"
     spec = importlib.util.spec_from_file_location(name, webapp.__file__)
     module = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, name, module)
 
-    with pytest.raises(RuntimeError, match="anthropic"):
+    with pytest.raises(RuntimeError, match=r"model lister.*anthropic"):
         spec.loader.exec_module(module)
 
 
@@ -5576,14 +5588,20 @@ def test_openrouter_empty_catalogue_copy_is_not_ollamas(tmp_path, monkeypatch):
 def test_openrouter_model_field_offers_no_blank_option(tmp_path, monkeypatch):
     """Unlike the CLI picker, a blank model here is not "no model": it falls
     through to `_MODEL_DEFAULTS['openrouter']`, so an option labelled as an
-    absence would misreport the model this KB would actually use."""
+    absence would misreport the model this KB would actually use.
+
+    `<option value=""` rather than a bare `value=""`, so this keeps asserting
+    what its name says: an empty Base URL input carries `value=""` too, and a
+    response that started including one would fail this test for a reason that
+    has nothing to do with the picker's options.
+    """
     _openrouter_lister(monkeypatch)
 
     r = _ollama_client(tmp_path, provider="openrouter", model="openai/gpt-oss-20b:free").get(
         "/settings/model-field?provider=openrouter&model=openai/gpt-oss-20b:free"
     )
 
-    assert 'value=""' not in r.text
+    assert '<option value=""' not in r.text
 
 
 def test_openrouter_model_field_puts_no_api_key_on_the_wire(tmp_path, monkeypatch):
@@ -5633,6 +5651,239 @@ def test_openrouter_model_field_puts_no_api_key_on_the_wire(tmp_path, monkeypatc
     assert sentinel not in req.full_url
     assert not [item for item in req.header_items() if sentinel in str(item)]
     assert req.data is None or sentinel.encode("utf-8") not in req.data
+
+
+# --- switching to OpenRouter clears the Base URL, and says what it discarded ---
+
+
+def test_switching_to_openrouter_clears_the_base_url(tmp_path, monkeypatch):
+    """The Base URL field's only job is to point verinote somewhere other than
+    the provider's own endpoint, so the value carried over from the provider
+    being left is not an OpenRouter endpoint at all -- `http://localhost:11434`
+    would be dialled as one. Clear it, and list against OpenRouter's own.
+
+    Mutation: drop the rule in `model_field` and the Ollama endpoint is still in
+    the field, and is what the catalogue is listed from.
+    """
+    fake = _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, base_url="http://localhost:11434").get(
+        "/settings/model-field?provider_changed=1&provider=openrouter"
+        "&model=&base_url=http://localhost:11434"
+    )
+
+    assert r.status_code == 200
+    assert '<input type="text" name="base_url" value=""' in r.text
+    assert fake.seen == [None]  # ...and the listing followed the clear
+
+
+def test_switching_to_another_provider_keeps_the_typed_base_url(tmp_path, monkeypatch):
+    """The falsifier for the test above. "Always clear" satisfies the OpenRouter
+    request and destroys the endpoint of everyone pointing Ollama at another box
+    -- and silently, since Save then writes it away.
+
+    Mutation: clear unconditionally (drop the `provider == "openrouter"` clause)
+    and this typed endpoint is gone.
+    """
+    fake = _FakeLister(models=["qwen3:8b"]).install(monkeypatch)
+
+    r = _ollama_client(tmp_path, provider="openrouter", model="").get(
+        "/settings/model-field?provider_changed=1&provider=ollama"
+        "&model=&base_url=http://box.lan:11434"
+    )
+
+    assert r.status_code == 200
+    assert '<input type="text" name="base_url" value="http://box.lan:11434"' in r.text
+    assert fake.seen == ["http://box.lan:11434"]
+    assert "cleared it" not in r.text  # nothing was discarded, so nothing is claimed
+
+
+def test_settings_renders_a_saved_openrouter_base_url(tmp_path):
+    """A page load is not a provider change. This KB's config.json really does
+    name a proxy, and blanking the field on load would make the page misreport
+    the KB's own state -- then destroy the value on the next Save.
+
+    Mutation: move the clear into the template and this saved proxy renders as
+    an empty field.
+
+    NOT the route's `provider_changed` condition, though, and this test must not
+    be read as covering it: `/settings` renders through `_settings`, which calls
+    `_model_field_context` directly and never enters `model_field`, so the
+    condition is not on this path at all and dropping it leaves this green. What
+    that condition protects is the plain model-field GET -- the one the Base URL
+    input itself fires -- and dropping it is caught by
+    `test_openrouter_model_field_names_a_configured_proxy_not_the_literal_default`,
+    where the clear would then take the configured proxy away before listing and
+    the catalogue would be read from OpenRouter's own endpoint instead.
+    """
+    r = _ollama_client(
+        tmp_path, provider="openrouter", model="a/b", base_url="https://proxy.internal/v1"
+    ).get("/settings")
+
+    assert r.status_code == 200
+    assert '<input type="text" name="base_url" value="https://proxy.internal/v1"' in r.text
+    assert "cleared it" not in r.text
+
+
+def test_the_provider_change_response_carries_the_model_and_the_base_url(tmp_path, monkeypatch):
+    """The swap has to land on a region holding both fields. Before this, the
+    provider select targeted `#model-field`, which the Base URL input sits
+    outside of -- so no provider change could reach it however the route decided.
+
+    Mutation: leave the base URL input out of the wrapper and the form loses the
+    field entirely after one provider change.
+    """
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path).get(
+        "/settings/model-field?provider_changed=1&provider=openrouter"
+        "&model=openai/gpt-oss-20b:free&base_url="
+    )
+
+    assert r.status_code == 200
+    assert 'id="provider-fields"' in r.text
+    assert 'name="model"' in r.text
+    assert 'name="base_url"' in r.text
+
+
+def test_a_base_url_change_re_renders_only_the_model_field(tmp_path, monkeypatch):
+    """This response is swapped into a DOM that already holds the Base URL input,
+    so it must not carry a second one: two `name="base_url"` inputs POST two
+    values, and it would also re-render the field being typed into.
+
+    Mutation: always render the wrapper and this count is 1, i.e. 2 in the page.
+    """
+    _FakeLister(models=["qwen3:8b"]).install(monkeypatch)
+
+    r = _ollama_client(tmp_path).get(
+        "/settings/model-field?provider=ollama&model=qwen3:8b&base_url=http://box.lan:11434"
+    )
+
+    assert r.status_code == 200
+    assert 'id="model-field"' in r.text
+    assert 'id="provider-fields"' not in r.text
+    assert r.text.count('name="base_url"') == 0
+
+
+def test_the_cleared_base_url_is_announced_not_silently_dropped(tmp_path, monkeypatch):
+    """`POST /settings` maps `base_url or None`, so Save on an empty field
+    DESTROYS the stored value. Between the clear and Save the page would
+    otherwise show an empty Base URL while config.json still holds one -- the
+    page asserting a state it does not have. Name what is going, and what would
+    be dialled instead.
+
+    Mutation: drop the note and the discard is silent.
+    """
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path, base_url="https://proxy.internal/v1").get(
+        "/settings/model-field?provider_changed=1&provider=openrouter"
+        "&model=&base_url=https://proxy.internal/v1"
+    )
+
+    assert r.status_code == 200
+    assert "https://proxy.internal/v1" in r.text  # what is being discarded
+    assert "https://openrouter.ai/api/v1" in r.text  # ...and what replaces it
+    assert "Nothing has been saved yet" in r.text  # a proposal, not a done deal
+
+
+def test_no_discard_note_when_there_was_nothing_to_discard(tmp_path, monkeypatch):
+    """An empty Base URL loses nothing, so a note would claim a discard that did
+    not happen -- and name a URL the user never had.
+
+    Mutation: render the note unconditionally and it appears here with an empty
+    `<code></code>` where the discarded URL should be.
+    """
+    _openrouter_lister(monkeypatch)
+
+    r = _ollama_client(tmp_path).get(
+        "/settings/model-field?provider_changed=1&provider=openrouter"
+        "&model=openai/gpt-oss-20b:free&base_url="
+    )
+
+    assert r.status_code == 200
+    assert "cleared it" not in r.text
+    assert "Nothing has been saved yet" not in r.text
+
+
+def test_settings_wires_the_provider_select_to_the_clearing_route(tmp_path):
+    """Every test above calls `/settings/model-field?provider_changed=1` on the
+    route directly. None of them reads the shipped page, so a broken `<select>`
+    could sit there inert -- switched from Ollama to OpenRouter by hand in a
+    browser -- while the whole suite around it stays green.
+
+    One test, not two, even though it names two mutations: both are the same
+    promise -- "the shipped select safely reaches the clearing route" -- read out
+    of `provider_fields.html`'s comment ("this wrapper is served only for a
+    provider change" via `hx-get`, "the provider select itself stays outside this
+    div" via `hx-target`). `test_the_provider_change_response_carries_the_model_and_the_base_url`
+    above bundles three assertions the same way, under one promise about what one
+    response carries, rather than one test per assertion.
+
+    Parses `<select name="provider" ...>` out of the page first and reads
+    attributes from within that match, the way
+    `test_the_provider_change_url_the_page_actually_uses_is_gated` in
+    `test_same_origin_guard.py` was just hardened to: a single pattern anchored on
+    `name="provider"` spanning the whole tag would go `None` the moment someone
+    reorders the template's attributes, which is a tidy-up, not a bug, and would
+    fail closed rather than reporting what actually broke.
+
+    Mutation (M7): drop `provider_changed=1` from the select's `hx-get`. The
+    route then returns `model_field.html` instead of the `#provider-fields`
+    wrapper, so switching from Ollama to OpenRouter never clears
+    `http://localhost:11434` -- Save stores it as OpenRouter's own endpoint.
+    Caught by the `hx-get` assertion below.
+
+    Mutation (M6): change the select's `hx-target` from `#provider-fields` to
+    `#model-field`. `#model-field` sits inside the wrapper, so the wrapper --
+    which carries its own `base_url` input and the discard note -- gets swapped
+    into a region it contains, and the original input outside it survives. The
+    page then holds two `name="base_url"` inputs, one still showing the old
+    proxy, sitting directly beneath a note claiming the field was cleared; Save
+    posts both. Caught by the `hx-target` assertion below.
+
+    Mutation (M8): drop `[name='base_url']` from the select's `hx-include`.
+    The route then receives `base_url=""` on every provider change, so
+    `discarded_base_url` is always empty and no note renders -- even when the
+    field held a real endpoint -- and `POST /settings` maps `base_url or
+    None`, so Save silently destroys the stored value with nothing on the page
+    ever having said so. This is worse than M6 or M7: those corrupt or
+    misroute the response, but this one makes the loss invisible. Caught by
+    the `hx-include` assertion below.
+
+    Mutation (M9): drop `[name='model']` from the select's `hx-include`. Same
+    class of bug, on the sibling field the same doc comment
+    (`settings.html:54-55`) also names. The route then receives `model=""` on
+    every provider change, so whatever model was configured is silently
+    dropped from the field -- and unlike the Base URL there is no discard note
+    for Model at all, so this loss is even less visible: `POST /settings`
+    stores `model` as given (no `or None` guard), so Save overwrites
+    config.json's model with an empty string with no warning shown anywhere.
+    Caught by the `hx-include` assertion below.
+    """
+    r = _ollama_client(tmp_path).get("/settings")
+    assert r.status_code == 200
+
+    select = re.search(r'<select\b[^>]*\bname="provider"[^>]*>', r.text)
+    assert select is not None, "the settings page no longer has a provider select"
+    tag = select.group(0)
+
+    hx_get = re.search(r'\bhx-get="([^"]*)"', tag)
+    assert hx_get is not None, "the provider select no longer has an hx-get"
+    assert "provider_changed=1" in hx_get.group(1)  # M7
+
+    hx_target = re.search(r'\bhx-target="([^"]*)"', tag)
+    assert hx_target is not None, "the provider select no longer has an hx-target"
+    assert hx_target.group(1) == "#provider-fields"  # M6
+
+    hx_include = re.search(r'\bhx-include="([^"]*)"', tag)
+    assert hx_include is not None, "the provider select no longer has an hx-include"
+    assert "[name='base_url']" in hx_include.group(1)  # M8
+    assert "[name='model']" in hx_include.group(1)  # M9
+
+    assert r.text.count('name="base_url"') == 1
+    # ...and it must stay outside the region it targets, never inside it.
+    assert select.start() < r.text.index('id="provider-fields"')
 
 
 # --- the default-endpoint map is checked at import, like the lister table ---
@@ -5971,4 +6222,60 @@ def test_the_module_body_runs_the_model_field_copy_check(tmp_path, monkeypatch):
     monkeypatch.setitem(sys.modules, name, module)
 
     with pytest.raises(RuntimeError, match="openrouter"):
+        spec.loader.exec_module(module)
+
+
+# --- which providers clear the Base URL is checked at import too ---
+
+
+def test_the_check_rejects_a_clearing_provider_that_cannot_name_its_replacement():
+    """The note the clear renders promises what verinote would dial instead, and
+    `_model_field_context` fills `endpoint` only for a listable provider -- so a
+    clearing provider outside `MODEL_LISTING_PROVIDERS` renders that promise
+    around an empty `<code></code>`. Same misreport the blank-endpoint clause
+    rejects, reached by a one-line edit to either set instead.
+
+    Mutation: drop the check body and this stops raising.
+    """
+    with pytest.raises(RuntimeError, match="anthropic"):
+        webapp._check_every_clearing_provider_can_name_its_replacement(
+            {"anthropic"}, {"ollama", "openrouter"}
+        )
+
+
+def test_the_check_allows_a_listable_provider_that_does_not_clear():
+    """The falsifier for the test above, and the reason this one is a subset test
+    and not the symmetric difference its three siblings use: Ollama is listable
+    and must NOT clear, since clearing on every switch would wipe an endpoint the
+    user typed. Asserted here rather than left to import, so the rule is stated
+    where a maintainer copying a sibling would read it.
+
+    Mutation: make it `set(clearing) ^ set(listable)` and this raises.
+    """
+    webapp._check_every_clearing_provider_can_name_its_replacement(
+        {"openrouter"}, {"ollama", "openrouter"}
+    )
+
+
+def test_the_module_body_runs_the_clearing_provider_check(monkeypatch):
+    """The predicate is only a gate if the module body calls it, and the tests
+    above call it themselves -- so deleting the module-level call leaves them
+    green (`sys.modules` cached the real import long before they ran).
+
+    Narrowing `MODEL_LISTING_PROVIDERS` is the only lever that can reach this
+    check, because `_BASE_URL_CLEARING_PROVIDERS` is a literal rebuilt by the
+    exec below. That narrowing also breaks the three table checks, so what
+    isolates THIS one is that its call site runs before theirs and that the match
+    below is a phrase only its message contains: move the call after them, or
+    delete it, and the error that arrives is the lister table's instead. A fresh
+    module object rather than `importlib.reload`, for the reason its siblings
+    state.
+    """
+    monkeypatch.setattr(verinote.config, "MODEL_LISTING_PROVIDERS", frozenset({"ollama"}))
+    name = "verinote_web_app_clearing_check_under_test"
+    spec = importlib.util.spec_from_file_location(name, webapp.__file__)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+
+    with pytest.raises(RuntimeError, match="clears the Base URL"):
         spec.loader.exec_module(module)

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1435,13 +1435,19 @@ def _refuse_on_corrupt_config(cfg: Config | None) -> int | None:
     resolve to the cloud default provider the user never chose (#269). A missing
     file is never corrupt, so a fresh KB is unaffected.
     """
-    from verinote.config import ConfigCorruptError, assert_settings_intact
+    from verinote.config import (
+        ConfigCorruptError,
+        CredentialsCorruptError,
+        assert_credentials_intact,
+        assert_settings_intact,
+    )
 
     if cfg is None:
         return None
     try:
         assert_settings_intact(cfg)
-    except ConfigCorruptError as exc:
+        assert_credentials_intact(cfg)
+    except (ConfigCorruptError, CredentialsCorruptError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     return None

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -102,17 +102,19 @@ PROVIDER_LABELS = {
 # extraction -- and it matters most there: its installed models cannot be
 # enumerated, so running the chosen one is the only way to learn it works.
 TESTABLE_PROVIDERS = frozenset({"anthropic", "claudecli", "openai", "openrouter", "ollama"})
-# Providers whose installed models can be enumerated from the very endpoint the
-# user configured, so the settings UI can offer a picker instead of free text.
-# A vendor's own catalogue is not a property of its endpoint and `claudecli` has
-# no listing at all, so neither can be answered truthfully here.
+# Providers whose models can be enumerated from the very endpoint the user
+# configured, so the settings UI can offer a picker instead of free text.
+# `anthropic` and `openai` are absent because a vendor's own catalogue is not a
+# property of the endpoint being configured, and `claudecli` because it has no
+# listing at all, so neither can be answered truthfully for them.
 #
 # `openrouter` is the exception that does not generalise: its catalogue IS
 # served by the endpoint being configured (`GET {base_url}/models`, unauthenticated),
-# so the original "a cloud catalogue is never endpoint-served" reasoning does not
-# cover it. It is absent here only because its picker is a separate unit of work,
-# not because the claim above applies to it.
-MODEL_LISTING_PROVIDERS = frozenset({"ollama"})
+# so the "a cloud catalogue is never endpoint-served" reasoning does not cover it.
+# What that listing enumerates is the published catalogue, not what this user's
+# account may call — the request carries no key, which is also what keeps the
+# listing seam keyless (`web.app._MODEL_LISTERS`).
+MODEL_LISTING_PROVIDERS = frozenset({"ollama", "openrouter"})
 # Providers that authenticate with an API key. The others never read
 # `cfg.api_key` at all (`claudecli` shells out, `ollama` talks to a local
 # endpoint), so resolving a key for them could only produce a value that cannot

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -10,12 +10,16 @@ model, or base URL value counts as unset and falls through the chain, so
 settings use the environment value when present, otherwise the saved file, then
 the default; if the selected value is blank or an invalid number, numeric
 parsers fall back to the default, while the boolean parser treats recognised
-truthy strings as true and everything else as false. The API key is **only**
-ever read from the environment — it is never persisted to or read from the
-settings file — but it shares the same blank-value handling: a blank (empty or
-whitespace-only) `VERINOTE_API_KEY` normalises to unset (`None`) and a used
-value is trimmed. With no saved or default source to fall back to, a blank key
-simply becomes `None` rather than falling through a chain.
+truthy strings as true and everything else as false. The API key is never in
+the settings file and never inside a KB — a KB gets synced and shared — but it
+is not environment-only either: it resolves from the provider-scoped
+`VERINOTE_<PROVIDER>_API_KEY`, then a key saved in the machine-wide
+`credentials.json` beside `app.json`, then the legacy provider-agnostic
+`VERINOTE_API_KEY`. That last tier sits *below* the saved key deliberately,
+against this module's usual env-first rule: naming no provider, it would
+otherwise replace a key saved for one provider with whatever single value
+happens to be exported. Every tier shares the blank-value handling — a blank
+value normalises to unset and a used value is trimmed.
 
 The saved file is also type-checked per key, since it is hand-editable JSON.
 A setting whose value has the wrong JSON type is never handed on to the code
@@ -42,6 +46,12 @@ import json
 import os
 import sys
 import tempfile
+from contextlib import contextmanager
+
+try:  # POSIX only; the credentials lock degrades to atomic-replace without it
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -50,6 +60,8 @@ from verinote.prompts import render_prompt
 
 SETTINGS_FILENAME = "config.json"
 APP_CONFIG_FILENAME = "app.json"
+CREDENTIALS_FILENAME = "credentials.json"
+CREDENTIALS_VERSION = 1
 APP_NAME = "verinote"
 APP_THEMES = ("system", "light", "dark")
 
@@ -101,6 +113,41 @@ TESTABLE_PROVIDERS = frozenset({"anthropic", "claudecli", "openai", "openrouter"
 # cover it. It is absent here only because its picker is a separate unit of work,
 # not because the claim above applies to it.
 MODEL_LISTING_PROVIDERS = frozenset({"ollama"})
+# Providers that authenticate with an API key. The others never read
+# `cfg.api_key` at all (`claudecli` shells out, `ollama` talks to a local
+# endpoint), so resolving a key for them could only produce a value that cannot
+# be used and can leak — resolution returns None for them unconditionally.
+PROVIDERS_REQUIRING_KEY = frozenset({"anthropic", "openai", "openrouter"})
+_KEYLESS_PROVIDERS = frozenset({"claudecli", "ollama"})
+
+
+def _check_every_provider_is_classified(providers, requiring, keyless) -> None:
+    """Every provider must be on exactly one side of "needs an API key".
+
+    A *partition* check, not a subset one. A subset assertion passes when a new
+    provider is added to `_MODEL_DEFAULTS` and classified nowhere — which is the
+    one case that must not slip through, because resolution would silently
+    return None for it and the provider would be called unauthenticated.
+
+    A function so it can be tested against a hypothetical provider set; raised
+    rather than asserted so `python -O` cannot strip the guard whose whole job
+    is to fail loudly.
+    """
+    # Both directions, and the contradiction: a provider missing from both sets
+    # would resolve to None silently, one in a set but not in PROVIDERS is a
+    # stale entry, and one in *both* sets is classified ambiguously — which a
+    # union-based check cannot see, because the union looks complete.
+    wrong = (set(providers) ^ (set(requiring) | set(keyless))) | (
+        set(requiring) & set(keyless)
+    )
+    if wrong:
+        raise RuntimeError(
+            "every provider must be classified as needing an API key or not, "
+            f"and exactly once: {sorted(wrong)}"
+        )
+
+
+_check_every_provider_is_classified(PROVIDERS, PROVIDERS_REQUIRING_KEY, _KEYLESS_PROVIDERS)
 
 
 def normalize_provider(provider: str | None) -> str:
@@ -135,6 +182,21 @@ def app_config_dir() -> Path:
 
 def app_config_path() -> Path:
     return app_config_dir() / APP_CONFIG_FILENAME
+
+
+def credentials_path() -> Path:
+    """Where stored API keys live: beside `app.json`, never inside a KB.
+
+    A KB is user data that gets synced, copied and shared; the app config
+    directory is machine-local. Keeping the two apart is what lets
+    `config.json` stay safe to hand to somebody else.
+    """
+    return app_config_dir() / CREDENTIALS_FILENAME
+
+
+def provider_key_env_var(provider: str) -> str:
+    """The provider-scoped environment variable name for `provider`'s key."""
+    return f"VERINOTE_{provider.upper()}_API_KEY"
 
 
 def _bad_config_reason(path: Path, error: Exception | None) -> str:
@@ -534,6 +596,172 @@ def _pick(env: str, saved: str | None, default: str | None) -> str | None:
     return default
 
 
+
+class CredentialsCorruptError(RuntimeError):
+    """Raised when `credentials.json` is present but unreadable.
+
+    Deliberately its own type rather than a `ConfigCorruptError`: that one names
+    a *KB's* `config.json` everywhere it surfaces — the halt page, the settings
+    banner, the KB-switch error, the CLI. Reusing it for a machine-wide secrets
+    file would tell the user the wrong file, the wrong scope, and a recovery
+    action ("re-save your provider") that does not touch this file at all.
+    """
+
+
+def _read_credentials() -> tuple[dict[str, str], str | None]:
+    """Stored keys, plus why they could not be read.
+
+    A missing file is not an error — that is the normal state before anyone
+    saves a key — so it returns `({}, None)`. Anything else that stops the file
+    being understood returns `({}, reason)`: an unreadable secrets file must
+    never be indistinguishable from "no keys are stored", because the two lead
+    to opposite conclusions about whether the user has to enter one again.
+    """
+    path = credentials_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}, None
+    except (OSError, UnicodeDecodeError) as exc:
+        return {}, _bad_config_reason(path, exc)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {}, _bad_config_reason(path, exc)
+    if not isinstance(data, dict):
+        return {}, _bad_config_reason(path, None)
+    keys = data.get("keys")
+    if keys is None:
+        return {}, None
+    if not isinstance(keys, dict):
+        return {}, f"{path} has a 'keys' entry that is not an object"
+    # A non-string value is refused, never coerced: `str()` on an object would
+    # invent a credential out of a structure a future version meant as
+    # something else (a keychain reference, say).
+    for provider, value in keys.items():
+        if not isinstance(value, str):
+            return {}, f"{path} holds a non-string key for {provider!r}"
+    return {str(k): v for k, v in keys.items()}, None
+
+
+def resolve_api_key(provider: str, stored: dict[str, str]) -> str | None:
+    """The key to authenticate `provider` with, or None.
+
+    Order: the provider-scoped environment variable, then the stored key, then
+    the legacy provider-agnostic `VERINOTE_API_KEY`.
+
+    This inverts the module's usual env-then-saved rule for that last tier, on
+    purpose. `VERINOTE_API_KEY` names no provider, so ranking it above a stored
+    key would take a key the user saved *for OpenAI* and replace it with
+    whatever single value happens to be exported — commonly their Anthropic key,
+    which would then be transmitted to `api.openai.com`. The scoped variable
+    keeps env-first available for anyone who wants it, without that ambiguity;
+    the legacy variable stays last so existing setups keep working unchanged for
+    any provider that has no stored key.
+    """
+    if provider not in PROVIDERS_REQUIRING_KEY:
+        return None
+    for candidate in (
+        os.environ.get(provider_key_env_var(provider)),
+        stored.get(provider),
+        os.environ.get("VERINOTE_API_KEY"),
+    ):
+        if isinstance(candidate, str):
+            candidate = candidate.strip()
+        if candidate:
+            return candidate
+    return None
+
+
+
+@contextmanager
+def _credentials_lock():
+    """Serialise read-modify-write on the credentials file across processes.
+
+    A save merges one provider's key into the others, so two verinote processes
+    saving at once can each write a payload built from the state before the
+    other's — losing a key with no error and no UI signal. The atomic replace
+    bounds that to a lost update rather than a corrupt file, but a silently
+    vanished secret is still the worst failure this file has.
+
+    POSIX only. `fcntl` is absent on Windows, where this degrades to the
+    atomic-replace guarantee alone; that gap is real and is not papered over.
+    """
+    directory = app_config_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    if fcntl is None:  # pragma: no cover - platform-dependent
+        yield
+        return
+    lock_path = directory / (CREDENTIALS_FILENAME + ".lock")
+    with open(lock_path, "w", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _ensure_config_dir_gitignore() -> None:
+    """Keep a secrets file out of a version-controlled config directory.
+
+    `XDG_CONFIG_HOME` is routinely `~/.config` tracked as a dotfiles repo, and a
+    subdirectory `.gitignore` is honoured by a repo rooted anywhere above it.
+    Written only when absent, so a user's own file is never overwritten.
+
+    Bounded value, stated so it is not mistaken for protection: it does nothing
+    for a file git already tracks, for a dotfiles manager that copies rather
+    than symlinks, or for a backup tool.
+    """
+    path = app_config_dir() / ".gitignore"
+    if path.exists():
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("*\n", encoding="utf-8")
+    except OSError:
+        pass  # advisory only; never block saving a key on it
+
+
+def save_credential(provider: str, key: str) -> None:
+    """Store `provider`'s API key, leaving every other provider's untouched."""
+    if provider not in PROVIDERS_REQUIRING_KEY:
+        raise ValueError(f"{provider} does not use an API key")
+    cleaned = key.strip()
+    if not cleaned:
+        raise ValueError("API key is empty")
+    with _credentials_lock():
+        stored, error = _read_credentials()
+        if error is not None:
+            # Refuse rather than clobber: a save is a *merge*, so writing a fresh
+            # file over an unreadable one would silently discard every other
+            # provider's key. (`save_settings` may rewrite a corrupt config.json
+            # because it writes a complete payload from the form; this cannot.)
+            raise CredentialsCorruptError(error)
+        _ensure_config_dir_gitignore()
+        _write_json_atomic(
+            credentials_path(),
+            {"version": CREDENTIALS_VERSION, "keys": {**stored, provider: cleaned}},
+            mode=0o600,
+        )
+
+
+def delete_credential(provider: str) -> bool:
+    """Remove `provider`'s stored key. True when one was actually removed."""
+    with _credentials_lock():
+        stored, error = _read_credentials()
+        if error is not None:
+            raise CredentialsCorruptError(error)
+        if provider not in stored:
+            return False
+        remaining = {k: v for k, v in stored.items() if k != provider}
+        _write_json_atomic(
+            credentials_path(),
+            {"version": CREDENTIALS_VERSION, "keys": remaining},
+            mode=0o600,
+        )
+        return True
+
+
 def _llm_timeout_seconds() -> float:
     raw = os.environ.get("VERINOTE_LLM_TIMEOUT")
     if raw is None:
@@ -595,6 +823,13 @@ class Config:
     # corrupt config from silently defaulting to a provider the user never chose
     # (#269).
     settings_error: str | None = None
+    # Set only when the machine-wide credentials file is PRESENT but unreadable
+    # AND the resolved provider needs a key AND no environment tier supplied one
+    # — i.e. only when the unreadable file is what actually decides the outcome.
+    # An Ollama user, or one with the scoped variable exported, is not halted by
+    # a file that could not have changed their result. A trailing, defaulted
+    # field so no existing `Config(...)` construction site has to change.
+    credentials_error: str | None = None
 
     def extraction_schema_hint(self) -> str:
         return render_prompt(
@@ -632,12 +867,17 @@ class Config:
             saved.get("auto_accept_recommendations"),
             False,
         )
+        stored_keys, credentials_error = _read_credentials()
+        api_key = resolve_api_key(provider, stored_keys)
+        if api_key is not None or provider not in PROVIDERS_REQUIRING_KEY:
+            # The file could not have changed the outcome, so it is not a halt.
+            credentials_error = None
         return cls(
             root=root,
             db_path=root / "kb.sqlite",
             provider=provider,
             model=model,
-            api_key=_pick("VERINOTE_API_KEY", None, None),  # no saved/default source — secrets only from env
+            api_key=api_key,
             base_url=base_url,
             llm_timeout_seconds=_llm_timeout_seconds(),
             extraction_chunk_chars=chunk_chars,
@@ -645,6 +885,7 @@ class Config:
             extraction_max_facts_per_chunk=max_facts,
             auto_accept_recommendations=auto_accept,
             settings_error=settings_error,
+            credentials_error=credentials_error,
         )
 
     @classmethod
@@ -668,6 +909,17 @@ class ConfigCorruptError(RuntimeError):
     config must NOT silently fall back to the cloud default provider the user
     never chose (#269).
     """
+
+
+def assert_credentials_intact(cfg: Config) -> None:
+    """Refuse to proceed when the stored-keys file is present but unreadable.
+
+    Separate from `assert_settings_intact` because it is a different file with a
+    different scope and a different fix. Only reached when the file is what
+    decides the key — see `Config.credentials_error`.
+    """
+    if cfg.credentials_error is not None:
+        raise CredentialsCorruptError(cfg.credentials_error)
 
 
 def assert_settings_intact(cfg: Config) -> None:

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from verinote.kb_location import resolve_kb_root
@@ -536,7 +536,11 @@ class Config:
     db_path: Path
     provider: str  # one of PROVIDERS — enumerating it here only goes stale
     model: str
-    api_key: str | None
+    # Kept out of the repr so a stray `logger.exception` with locals, or a
+    # pytest assertion diff, cannot print the credential. Necessary but not
+    # sufficient once keys are stored on disk: that unit must also handle file
+    # mode, `asdict`, and the fact that a frozen dataclass compares on this field.
+    api_key: str | None = field(repr=False)
     base_url: str | None
     llm_timeout_seconds: float = 600.0
     extraction_chunk_chars: int = 300

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -644,6 +644,43 @@ def _read_credentials() -> tuple[dict[str, str], str | None]:
     return {str(k): v for k, v in keys.items()}, None
 
 
+def api_key_source(
+    provider: str, stored: dict[str, str], error: str | None = None
+) -> tuple[str, str | None]:
+    """Where `provider`'s key comes from, and what it is.
+
+    One walk, two answers: the settings badge and the resolved value apply the
+    same precedence rather than two hand-kept copies of it, so neither can rank
+    the sources differently from the other.
+
+    What this does NOT make identical is the *inputs*. The badge reads the file
+    fresh on every render; a running app holds `Config` as a snapshot. If the
+    file changes out of band — a second verinote process, a hand edit — the page
+    leads the snapshot until something rebuilds it. Every credentials route
+    rebuilds it, so the in-app flow stays consistent; the residue is a
+    deliberately fresh page, not a shared-input guarantee.
+
+    States: `not_needed`, `env_provider`, `stored`, `env_global`, `unknown`
+    (the file is present but unreadable, so we cannot say), `unset`.
+    """
+    if provider not in PROVIDERS_REQUIRING_KEY:
+        return "not_needed", None
+    scoped = os.environ.get(provider_key_env_var(provider))
+    if isinstance(scoped, str) and scoped.strip():
+        return "env_provider", scoped.strip()
+    saved = stored.get(provider)
+    if isinstance(saved, str) and saved.strip():
+        return "stored", saved.strip()
+    legacy = os.environ.get("VERINOTE_API_KEY")
+    if isinstance(legacy, str) and legacy.strip():
+        return "env_global", legacy.strip()
+    # Only now does an unreadable file matter: every tier above it came back
+    # empty, so the file is what would have decided.
+    if error is not None:
+        return "unknown", None
+    return "unset", None
+
+
 def resolve_api_key(provider: str, stored: dict[str, str]) -> str | None:
     """The key to authenticate `provider` with, or None.
 
@@ -659,20 +696,7 @@ def resolve_api_key(provider: str, stored: dict[str, str]) -> str | None:
     the legacy variable stays last so existing setups keep working unchanged for
     any provider that has no stored key.
     """
-    if provider not in PROVIDERS_REQUIRING_KEY:
-        return None
-    for candidate in (
-        os.environ.get(provider_key_env_var(provider)),
-        stored.get(provider),
-        os.environ.get("VERINOTE_API_KEY"),
-    ):
-        if isinstance(candidate, str):
-            candidate = candidate.strip()
-        if candidate:
-            return candidate
-    return None
-
-
+    return api_key_source(provider, stored)[1]
 
 @contextmanager
 def _credentials_lock():
@@ -747,6 +771,10 @@ def save_credential(provider: str, key: str) -> None:
 
 def delete_credential(provider: str) -> bool:
     """Remove `provider`'s stored key. True when one was actually removed."""
+    if provider not in PROVIDERS_REQUIRING_KEY:
+        # Same membership rule as `save_credential`: without it a bogus id gets a
+        # cheerful "nothing to remove" while the same id is refused on save.
+        raise ValueError(f"{provider} does not use an API key")
     with _credentials_lock():
         stored, error = _read_credentials()
         if error is not None:
@@ -867,11 +895,12 @@ class Config:
             saved.get("auto_accept_recommendations"),
             False,
         )
-        stored_keys, credentials_error = _read_credentials()
-        api_key = resolve_api_key(provider, stored_keys)
-        if api_key is not None or provider not in PROVIDERS_REQUIRING_KEY:
-            # The file could not have changed the outcome, so it is not a halt.
-            credentials_error = None
+        stored_keys, credentials_read_error = _read_credentials()
+        state, api_key = api_key_source(provider, stored_keys, credentials_read_error)
+        # The halt is exactly the state that says we cannot tell — every other
+        # state means some tier answered, so the unreadable file could not have
+        # changed the outcome and must not stop this provider.
+        credentials_error = credentials_read_error if state == "unknown" else None
         return cls(
             root=root,
             db_path=root / "kb.sqlite",

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -218,7 +218,7 @@ def _saved_root(config: dict) -> Path | None:
     return _normalize_root(str(saved))
 
 
-def _write_json_atomic(path: Path, payload: dict) -> None:
+def _write_json_atomic(path: Path, payload: dict, *, mode: int = 0o600) -> None:
     """Replace `path` with `payload`, or leave it exactly as it was.
 
     `write_text` truncates in place, so a crash, a full disk, or two verinote
@@ -234,12 +234,28 @@ def _write_json_atomic(path: Path, payload: dict) -> None:
     also durably record the rename itself is deliberately skipped — it is not
     portable, and the guarantee being bought here is "never torn", not
     "committed before we return".
+
+    `mode` is explicit because `mkstemp` creates its file 0o600 and `os.replace`
+    carries that over — so switching to this writer silently tightened `app.json`
+    from the 0o644 `write_text` produced, on existing files too. That tightening
+    is kept (this directory is per-user, and it is about to hold a secrets file
+    beside it), but it is stated here rather than left as a side effect of the
+    temp-file mechanism.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp = Path(tmp_name)
     try:
+        # Set on the fd, not the path: the mode then lands on *this* file rather
+        # than on whatever might occupy `tmp`'s name, and `os.replace` carries it
+        # over. Guarded because `os.fchmod` is absent on Windows, which this
+        # module explicitly supports — and unlike a best-effort restore, a
+        # secrets file must not proceed as though a failed chmod had succeeded.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, mode)
+        else:
+            os.chmod(tmp, mode)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(text)
             handle.flush()

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -56,6 +56,24 @@ _MODEL_DEFAULTS = {
     "anthropic": "claude-opus-4-8",
     "claudecli": "",
     "openai": "gpt-4o",
+    # A concrete free model that advertises the structured output verinote
+    # forces, NOT the `openrouter/free` router. A router picks a different model
+    # per request, so the settings banner's "answered ... from <model>" and a
+    # captured fixture's recorded model would both name something that did not
+    # answer — and one Test connection could not stand for the next request.
+    #
+    # Chosen because *every* endpoint serving it advertises structured output —
+    # it has exactly one. More endpoints is the wrong criterion here: OpenRouter
+    # routes across them per request, and `google/gemma-4-26b-a4b-it:free`, the
+    # only free structured-output model with two, is served by one endpoint that
+    # advertises it and one that does not. Being routed to the second would drop
+    # the schema, so a Test connection that passed would say nothing about the
+    # next extraction — the same failure the router above is rejected for.
+    #
+    # What is verified is that OpenRouter *advertises* structured output for this
+    # model and its endpoint. Whether the endpoint honours `strict` is only
+    # knowable by running it, which is what Test connection is for.
+    "openrouter": "openai/gpt-oss-20b:free",
     "ollama": "llama3.1",
 }
 PROVIDERS = tuple(_MODEL_DEFAULTS)
@@ -63,17 +81,24 @@ PROVIDER_LABELS = {
     "anthropic": "Anthropic",
     "claudecli": "ClaudeCLI",
     "openai": "OpenAI",
+    "openrouter": "OpenRouter",
     "ollama": "Ollama",
 }
 # Providers whose configuration can be checked by actually running it. `claudecli`
 # belongs here for the same reason the others do -- the check is one real
 # extraction -- and it matters most there: its installed models cannot be
 # enumerated, so running the chosen one is the only way to learn it works.
-TESTABLE_PROVIDERS = frozenset({"anthropic", "claudecli", "openai", "ollama"})
+TESTABLE_PROVIDERS = frozenset({"anthropic", "claudecli", "openai", "openrouter", "ollama"})
 # Providers whose installed models can be enumerated from the very endpoint the
 # user configured, so the settings UI can offer a picker instead of free text.
-# A cloud catalogue is not a property of its endpoint and `claudecli` has no
-# listing at all, so neither can be answered truthfully here.
+# A vendor's own catalogue is not a property of its endpoint and `claudecli` has
+# no listing at all, so neither can be answered truthfully here.
+#
+# `openrouter` is the exception that does not generalise: its catalogue IS
+# served by the endpoint being configured (`GET {base_url}/models`, unauthenticated),
+# so the original "a cloud catalogue is never endpoint-served" reasoning does not
+# cover it. It is absent here only because its picker is a separate unit of work,
+# not because the claim above applies to it.
 MODEL_LISTING_PROVIDERS = frozenset({"ollama"})
 
 
@@ -509,7 +534,7 @@ def _pick_bool(env: str, saved: object, default: bool) -> bool:
 class Config:
     root: Path
     db_path: Path
-    provider: str  # "anthropic" | "claudecli" | "openai" | "ollama"
+    provider: str  # one of PROVIDERS — enumerating it here only goes stale
     model: str
     api_key: str | None
     base_url: str | None

--- a/verinote/config.py
+++ b/verinote/config.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -217,6 +218,38 @@ def _saved_root(config: dict) -> Path | None:
     return _normalize_root(str(saved))
 
 
+def _write_json_atomic(path: Path, payload: dict) -> None:
+    """Replace `path` with `payload`, or leave it exactly as it was.
+
+    `write_text` truncates in place, so a crash, a full disk, or two verinote
+    processes writing at once can leave a half-written file. The reader
+    (`read_app_config`) turns unparsable JSON into `{}` after a stderr-only
+    warning, which in the web UI is invisible: the app silently forgets the
+    active KB and the chosen theme rather than reporting that it lost them.
+
+    Writing a sibling temp file and `os.replace`-ing it makes the swap atomic on
+    POSIX and Windows alike, so a reader sees either the whole old file or the
+    whole new one. `fsync` before the rename is what makes that survive a power
+    loss rather than only a process crash; the parent-directory fsync that would
+    also durably record the rename itself is deliberately skipped — it is not
+    portable, and the guarantee being bought here is "never torn", not
+    "committed before we return".
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
 def save_active_root(root: Path) -> None:
     """Persist the active KB root outside any individual KB.
 
@@ -230,12 +263,7 @@ def save_active_root(root: Path) -> None:
     existing = read_app_config()
     if _saved_root(existing) == resolved:
         return
-    path = app_config_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {**existing, "active_root": str(resolved)}
-    path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
+    _write_json_atomic(app_config_path(), {**existing, "active_root": str(resolved)})
 
 
 def app_theme() -> str:
@@ -251,12 +279,7 @@ def save_app_theme(theme: str) -> None:
     existing = read_app_config()
     if existing.get("theme") == theme:
         return
-    path = app_config_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {**existing, "theme": theme}
-    path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
+    _write_json_atomic(app_config_path(), {**existing, "theme": theme})
 
 
 def active_root() -> Path | None:

--- a/verinote/llm/__init__.py
+++ b/verinote/llm/__init__.py
@@ -8,7 +8,7 @@ the deterministic DuckDB-backed verifier re-checks every fact, so the provider/m
 is freely swappable.
 """
 
-from verinote.llm.base import ExtractedFact, LLMClient, LLMError
+from verinote.llm.base import MIN_REDACTABLE_SECRET, ExtractedFact, LLMClient, LLMError
 from verinote.llm.factory import get_client
 
-__all__ = ["LLMClient", "ExtractedFact", "LLMError", "get_client"]
+__all__ = ["LLMClient", "ExtractedFact", "LLMError", "MIN_REDACTABLE_SECRET", "get_client"]

--- a/verinote/llm/__init__.py
+++ b/verinote/llm/__init__.py
@@ -2,8 +2,8 @@
 """Provider-agnostic LLM layer.
 
 `LLMClient` is the single seam the rest of verinote talks to. Concrete adapters
-(Anthropic / Claude CLI / OpenAI / Ollama) normalise structured (JSON-schema)
-output in-house so no vendor API leaks upward. This is the anti-lock-in design:
+(one per entry in `config.PROVIDERS`) normalise structured (JSON-schema) output
+in-house so no vendor API leaks upward. This is the anti-lock-in design:
 the deterministic DuckDB-backed verifier re-checks every fact, so the provider/model
 is freely swappable.
 """

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -47,7 +47,8 @@ class AnthropicAdapter:
         """
         if not self.cfg.api_key:
             raise LLMError(
-                f"{self.name} requires an API key; set VERINOTE_API_KEY "
+                f"{self.name} requires an API key; set "
+                f"VERINOTE_{self.name.upper()}_API_KEY "
                 f"(the {self.name} SDK's own environment variable is deliberately not used)"
             )
         return self.cfg.api_key

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError
+from verinote.llm.base import ExtractedFact, LLMError, redact_secret
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -22,6 +22,36 @@ class AnthropicAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
+    def _request_failed(self, exc: Exception) -> LLMError:
+        """One construction site for provider failures, so a raise site somebody
+        forgot cannot let the configured key survive into an error message.
+
+        It can only redact the key it knows about, which is why `_require_key`
+        refuses to let the SDK authenticate with one this process never saw.
+        """
+        return LLMError(redact_secret(f"{self.name} request failed: {exc}", self.cfg.api_key))
+
+    def _require_key(self) -> str:
+        """The configured key, or a clear failure instead of a silent fallback.
+
+        Handing `api_key=None` to either vendor SDK makes it read its own
+        `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` instead — verified against the
+        installed SDKs. The request then authenticates with a credential verinote
+        never resolved, so `redact_secret` cannot match it and a 4xx body echoing
+        it is persisted verbatim into `source_chunks.error`. Since `base_url` is
+        caller-supplied, that echo is attacker-influenced.
+
+        Raising `LLMError` rather than passing `""` (which the SDK rejects with
+        its own error type, outside the `except LLMError` every caller uses) keeps
+        the failure inside the contract callers already handle.
+        """
+        if not self.cfg.api_key:
+            raise LLMError(
+                f"{self.name} requires an API key; set VERINOTE_API_KEY "
+                f"(the {self.name} SDK's own environment variable is deliberately not used)"
+            )
+        return self.cfg.api_key
+
     def _client(self):
         """Build a client that honours the configured request timeout.
 
@@ -33,7 +63,7 @@ class AnthropicAdapter:
         except ImportError as exc:  # pragma: no cover - optional dep
             raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
         return anthropic.Anthropic(
-            api_key=self.cfg.api_key,
+            api_key=self._require_key(),
             base_url=self.cfg.base_url,
             timeout=self.cfg.llm_timeout_seconds,
         )
@@ -57,7 +87,7 @@ class AnthropicAdapter:
                 messages=[{"role": "user", "content": source_text}],
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"anthropic request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
@@ -84,7 +114,7 @@ class AnthropicAdapter:
                 messages=[{"role": "user", "content": question}],
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"anthropic request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
@@ -110,7 +140,7 @@ class AnthropicAdapter:
                 messages=[{"role": "user", "content": question}],
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"anthropic request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
@@ -132,7 +162,7 @@ class AnthropicAdapter:
                 ],
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"anthropic request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         parts = [
             str(getattr(block, "text", "")).strip()

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -16,6 +16,38 @@ class LLMError(RuntimeError):
     """Any provider-side or parsing failure, normalised across adapters."""
 
 
+# A secret shorter than this cannot be replaced without mangling ordinary text —
+# a key of "key" would turn "invalid api key" into "invalid api ***" — so it is
+# deliberately left alone. That is a statement about collateral damage, not about
+# what counts as a credential: a short key (a self-hosted gateway's shared token,
+# say) is NOT protected here. Error text that varies with the key's content is
+# itself a small oracle, which is the other half of why the floor exists.
+_MIN_REDACTABLE_SECRET = 8
+
+
+def redact_secret(text: str, secret: str | None) -> str:
+    """Replace `secret` wherever it appears in `text`.
+
+    Applied where an `LLMError` is *constructed*, not where one is stored. A
+    provider's 401 body can echo the key it rejected, and that text reaches four
+    different sinks — the settings banner, `source_chunks.error`, a question's
+    failure reason, and the model-list error. Redacting at the sinks means
+    enumerating sinks; redacting at construction means the secret never enters
+    an `LLMError` in the first place, which is the same protected-by-construction
+    argument `factory.get_client` makes for the corrupt-config halt.
+
+    Substring replacement on the one string known to be secret, never a
+    `sk-`-style pattern: key formats differ per vendor and self-hosted gateways
+    invent their own, so a pattern both misses real keys and mangles innocent
+    text. This does not cover a key echoed back *transformed* (encoded, hashed);
+    that residue is why not shipping keys to caller-named endpoints is the
+    primary control and this is defence in depth.
+    """
+    if not secret or len(secret) < _MIN_REDACTABLE_SECRET:
+        return text
+    return text.replace(secret, "***")
+
+
 @dataclass(frozen=True)
 class ExtractedFact:
     """One candidate fact the extractor proposes from a source.

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -73,6 +73,32 @@ class ExtractedFact:
                 raise ValueError(f"{name} must be 'string' or 'term', got {value!r}")
 
 
+@dataclass(frozen=True)
+class ModelListing:
+    """What one provider's model listing reported, for the settings picker.
+
+    Every lister in `web.app._MODEL_LISTERS` returns this, so the dispatch has
+    one return contract however many listers exist. Chosen over the two values
+    (`list[str]` plus a parallel `frozenset[str] | None`) the design review also
+    offered: those carry the same facts, but a bare pair is unpacked positionally,
+    so swapping the two at one call site is a silent misgrouping rather than an
+    error, and neither element can be named where a reader meets it.
+
+    `models` is every id the listing returned, ordered.
+
+    `structured_output_ids` is the subset the listing said advertises structured
+    output, or `None` when the listing does not report that property at all.
+    Those are different facts and the UI renders them differently: Ollama's
+    `/api/tags` carries no such field, so `None` means "this listing does not
+    say", while an empty frozenset means "it does say, and nothing advertised
+    it". Collapsing the two would put every Ollama model under a heading
+    claiming its server declared something it never mentioned.
+    """
+
+    models: tuple[str, ...]
+    structured_output_ids: frozenset[str] | None = None
+
+
 @runtime_checkable
 class LLMClient(Protocol):
     """Every provider adapter implements this; callers depend only on it.

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -22,7 +22,7 @@ class LLMError(RuntimeError):
 # what counts as a credential: a short key (a self-hosted gateway's shared token,
 # say) is NOT protected here. Error text that varies with the key's content is
 # itself a small oracle, which is the other half of why the floor exists.
-_MIN_REDACTABLE_SECRET = 8
+MIN_REDACTABLE_SECRET = 8
 
 
 def redact_secret(text: str, secret: str | None) -> str:
@@ -43,7 +43,7 @@ def redact_secret(text: str, secret: str | None) -> str:
     that residue is why not shipping keys to caller-named endpoints is the
     primary control and this is defence in depth.
     """
-    if not secret or len(secret) < _MIN_REDACTABLE_SECRET:
+    if not secret or len(secret) < MIN_REDACTABLE_SECRET:
         return text
     return text.replace(secret, "***")
 

--- a/verinote/llm/factory.py
+++ b/verinote/llm/factory.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
-from verinote.config import PROVIDERS, Config, assert_settings_intact
+from verinote.config import (
+    PROVIDERS,
+    Config,
+    assert_credentials_intact,
+    assert_settings_intact,
+)
 from verinote.llm.base import LLMClient, LLMError
 
 
@@ -12,6 +17,9 @@ def get_client(cfg: Config) -> LLMClient:
     # resolve to a silent cloud fallback. Every current and future caller is
     # protected here by construction, so no route enumeration is needed (#269).
     assert_settings_intact(cfg)
+    # Same reasoning, different file: an unreadable credentials file must not
+    # resolve to "no key" and let a provider be called unauthenticated.
+    assert_credentials_intact(cfg)
     provider = cfg.provider
     if provider == "anthropic":
         from verinote.llm.anthropic_adapter import AnthropicAdapter

--- a/verinote/llm/factory.py
+++ b/verinote/llm/factory.py
@@ -16,6 +16,10 @@ def get_client(cfg: Config) -> LLMClient:
     # First act, before any provider branch: a corrupt config.json must never
     # resolve to a silent cloud fallback. Every current and future caller is
     # protected here by construction, so no route enumeration is needed (#269).
+    # One deliberate exception, and it is not a caller: the settings
+    # model-listing seam (`web.app._list_models_for`) builds no client at all,
+    # precisely so it cannot hold an API key while dialling a caller-supplied
+    # URL. It therefore re-asserts both halts below by hand.
     assert_settings_intact(cfg)
     # Same reasoning, different file: an unreadable credentials file must not
     # resolve to "no key" and let a provider be called unauthenticated.

--- a/verinote/llm/factory.py
+++ b/verinote/llm/factory.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from verinote.config import Config, assert_settings_intact
+from verinote.config import PROVIDERS, Config, assert_settings_intact
 from verinote.llm.base import LLMClient, LLMError
 
 
@@ -25,10 +25,17 @@ def get_client(cfg: Config) -> LLMClient:
         from verinote.llm.openai_adapter import OpenAIAdapter
 
         return OpenAIAdapter(cfg)
+    if provider == "openrouter":
+        from verinote.llm.openrouter_adapter import OpenRouterAdapter
+
+        return OpenRouterAdapter(cfg)
     if provider == "ollama":
         from verinote.llm.ollama_adapter import OllamaAdapter
 
         return OllamaAdapter(cfg)
+    # Derived from PROVIDERS rather than spelled out: a hand-written list here
+    # goes stale the moment a provider is added, and this message is what tells
+    # a user with a typo in config.json what they were allowed to write.
     raise LLMError(
-        f"unknown VERINOTE_PROVIDER={provider!r}; expected anthropic|claudecli|openai|ollama"
+        f"unknown VERINOTE_PROVIDER={provider!r}; expected {'|'.join(PROVIDERS)}"
     )

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -22,15 +22,52 @@ from verinote.llm.schema import (
 from verinote.pipeline.query_intent import QueryIntent, parse_query_intent
 from verinote.prompts import PromptError, render_prompt
 
-# `list_models` is an interactive page-load call, not a generation, so it is
-# bounded far tighter than `cfg.llm_timeout_seconds` (minutes, sized for a long
-# local completion). The effective bound is still the *smaller* of the two, so a
-# user who configures an even shorter timeout keeps it.
-MODEL_LIST_TIMEOUT_SECONDS = 5.0
-
 # The endpoint an unset `base_url` resolves to. Named so the settings UI can
 # report the *same* URL it will actually talk to instead of printing "(default)".
 OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
+
+
+def list_models(base_url: str | None, timeout: float) -> list[str]:
+    """Model ids this Ollama server has installed, sorted, deduplicated.
+
+    A module-level function taking a URL and a timeout, deliberately NOT a
+    method on `OllamaAdapter`. The settings picker dials an endpoint the caller
+    supplied in a query string, and a method would have `self.cfg.api_key` in
+    reach — so "this listing sends no key" would be a property of what the body
+    happens to read today, which an edit can change without review. Taking no
+    `Config` at all moves it into the signature, where a reviewer sees it. The web
+    layer checks that shape at import for every lister in its shipped table — not
+    at dispatch, and it constrains only what a lister is handed, never what a body
+    can reach for on its own; see `_MODEL_LISTERS` for what that does and does not
+    buy. The timeout ceiling this parameter is clamped against lives there too,
+    because that dispatch is the last caller still holding a `Config`.
+
+    Raises `LLMError` on any transport or shape failure rather than
+    returning `[]` — an empty list means "this server has no models pulled",
+    and a caller must be able to tell that apart from "the server could not
+    be reached" (which the settings UI reports verbatim instead of showing
+    an empty picker).
+    """
+    root = (base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/")
+    req = urllib.request.Request(f"{root}/api/tags")
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+            req, timeout=timeout
+        ) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+        raise LLMError(f"ollama request failed: {exc}") from exc
+
+    if not isinstance(body, dict) or not isinstance(body.get("models"), list):
+        raise LLMError("ollama model list did not match schema: expected {'models': [...]}")
+    names = {
+        entry["name"].strip()
+        for entry in body["models"]
+        if isinstance(entry, dict)
+        and isinstance(entry.get("name"), str)
+        and entry["name"].strip()
+    }
+    return sorted(names)
 
 
 class OllamaAdapter:
@@ -39,40 +76,6 @@ class OllamaAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
         self.base_url = (cfg.base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/")
-
-    def list_models(self) -> list[str]:
-        """Model ids this Ollama server has installed, sorted, deduplicated.
-
-        Ollama-specific by design, so it is deliberately NOT on the `LLMClient`
-        protocol: the cloud adapters' catalogues are not a property of the
-        endpoint the user pointed at, and `claudecli` has nothing to enumerate.
-        Callers that want the list ask the Ollama adapter for it.
-
-        Raises `LLMError` on any transport or shape failure rather than
-        returning `[]` — an empty list means "this server has no models pulled",
-        and a caller must be able to tell that apart from "the server could not
-        be reached" (which the settings UI reports verbatim instead of showing
-        an empty picker).
-        """
-        req = urllib.request.Request(f"{self.base_url}/api/tags")
-        try:
-            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
-                req, timeout=min(self.cfg.llm_timeout_seconds, MODEL_LIST_TIMEOUT_SECONDS)
-            ) as resp:
-                body = json.loads(resp.read().decode("utf-8"))
-        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
-            raise LLMError(f"ollama request failed: {exc}") from exc
-
-        if not isinstance(body, dict) or not isinstance(body.get("models"), list):
-            raise LLMError("ollama model list did not match schema: expected {'models': [...]}")
-        names = {
-            entry["name"].strip()
-            for entry in body["models"]
-            if isinstance(entry, dict)
-            and isinstance(entry.get("name"), str)
-            and entry["name"].strip()
-        }
-        return sorted(names)
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         system = _with_schema_hint(

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -11,7 +11,7 @@ import json
 import urllib.request
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError
+from verinote.llm.base import ExtractedFact, LLMError, ModelListing
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -27,7 +27,7 @@ from verinote.prompts import PromptError, render_prompt
 OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
 
 
-def list_models(base_url: str | None, timeout: float) -> list[str]:
+def list_models(base_url: str | None, timeout: float) -> ModelListing:
     """Model ids this Ollama server has installed, sorted, deduplicated.
 
     A module-level function taking a URL and a timeout, deliberately NOT a
@@ -42,11 +42,17 @@ def list_models(base_url: str | None, timeout: float) -> list[str]:
     buy. The timeout ceiling this parameter is clamped against lives there too,
     because that dispatch is the last caller still holding a `Config`.
 
+    `structured_output_ids` is left `None`: `/api/tags` reports a name, a size
+    and a digest per model and nothing about capabilities, so this listing has
+    no answer to give. `None` says exactly that, and is not the same as the
+    empty set a listing that *does* report the property and found none would
+    return — see `ModelListing`.
+
     Raises `LLMError` on any transport or shape failure rather than
-    returning `[]` — an empty list means "this server has no models pulled",
-    and a caller must be able to tell that apart from "the server could not
-    be reached" (which the settings UI reports verbatim instead of showing
-    an empty picker).
+    returning an empty listing — no models means "this server has no models
+    pulled", and a caller must be able to tell that apart from "the server
+    could not be reached" (which the settings UI reports verbatim instead of
+    showing an empty picker).
     """
     root = (base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/")
     req = urllib.request.Request(f"{root}/api/tags")
@@ -67,7 +73,7 @@ def list_models(base_url: str | None, timeout: float) -> list[str]:
         and isinstance(entry.get("name"), str)
         and entry["name"].strip()
     }
-    return sorted(names)
+    return ModelListing(models=tuple(sorted(names)))
 
 
 class OllamaAdapter:

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -35,9 +35,20 @@ class OpenAIAdapter:
             raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
         return OpenAI(
             api_key=self.cfg.api_key,
-            base_url=self.cfg.base_url,
+            base_url=self._base_url(),
             timeout=self.cfg.llm_timeout_seconds,
         )
+
+    def _base_url(self) -> str | None:
+        """The endpoint to dial. `None` lets the SDK use its own default.
+
+        A seam, not indirection for its own sake: a subclass that IS one
+        specific service overrides this so an unset `base_url` cannot silently
+        resolve to `api.openai.com` and ship documents to a vendor the user did
+        not choose. Keeping it here means there is still exactly one `OpenAI(...)`
+        construction site.
+        """
+        return self.cfg.base_url
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()
@@ -59,7 +70,7 @@ class OpenAIAdapter:
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"openai request failed: {exc}") from exc
+            raise LLMError(f"{self.name} request failed: {exc}") from exc
 
         return parse_facts(resp.choices[0].message.content or "")
 
@@ -86,7 +97,7 @@ class OpenAIAdapter:
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"openai request failed: {exc}") from exc
+            raise LLMError(f"{self.name} request failed: {exc}") from exc
 
         return parse_query(resp.choices[0].message.content or "")
 
@@ -115,7 +126,7 @@ class OpenAIAdapter:
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"openai request failed: {exc}") from exc
+            raise LLMError(f"{self.name} request failed: {exc}") from exc
 
         return parse_query_intent(resp.choices[0].message.content or "")
 
@@ -137,7 +148,7 @@ class OpenAIAdapter:
                 temperature=0,
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"openai request failed: {exc}") from exc
+            raise LLMError(f"{self.name} request failed: {exc}") from exc
 
         return (resp.choices[0].message.content or "").strip()
 

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError
+from verinote.llm.base import ExtractedFact, LLMError, redact_secret
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -22,6 +22,36 @@ class OpenAIAdapter:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
 
+    def _request_failed(self, exc: Exception) -> LLMError:
+        """One construction site for provider failures, so a raise site somebody
+        forgot cannot let the configured key survive into an error message.
+
+        It can only redact the key it knows about, which is why `_require_key`
+        refuses to let the SDK authenticate with one this process never saw.
+        """
+        return LLMError(redact_secret(f"{self.name} request failed: {exc}", self.cfg.api_key))
+
+    def _require_key(self) -> str:
+        """The configured key, or a clear failure instead of a silent fallback.
+
+        Handing `api_key=None` to either vendor SDK makes it read its own
+        `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` instead — verified against the
+        installed SDKs. The request then authenticates with a credential verinote
+        never resolved, so `redact_secret` cannot match it and a 4xx body echoing
+        it is persisted verbatim into `source_chunks.error`. Since `base_url` is
+        caller-supplied, that echo is attacker-influenced.
+
+        Raising `LLMError` rather than passing `""` (which the SDK rejects with
+        its own error type, outside the `except LLMError` every caller uses) keeps
+        the failure inside the contract callers already handle.
+        """
+        if not self.cfg.api_key:
+            raise LLMError(
+                f"{self.name} requires an API key; set VERINOTE_API_KEY "
+                f"(the {self.name} SDK's own environment variable is deliberately not used)"
+            )
+        return self.cfg.api_key
+
     def _client(self):
         """Build a client that honours the configured request timeout.
 
@@ -34,7 +64,7 @@ class OpenAIAdapter:
         except ImportError as exc:  # pragma: no cover - optional dep
             raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
         return OpenAI(
-            api_key=self.cfg.api_key,
+            api_key=self._require_key(),
             base_url=self._base_url(),
             timeout=self.cfg.llm_timeout_seconds,
         )
@@ -70,7 +100,7 @@ class OpenAIAdapter:
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"{self.name} request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         return parse_facts(resp.choices[0].message.content or "")
 
@@ -97,7 +127,7 @@ class OpenAIAdapter:
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"{self.name} request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         return parse_query(resp.choices[0].message.content or "")
 
@@ -126,7 +156,7 @@ class OpenAIAdapter:
                 },
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"{self.name} request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         return parse_query_intent(resp.choices[0].message.content or "")
 
@@ -148,7 +178,7 @@ class OpenAIAdapter:
                 temperature=0,
             )
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
-            raise LLMError(f"{self.name} request failed: {exc}") from exc
+            raise self._request_failed(exc) from exc
 
         return (resp.choices[0].message.content or "").strip()
 

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -47,7 +47,8 @@ class OpenAIAdapter:
         """
         if not self.cfg.api_key:
             raise LLMError(
-                f"{self.name} requires an API key; set VERINOTE_API_KEY "
+                f"{self.name} requires an API key; set "
+                f"VERINOTE_{self.name.upper()}_API_KEY "
                 f"(the {self.name} SDK's own environment variable is deliberately not used)"
             )
         return self.cfg.api_key

--- a/verinote/llm/openrouter_adapter.py
+++ b/verinote/llm/openrouter_adapter.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MPL-2.0
+"""OpenRouter adapter — one endpoint that routes to many vendors' models.
+
+OpenRouter speaks the OpenAI wire protocol, so every generation path is
+inherited from `OpenAIAdapter` unchanged. What this module adds is the part
+that is *not* the protocol: an endpoint bound to the provider the user picked
+rather than to a text field they can leave blank.
+
+That binding is why this is a provider of its own instead of a documented
+`openai` + `base_url` recipe. Under the recipe an unset `base_url` resolves to
+`api.openai.com`, so a user who chose OpenRouter and cleared the field would
+ship their documents to a vendor they never selected — the confidentiality
+failure `assert_settings_intact` exists to prevent (#269), arriving through
+ordinary configuration instead of corruption. `OllamaAdapter` binds its
+endpoint the same way and for the same reason.
+"""
+
+from __future__ import annotations
+
+from verinote.llm.openai_adapter import OpenAIAdapter
+
+# The endpoint an unset `base_url` resolves to. Named rather than inlined so a
+# settings surface can eventually report the same URL this adapter dials; today
+# the only consumers are `_base_url` and its tests.
+OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+class OpenRouterAdapter(OpenAIAdapter):
+    """OpenAI-protocol generation against OpenRouter.
+
+    `name` is not cosmetic: the inherited request paths raise
+    `LLMError(f"{self.name} request failed: ...")`, and that string is what the
+    settings banner shows and what a failed extraction persists as its chunk
+    error. Left at `openai` it would name the wrong provider in the one place a
+    user looks to find out which provider broke.
+    """
+
+    name = "openrouter"
+
+    def _base_url(self) -> str:
+        return self.cfg.base_url or OPENROUTER_DEFAULT_BASE_URL

--- a/verinote/llm/openrouter_adapter.py
+++ b/verinote/llm/openrouter_adapter.py
@@ -4,7 +4,9 @@
 OpenRouter speaks the OpenAI wire protocol, so every generation path is
 inherited from `OpenAIAdapter` unchanged. What this module adds is the part
 that is *not* the protocol: an endpoint bound to the provider the user picked
-rather than to a text field they can leave blank.
+rather than to a text field they can leave blank, and the catalogue that
+endpoint serves — `GET {base_url}/models`, keyless, which is why the settings
+Model field can be a picker here and not for the other cloud providers.
 
 That binding is why this is a provider of its own instead of a documented
 `openai` + `base_url` recipe. Under the recipe an unset `base_url` resolves to
@@ -17,12 +19,92 @@ endpoint the same way and for the same reason.
 
 from __future__ import annotations
 
+import json
+import urllib.request
+
+from verinote.llm.base import LLMError, ModelListing
 from verinote.llm.openai_adapter import OpenAIAdapter
 
-# The endpoint an unset `base_url` resolves to. Named rather than inlined so a
-# settings surface can eventually report the same URL this adapter dials; today
-# the only consumers are `_base_url` and its tests.
+# The endpoint an unset `base_url` resolves to. Named rather than inlined so the
+# settings surface reports the same URL this adapter dials, and so the web
+# layer's per-provider default-endpoint map cannot drift from it.
 OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+# What a catalogue entry lists in `supported_parameters` when it declares
+# structured output. Named because it is the string the settings picker's two
+# groups are built from, and a rename upstream must change one place here and
+# one assertion in `tests/contract/test_openrouter_catalogue_contract.py`.
+_STRUCTURED_OUTPUTS_PARAMETER = "structured_outputs"
+
+
+def list_models(base_url: str | None, timeout: float) -> ModelListing:
+    """Model ids OpenRouter's catalogue lists, sorted, with the advertising subset.
+
+    A module-level function taking a URL and a timeout, deliberately NOT a
+    method on `OpenRouterAdapter`, for the reason `ollama_adapter.list_models`
+    states: the settings picker dials an endpoint the caller supplied in a query
+    string, and a method would have `self.cfg.api_key` in reach — so "this
+    listing sends no key" would be a property of what the body happens to read
+    today. It matters more here than it does for Ollama, because `openrouter` IS
+    a key-holding provider (`PROVIDERS_REQUIRING_KEY`), so there is a real key to
+    leak. No `Authorization` header is built below, and none needs to be: the
+    catalogue endpoint answers unauthenticated, so nothing is traded for the
+    omission. A later body edit *could* still add one, which is the residual the
+    next sentence is about: the web layer checks that shape at import for every
+    lister in its shipped table — not at dispatch, and it constrains only what a
+    lister is handed, never what a body can reach for on its own; see
+    `_MODEL_LISTERS`.
+
+    Because the request carries no key, what comes back is the published
+    catalogue, NOT the set of models the user's account may call. The settings
+    note says so; do not let a caller quietly restate it as availability.
+
+    `structured_output_ids` reports which entries listed
+    `structured_outputs` among their `supported_parameters` — a repetition of what
+    the catalogue declares, not a measurement: nothing here runs a model.
+
+    Raises `LLMError` on any transport or shape failure rather than returning an
+    empty listing — an empty catalogue means "this endpoint listed nothing", and
+    a caller must be able to tell that apart from "the endpoint could not be
+    reached" (which the settings UI reports verbatim instead of showing an empty
+    picker). An entry whose `supported_parameters` is missing or not a list is a
+    shape failure for the same reason: it cannot be grouped, and dropping it into
+    "does not advertise" would report a claim the catalogue never made.
+    """
+    root = (base_url or OPENROUTER_DEFAULT_BASE_URL).rstrip("/")
+    req = urllib.request.Request(f"{root}/models")
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - caller-named endpoint, dialled with no key
+            req, timeout=timeout
+        ) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+        raise LLMError(f"openrouter request failed: {exc}") from exc
+
+    if not isinstance(body, dict) or not isinstance(body.get("data"), list):
+        raise LLMError("openrouter model list did not match schema: expected {'data': [...]}")
+    ids: set[str] = set()
+    advertising: set[str] = set()
+    for entry in body["data"]:
+        if (
+            not isinstance(entry, dict)
+            or not isinstance(entry.get("id"), str)
+            or not entry["id"].strip()
+        ):
+            raise LLMError(
+                "openrouter model list did not match schema: an entry has no string id"
+            )
+        model_id = entry["id"].strip()
+        parameters = entry.get("supported_parameters")
+        if not isinstance(parameters, list):
+            raise LLMError(
+                "openrouter model list did not match schema: "
+                f"{model_id} has no supported_parameters list"
+            )
+        ids.add(model_id)
+        if _STRUCTURED_OUTPUTS_PARAMETER in parameters:
+            advertising.add(model_id)
+    return ModelListing(models=tuple(sorted(ids)), structured_output_ids=frozenset(advertising))
 
 
 class OpenRouterAdapter(OpenAIAdapter):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -33,8 +33,12 @@ from verinote.config import (
     ConfigCorruptError,
     CredentialsCorruptError,
     app_theme,
+    _read_credentials,
+    api_key_source,
     credentials_path,
+    delete_credential,
     provider_key_env_var,
+    save_credential,
     assert_credentials_intact,
     assert_settings_intact,
     normalize_provider,
@@ -43,7 +47,7 @@ from verinote.config import (
     save_settings,
 )
 from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
-from verinote.llm import LLMError, get_client
+from verinote.llm import MIN_REDACTABLE_SECRET, LLMError, get_client
 from verinote.llm.claude_cli_adapter import CLI_MODEL_ALIASES
 from verinote.llm.ollama_adapter import OLLAMA_DEFAULT_BASE_URL
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
@@ -1968,11 +1972,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if c is None:
             return _kb_select(request)
         theme_editable = True
+        # Same treatment as the theme, and for the same reason: `/settings/root/persist`
+        # also writes machine-wide state and is NOT exempt from the policy guard,
+        # so "it writes outside the KB" is not this repo's rule. Disabling the
+        # control beats a live form that 409s about an unrelated KB.
+        credentials_editable = True
         if app.state.store is not None:
             try:
                 assert_writable(app.state.store)
             except PolicyMissingError:
                 theme_editable = False
+                credentials_editable = False
         return templates.TemplateResponse(
             request,
             "settings.html",
@@ -1988,10 +1998,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "extraction_max_facts_per_chunk": c.extraction_max_facts_per_chunk,
                 "auto_accept_recommendations": c.auto_accept_recommendations,
                 "root": c.root,
-                "has_key": bool(c.api_key),  # never render the key itself
-                # "not set" would assert the user has no key stored; when the
-                # file cannot be read the honest answer is that we do not know.
-                "credentials_error": c.credentials_error,
+                # Read from disk, not from `c`: `app.state.cfg` is a snapshot, and
+                # the page must report what is stored now. Never the value — only
+                # which source answered.
+                # Both from the SAME fresh read: rows disk-fresh while the banner
+                # came from the snapshot meant the one state that most needs the
+                # recovery link — "unknown" — could render without it.
+                **_credentials_context(c.provider),
+                "credentials_editable": credentials_editable,
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
                 "relation_aliases": _relation_aliases_text(),
                 # The Model field starts as the plain text input and, for a
@@ -2014,6 +2028,51 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             },
             status_code=status_code,
         )
+
+    def _credentials_context(active_provider: str) -> dict:
+        """The API-keys section, all from one read of the file."""
+        stored, error = _read_credentials()
+        rows = _provider_key_rows(stored, error)
+        # The read error and the *refusal* are different facts. An unreadable
+        # file only halts a provider whose key it would have decided, so with an
+        # environment key in place nothing is refused — reporting the raw read
+        # error as a refusal put a red "extraction is halted" alert on a setup
+        # that was working. `halting` is the claim; `credentials_error` is the
+        # detail, shown either way because an unreadable file is worth saying.
+        return {
+            "provider_keys": rows,
+            "credentials_error": error,
+            # The ACTIVE provider decides the claim: `any(unknown)` is true as
+            # soon as some other provider would be affected, which turned a
+            # working setup into a red "extraction is halted" alert. The other
+            # providers' own rows already say `unknown` for themselves.
+            "credentials_halting": any(
+                row["provider"] == active_provider and row["state"] == "unknown"
+                for row in rows
+            ),
+        }
+
+    def _provider_key_rows(stored: dict, error: str | None) -> list[dict]:
+        """One row per provider: which source supplies its key, never the key.
+
+        `shadowed` exists because "set from the environment" alone would hide
+        that a key the user saved is being overridden — they would edit the
+        saved one and see nothing change.
+        """
+        rows = []
+        for provider in PROVIDERS:
+            state, _ = api_key_source(provider, stored, error)
+            rows.append(
+                {
+                    "provider": provider,
+                    "label": PROVIDER_LABELS.get(provider, provider),
+                    "state": state,
+                    "env_var": provider_key_env_var(provider),
+                    "shadowed": state == "env_provider" and bool(stored.get(provider)),
+                    "stored": bool(stored.get(provider)),
+                }
+            )
+        return rows
 
     @app.get("/settings", response_class=HTMLResponse)
     def settings_page(request: Request):
@@ -2081,6 +2140,69 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # reload from the app's own root so the change takes effect on next sync
         app.state.cfg = Config.for_root(cfg.root)
         return RedirectResponse("/settings", status_code=303)
+
+    @app.post("/settings/credentials", response_class=HTMLResponse)
+    def save_credential_route(
+        request: Request,
+        provider: str = Form(...),
+        api_key: str = Form(""),
+    ):
+        """Store one provider's key. An empty field means "leave it alone".
+
+        The input renders empty on every load because the key is never echoed
+        back, so an empty POST is indistinguishable from "did not touch it";
+        treating it as a clear would silently unset a working key. Removing one
+        is its own explicit action.
+        """
+        canonical = normalize_provider(provider)
+        if not api_key.strip():
+            return _settings(request)
+        try:
+            save_credential(canonical, api_key)
+        except (ValueError, CredentialsCorruptError, OSError) as exc:
+            return _settings(request, error=str(exc), status_code=400)
+        # Rebuild the snapshot: without this the badge would read the new key
+        # from disk while every provider call kept using the old one.
+        # Guarded because `_active_cfg()` raises when no KB is selected: the
+        # write has already succeeded by then, so raising would report a stored
+        # key as a server error.
+        if app.state.cfg is not None:
+            app.state.cfg = Config.for_root(app.state.cfg.root)
+        note = f"Saved an API key for {PROVIDER_LABELS.get(canonical, canonical)}."
+        if len(api_key.strip()) < MIN_REDACTABLE_SECRET:
+            # Not rejected: a self-hosted gateway token can legitimately be this
+            # short. But it will not be redacted from provider error text, which
+            # is persisted, so say so rather than let it be discovered later.
+            note += (
+                f" It is shorter than {MIN_REDACTABLE_SECRET} characters, so it"
+                " cannot be redacted from provider error messages, which are"
+                " stored in this KB."
+            )
+        return _settings(request, test_result=note)
+
+    @app.post("/settings/credentials/remove", response_class=HTMLResponse)
+    def remove_credential_route(request: Request, provider: str = Form(...)):
+        canonical = normalize_provider(provider)
+        try:
+            removed = delete_credential(canonical)
+        except (ValueError, CredentialsCorruptError, OSError) as exc:
+            return _settings(request, error=str(exc), status_code=400)
+        # Guarded because `_active_cfg()` raises when no KB is selected: the
+        # write has already succeeded by then, so raising would report a stored
+        # key as a server error.
+        if app.state.cfg is not None:
+            app.state.cfg = Config.for_root(app.state.cfg.root)
+        label = PROVIDER_LABELS.get(canonical, canonical)
+        if not removed:
+            return _settings(request, test_result=f"No saved key to remove for {label}.")
+        # A bare "removed" would read as "this provider has no key now", which is
+        # false when the environment still supplies one.
+        stored, _error = _read_credentials()
+        state, _ = api_key_source(canonical, stored)
+        note = f"Removed the saved key for {label}."
+        if state in {"env_provider", "env_global"}:
+            note += " An environment variable still supplies a key for it."
+        return _settings(request, test_result=note)
 
     @app.post("/settings/theme", response_class=HTMLResponse)
     def save_theme_route(request: Request, theme: str = Form(...)):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import threading
 from threading import Lock
 import unicodedata
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, Response, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -153,8 +153,78 @@ _FACT_DECISION_LOG_ACTIONS = {
 }
 
 
+# A browser attaches ambient authority to requests a *different* site provokes:
+# verinote listens on a fixed loopback port, has no auth, and a urlencoded form
+# POST is a CORS "simple" request, so any page the user visits can drive one. The
+# concrete reach today is `POST /settings` (which stores an unvalidated base_url)
+# followed by `POST /settings/test` (which dials it carrying the API key).
+#
+# This is a browser-ambient-authority gate, NOT an authorization mechanism: it is
+# deliberately fail-open for clients that send neither header, because no browser
+# page can produce that combination on a state-changing request (see below).
+_SAFE_FETCH_SITES = frozenset({"same-origin", "none"})
+# Reads are not gated: no CORS header is set anywhere, so a cross-origin GET is
+# issued but unreadable, and gating navigation would 403 an ordinary inbound
+# link. The exception is keyed on "does this dial a caller-supplied endpoint",
+# not on "does this mutate" — `/settings/model-field` takes `base_url` from the
+# query string and builds a client from it. That is a blind SSRF probe today
+# because only Ollama is listable and it sends no key; the moment a keyed
+# provider joins MODEL_LISTING_PROVIDERS it becomes one-request key exfiltration.
+_ORIGIN_GUARD_GET_PATHS = ("/settings/model-field",)
+
+
 def _matches(path: str, allowed: tuple[str, ...]) -> bool:
     return any(path == a or path.startswith(a + "/") for a in allowed)
+
+
+def _origin_guard_applies(method: str, path: str) -> bool:
+    if method not in {"GET", "HEAD", "OPTIONS"}:
+        return True
+    return _matches(path, _ORIGIN_GUARD_GET_PATHS)
+
+
+def _is_same_origin(request: Request) -> bool:
+    """Whether a request's declared origin matches the authority it was sent to.
+
+    Deliberately NOT "attributable to verinote's own UI": this does not survive
+    DNS rebinding. A page on a domain the attacker rebinds to loopback is
+    genuinely same-origin with the service, so `Origin` and `Host` agree and this
+    returns True. Blocking that needs the request authority checked against the
+    bind address, which this process cannot see (uvicorn is handed `--host` by
+    the CLI) — a separate change, and one that would refuse every non-loopback
+    deployment. What this does close is the ordinary cross-origin case, where an
+    attacker's page keeps its own origin and cannot forge these headers.
+
+    `Origin` is authoritative when present: the Fetch spec attaches it to every
+    request whose method is not GET/HEAD regardless of CORS mode — which is
+    exactly why a form POST needs no preflight and *still* carries it — and no
+    HTML or JS API lets a page suppress it. Compared against `Host` rather than a
+    hardcoded loopback address because the port is configurable and the app
+    cannot see uvicorn's bind address; host:port only, since a TLS-terminating
+    proxy legitimately changes the scheme.
+
+    Falling back to `Sec-Fetch-Site` covers same-origin POSTs from browsers that
+    omit `Origin`. `same-site` is refused along with `cross-site`: for an IP host
+    every loopback port is same-site but cross-origin, so accepting it would let
+    any other local dev server drive verinote.
+
+    Both absent means the caller is not a browser page this project supports —
+    curl, a script, the test client. Such a caller carries no ambient authority
+    to abuse, so it is allowed. Note the two paths are not equally defended: a
+    POST always carries `Origin`, so it has two independent signals, whereas a
+    cross-origin GET (`<img>`, `<script>`, a `form method=get`) never carries one
+    at all, leaving the gated GET below resting entirely on `Sec-Fetch-Site`.
+    """
+    origin = request.headers.get("origin")
+    if origin is not None:
+        netloc = urlsplit(origin).netloc
+        # `Origin: null` (sandboxed iframe, opaque origin) has no netloc, and
+        # must not be allowed to match an empty or missing Host header.
+        return bool(netloc) and netloc.lower() == (request.headers.get("host") or "").lower()
+    site = request.headers.get("sec-fetch-site")
+    if site is not None:
+        return site in _SAFE_FETCH_SITES
+    return True
 
 
 def _policy_guard_exempt(method: str, path: str) -> bool:
@@ -223,6 +293,40 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 assert_writable(store)
             except PolicyMissingError as exc:
                 return _policy_halted(request, str(exc))
+        return await call_next(request)
+
+    # Defined AFTER `policy_halted_guard` so it runs BEFORE it: `add_middleware`
+    # inserts at index 0, so the last one defined is the outermost. That
+    # inversion is easy to undo by reordering, so it is asserted by a test.
+    #
+    # Outermost is the point. An unattributable request must not reach the policy
+    # guard, which reads the store and renders a templated 409 — that would be an
+    # attacker-triggerable oracle for the KB's policy state. It also keeps this
+    # guard's exemptions exactly its own, so another guard's allowlist can never
+    # silently widen this one.
+    @app.middleware("http")
+    async def same_origin_guard(request: Request, call_next):
+        if _origin_guard_applies(request.method, request.url.path) and not _is_same_origin(
+            request
+        ):
+            logger.warning(
+                "refused cross-origin %s %s (origin=%r)",
+                request.method,
+                request.url.path,
+                request.headers.get("origin"),
+            )
+            # Plain text, not a template: rendering one runs the shared context
+            # processor, which reads the store for a request just judged
+            # untrustworthy. 403 rather than this app's 409 halt vocabulary, so a
+            # forged request is never mistaken for a KB halt. No HX-Redirect —
+            # that pattern exists so a *user's* htmx action cannot silently
+            # no-op, and this response is delivered to the attacker's document,
+            # not the user's tab.
+            return Response(
+                "cross-origin request refused\n",
+                status_code=403,
+                media_type="text/plain",
+            )
         return await call_next(request)
 
     def _policy_missing_handler(request: Request, exc: Exception):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI, File, Form, HTTPException, Request, Response, Uploa
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, nodes
 
 from verinote.config import (
     APP_THEMES,
@@ -48,10 +49,15 @@ from verinote.config import (
 )
 from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
 from verinote.llm import MIN_REDACTABLE_SECRET, LLMError, get_client
+from verinote.llm.base import ModelListing
 from verinote.llm.claude_cli_adapter import CLI_MODEL_ALIASES
 from verinote.llm.ollama_adapter import (
     OLLAMA_DEFAULT_BASE_URL,
     list_models as _list_ollama_models,
+)
+from verinote.llm.openrouter_adapter import (
+    OPENROUTER_DEFAULT_BASE_URL,
+    list_models as _list_openrouter_models,
 )
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
@@ -189,9 +195,44 @@ MODEL_LIST_TIMEOUT_SECONDS = 5.0
 # dict. The trade was accepted because dropping the `get_client` call is itself
 # what puts the API key out of this seam's reach — the check exists to keep an
 # ordinary-looking edit from quietly undoing that, not to make it unconditional.
-_MODEL_LISTERS = {"ollama": _list_ollama_models}
+#
+# Every lister returns a `ModelListing`, not a bare list: a listing that reports
+# which models advertise structured output and one that reports nothing but names
+# have to arrive as the same type here, or this dispatch would need a per-provider
+# branch to read its own table's results.
+_MODEL_LISTERS = {
+    "ollama": _list_ollama_models,
+    "openrouter": _list_openrouter_models,
+}
 # The parameter names every lister must have, checked below rather than trusted.
 _LISTER_SIGNATURE = ("base_url", "timeout")
+
+# The URL each listable provider dials when the Base URL field is left blank,
+# keyed to the adapter constant so the page cannot name one endpoint while the
+# lister dials another. Deliberately not a mapping in `config`, for the reason
+# `MODEL_ALIASES_BY_PROVIDER` is not either: the values live in the adapter
+# modules, which import `config`, so this is the layer that can name both.
+#
+# It exists because the endpoint is *reported to the user*. Hardcoding
+# `OLLAMA_DEFAULT_BASE_URL` here was correct while Ollama was the only listable
+# provider and became a flat misreport the moment a second one joined — an
+# OpenRouter user would have been told the page dialled `http://localhost:11434`.
+_LISTABLE_DEFAULT_ENDPOINTS = {
+    "ollama": OLLAMA_DEFAULT_BASE_URL,
+    "openrouter": OPENROUTER_DEFAULT_BASE_URL,
+}
+
+# The Model field's copy is not shared prose: what a listing IS differs per
+# provider (an installed set on a machine the user controls, versus a published
+# catalogue read with no key), so the partial branches on the provider name and
+# each arm asserts things true only of its own. The check that follows finds
+# those arms by parsing the shipped template and walking its `if`/`elif` chains
+# as syntax rather than matching its text, so what it counts as an arm is what
+# Jinja will actually branch on. That is what lets it read the template instead
+# of a list kept beside it: a list would be satisfied by appending a name, which
+# is the edit the check exists to stop — and so, against a text scan, would
+# writing that name into one of this file's comments.
+_MODEL_FIELD_TEMPLATE = "partials/model_field.html"
 
 
 def _check_every_listable_provider_has_a_keyless_lister(providers, listers) -> None:
@@ -245,10 +286,205 @@ def _check_every_listable_provider_has_a_keyless_lister(providers, listers) -> N
         )
 
 
+def _check_every_listable_provider_names_its_default_endpoint(providers, endpoints) -> None:
+    """Fail at import if a listable provider has no default endpoint to name.
+
+    A sibling of the lister check rather than another clause inside it, because
+    it guards a different failure: not "the picker can never fill" but "the page
+    names the wrong host".
+
+    The two ways this map can be wrong fail differently, and the check is worth
+    having for both. A *missing* entry is loud only where it bites: the
+    subscript in `_model_field_context` sits behind `base_url.strip() or …`, so
+    it raises `KeyError` and the route answers 500 only when the Base URL field
+    is blank — a broken picker, not a misreport. A user who instead configured
+    a proxy or gateway never reaches the subscript: the picker renders and
+    names their own host correctly, and the missing entry stays invisible to
+    exactly the users most likely to have a non-default endpoint. This check
+    turns that split outcome into one import-time failure with a name in it,
+    catching the entry before either half can happen. A *present but wrong*
+    entry is the quiet one, and the misreport this map exists to prevent: the
+    page renders and prints a URL that is not the one the lister dialled. No
+    import-time check can tell a wrong URL from a right one, so what the map
+    buys there is that each provider's URL is written once, beside the adapter
+    constant it must equal.
+
+    Both directions again, and the second is not cosmetic: an entry for a
+    provider that is not listable is a default endpoint nothing dials, and the
+    next edit to `MODEL_LISTING_PROVIDERS` would silently adopt it without anyone
+    checking it is still right.
+
+    A present-but-blank entry is rejected too: it satisfies membership and then
+    renders as an empty `<code></code>` where the dialled host should be, which
+    is the same misreport arriving quietly.
+
+    Raised rather than asserted so `python -O` cannot strip it, matching
+    `config._check_every_provider_is_classified`.
+    """
+    missing = set(providers) ^ set(endpoints)
+    if missing:
+        raise RuntimeError(
+            "every listable provider needs exactly one default endpoint and vice versa: "
+            "a missing entry raises KeyError on a model-field render with a blank "
+            "Base URL, and is invisible on one with a Base URL set, and an entry no "
+            "listable provider claims is a URL nothing dials "
+            f"that the next edit would adopt unchecked: {sorted(missing)}"
+        )
+    blank = sorted(name for name, url in endpoints.items() if not (url or "").strip())
+    if blank:
+        raise RuntimeError(
+            "a listable provider's default endpoint must be a URL the settings page "
+            f"can name, not an empty string: {blank}"
+        )
+
+
+def _provider_names_compared(test) -> list[str]:
+    """The literals one `if`/`elif` test compares `provider` against, in order.
+
+    Every `provider == '<name>'` anywhere inside the test counts, not just a test
+    that is exactly that comparison, so an arm guarded by `provider == 'x' and …`
+    is still that provider's arm rather than a chain the walk fails to recognise.
+    """
+    found = []
+    for node in (test, *test.find_all(nodes.Compare)):
+        if not isinstance(node, nodes.Compare):
+            continue
+        if not (isinstance(node.expr, nodes.Name) and node.expr.name == "provider"):
+            continue
+        found.extend(
+            op.expr.value
+            for op in node.ops
+            if op.op == "eq" and isinstance(op.expr, nodes.Const)
+        )
+    return found
+
+
+def _model_field_provider_chains(template_source) -> list[tuple[int, list[str]]]:
+    """Parse the template; return `(line, names)` per `if`/`elif` chain on `provider`.
+
+    A chain is one `if` head plus the `elif` arms Jinja hangs off it, which is
+    the unit the check reasons about: those arms are alternatives to each other,
+    so a provider missing from one of them is a render that shows that provider
+    nothing. Arms are collected off `elif_`; an `if` written inside another
+    chain's body is a chain of its own rather than an arm of it. Nothing here
+    cares whether a chain is a block or is written inline, so the four the
+    template has — including the one inside an `<option>` tag — are all found.
+
+    Chains whose tests never compare `provider` are not returned at all — the
+    template's `{% if models %}` is not a place a provider needs an arm.
+    """
+
+    def arms(head):
+        yield head
+        for arm in head.elif_:
+            yield from arms(arm)
+
+    parsed = Environment().parse(template_source)
+    all_ifs = list(parsed.find_all(nodes.If))
+    continuations = {id(arm) for head in all_ifs for arm in head.elif_}
+    chains = []
+    for head in all_ifs:
+        if id(head) in continuations:
+            continue
+        names = [name for arm in arms(head) for name in _provider_names_compared(arm.test)]
+        if names:
+            chains.append((head.lineno, names))
+    return chains
+
+
+def _check_every_listable_provider_has_model_field_copy(providers, template_source) -> None:
+    """Fail at import if the Model field's copy does not branch per listable provider.
+
+    The third sibling, guarding the third way this surface misreports. The
+    lister check keeps the picker fillable and the endpoint check keeps the host
+    name right; this one keeps the *sentences around them* attached to the
+    provider they are true of. `{% if provider == 'ollama' %}…{% else %}…` was
+    the shape here before, and it is the same mistake the hardcoded
+    `OLLAMA_DEFAULT_BASE_URL` was: correct only while the set has exactly two
+    members, and a flat misreport the moment a third joins — an else arm telling
+    that third provider's users their endpoint "answered without an API key".
+
+    So the shipped template is parsed, and every `if`/`elif` chain in it that
+    compares `provider` to a literal must — on its own — give each listable
+    provider exactly one arm and no other provider any. Per chain, not in total:
+    totals are what the likely mistake slips past, because the template branches
+    on the provider in four separate places and copy written at one chain and
+    dropped from another leaves those renders showing that provider nothing
+    while the totals still balance. Both directions at every chain, too. An
+    unbranched listable provider has no copy there; an arm for a provider that is
+    not listable is copy no render reaches, which the next edit to
+    `MODEL_LISTING_PROVIDERS` would silently adopt without anyone re-reading it;
+    a provider with two arms in one chain has a second one nothing can reach.
+    At least one such chain has to exist, too: a per-chain rule has nothing left
+    to fail on once every arm has been flattened back into shared prose.
+
+    Parsed rather than matched over the file's text, and that is what makes "an
+    arm" mean an arm. Jinja drops `{# … #}` in the lexer, so a name that appears
+    only in the header comment above the markup is not seen here at all: it
+    cannot stand in for an arm nobody wrote, and — the other direction, and the
+    live one, since that comment already spends a paragraph explaining these
+    chains — a comment that quotes one of these tests cannot fail the build, nor
+    accuse a provider whose arms are all present.
+
+    What it does NOT check, and cannot: whether the copy inside an arm is *true*
+    of that provider. An arm could name the other provider's endpoint, or say
+    "installed" about a published catalogue, and this would pass. Nor does it
+    ask that per-provider copy live inside one of these chains — a sentence
+    written outside every `provider` chain is a sentence this never sees. Like its
+    siblings it is a shape rule over the shipped file, evaluated once at import.
+    It forces a maintainer to write a sentence at each site it can see; a
+    reviewer is what makes the sentence right.
+    """
+    location = f"verinote/web/templates/{_MODEL_FIELD_TEMPLATE}"
+    chains = _model_field_provider_chains(template_source)
+    if not chains:
+        raise RuntimeError(
+            f"{location} no longer branches on `provider` anywhere, so either its "
+            "per-provider copy has become prose that claims one provider's listing is "
+            "every provider's, or the arms moved somewhere this check cannot see them: "
+            f"restore the `{{% if provider == '<name>' %}}` chains. Listable: "
+            f"{sorted(providers)}"
+        )
+    faults = []
+    for lineno, names in chains:
+        missing = sorted(set(providers) - set(names))
+        unlistable = sorted(set(names) - set(providers))
+        repeated = sorted({name for name in names if names.count(name) > 1})
+        if not (missing or unlistable or repeated):
+            continue
+        fault = f"the chain starting at line {lineno} has arms {names}"
+        if missing:
+            fault += f", missing {missing}"
+        if unlistable:
+            fault += f", arms for providers that are not listable {unlistable}"
+        if repeated:
+            fault += f", unreachable duplicate arms {repeated}"
+        faults.append(fault)
+    if faults:
+        raise RuntimeError(
+            "every `if`/`elif` chain that tests `provider` in "
+            f"{location} must give each listable provider exactly one arm, and no "
+            "other provider any, or those renders show that provider nothing at all. "
+            "Where a chain below is missing one, add `{% elif provider == '<name>' %}` "
+            "to that chain with copy that is true of <name> (what its listing "
+            "enumerates, and what fixes a model missing from it); where it names an "
+            "arm as unlistable or duplicated, delete that arm. Listable: "
+            f"{sorted(providers)}. Wrong: "
+            + "; ".join(faults)
+        )
+
+
 _check_every_listable_provider_has_a_keyless_lister(MODEL_LISTING_PROVIDERS, _MODEL_LISTERS)
+_check_every_listable_provider_names_its_default_endpoint(
+    MODEL_LISTING_PROVIDERS, _LISTABLE_DEFAULT_ENDPOINTS
+)
+_check_every_listable_provider_has_model_field_copy(
+    MODEL_LISTING_PROVIDERS,
+    _TEMPLATES.joinpath(_MODEL_FIELD_TEMPLATE).read_text(encoding="utf-8"),
+)
 
 
-def _list_models_for(cfg: Config, provider: str, base_url: str | None) -> list[str]:
+def _list_models_for(cfg: Config, provider: str, base_url: str | None) -> ModelListing:
     """Enumerate `provider`'s models at `base_url`, handing the lister no key.
 
     This must remain the only place a lister from `_MODEL_LISTERS` is called.
@@ -263,6 +499,18 @@ def _list_models_for(cfg: Config, provider: str, base_url: str | None) -> list[s
     accepted here because dropping the factory call is precisely what puts the
     API key out of the listing seam's reach. A corrupt config.json or an
     unreadable credentials file must still halt before any provider is dialled.
+
+    Settings before credentials, matching `get_client`'s order -- this seam
+    hand-writes what that function centralises, so nothing besides this
+    comment and a test keeps the two surfaces agreeing. The order is
+    observable, not academic: a corrupt config.json falls back to the
+    built-in cloud default, which requires a key, so `credentials_error` can
+    be set on the very same `Config` that carries `settings_error`. Config
+    wins that race because it is the more fundamental failure -- the
+    provider itself could not be resolved, so a credentials verdict for
+    whatever provider *would* have been resolved is not yet meaningful.
+    Swapping these two lines produces zero test failures anywhere else in
+    the suite; see `test_model_field_halts_on_config_first_when_both_errors_are_set`.
     """
     assert_settings_intact(cfg)
     assert_credentials_intact(cfg)
@@ -2034,12 +2282,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
         `lazy=True` returns the not-yet-loaded state without touching the
         network; the partial then fetches itself. Only the eager call reaches
-        the provider, and only for a provider whose installed models are a
-        property of the endpoint the user pointed at.
+        the provider, and only for a provider whose models are enumerable from
+        the endpoint the user pointed at.
 
-        `models` distinguishes three outcomes the UI must not conflate: a list
-        (what that server has, possibly empty), or `None` with `models_error`
-        set (the server could not be asked). `ConfigCorruptError` is left to
+        `models` distinguishes three outcomes the UI must not conflate: a
+        sequence of ids (what that endpoint listed, possibly empty), or `None`
+        with `models_error`
+        set (the endpoint could not be asked). `structured_output_ids` carries a
+        further distinction alongside it, orthogonal to those three — the subset
+        that advertises structured output, or `None` when the listing does not
+        report the property at all (see `ModelListing`), which is why the picker
+        only groups for some providers. `ConfigCorruptError` is left to
         propagate to the app-wide halt handler — a corrupt config.json means the
         resolved provider is untrustworthy, and this route would otherwise
         report on a provider the user never chose (#269).
@@ -2058,22 +2311,26 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             "aliases": MODEL_ALIASES_BY_PROVIDER.get(provider, ()),
             "custom": custom,
             # The URL actually dialled, not the literal "(default)" — so the
-            # page names the same endpoint the adapter will use.
-            "endpoint": (base_url.strip() or OLLAMA_DEFAULT_BASE_URL) if listable else "",
+            # page names the same endpoint the lister will use, per provider.
+            "endpoint": (
+                (base_url.strip() or _LISTABLE_DEFAULT_ENDPOINTS[provider]) if listable else ""
+            ),
             # A provider with nothing to enumerate must not sit in a lazy state
             # forever: it renders its text input once and never self-fetches.
             "lazy": lazy and listable,
             "models": None,
+            "structured_output_ids": None,
             "models_error": None,
         }
         if lazy or not listable:
             return base
         try:
-            base["models"] = _list_models_for(
-                app.state.cfg, provider, base_url.strip() or None
-            )
+            listing = _list_models_for(app.state.cfg, provider, base_url.strip() or None)
         except LLMError as exc:
             base["models_error"] = str(exc)
+            return base
+        base["models"] = listing.models
+        base["structured_output_ids"] = listing.structured_output_ids
         return base
 
     @app.get("/settings/model-field", response_class=HTMLResponse)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -31,7 +31,11 @@ from verinote.config import (
     TESTABLE_PROVIDERS,
     Config,
     ConfigCorruptError,
+    CredentialsCorruptError,
     app_theme,
+    credentials_path,
+    provider_key_env_var,
+    assert_credentials_intact,
     assert_settings_intact,
     normalize_provider,
     save_active_root,
@@ -143,6 +147,11 @@ FACT_TERMS_UNAVAILABLE_PATH = "/fact-terms-unavailable"
 # HX-Redirect treatment as the fact-terms halt for the same htmx reason -- see
 # `_config_corrupt_handler`.
 CONFIG_UNAVAILABLE_PATH = "/config-unavailable"
+
+# Full-page halt shown when the machine-wide credentials file is present but
+# unreadable. A distinct path and page from the config.json halt on purpose: a
+# different file, a different scope (every KB, not one), and a different fix.
+CREDENTIALS_UNAVAILABLE_PATH = "/credentials-unavailable"
 
 # The public action names are deliberately separate from the append-only audit
 # vocabulary. A halt redirect carries both forms through SQLite validation.
@@ -509,6 +518,37 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     app.add_exception_handler(ConfigCorruptError, _config_corrupt_handler)
 
+    def _credentials_corrupt_page(request: Request, reason: str | None):
+        cfg = app.state.cfg
+        provider = cfg.provider if cfg else ""
+        return templates.TemplateResponse(
+            request,
+            "credentials_corrupt.html",
+            {
+                "reason": reason,
+                "credentials_path": str(credentials_path()),
+                "env_var": provider_key_env_var(provider) if provider else "VERINOTE_API_KEY",
+            },
+            status_code=409,
+        )
+
+    @app.get(CREDENTIALS_UNAVAILABLE_PATH, response_class=HTMLResponse)
+    def credentials_unavailable(request: Request):
+        cfg = app.state.cfg
+        return _credentials_corrupt_page(request, cfg.credentials_error if cfg else None)
+
+    def _credentials_corrupt_handler(request: Request, exc: Exception):
+        """Same htmx reasoning as the config halt (#173): a 4xx is never swapped,
+        so an inline body would be a silent no-op."""
+        if request.headers.get("HX-Request") == "true":
+            return Response(
+                status_code=409,
+                headers={"HX-Redirect": CREDENTIALS_UNAVAILABLE_PATH},
+            )
+        return _credentials_corrupt_page(request, str(exc))
+
+    app.add_exception_handler(CredentialsCorruptError, _credentials_corrupt_handler)
+
     def _active_store() -> Store:
         store = app.state.store
         if store is None:
@@ -614,6 +654,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # a provider call in the gap resolve to the silent cloud default. On a
         # raise the old healthy cfg stays active and the caller renders the halt.
         assert_settings_intact(next_cfg)
+        # Deliberately NOT assert_credentials_intact here. That file is
+        # machine-wide and byte-identical before and after the switch, so
+        # refusing the open prevents no provider call that `get_client`, the job
+        # starts and the connection test do not already gate — while making
+        # every KB unopenable, including the one the user would switch to in
+        # order to select a provider that needs no key. The per-KB reasoning
+        # above does not transfer to a machine-wide file.
         next_store = Store(next_cfg.db_path)
         next_store.init_schema()
 
@@ -1117,6 +1164,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # get_client(cfg) below stays as a narrow backstop for the race window
         # between this check and the thread actually running (#269).
         assert_settings_intact(cfg)
+        assert_credentials_intact(cfg)
 
         def run() -> None:
             try:
@@ -1223,7 +1271,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     "extraction job %s already owned by another worker; not started here",
                     job_id,
                 )
-            except ConfigCorruptError as exc:
+            except (ConfigCorruptError, CredentialsCorruptError) as exc:
                 # ORDER IS LOAD-BEARING — above `except Exception`. Defense-in-depth,
                 # NOT a currently-reachable path: the worker's get_client(cfg) reads
                 # the SAME frozen cfg that already passed the synchronous hoist check
@@ -1240,7 +1288,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # consuming this session's MAX_CHUNK_ATTEMPTS retry budget for a cause
                 # unrelated to the source content (#269).
                 logger.warning(
-                    "extraction job %s halted (config.json corrupt): %s", job_id, exc
+                    "extraction job %s halted (%s): %s", job_id, type(exc).__name__, exc
                 )
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:
@@ -1302,7 +1350,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return
         try:
             assert_settings_intact(app.state.cfg)
-        except ConfigCorruptError as exc:
+            assert_credentials_intact(app.state.cfg)
+        except (ConfigCorruptError, CredentialsCorruptError) as exc:
             # Same shape as the policy gate below: launching against a corrupt
             # config must not resume a job that would reach the cloud default with
             # zero HTTP requests made. Log and touch nothing (#269).
@@ -1327,6 +1376,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _start_repair_job(job_id: int, cfg: Config) -> None:
         """Schedule durable repair work; the request path never reaches an LLM."""
         assert_settings_intact(cfg)
+        assert_credentials_intact(cfg)
 
         with app.state.repair_scheduler_lock:
             if job_id in app.state.repair_scheduled:
@@ -1340,6 +1390,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     # Repeat both gates in the worker: settings and policy may have
                     # changed after enqueue but before this daemon gets CPU time.
                     assert_settings_intact(cfg)
+                    assert_credentials_intact(cfg)
                     assert_writable(worker_store)
                     client = get_client(cfg)
                     process_repair_job(
@@ -1349,7 +1400,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             except PolicyMissingError as exc:
                 # Do not write a halted KB merely to annotate a background job.
                 logger.warning("repair job %s halted (KB policy missing): %s", job_id, exc)
-            except ConfigCorruptError as exc:
+            except (ConfigCorruptError, CredentialsCorruptError) as exc:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
                     worker_store.fail_pending_repair_job(job_id, f"repair failed: {exc}")
@@ -1376,8 +1427,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return
         try:
             assert_settings_intact(app.state.cfg)
+            assert_credentials_intact(app.state.cfg)
             assert_writable(app.state.store)
-        except (ConfigCorruptError, PolicyMissingError) as exc:
+        except (ConfigCorruptError, CredentialsCorruptError, PolicyMissingError) as exc:
             logger.warning("not resuming repair jobs: %s", exc)
             return
         for job in app.state.store.repair_jobs_to_resume():
@@ -1807,6 +1859,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # This is intentionally the only synchronous validation. Constructing a
         # client can touch provider configuration; LLM work belongs to the worker.
         assert_settings_intact(cfg)
+        assert_credentials_intact(cfg)
         job, _created = store.enqueue_repair_job(provider=cfg.provider, model=cfg.model)
         if job["status"] == "pending":
             _start_repair_job(int(job["id"]), cfg)
@@ -1936,6 +1989,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "auto_accept_recommendations": c.auto_accept_recommendations,
                 "root": c.root,
                 "has_key": bool(c.api_key),  # never render the key itself
+                # "not set" would assert the user has no key stored; when the
+                # file cannot be read the honest answer is that we do not know.
+                "credentials_error": c.credentials_error,
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
                 "relation_aliases": _relation_aliases_text(),
                 # The Model field starts as the plain text input and, for a

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -7,8 +7,8 @@ swaps a single row partial). No JS build step. The app owns one `Store` (SQLite)
 
 from __future__ import annotations
 
-from dataclasses import replace
 from importlib import resources
+import inspect
 import json
 import logging
 import os
@@ -49,7 +49,10 @@ from verinote.config import (
 from verinote.kb_location import KBLocationError, assert_kb_root_is_safe_to_create
 from verinote.llm import MIN_REDACTABLE_SECRET, LLMError, get_client
 from verinote.llm.claude_cli_adapter import CLI_MODEL_ALIASES
-from verinote.llm.ollama_adapter import OLLAMA_DEFAULT_BASE_URL
+from verinote.llm.ollama_adapter import (
+    OLLAMA_DEFAULT_BASE_URL,
+    list_models as _list_ollama_models,
+)
 from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
 from verinote.pipeline import (
     create_chunked_extraction_job,
@@ -142,6 +145,132 @@ _POLICY_GUARD_WRITE_PATHS = ("/kb/select", "/settings/root")
 # modules, which import `config`, so this is the layer that can name both.
 MODEL_ALIASES_BY_PROVIDER = {"claudecli": CLI_MODEL_ALIASES}
 
+# `list_models` is an interactive page-load call, not a generation, so it is
+# bounded far tighter than `cfg.llm_timeout_seconds` (minutes, sized for a long
+# local completion). It is provider-neutral on purpose: `_list_models_for`
+# applies it to every lister, so it bounds any interactive model listing rather
+# than Ollama's in particular, and it lives here because this dispatch is the
+# last place that still holds a `Config` to clamp against. The effective bound
+# stays the *smaller* of the two so a user who configures an even shorter
+# timeout keeps it.
+MODEL_LIST_TIMEOUT_SECONDS = 5.0
+
+# How each listable provider's models are enumerated. Every lister takes
+# `(base_url, timeout)` and NOTHING else — in particular never a `Config`.
+#
+# That signature is a security control, not a convention. `/settings/model-field`
+# dials an endpoint the caller supplied in a query string, and `Config` carries a
+# resolved `api_key`; worse, it is the key of the *saved* provider, because
+# `Config.for_root` resolves it once and `dataclasses.replace(provider=...)` does
+# not recompute it. Handing that object to a listing routine would mean one
+# request could send, say, an Anthropic key to an attacker-named URL.
+#
+# What the check below buys, stated exactly, because an over-claim here is worse
+# than no comment at all: nothing in the *shipped* table can be handed a key at
+# the call site. Parameter names alone would not get that far — a
+# `functools.partial(keyed_lister, cfg)`, a closure over a `Config`, and an
+# object whose `__call__` takes `(base_url, timeout)` each present exactly the
+# right parameters while carrying a key — so the check also demands a plain,
+# non-closing function.
+#
+# Two things it does NOT buy, and neither is closed anywhere else:
+#   1. It runs once at import, over the table as shipped — not at dispatch.
+#      A test's `monkeypatch.setitem`, or any other runtime mutation of this
+#      dict, is never seen by it; `_list_models_for` dispatches whatever it
+#      finds there at call time.
+#   2. It constrains what a lister is *handed*, never what its body can *reach*.
+#      One line of `os.environ[...]` or `Config.for_root(...)` inside a lister
+#      would put a key back within reach and still pass every clause.
+#
+# So this is a *weaker* control than the corrupt-config halt in `get_client`, and
+# deliberately not the same argument (#269): that assert is the unavoidable first
+# statement of the only construction path, which protects every caller by
+# construction, whereas this is a shape rule evaluated once at import over one
+# dict. The trade was accepted because dropping the `get_client` call is itself
+# what puts the API key out of this seam's reach — the check exists to keep an
+# ordinary-looking edit from quietly undoing that, not to make it unconditional.
+_MODEL_LISTERS = {"ollama": _list_ollama_models}
+# The parameter names every lister must have, checked below rather than trusted.
+_LISTER_SIGNATURE = ("base_url", "timeout")
+
+
+def _check_every_listable_provider_has_a_keyless_lister(providers, listers) -> None:
+    """Fail at import if the listing table and `MODEL_LISTING_PROVIDERS` disagree.
+
+    Both directions matter and for different reasons. A provider in
+    `MODEL_LISTING_PROVIDERS` with no lister would render a picker that can
+    never fill; a lister for a provider not declared listable is dead code that
+    a later edit could wire up without passing this gate.
+
+    The shape clauses are the half that keeps "keyless" a fact about the shipped
+    table rather than a claim in a comment. Each rejects a different way to smuggle
+    a `Config` in: a `cfg` parameter (caught by the names), a `functools.partial`
+    or a callable object that has already bound one (caught by `isfunction`), and
+    a closure cell holding one (caught by `__closure__`). The clauses run in that
+    order so `__closure__` is only read off something that has one. The names are
+    read with `follow_wrapped=False` because `inspect.signature` otherwise reports
+    the parameters of `__wrapped__`, which a lister that really takes a `cfg` can
+    set to a two-parameter decoy. What none of them constrain is a body that
+    *reaches* a key it was never handed, and none of them see the table after
+    import — see the comment above.
+    """
+    missing = set(providers) ^ set(listers)
+    if missing:
+        raise RuntimeError(
+            "every listable provider needs exactly one model lister and vice versa: "
+            f"{sorted(missing)}"
+        )
+    not_plain = sorted(name for name, fn in listers.items() if not inspect.isfunction(fn))
+    if not_plain:
+        raise RuntimeError(
+            "a model lister must be a plain function, not a functools.partial, a "
+            "callable object, a bound method, or a builtin: each of those can already "
+            f"hold a Config that its parameter names never mention: {not_plain}"
+        )
+    closing = sorted(name for name, fn in listers.items() if fn.__closure__ is not None)
+    if closing:
+        raise RuntimeError(
+            "a model lister must not close over anything: a closure cell can hold a "
+            f"Config that its parameter names never mention: {closing}"
+        )
+    wrong = sorted(
+        name
+        for name, fn in listers.items()
+        if tuple(inspect.signature(fn, follow_wrapped=False).parameters) != _LISTER_SIGNATURE
+    )
+    if wrong:
+        raise RuntimeError(
+            f"a model lister must take exactly {_LISTER_SIGNATURE} so it cannot be "
+            f"handed an API key: {wrong}"
+        )
+
+
+_check_every_listable_provider_has_a_keyless_lister(MODEL_LISTING_PROVIDERS, _MODEL_LISTERS)
+
+
+def _list_models_for(cfg: Config, provider: str, base_url: str | None) -> list[str]:
+    """Enumerate `provider`'s models at `base_url`, handing the lister no key.
+
+    This must remain the only place a lister from `_MODEL_LISTERS` is called.
+    Nothing enforces that; it is an invariant maintainers have to uphold, and
+    the safety argument rests on it — a second call site could reach a lister
+    without the two halts below, so a lister added later would be dialled
+    unguarded.
+
+    Those halts are hand-written per-route: exactly the enumeration #269 was
+    able to avoid, because it centralised both asserts in `get_client` as that
+    function's first act, protecting every caller by construction. That cost is
+    accepted here because dropping the factory call is precisely what puts the
+    API key out of the listing seam's reach. A corrupt config.json or an
+    unreadable credentials file must still halt before any provider is dialled.
+    """
+    assert_settings_intact(cfg)
+    assert_credentials_intact(cfg)
+    return _MODEL_LISTERS[provider](
+        base_url, min(cfg.llm_timeout_seconds, MODEL_LIST_TIMEOUT_SECONDS)
+    )
+
+
 # Full-page halt shown when a fact's logical terms cannot be read. htmx partial
 # swaps are redirected here (HX-Redirect) because htmx will not swap an error
 # response into the DOM -- see `_fact_terms_unreadable_handler`.
@@ -180,9 +309,14 @@ _SAFE_FETCH_SITES = frozenset({"same-origin", "none"})
 # issued but unreadable, and gating navigation would 403 an ordinary inbound
 # link. The exception is keyed on "does this dial a caller-supplied endpoint",
 # not on "does this mutate" — `/settings/model-field` takes `base_url` from the
-# query string and builds a client from it. That is a blind SSRF probe today
-# because only Ollama is listable and it sends no key; the moment a keyed
-# provider joins MODEL_LISTING_PROVIDERS it becomes one-request key exfiltration.
+# query string and dials it. `_MODEL_LISTERS` is what keeps that a blind SSRF
+# probe rather than key exfiltration, by handing the listing seam no key and
+# building no client that holds one — narrower than "no way to hold a key",
+# since an import-time shape rule cannot stop a lister body from going and
+# fetching one (see `_MODEL_LISTERS`). This guard is the separate, weaker
+# control that stops another site from provoking the probe at all. Neither
+# substitutes for the other, which is why this path stays listed even though
+# the listing is handed no key.
 _ORIGIN_GUARD_GET_PATHS = ("/settings/model-field",)
 
 
@@ -1934,13 +2068,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         }
         if lazy or not listable:
             return base
-        # Routed through the factory, never by constructing the adapter here, so
-        # this path inherits the corrupt-config halt every provider call gets.
-        client = get_client(
-            replace(app.state.cfg, provider=provider, base_url=base_url.strip() or None)
-        )
         try:
-            base["models"] = client.list_models()
+            base["models"] = _list_models_for(
+                app.state.cfg, provider, base_url.strip() or None
+            )
         except LLMError as exc:
             base["models_error"] = str(exc)
         return base

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -222,6 +222,17 @@ _LISTABLE_DEFAULT_ENDPOINTS = {
     "openrouter": OPENROUTER_DEFAULT_BASE_URL,
 }
 
+# The providers a provider CHANGE clears the Base URL for (see `model_field`).
+# A set named here rather than a literal at the decision site, so the rule can be
+# checked against `MODEL_LISTING_PROVIDERS` at import: the clear renders a note
+# naming the endpoint that would be dialled instead, and `_model_field_context`
+# fills `endpoint` only for a listable provider. So a clearing provider that is
+# not listable renders that sentence around an empty `<code></code>` — the same
+# misreport `_check_every_listable_provider_names_its_default_endpoint` rejects a
+# blank entry for, arriving through a door that check does not watch, since a
+# one-line edit to either set opens it.
+_BASE_URL_CLEARING_PROVIDERS = frozenset({"openrouter"})
+
 # The Model field's copy is not shared prose: what a listing IS differs per
 # provider (an installed set on a machine the user controls, versus a published
 # catalogue read with no key), so the partial branches on the provider name and
@@ -474,6 +485,62 @@ def _check_every_listable_provider_has_model_field_copy(providers, template_sour
         )
 
 
+def _check_every_clearing_provider_can_name_its_replacement(clearing, listable) -> None:
+    """Fail at import if a Base-URL-clearing provider has no endpoint to name.
+
+    The fourth sibling, and the subset relation is the whole of it: every
+    provider that clears the Base URL must be one whose models are listable.
+    Not because the clear needs a listing, but because of what the clear must
+    SAY. Taking the field away means the next Save stores no Base URL, so the
+    note has to name what verinote would dial instead — and `endpoint` is filled
+    by `_model_field_context` only for a provider in `MODEL_LISTING_PROVIDERS`.
+    A clearing provider outside that set renders the sentence "verinote would
+    dial <label>'s own <code></code> instead": a promise about the endpoint with
+    the endpoint missing, which is the misreport the blank-entry clause of
+    `_check_every_listable_provider_names_its_default_endpoint` already rejects,
+    reached here by a different door — a one-line edit to either set.
+
+    One direction only, unlike its siblings. A listable provider that does NOT
+    clear is the normal case and the one Ollama is: clearing on every switch
+    would wipe an endpoint the user typed. So this must stay a subset test, never
+    a symmetric difference.
+
+    Raised rather than asserted so `python -O` cannot strip it, matching its
+    siblings.
+    """
+    stray = sorted(set(clearing) - set(listable))
+    if stray:
+        raise RuntimeError(
+            "a provider that clears the Base URL must be one whose models are "
+            "listable, because the note the clear renders names the default "
+            "endpoint that would be dialled instead and only a listable provider "
+            f"has one to name: {stray}"
+        )
+
+
+# The clearing check goes first: the only edit that can reach it while the three
+# below still pass is one to `_BASE_URL_CLEARING_PROVIDERS`, and the one that can
+# reach it while they do NOT — narrowing `MODEL_LISTING_PROVIDERS` — has to be
+# seen here before the table checks reject the same narrowing under their own
+# names. That ordering is also what lets a test prove this call site exists.
+#
+# Invariant these four call sites hold, and how to re-establish it: deleting any
+# one call site, on its own, must make exactly one module-body test fail — the
+# one below that pins THAT guard (`test_the_module_body_runs_the_clearing_provider_check`,
+# `test_the_module_body_runs_the_check` for the keyless-lister guard,
+# `test_the_module_body_runs_the_default_endpoint_check`,
+# `test_the_module_body_runs_the_model_field_copy_check`). This is not
+# self-enforcing — nothing here runs that matrix automatically — so it is only
+# as true as the last time someone ran it by hand. It failed silently once
+# already: a sibling guard raised on the same narrowed fixture the lister
+# check's test used, on a message that happened to name the same provider, so
+# the lister test kept passing for the wrong reason for two commits. Adding a
+# guard, deleting one, or reordering these calls means re-running the
+# delete-one-at-a-time matrix by hand, because a sibling raising on the same
+# fixture can silently make a neighbour's test vacuous.
+_check_every_clearing_provider_can_name_its_replacement(
+    _BASE_URL_CLEARING_PROVIDERS, MODEL_LISTING_PROVIDERS
+)
 _check_every_listable_provider_has_a_keyless_lister(MODEL_LISTING_PROVIDERS, _MODEL_LISTERS)
 _check_every_listable_provider_names_its_default_endpoint(
     MODEL_LISTING_PROVIDERS, _LISTABLE_DEFAULT_ENDPOINTS
@@ -2340,19 +2407,60 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         model: str = "",
         base_url: str = "",
         custom: int = 0,
+        provider_changed: int = 0,
     ):
+        """The Model field, or — on a provider change — Model plus Base URL.
+
+        `provider_changed=1` is the provider select's request, and it is the only
+        one that renders the wrapper. Deliberately this route under a query
+        parameter rather than a route of its own: `_ORIGIN_GUARD_GET_PATHS` lists
+        this exact path because it dials a caller-supplied `base_url`, and a
+        sibling path would fall outside that guard.
+
+        Switching to OpenRouter clears the Base URL, because that field's only
+        job is to point verinote at a different endpoint and the endpoint being
+        left belongs to the provider being left — `http://localhost:11434` is not
+        an OpenRouter endpoint. Only OpenRouter: clearing on every switch would
+        wipe an Ollama user's endpoint whenever they touched the provider select.
+        Which providers those are is `_BASE_URL_CLEARING_PROVIDERS`, named as a
+        set so the import-time check can hold it inside the listable ones — the
+        note below has an endpoint to name only for a listable provider.
+
+        The clear lives here and not in the template because it must happen on a
+        provider CHANGE and never on a page load. `_settings` renders this same
+        context, so a template-side rule would blank a KB whose config.json
+        really does name a proxy — the page misreporting the KB's own state.
+
+        And it is announced, not silent: `POST /settings` maps `base_url or None`,
+        so Save on an empty field destroys the stored value. `discarded_base_url`
+        carries what the field held into the note, which says plainly that this is
+        a proposal until Save and what would be dialled instead.
+        """
         if app.state.cfg is None:
             return _kb_select(request)
+        provider = normalize_provider(provider)
+        clears_base_url = bool(provider_changed) and provider in _BASE_URL_CLEARING_PROVIDERS
+        discarded_base_url = base_url.strip() if clears_base_url else ""
+        if clears_base_url:
+            base_url = ""
+        context = _model_field_context(
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            lazy=False,
+            custom=bool(custom),
+        )
+        if not provider_changed:
+            return templates.TemplateResponse(request, "partials/model_field.html", context)
         return templates.TemplateResponse(
             request,
-            "partials/model_field.html",
-            _model_field_context(
-                provider=normalize_provider(provider),
-                model=model,
-                base_url=base_url,
-                lazy=False,
-                custom=bool(custom),
-            ),
+            "partials/provider_fields.html",
+            {
+                **context,
+                "base_url": base_url,
+                "discarded_base_url": discarded_base_url,
+                "provider_label": PROVIDER_LABELS.get(provider, provider),
+            },
         )
 
     def _settings(request: Request, *, test_result=None, error=None, status_code=200):

--- a/verinote/web/static/app.css
+++ b/verinote/web/static/app.css
@@ -412,3 +412,8 @@ tr.editing td { background: var(--editing-bg); }
   );
 }
 .progress-failed { background: var(--danger); }
+/* One block per provider in the API keys section. Each carries its own form, so
+   the rows need visible separation or the Save buttons read as one control. */
+.key-row { border-top: 1px solid var(--line); padding: .7rem 0; }
+.key-row .key-form { margin: .4rem 0 0; max-width: 32rem; }
+.key-row .warn-inline { display: block; margin: .3rem 0 0; }

--- a/verinote/web/templates/base.html
+++ b/verinote/web/templates/base.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}verinote{% endblock %}</title>
   <script src="/static/htmx.min.js"></script>
-  <link rel="stylesheet" href="/static/app.css?v=6">
+  <link rel="stylesheet" href="/static/app.css?v=7">
 </head>
 <body>
   <header>

--- a/verinote/web/templates/config_corrupt.html
+++ b/verinote/web/templates/config_corrupt.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Config unreadable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=6">
+  <link rel="stylesheet" href="/static/app.css?v=7">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/credentials_corrupt.html
+++ b/verinote/web/templates/credentials_corrupt.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="{{ theme }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Stored keys unreadable — verinote</title>
+  <link rel="stylesheet" href="/static/app.css?v=6">
+</head>
+<body>
+  <main class="chooser">
+    <h1>Halted: the stored API keys could not be read</h1>
+
+    {# Deliberately a separate page from the config.json halt. That one is about
+       one KB's provider choice and is cleared by re-saving a provider; this is a
+       machine-wide secrets file, shared by every KB, and re-saving a provider
+       does not touch it. Telling the user the wrong file and a fix that does
+       nothing would be worse than saying less. #}
+    <p class="error" role="alert">verinote found a credentials file it could not
+      read, so it refused to proceed rather than treating your saved keys as
+      absent and calling a provider unauthenticated.{% if reason %} ({{ reason }}){% endif %}</p>
+
+    <p class="muted">The file is
+      <code>{{ credentials_path }}</code>. It is not inside any knowledge base —
+      no KB is affected, and every KB sees this same halt. Recover by restoring
+      it from a backup, or by deleting it. Writing to it is refused while it is
+      unreadable, because a write merges into the other providers' entries and
+      would silently discard them.</p>
+
+    <p class="muted">You can also work around it without touching the file:
+      export <code>{{ env_var }}</code> for the provider you are using, or switch
+      to a provider that needs no key.</p>
+
+    <p><a href="/settings">Settings</a> · <a href="/">Dashboard</a></p>
+  </main>
+</body>
+</html>

--- a/verinote/web/templates/credentials_corrupt.html
+++ b/verinote/web/templates/credentials_corrupt.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Stored keys unreadable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=6">
+  <link rel="stylesheet" href="/static/app.css?v=7">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/kb_select.html
+++ b/verinote/web/templates/kb_select.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Select KB — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=6">
+  <link rel="stylesheet" href="/static/app.css?v=7">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/partials/model_field.html
+++ b/verinote/web/templates/partials/model_field.html
@@ -1,18 +1,57 @@
 {# The Model field of the LLM provider form, swapped in place by HTMX whenever
    the chosen provider or base URL changes.
 
-   For Ollama the installed models ARE enumerable from the endpoint the user
-   pointed at (`GET /api/tags`), so the field is a picker over what that server
-   actually has rather than free text a typo turns into a runtime failure. Every
-   other provider keeps the text input: a cloud catalogue is not a property of
-   the endpoint, so there is nothing truthful to enumerate there.
+   Two providers are enumerable from the endpoint the user pointed at, so the
+   field is a picker there rather than free text a typo turns into a runtime
+   failure. For Ollama the models installed on that server are what is
+   enumerated (`GET /api/tags`); for OpenRouter it is the catalogue the endpoint
+   being configured publishes (`GET {base_url}/models`, unauthenticated). No
+   other provider's field is a discovery: `claudecli` has no listing at all (its
+   options below are curated from the adapter, which the wording says), and a
+   vendor's catalogue is not otherwise a property of the endpoint being
+   configured, so `anthropic` and `openai` keep the text input.
+   `MODEL_LISTING_PROVIDERS` in `config.py` states the same rule.
 
-   Three states, kept distinct on purpose (#state-honesty): a reachable server
-   WITH models becomes a picker; a reachable server with NO models pulled and an
-   UNREACHABLE server both fall back to the text input plus a note saying which
-   of the two happened. An empty picker would look like a normal empty field and
-   quietly claim "your server offers nothing to choose", which is a different
-   statement from "your server could not be reached".
+   The two listings are not the same claim, so the wording differs and every
+   sentence that depends on which one it is sits in a named arm. Ollama's is
+   about a machine the user controls, where a missing model is fixed with
+   `ollama pull`. OpenRouter's was read with no API key: it is what the catalogue
+   publishes, not what this user's account may call, and `ollama pull` would be
+   nonsense advice.
+
+   Each of those chains names both providers and has no catch-all `{% else %}`,
+   which is the point: an else arm would hand its copy to whatever listable
+   provider joins next, telling that provider's users their endpoint "answered
+   without an API key" -- the same failure the hardcoded default endpoint was,
+   one provider later. Nothing here can notice that on its own, so
+   `_check_every_listable_provider_has_model_field_copy` in `web/app.py` parses
+   this file at import and refuses to start unless every chain that branches on
+   `provider` gives each listable provider exactly one arm. It walks the parsed
+   arms rather than the file's text, so a provider named in a comment -- this
+   one included -- is neither counted as an arm nor mistaken for a missing one.
+   Renaming a provider, or adding a chain, means updating the arms together or
+   that check fails, naming the file, the chain's line, and what is missing from
+   it.
+
+   What that check does not do is forbid the `{% else %}` these chains leave out;
+   the absence above is a convention. What it forbids is a listable provider with
+   no arm of its own, which is the half an else arm would otherwise paper over.
+   Nor can it tell whether an arm's sentences are true of the provider named on
+   that arm; that is a reviewer's job.
+
+   Three states, kept distinct on purpose (#state-honesty): a reachable endpoint
+   WITH models becomes a picker; a reachable endpoint listing NOTHING and an
+   UNREACHABLE one both fall back to the text input plus a note saying which of
+   the two happened. An empty picker would look like a normal empty field and
+   quietly claim "there is nothing to choose", which is a different statement
+   from "that endpoint could not be reached".
+
+   A listing that reports which models advertise structured output is grouped
+   into two <optgroup>s; one that does not (Ollama) stays flat. The two are told
+   apart by `structured_output_ids` being `None` rather than empty, so "this
+   listing does not say" never renders as "none of them advertise it". Both
+   groups are rendered whenever the property IS reported, even if one is empty:
+   an empty group under its heading is itself the honest answer.
 
    The Claude CLI has no listing to read -- its `--model` help documents three
    aliases and otherwise takes a full model id -- so its options are curated,
@@ -36,29 +75,64 @@
   <label>Model
     <select name="model">
       {% if model and model not in models %}
-      {# Never drop the configured model just because this server lacks it: the
+      {# Never drop the configured model just because this listing lacks it: the
          KB's config.json really does name it, and silently selecting a
          different model would make the page misreport the KB's own state. Show
-         it, keep it selected, and say plainly that it is not installed. #}
-      <option value="{{ model }}" selected>{{ model }} — not installed</option>
+         it, keep it selected, and say plainly what the listing said about it --
+         which is a different sentence per provider, so it is not "not
+         installed" everywhere. Outside the groups below on purpose: the listing
+         said nothing about this id, so it belongs under neither heading. #}
+      <option value="{{ model }}" selected>{{ model }}{% if provider == 'ollama' %} — not installed{% elif provider == 'openrouter' %} — not in this catalogue{% endif %}</option>
       {% endif %}
+      {% if structured_output_ids is none %}
       {% for m in models %}
       <option value="{{ m }}" {{ 'selected' if m == model else '' }}>{{ m }}</option>
       {% endfor %}
+      {% else %}
+      <optgroup label="Advertises structured output">
+        {% for m in models if m in structured_output_ids %}
+        <option value="{{ m }}" {{ 'selected' if m == model else '' }}>{{ m }}</option>
+        {% endfor %}
+      </optgroup>
+      <optgroup label="Does not advertise structured output">
+        {% for m in models if m not in structured_output_ids %}
+        <option value="{{ m }}" {{ 'selected' if m == model else '' }}>{{ m }}</option>
+        {% endfor %}
+      </optgroup>
+      {% endif %}
     </select>
   </label>
   <p class="muted field-note">
+    {% if provider == 'ollama' %}
     {{ models|length }} model{{ '' if models|length == 1 else 's' }} installed on
     <code>{{ endpoint }}</code>.
+    {% elif provider == 'openrouter' %}
+    {{ models|length }} model{{ '' if models|length == 1 else 's' }} listed by
+    <code>{{ endpoint }}</code>, which answered without an API key — so this is the
+    catalogue it publishes, not a list of what your account can reach. The two
+    groups repeat what each entry declares in its <code>supported_parameters</code>;
+    verinote has not run any of them. The distinction matters because verinote
+    asks for a JSON-schema <code>response_format</code> on every call that has to
+    come back as JSON — extraction, query translation, query intent — so a model
+    in the second group is being asked for something its own entry does not
+    advertise.
+    {% endif %}
     <button class="btn ghost" type="button"
             hx-get="/settings/model-field"
             hx-include="[name='provider'], [name='base_url'], [name='model']"
             hx-target="#model-field" hx-swap="outerHTML">Refresh list</button>
   </p>
   {% if model and model not in models %}
+  {% if provider == 'ollama' %}
   <p class="warn field-note" role="alert">This KB is configured for
     <code>{{ model }}</code>, which is not installed on <code>{{ endpoint }}</code>.
     Pick an installed model, or run <code>ollama pull {{ model }}</code>.</p>
+  {% elif provider == 'openrouter' %}
+  <p class="warn field-note" role="alert">This KB is configured for
+    <code>{{ model }}</code>, which <code>{{ endpoint }}</code> did not list. It stays
+    selected because this KB's config.json names it; pick a listed model to change
+    that.</p>
+  {% endif %}
   {% endif %}
   {% elif aliases and not custom %}
   <label>Model
@@ -111,6 +185,7 @@
             hx-target="#model-field" hx-swap="outerHTML">Retry</button>
   </p>
   {% elif models is not none %}
+  {% if provider == 'ollama' %}
   <p class="warn field-note" role="alert"><code>{{ endpoint }}</code> is reachable but
     has no models installed. Run <code>ollama pull &lt;model&gt;</code>, then
     <button class="btn ghost" type="button"
@@ -118,8 +193,19 @@
             hx-include="[name='provider'], [name='base_url'], [name='model']"
             hx-target="#model-field" hx-swap="outerHTML">refresh the list</button>.
   </p>
+  {% elif provider == 'openrouter' %}
+  <p class="warn field-note" role="alert"><code>{{ endpoint }}</code> is reachable but
+    listed no models, so the model must be typed in.
+    <button class="btn ghost" type="button"
+            hx-get="/settings/model-field"
+            hx-include="[name='provider'], [name='base_url'], [name='model']"
+            hx-target="#model-field" hx-swap="outerHTML">refresh the list</button>
+  </p>
+  {% endif %}
   {% elif lazy %}
-  <p class="muted field-note" role="status">Loading installed models…</p>
+  {# Not "installed": this state is shared with a provider whose listing is a
+     published catalogue, where nothing is installed anywhere. #}
+  <p class="muted field-note" role="status">Loading the model list…</p>
   {% endif %}
   {% endif %}
 </div>

--- a/verinote/web/templates/partials/provider_fields.html
+++ b/verinote/web/templates/partials/provider_fields.html
@@ -1,0 +1,57 @@
+{# The two fields a provider change can invalidate — Model and Base URL — plus a
+   note naming anything that change is proposing to throw away.
+
+   It is a wrapper because of where the swap has to land. The Model field alone
+   was `#model-field`, so a provider change could only ever reach the Model
+   field; clearing the Base URL means the provider select must swap a region
+   that contains BOTH. The provider `<select>` itself stays outside this div on
+   purpose: swapping it would destroy the focused control mid-interaction, and
+   in Firefox a keyboard user arrowing through the options fires `change` per
+   arrow, so each arrow key would replace the element being arrowed.
+
+   The Base URL input keeps its own `hx-trigger="change"` aimed at the inner
+   `#model-field`, exactly as before, so editing it re-renders only the Model
+   field and never the element being typed into. That is also what keeps
+   `name="base_url"` present exactly once after any swap: this wrapper is served
+   only for a provider change, and the base-URL-triggered swap gets the Model
+   field partial, which has no base_url input to duplicate.
+
+   Served by `GET /settings/model-field?provider_changed=1`, not by a route of
+   its own. `_ORIGIN_GUARD_GET_PATHS` lists that exact path because it dials a
+   caller-supplied `base_url`; a sibling path would be an ungated caller-URL
+   dialer, which is precisely what that guard exists to stop.
+
+   The discard note below is deliberately NOT a per-provider `if` chain. Which
+   provider clears the Base URL is decided in `model_field` in `web/app.py`, and
+   every provider-specific noun in the sentence — the label, the endpoint that
+   would be dialled instead — is a context value the route filled in for the
+   provider it actually decided about. So the sentence is true of whatever
+   provider is cleared, and there is no arm here for
+   `_check_every_listable_provider_has_model_field_copy` to demand: that check
+   reads `model_field.html`, where the copy really is a claim about a specific
+   provider's listing. Pointing it at this file would refuse startup outright,
+   since it raises when a file it checks branches on `provider` nowhere.
+
+   Why the note has to exist at all: `POST /settings` maps `base_url or None`,
+   so an empty field DESTROYS the stored value. Between this clear and Save,
+   the page would otherwise show an empty Base URL while config.json still holds
+   one — the page misreporting the state it is supposed to report. Same
+   resolution as the Model field one line up, where a configured model missing
+   from a listing is shown and named rather than silently dropped. #}
+<div id="provider-fields">
+  {% include "partials/model_field.html" %}
+  <label>Base URL <span class="muted">(optional)</span>
+    <input type="text" name="base_url" value="{{ base_url }}" placeholder="https://…"
+           hx-get="/settings/model-field" hx-trigger="change"
+           hx-include="[name='provider'], [name='model']"
+           hx-target="#model-field" hx-swap="outerHTML">
+  </label>
+  {% if discarded_base_url %}
+  <p class="warn field-note" role="alert">The Base URL field held
+    <code>{{ discarded_base_url }}</code>, and switching to {{ provider_label }}
+    cleared it. Nothing has been saved yet — this is what <strong>Save</strong>
+    would store: no Base URL, so verinote would dial {{ provider_label }}'s own
+    <code>{{ endpoint }}</code> instead. Type <code>{{ discarded_base_url }}</code>
+    back in above to keep it.</p>
+  {% endif %}
+</div>

--- a/verinote/web/templates/policy_halted.html
+++ b/verinote/web/templates/policy_halted.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Verification halted — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=6">
+  <link rel="stylesheet" href="/static/app.css?v=7">
 </head>
 <body>
   <main class="chooser">

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -88,17 +88,70 @@
   <button class="btn" type="submit">Save</button>
 </form>
 
-{# Deliberately says only whether a key resolved, not where it came from: with
-   three possible sources naming one would be a guess. The per-provider source
-   breakdown is the next unit's work. #}
-{% if credentials_error %}
+<h2>API keys</h2>
+{% if credentials_halting %}
 <p class="warn" role="alert">Your saved API keys could not be read, so verinote
   refuses provider calls rather than treating them as absent. ({{ credentials_error }})
   <a href="/credentials-unavailable">How to recover</a></p>
-<p class="muted">API key: unknown — the stored keys are unreadable</p>
-{% else %}
-<p class="muted">API key: {{ 'set' if has_key else 'not set' }}</p>
+{% elif credentials_error %}
+<p class="warn" role="alert">Your saved API keys could not be read
+  ({{ credentials_error }}), but every provider below is getting its key from the
+  environment, so nothing is being refused. Saving a key stays refused until the
+  file is repaired. <a href="/credentials-unavailable">How to recover</a></p>
 {% endif %}
+<p class="muted">Saved keys are written to this machine's config directory, never
+  into a KB, so a KB stays safe to copy or share. Each provider is separate: a key
+  saved for one is never sent to another.</p>
+{% if not credentials_editable %}
+<p class="warn" role="alert">Saving keys is unavailable while this KB's logic policy
+  is halted. Restore the policy or open another KB.</p>
+{% endif %}
+
+{# One form per provider, not fields inside the big settings form: a key must
+   never ride along with a provider/model save, and a browser offered a password
+   field inside a larger form tends to save the whole thing as a site login.
+   The value is never rendered back, so the input is always empty. #}
+{% for row in provider_keys %}
+<div class="key-row">
+  <strong>{{ row.label }}</strong>
+  {% if row.state == 'not_needed' %}
+    <span class="muted">no API key needed</span>
+  {% else %}
+    {% if row.state == 'env_provider' %}
+      <span class="muted">set from <code>{{ row.env_var }}</code></span>
+      {% if row.shadowed %}
+      <span class="warn-inline">a saved key exists but the environment variable takes precedence</span>
+      {% endif %}
+    {% elif row.state == 'stored' %}
+      <span class="muted">saved in this app</span>
+    {% elif row.state == 'env_global' %}
+      <span class="muted">set from <code>VERINOTE_API_KEY</code> (applies to every provider)</span>
+    {% elif row.state == 'unknown' %}
+      <span class="warn-inline">unknown — the saved keys could not be read</span>
+    {% else %}
+      <span class="muted">not set</span>
+    {% endif %}
+    <form class="settings key-form" action="/settings/credentials" method="post"
+          autocomplete="off">
+      <input type="hidden" name="provider" value="{{ row.provider }}">
+      <label>Key for {{ row.label }}
+        <input type="password" name="api_key" autocomplete="new-password"
+               spellcheck="false" placeholder="leave empty to keep the current one"
+               {% if not credentials_editable %}disabled{% endif %}>
+      </label>
+      <button class="btn" type="submit"
+              {% if not credentials_editable %}disabled aria-disabled="true"{% endif %}>Save key</button>
+    </form>
+    {% if row.stored %}
+    <form class="key-form" action="/settings/credentials/remove" method="post">
+      <input type="hidden" name="provider" value="{{ row.provider }}">
+      <button class="btn ghost" type="submit"
+              {% if not credentials_editable %}disabled aria-disabled="true"{% endif %}>Remove saved key</button>
+    </form>
+    {% endif %}
+  {% endif %}
+</div>
+{% endfor %}
 
 <form class="connection-test" action="/settings/test" method="post"
       hx-post="/settings/test" hx-target="main" hx-select="main" hx-swap="outerHTML"

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -4,7 +4,7 @@
 <h1>Settings</h1>
 <p class="muted">Choose the local KB directory and swap the LLM provider/model
   freely. Non-secret model settings are saved to that KB's <code>config.json</code>;
-  the API key stays in the environment (<code>VERINOTE_API_KEY</code>).</p>
+  the API key is never written into the KB.</p>
 
 {% if settings_error %}
 <p class="warn" role="alert">This KB's <code>config.json</code> is unreadable, so the
@@ -88,7 +88,17 @@
   <button class="btn" type="submit">Save</button>
 </form>
 
-<p class="muted">API key: {{ 'set (from environment)' if has_key else 'not set — export VERINOTE_API_KEY' }}</p>
+{# Deliberately says only whether a key resolved, not where it came from: with
+   three possible sources naming one would be a guess. The per-provider source
+   breakdown is the next unit's work. #}
+{% if credentials_error %}
+<p class="warn" role="alert">Your saved API keys could not be read, so verinote
+  refuses provider calls rather than treating them as absent. ({{ credentials_error }})
+  <a href="/credentials-unavailable">How to recover</a></p>
+<p class="muted">API key: unknown — the stored keys are unreadable</p>
+{% else %}
+<p class="muted">API key: {{ 'set' if has_key else 'not set' }}</p>
+{% endif %}
 
 <form class="connection-test" action="/settings/test" method="post"
       hx-post="/settings/test" hx-target="main" hx-select="main" hx-swap="outerHTML"

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -51,13 +51,18 @@
 <h2>LLM provider</h2>
 <form class="settings" action="/settings" method="post">
   {# Provider and base URL both decide what the Model field can offer, so both
-     re-render it. `hx-include` carries the current model along so switching
-     provider never silently discards what is configured. #}
+     re-render it. `hx-include` carries the current model and base URL along so
+     switching provider never silently discards what is configured — and, for a
+     provider whose Base URL is cleared by the switch, so the response can name
+     what it is proposing to discard. A provider change swaps the whole
+     `#provider-fields` region because it can invalidate the Base URL as well as
+     the Model; this select stays outside that region so the swap never destroys
+     the control being used. #}
   <label>Provider
     <select name="provider"
-            hx-get="/settings/model-field"
+            hx-get="/settings/model-field?provider_changed=1"
             hx-include="[name='base_url'], [name='model']"
-            hx-target="#model-field" hx-swap="outerHTML">
+            hx-target="#provider-fields" hx-swap="outerHTML">
       {% for p in providers %}
       <option value="{{ p }}" {{ 'selected' if p == provider else '' }}>
         {{ provider_labels.get(p, p) }}
@@ -65,13 +70,7 @@
       {% endfor %}
     </select>
   </label>
-  {% include "partials/model_field.html" %}
-  <label>Base URL <span class="muted">(optional)</span>
-    <input type="text" name="base_url" value="{{ base_url }}" placeholder="https://…"
-           hx-get="/settings/model-field" hx-trigger="change"
-           hx-include="[name='provider'], [name='model']"
-           hx-target="#model-field" hx-swap="outerHTML">
-  </label>
+  {% include "partials/provider_fields.html" %}
   <label>Chunk size
     <input type="number" name="extraction_chunk_chars" value="{{ extraction_chunk_chars }}" min="1" step="50">
   </label>

--- a/verinote/web/templates/sidecar_unreadable.html
+++ b/verinote/web/templates/sidecar_unreadable.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fact terms unavailable — verinote</title>
-  <link rel="stylesheet" href="/static/app.css?v=6">
+  <link rel="stylesheet" href="/static/app.css?v=7">
 </head>
 <body>
   <main class="chooser">


### PR DESCRIPTION
Adds OpenRouter as a provider of its own, a place to enter API keys, and a model picker over OpenRouter's catalogue.

## What a user gets

- **OpenRouter is selectable in Settings**, with its own endpoint. It is not `openai` + a `base_url` recipe: under that recipe an unset Base URL resolves to `api.openai.com`, so a user who chose OpenRouter and cleared the field would ship documents to a vendor they never selected.
- **API keys are entered in Settings**, one small form per key-using provider. Keys live in the app config directory (`credentials.json`, mode `0600`), never inside a KB, separated per provider. A provider-scoped environment variable still wins.
- **The Model field is a dropdown for OpenRouter** — 338 models in two groups, *advertises structured output* and *does not*. verinote asks for a JSON-schema `response_format` on every call that must return JSON, so the split is what makes the second group's risk visible.
- **Selecting OpenRouter clears the Base URL**, because the endpoint you are leaving belongs to the provider you are leaving. The clear is announced: a note names the discarded URL, what would be dialled instead, that nothing is saved yet, and how to put it back.

Verified end to end against the real service: a saved key resolved from `stored`, `OpenRouterAdapter` on `https://openrouter.ai/api/v1`, one real extraction returning structured facts including a typed term — so the free default model honours the schema, not merely advertises it.

## The security work, and why a refactor sits in the middle

`GET /settings/model-field` takes `base_url` from a query string. It used to build a client from `get_client(replace(cfg, provider=..., base_url=...))`, and `Config.for_root` resolves `api_key` once for the *saved* provider while `replace(provider=...)` does not recompute it. Measured:

```
saved provider      : anthropic | api_key: sk-ant-SECRET-ANTHROPIC-KEY
after replace(provider='openrouter', base_url='http://evil.example')
api_key CARRIED OVER: sk-ant-SECRET-ANTHROPIC-KEY
```

Nothing stopped that key reaching an attacker-named host except that Ollama's listing happened not to read `cfg.api_key`. OpenRouter is a key-requiring provider, so making it listable is exactly the move the old code comment warned would turn a blind SSRF probe into one-request key exfiltration.

`66c734b` therefore retypes the listing seam to `(base_url, timeout)` before anything is added to it — a lister is handed no `Config`, so it has none to send. Confirmed at the wire with a capture server across three upstream modes, including a key resolved for one provider while listing another: no `Authorization`, and no key in the URL, the HTML, the error text, or the logs.

## Review

Four gates (reviewer, architect, critic, and a plan critique) ran on each commit, with every finding reproduced independently before being accepted. They caught, among others:

- a security comment of mine claiming a guarantee the code did not provide — `functools.partial` and a closure both satisfied the shape check while holding a `Config`. The check was strengthened rather than the words merely weakened, and the residuals it still has are written down.
- a guard added to prevent misreports that was itself misdescribed: a regex over template text, so a provider named only in a comment passed with zero real arms, one illustrative comment line refused startup naming the wrong provider, and moving an arm between chains kept totals equal while the OpenRouter note vanished. It now parses.
- a test whose docstring named a mutation that does not falsify it, and the wiring that invokes the Base-URL feature being untested — three one-attribute edits each left the suite green, one of them silently destroying a configured endpoint.
- the docs asserting "The environment still wins" when a Settings-saved key deliberately outranks `VERINOTE_API_KEY` — a precedence misreport about which credential leaves the machine.

`2397 passed, 12 skipped`; `ruff@0.15.18 check` clean.

## Follow-ups deliberately not in scope

- `POST /settings` stores a whitespace-only Base URL rather than treating it as unset.
- No scheme allowlist on `base_url`; `file://` still reaches the URL opener. Pre-existing, origin-gated, impractical given the appended path.
- A one-click "keep it" in the discard note, so a legitimate OpenRouter proxy need not be retyped after a provider round trip.
- The `__signature__` attribute still spoofs the lister shape check. Unreachable — the call site passes two positional arguments — and nothing in the tree claims otherwise.
