### PR TITLE
fix: read 누구/얼마/어디/언제 as interrogatives, not as the relation

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -501,6 +501,34 @@ def test_ask_answers_generic_korean_attribute_question_from_engine(tmp_path):
     assert result.grounding_facts[0].source == "sources/sample-project.txt"
 
 
+def test_ask_answers_a_who_question_from_the_engine_without_a_provider_call(tmp_path):
+    """`X의 <relation>는 누구인가?` is answerable from the KB, and for free.
+
+    The relation is stored under the exact label the question names, so nothing
+    here needs a model: the deterministic reading alone should reach the engine.
+    `DeterministicOnlyClient` raises on every provider entry point, so this fails
+    if the interrogative leaks into the relation candidate and the planner falls
+    through to the UNVERIFIED source-exploration route.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-project.txt")
+    store.add_fact(
+        "샘플프로젝트", "담당자", "샘플인물", status="confirmed", source_id=source_id
+    )
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플프로젝트의 담당자는 누구인가?",
+    )
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "샘플인물" in result.answer
+    assert result.grounding_facts[0].source == "sources/sample-project.txt"
+
+
 def test_ask_does_not_call_stale_fact_terms_verified(tmp_path):
     store = _store(tmp_path)
     source_id = store.add_source("sources/sample-project.txt")

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -415,6 +415,98 @@ def test_generic_korean_attribute_requires_question_shape():
     assert intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
 
 
+# Built as an actual cross-product rather than a hand-written list, so that
+# every added stem really is pinned against every suffix form the rule admits.
+# A hand-list drifts: with `이에요` written out for one stem only, dropping it
+# from the other three fails no test, because the stem that still carries it
+# masks them.
+_KOREAN_INTERROGATIVE_STEMS = (
+    ("샘플프로젝트의 담당자는 누구", ("담당자",)),
+    ("샘플제품의 가격은 얼마", ("가격",)),
+    ("샘플조직의 본사는 어디", ("본사",)),
+    ("샘플프로젝트의 착수일은 언제", ("착수일",)),
+)
+_KOREAN_INTERROGATIVE_QUESTION_FORMS = (
+    "인가?",
+    "인가요?",
+    "입니까?",
+    "예요?",
+    "이에요?",
+    "야?",
+    "?",
+)
+
+
+@pytest.mark.parametrize(
+    ("question", "candidates"),
+    [
+        (stem + form, expected)
+        for stem, expected in _KOREAN_INTERROGATIVE_STEMS
+        for form in _KOREAN_INTERROGATIVE_QUESTION_FORMS
+    ]
+    # The pre-existing stems keep working, including the forms this rule newly
+    # admits on each of them. They are listed separately because they do not
+    # carry the same suffix set as the four added stems.
+    + [
+        ("샘플프로젝트의 목적은 무엇인가요?", PURPOSE_RELATION_CANDIDATES),
+        ("샘플프로젝트의 목적이 뭐인가요?", PURPOSE_RELATION_CANDIDATES),
+        ("샘플프로젝트의 목적이 뭐예요?", PURPOSE_RELATION_CANDIDATES),
+        ("샘플문서의 형식은 어떤 것인가요?", ("형식",)),
+    ],
+)
+def test_korean_attribute_questions_strip_person_place_time_and_amount_words(
+    question, candidates
+):
+    """`누구`/`얼마`/`어디`/`언제` are interrogatives, not part of the relation.
+
+    Stripping only `무엇` left the relation candidate as the entire phrase (e.g.
+    `담당자는 누구`), which no schema can hold, so a question that named its
+    relation exactly still planned no candidates and was answered UNVERIFIED.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+@pytest.mark.parametrize("relation", ["개요", "분야"])
+def test_korean_attribute_label_keeps_a_relation_whose_last_syllable_is_an_ending(
+    relation,
+):
+    """The interrogative strip must not eat a syllable a relation name owns.
+
+    `개요` and `분야` end in `요` and `야`, the two endings the added stems carry
+    that are also ordinary final syllables. Admitting either as an alternative
+    that can match with an empty stem would ask the schema for `개` or `분`, and
+    the question would stop matching its own relation.
+
+    Only the bare form is asserted. Behind a josa the label is protected anyway
+    -- in `개요는 무엇인가요?` the `무엇인가요` wins the end-of-string anchor --
+    so that form cannot fail and would be coverage in name only.
+    """
+    assert deterministic_query_intent(f"샘플문서의 {relation}?").relation_candidates == (
+        relation,
+    )
+
+
+def test_korean_attribute_label_does_not_strip_a_stemless_politeness_ending():
+    """The stemless `인가`/`입니까` alternatives must stay unwidened.
+
+    They are the only alternatives that match with no interrogative stem in
+    front, so giving either one an optional `요` puts the whole rule back in the
+    hazard the stem-bound suffixes avoid: `재인가요` would lose four syllables
+    and ask the schema for `재`.
+    """
+    assert deterministic_query_intent("샘플사업의 재인가요?").relation_candidates == (
+        "재인가요",
+    )
+    # The form a KB holding `재인가` actually answers keeps working, because the
+    # `는` here is a real josa rather than a politeness ending.
+    assert deterministic_query_intent("샘플사업의 재인가는?").relation_candidates == (
+        "재인가",
+    )
+
+
 def test_deterministic_entity_relation_discovery_questions_are_generic():
     english = deterministic_query_intent("How is Sample Entity related?")
     connected = deterministic_query_intent(

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -562,14 +562,49 @@ def _is_generic_entity_anchor(value: str) -> bool:
     return value.strip().casefold() in _GENERIC_ENTITY_ANCHORS
 
 
+_KOREAN_INTERROGATIVE_TAIL = (
+    r"무엇(?:인가요?|입니까)?"
+    r"|누구(?:인가요?|입니까|예요|이에요|야)?"
+    r"|얼마(?:인가요?|입니까|예요|이에요|야)?"
+    r"|어디(?:인가요?|입니까|예요|이에요|야)?"
+    r"|언제(?:인가요?|입니까|예요|이에요|야)?"
+    r"|뭐(?:인가요?|입니까|예요|야)?"
+    r"|어떤\s*것(?:인가요?|입니까)?"
+    r"|인가|입니까"
+)
+"""The interrogative tails `_clean_korean_attribute_label` strips.
+
+`누구` and `얼마` are how Korean asks for a person and an amount, and stripping
+only `무엇` left `프로젝트A의 담당자는 누구인가?` asking for a relation literally
+named `담당자는 누구` -- a label no schema can hold, so the planner built no
+candidates and a question naming its relation exactly was answered UNVERIFIED.
+`어디` and `언제` are the same defect for a place and a time.
+
+This is the stems and suffix forms observed so far, not the whole interrogative
+class: `무엇` and `어떤 것` take no `예요`/`야` here, and no stem takes a past
+form, so `담당자는 누구였나요?` is still left unstripped -- untouched by this
+rule rather than handled by it.
+
+Every suffix this rule adds is reachable only bound to a stem. That is what
+keeps it safe: admitting a stemless `요` or `야` alternative would cut a relation
+named `개요` down to `개`, or `분야` to `분`. The two stemless alternatives,
+`인가` and `입니까`, are HEAD's and are left exactly as they were -- deliberately
+not widened to `인가요?`, which would have cut `샘플사업의 재인가요?` down to
+`재`, the very hazard the stem-bound rule exists to avoid. They are also why
+`샘플사업의 인가?`, naming a relation spelled like the copula, already loses its
+whole label on the unchanged path.
+"""
+
+_KOREAN_ATTRIBUTE_LABEL_TAIL = re.compile(
+    rf"\s*(?:{_KOREAN_INTERROGATIVE_TAIL})\s*$"
+)
+_KOREAN_ATTRIBUTE_LABEL_JOSA = re.compile(r"(?:은|는|이|가)\s*$")
+
+
 def _clean_korean_attribute_label(value: str) -> str:
     label = " ".join(value.strip().split())
-    label = re.sub(
-        r"\s*(?:무엇(?:인가|입니까)?|뭐(?:야|입니까)?|어떤\s*것(?:인가|입니까)?|인가|입니까)\s*$",
-        "",
-        label,
-    ).strip()
-    label = re.sub(r"(?:은|는|이|가)\s*$", "", label).strip()
+    label = _KOREAN_ATTRIBUTE_LABEL_TAIL.sub("", label).strip()
+    label = _KOREAN_ATTRIBUTE_LABEL_JOSA.sub("", label).strip()
     return label
 
 
@@ -577,6 +612,16 @@ def _looks_like_korean_attribute_question(raw_label: str, question: str) -> bool
     tail = raw_label.strip()
     if question.rstrip().endswith(("?", "？")):
         return True
+    # Deliberately NOT widened alongside the label cleaner. This decides whether
+    # the flat attribute shape is claimed at all, and only for a question with no
+    # `?` -- the branch above short-circuits otherwise -- so widening it changes
+    # nothing for a `?`-terminated question. For one without a `?` it cuts both
+    # ways: it would claim `샘플제품의 가격은 얼마` deterministically, but would
+    # also flatten `샘플프로젝트의 담당자의 상사는 누구` into a single-hop label
+    # that can only plan empty, taking it from the LLM, which can read it as a
+    # two-hop lookup. Neither population is measured, so the cleaner is widened
+    # and this is not. A `?`-terminated multi-hop question flattens either way;
+    # that is a separate, larger defect this rule does not address.
     return bool(
         re.search(
             r"(?:은|는|이|가|무엇(?:인가|입니까)?|뭐(?:야|입니까)?|"


### PR DESCRIPTION
## Problem

Ask returned `UNVERIFIED — source exploration` for Korean questions that named their stored relation **exactly**.

`_clean_korean_attribute_label` stripped only the `무엇`/`뭐`/`어떤 것` tails, so `프로젝트A의 담당자는 누구인가?` asked the schema for a relation literally named `담당자는 누구`. No schema can hold that label, the planner built zero candidates, and the question fell through to the unverified route. `얼마`, `어디` and `언제` — how Korean asks for an amount, a place and a time — failed the same way.

Measured on a synthetic KB holding `(샘플프로젝트, 담당자, 샘플인물)`:

| question | before | after |
|---|---|---|
| `샘플프로젝트의 담당자는 누구인가?` | UNVERIFIED, `('담당자는 누구',)` | **VERIFIED — engine**, 0 provider calls |
| `샘플프로젝트의 담당자는?` | VERIFIED — engine | unchanged |

## No verification guarantee moves

The rule only chooses which relation **label** is proposed to the planner. Every resulting candidate still goes through the unchanged engine gate, so a mis-parse degrades to an empty plan and UNVERIFIED — never to a false VERIFIED. `_schema_aware_query_flow_result` is untouched.

## Deliberately not changed

Both omissions are because measurement did not support the change, not oversight:

- **`_looks_like_korean_attribute_question` keeps its old tail set.** It is consulted only for a question with no `?`, so widening it changed nothing for any `?`-terminated question — while flattening no-`?` multi-hop questions such as `샘플프로젝트의 담당자의 상사는 누구` into a single-hop label that can only plan empty, taking them from the LLM that can read them as a two-hop lookup.
- **The stemless `인가`/`입니까` alternatives are left as they were.** Adding an optional `요` there would cut `샘플사업의 재인가요?` down to `재` — the very hazard the stem-bound suffixes exist to avoid.

A schema-aware LLM reinterpretation of empty plans was designed and then **not** shipped: a population sweep put its honest yield at roughly 25% of today's UNVERIFIED, because most empty plans come from an entity-surface mismatch or an absent fact, neither of which a model can fix (the schema hint renders no entity surfaces). See #434.

## Tests

The stem/suffix matrix is **generated as a cross-product** (4 stems × 7 forms) rather than written out, because a hand-list let a suffix present on one stem mask its absence on the others. Guards pin the over-strip hazards: `개요`/`분야` must survive, and the stemless alternatives must stay unwidened.

Mutation matrix — every mutation fails at least one test: drop any single stem (7 each), drop any single suffix from any single stem (1 each), stemless `요` or `야` (1 each), stemless `요` re-widening (1), revert the pre-existing-stem additions (3), full revert (21+).

Full suite **2447 passed, 20 skipped** against a frozen tree (digest verified identical before and after the run). Ruff findings identical to `main` (8 pre-existing, none new).

## Follow-ups filed while reviewing this

Each is self-contained and none is a prerequisite for this change:

- #432 — multi-hop questions flatten into an unplannable single-hop label and never reach the LLM. Assessed as the **largest remaining source of UNVERIFIED** for Korean, since it bites the `?`-terminated form users actually type.
- #431 — the josa strip cuts `단가` to `단`, `허가` to `허`.
- #434 — an empty plan reports one opaque reason for three different causes; prerequisite for both an actionable diagnostic and a worthwhile reinterpretation.
- #433 — English admits only `what is`/`what was`/`find`/`show`.

Synthetic fixtures only.