### PR TITLE
fix: catch sqlite3.OperationalError when opening a KB root

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -103,6 +103,23 @@ inside the working tree destroys the KB and its audit log with no undo.
 Moving the default root outside the working tree is tracked in
 [#185](https://github.com/semantic-reasoning/verinote/issues/185).
 
+## Windows: don't launch verinote from an elevated terminal
+
+Opening a KB root the process cannot write to fails with `sqlite3.OperationalError:
+unable to open database file` (caught and rendered as a 400 on the KB-select
+page, not a 500 — but still a hard stop; see `_open_root`'s callers in
+`verinote/web/app.py`). The common cause on Windows: `scripts\run.cmd` (or
+`verinote ui` run directly) was launched from an elevated ("Run as
+Administrator") terminal. A folder created by a full-admin token is owned by
+`BUILTIN\Administrators`, and your normal account only inherits Read+Execute on
+it, not Write — so the KB folder gets created, but `kb.sqlite` inside it
+cannot be. Launch verinote from a normal, non-elevated terminal instead.
+
+If a KB folder already got created this way, either delete the empty folder
+and let a non-elevated launch recreate it, or fix it in place from an elevated
+prompt (only an admin token can grant rights on an Administrators-owned
+object): `icacls <path> /grant <you>:(OI)(CI)F /T`.
+
 ## Backups are your responsibility
 
 verinote takes none. Copy **the whole KB root** — it is a plain folder — on your

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import logging
 import re
+import sqlite3
 import sys
 import threading
 import time
@@ -424,6 +425,27 @@ def test_ui_root_selection_refuses_worktree_descendant_before_initializing(
     assert response.status_code == 400
     assert "inside Git worktree" in response.text
     assert not expected.exists()
+
+
+@pytest.mark.parametrize("path", ["/kb/select", "/settings/root"])
+def test_kb_root_selection_reports_unopenable_db_instead_of_500(tmp_path, path, monkeypatch):
+    """A KB root whose kb.sqlite cannot be opened (e.g. a directory owned by a
+    different account, or a locked file) surfaces as a 400 with a clear message,
+    not an unhandled 500 — sqlite3.OperationalError must be caught alongside
+    KBLocationError/OSError in _open_root's callers (#Windows admin-owned KB dir)."""
+    target = tmp_path / "kb"
+    target.mkdir()
+    client = _client(tmp_path) if path == "/settings/root" else TestClient(create_app())
+
+    def boom(self, db_path):
+        raise sqlite3.OperationalError("unable to open database file")
+
+    monkeypatch.setattr(store_db.Store, "__init__", boom)
+
+    response = client.post(path, data={"root": str(target)}, follow_redirects=False)
+
+    assert response.status_code == 400
+    assert "could not open KB" in response.text
 
 
 def test_dashboard_shows_coverage_gap(tmp_path):

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import sqlite3
 import threading
 from threading import Lock
 import unicodedata
@@ -1905,7 +1906,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 error=f"refused to open KB — its config.json is corrupt: {e}",
                 status_code=400,
             )
-        except (KBLocationError, OSError) as e:
+        except (KBLocationError, OSError, sqlite3.OperationalError) as e:
             return _kb_select(request, error=f"could not open KB: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
 
@@ -2738,7 +2739,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 error=f"refused to open KB — its config.json is corrupt: {e}",
                 status_code=400,
             )
-        except (KBLocationError, OSError) as e:
+        except (KBLocationError, OSError, sqlite3.OperationalError) as e:
             return _settings(request, error=f"could not open KB directory: {e}", status_code=400)
         return RedirectResponse("/", status_code=303)
 


### PR DESCRIPTION
Opening a KB whose kb.sqlite cannot be opened (e.g. a directory owned by a different account, or a locked file) raised an unhandled 500 instead of the existing friendly "could not open KB" 400 response: select_kb and switch_root only caught (KBLocationError, OSError), and sqlite3.OperationalError is not an OSError subclass.

On Windows this is commonly hit by launching the app from an elevated terminal, which leaves a newly-created KB folder owned by BUILTIN\Administrators and unwritable by the normal account. Documented the gotcha and its workaround in docs/operations.md.