### PR TITLE
fix: re-read a question the schema planned nothing for (#432)

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
+import pytest
+
 import verinote.pipeline.ask as ask_module
 from verinote.llm.base import LLMError
 from verinote.pipeline.ask import ask_question, search_source_excerpts
@@ -527,6 +529,232 @@ def test_ask_answers_a_who_question_from_the_engine_without_a_provider_call(tmp_
     assert result.label == "VERIFIED — engine"
     assert "샘플인물" in result.answer
     assert result.grounding_facts[0].source == "sources/sample-project.txt"
+
+
+class KoreanChainIntentClient:
+    """Reads `X의 <relation>의 <relation>` as the two-hop lookup it is."""
+
+    name = "korean-chain-intent"
+
+    def __init__(self):
+        self.intent_calls = 0
+        self.schema_hints: list[str] = []
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        from verinote.pipeline.query_intent import parse_query_intent
+
+        self.intent_calls += 1
+        self.schema_hints.append(schema_hint)
+        return parse_query_intent(
+            {
+                "kind": "conjunctive_lookup",
+                "subject": None,
+                "relation": None,
+                "object": None,
+                "relation_candidates": None,
+                "operator": None,
+                "value_type": None,
+                "value": None,
+                "reason": None,
+                "hops": [
+                    {
+                        "subject": {"kind": "entity", "value": "샘플프로젝트"},
+                        "relation": {"kind": "relation", "value": "담당자"},
+                        "object": {"kind": "var", "value": "M"},
+                    },
+                    {
+                        "subject": {"kind": "var", "value": "M"},
+                        "relation": {"kind": "relation", "value": "상사"},
+                        "object": {"kind": "var", "value": "A"},
+                    },
+                ],
+                "conditions": None,
+                "answer_var": "A",
+            }
+        )
+
+    def translate_query(self, **kwargs):
+        raise AssertionError("Ask must not call direct Datalog translation")
+
+    def answer_question(self, **kwargs):
+        raise AssertionError("a verified chain answer must not call the fallback LLM")
+
+
+def _chain_store(tmp_path) -> Store:
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-project.txt")
+    store.add_fact("샘플프로젝트", "담당자", "샘플인물", status="confirmed", source_id=source_id)
+    store.add_fact("샘플인물", "상사", "샘플상급자", status="confirmed", source_id=source_id)
+    return store
+
+
+@pytest.mark.parametrize(
+    "question",
+    ["샘플프로젝트의 담당자의 상사는 누구인가?", "샘플프로젝트의 담당자의상사는 누구인가?"],
+)
+def test_ask_answers_a_korean_chain_question_by_reinterpreting_an_empty_plan(
+    tmp_path, question
+):
+    """A chained question must reach the model that can read it as two hops.
+
+    The deterministic parser is schema-blind: it claims `X의 <label>?` and hands
+    the whole chain over as one relation name. Nothing in the question says
+    whether `담당자의 상사` is a relation the KB holds or a path through two --
+    only the schema does, and it answers by planning no candidates at all. That
+    empty plan is the signal to re-read the question.
+
+    The second case has no space inside the chain, which is part of why this
+    cannot be solved by looking for a particle in the label. The markers issue
+    #432 proposes -- `의`/`와`/`과`/`중` -- fail in both directions. Bound to a
+    word and followed by a space they decline ordinary multi-token relations
+    (`회의 일정` and `협의 결과` on `의`, `성과 지표` on `과`) and still miss
+    this chain. Narrowed to `의` and allowed to match without a space they do
+    catch it, but then decline ordinary nouns that merely contain the syllable
+    (`회의실`, `주의사항`, `편의점`). Which of the two any label is depends on
+    the schema, and the parser cannot see it.
+    """
+    store = _chain_store(tmp_path)
+    client = KoreanChainIntentClient()
+
+    result = ask_question(store, client, root=tmp_path, question=question)
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "샘플상급자" in result.answer
+    assert client.intent_calls == 1
+    assert {fact.relation for fact in result.grounding_facts} == {"담당자", "상사"}
+
+
+class EnglishChainIntentClient(KoreanChainIntentClient):
+    """The same two-hop reading, for the English chain shapes."""
+
+    name = "english-chain-intent"
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        from verinote.pipeline.query_intent import parse_query_intent
+
+        self.intent_calls += 1
+        self.schema_hints.append(schema_hint)
+        return parse_query_intent(
+            {
+                "kind": "conjunctive_lookup",
+                "subject": None,
+                "relation": None,
+                "object": None,
+                "relation_candidates": None,
+                "operator": None,
+                "value_type": None,
+                "value": None,
+                "reason": None,
+                "hops": [
+                    {
+                        "subject": {"kind": "entity", "value": "Sample Project"},
+                        "relation": {"kind": "relation", "value": "owner"},
+                        "object": {"kind": "var", "value": "M"},
+                    },
+                    {
+                        "subject": {"kind": "var", "value": "M"},
+                        "relation": {"kind": "relation", "value": "manager"},
+                        "object": {"kind": "var", "value": "A"},
+                    },
+                ],
+                "conditions": None,
+                "answer_var": "A",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "What is the manager of the owner of Sample Project?",
+        "What is Sample Project's owner's manager?",
+    ],
+)
+def test_ask_answers_an_english_chain_question_by_reinterpreting_an_empty_plan(
+    tmp_path, question
+):
+    """English chains reach the re-reading too, by two different routes.
+
+    They are worth pinning together because they fail differently. The `of` form
+    flattens the chain into the *label* (`manager of the owner`), the same defect
+    as the Korean case. The possessive form does not: the regex takes
+    `Sample Project's owner` as the **entity** and leaves a clean `manager`
+    label, so it plans nothing because no such subject exists. One empty plan,
+    two causes -- which is the argument for guarding at the plan rather than at
+    any one parse rule.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-project.txt")
+    store.add_fact(
+        "Sample Project", "owner", "Sample Person", status="confirmed", source_id=source_id
+    )
+    store.add_fact(
+        "Sample Person", "manager", "Sample Lead", status="confirmed", source_id=source_id
+    )
+    client = EnglishChainIntentClient()
+
+    result = ask_question(store, client, root=tmp_path, question=question)
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "Sample Lead" in result.answer
+    assert client.intent_calls == 1
+    assert {fact.relation for fact in result.grounding_facts} == {"owner", "manager"}
+
+
+def test_ask_gives_the_reinterpretation_the_observed_schema(tmp_path):
+    """The re-reading is only worth making if the model can see the schema.
+
+    Mapping the question's words onto relation labels the KB actually uses is
+    the whole reason to ask a model at all -- without the hint it is guessing at
+    exactly what the schema-blind parser already guessed at. Every other stub
+    client in this file ignores the parameter, so nothing else would notice it
+    going blank.
+    """
+    store = _chain_store(tmp_path)
+    client = KoreanChainIntentClient()
+
+    ask_question(
+        store, client, root=tmp_path, question="샘플프로젝트의 담당자의 상사는 누구인가?"
+    )
+
+    assert len(client.schema_hints) == 1
+    hint = client.schema_hints[0]
+    assert "담당자" in hint
+    assert "상사" in hint
+
+
+@pytest.mark.parametrize("relation", ["회의 일정", "성과 지표"])
+def test_ask_answers_a_multi_token_relation_without_a_provider_call(tmp_path, relation):
+    """A label that names a real relation must never reach the re-reading.
+
+    These are the labels that killed the parse-time approach: a rule looking for
+    one of issue #432's markers (`의`/`와`/`과`/`중`) bound inside the label
+    declines `회의 일정` on its `의` and `성과 지표` on its `과`, along with the
+    chains. At the empty-plan boundary they are safe for free, because a
+    label this subject really holds plans VALID and is never reconsidered --
+    `DeterministicOnlyClient` raises on every provider entry point, so it is not
+    consulted rather than merely not counted.
+
+    The subject matters: a relation the KB holds for some *other* subject still
+    plans nothing here and is re-read like any other empty plan. That is a cost,
+    not a correctness problem, and it is what makes issue #434 worth doing.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-project.txt")
+    store.add_fact("샘플프로젝트", relation, "샘플값", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question=f"샘플프로젝트의 {relation}은?",
+    )
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "샘플값" in result.answer
 
 
 def test_ask_does_not_call_stale_fact_terms_verified(tmp_path):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -929,3 +929,146 @@ def test_translate_only_touches_pending(tmp_path, fake_client):
     # second run with no new pending questions returns nothing
     again = translate_questions(s, fake_client(), root=tmp_path)
     assert again == []
+
+
+_DETERMINISTIC_QUESTION = "What is Sample Person's birth place?"
+
+
+@pytest.mark.parametrize(
+    "outcome_name",
+    ["NO_ANSWER", "AMBIGUOUS_CONFLICTING", "REVIEW_REQUIRED", "ENGINE_POLICY_ERROR"],
+)
+def test_engine_verdicts_are_not_reinterpreted(
+    tmp_path, fake_client, monkeypatch, outcome_name
+):
+    """Only an empty plan may be re-read; every engine verdict stands.
+
+    An empty plan is the schema declining to build anything, so it says nothing
+    about the facts. Each of these outcomes is the engine's answer over
+    candidates that were actually built, and re-reading the question until an
+    answer changes is how a system talks itself out of a verdict it already has.
+
+    Parametrized rather than looped so that a change re-litigating only one
+    outcome still fails: a single test asserting all four would let three pass
+    for the fourth.
+    """
+    from verinote.pipeline.query_candidate_eval import (
+        QueryCandidateSetEvaluation,
+        QueryCandidateSetOutcome,
+    )
+
+    s = _store(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    s.add_question(_DETERMINISTIC_QUESTION)
+    client = fake_client()
+    client.extract_query_intent = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError(f"{outcome_name} is an engine verdict and must not be re-read")
+    )
+    monkeypatch.setattr(
+        "verinote.pipeline.query.evaluate_query_candidate_plan",
+        lambda store, plan: QueryCandidateSetEvaluation(
+            plan=plan, outcome=getattr(QueryCandidateSetOutcome, outcome_name)
+        ),
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results[0]["status"] != "translated"
+    assert client.calls == 0
+
+
+def test_truncated_plan_is_not_reinterpreted(tmp_path, fake_client, monkeypatch):
+    """A truncated plan reports no outcome at all, so it cannot reach the re-read.
+
+    Truncation means too many candidates matched, the opposite of the empty plan
+    the re-reading exists for. It also returns before the engine runs, so there
+    is no verdict to compare against -- which is why the planner helper answers
+    `None` rather than folding it into `EMPTY`.
+    """
+    from verinote.pipeline.query_planner import (
+        QueryCandidate,
+        QueryCandidateFamily,
+        QueryCandidatePlan,
+    )
+
+    s = _store(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    qid = s.add_question(_DETERMINISTIC_QUESTION)
+    client = fake_client()
+    client.extract_query_intent = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("a truncated plan must not be re-read")
+    )
+    candidate = QueryCandidate(
+        query_dl=f".decl answer_q{qid}(value: symbol)\nanswer_q{qid}(O) :- relation(\"Sample Person\", \"born_in\", O).",
+        family=QueryCandidateFamily.DIRECT_OBJECT_LOOKUP,
+        direction=None,
+        relation_display=None,
+        relation_executable=None,
+        subject_executable=None,
+        object_executable=None,
+    )
+    monkeypatch.setattr(
+        "verinote.pipeline.query.plan_query_candidates",
+        lambda *args, **kwargs: QueryCandidatePlan(
+            qid=qid, candidates=(candidate,), truncated=True
+        ),
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results[0]["status"] == "review_required"
+    assert results[0]["reason"] == "too many query candidates matched the schema"
+    assert client.calls == 0
+
+
+def test_llm_first_path_makes_exactly_one_intent_call(
+    tmp_path, fake_client, intent_payload
+):
+    """A question the parser declined is already the model's reading.
+
+    Re-reading it would ask the same provider the same question twice. The gate
+    is the deterministic parser's support, not the empty plan alone -- this
+    fixture plans empty, so a trigger that dropped that half would call twice.
+    """
+    s = _store(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    s.add_question("Tell me something about Sample Person, synthetically speaking")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="missing_relation"
+        )
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results[0]["status"] == "review_required"
+    assert results[0]["reason"] == "no query candidates matched the schema"
+    assert client.calls == 1
+
+
+def test_reinterpretation_llm_error_declines_the_direct_datalog_fallback(
+    tmp_path, fake_client
+):
+    """A failed re-reading must not be laundered, and must not invite a retry.
+
+    `_prepare_repair_question` checks `allow_direct_datalog_fallback` before it
+    checks `provider_failed`, so leaving the permission on would send a second
+    request to the provider that has just failed.
+    """
+    s = _store(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(error=LLMError("synthetic outage"))
+
+    flow = query_module._schema_aware_query_flow_result(
+        s,
+        client,
+        qid=1,
+        question=_DETERMINISTIC_QUESTION,
+        llm_error_status="review_required",
+    )
+
+    assert flow.status == "review_required"
+    assert "no query candidates matched the schema" in flow.reason
+    assert "synthetic outage" in flow.reason
+    assert flow.provider_failed is True
+    assert flow.allow_direct_datalog_fallback is False

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -326,24 +326,188 @@ def test_repair_persists_ambiguous_lifecycle_outcome(
     assert "ambiguous" not in (load_query(s) or "")
 
 
-def test_repair_default_runs_direct_datalog_for_deterministic_planner_empty(
+def test_repair_reaches_direct_datalog_after_a_declining_reinterpretation(
     tmp_path, fake_client
 ):
+    """A re-reading that declines must not cost the question its rescue.
+
+    A deterministically supported intent that plans nothing stays
+    `review_required` with the direct-Datalog fallback still permitted, and
+    `/repair` uses that permission to translate the question. The schema-aware
+    reinterpretation now runs first; when it produces nothing executable, the
+    question has to arrive at the fallback exactly as it does today.
+    """
     s, qid = _store_with_deterministic_planner_empty(tmp_path)
     s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
     client = fake_client(
         query=lambda q, i: f'answer_q{i}(O) :- relation("Sample Person", "born_in", O).',
     )
-    client.extract_query_intent = lambda **kwargs: (_ for _ in ()).throw(
-        AssertionError("deterministic planner-empty repair must not extract intent")
-    )
+    # No intent override: the fake client answers `unknown_or_unsupported`, so
+    # the model declines to re-read the question.
     # No flag passed: exercises the production default wiring.
     results = repair_questions(s, client, root=tmp_path)
 
-    assert client.calls == 1
+    assert client.calls == 2  # the reinterpretation, then the rescue
     assert results == [{"id": qid, "accepted": True, "reason": ""}]
     assert s.questions()[0]["status"] == "translated"
     assert f"answer_q{qid}" in (load_query(s) or "")
+
+
+@pytest.mark.parametrize(
+    "retry_outcome_name",
+    ["NO_ANSWER", "AMBIGUOUS_CONFLICTING", "REVIEW_REQUIRED", "EMPTY"],
+)
+def test_repair_reaches_direct_datalog_after_any_declining_reinterpretation(
+    tmp_path, fake_client, intent_payload, monkeypatch, retry_outcome_name
+):
+    """No re-reading verdict short of an executable query may close the question.
+
+    `no_answer` and `ambiguous` are terminal -- nothing re-picks them -- and the
+    repair gate forwards only `review_required` to the direct-Datalog fallback.
+    So letting a re-reading's verdict replace the deterministic result would take
+    away the rescue that translates this question today, on a reading of the
+    question the deterministic layer never understood. `review_required` and a
+    second `empty` lose the rescue a different way: the re-reading's result is
+    built with `deterministic_intent_supported=False`, so it carries
+    `allow_direct_datalog_fallback=False` where the deterministic one carried
+    True.
+
+    Parametrized so each outcome is independently falsifiable: admitting just one
+    of them into the accept set must fail here, not be masked by the others.
+    """
+    from verinote.pipeline.query_candidate_eval import (
+        QueryCandidateSetEvaluation,
+        QueryCandidateSetOutcome,
+    )
+
+    s, qid = _store_with_deterministic_planner_empty(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="born_in"
+        ),
+        query=lambda q, i: f'answer_q{i}(O) :- relation("Sample Person", "born_in", O).',
+    )
+
+    def declining(store, plan):
+        # The deterministic pass plans nothing, so it must see a real EMPTY. The
+        # re-reading's intent names a relation this KB holds, so its plan really
+        # does carry a candidate and the verdict below is a verdict over one.
+        if not plan.candidates:
+            return QueryCandidateSetEvaluation(
+                plan=plan, outcome=QueryCandidateSetOutcome.EMPTY
+            )
+        return QueryCandidateSetEvaluation(
+            plan=plan, outcome=getattr(QueryCandidateSetOutcome, retry_outcome_name)
+        )
+
+    monkeypatch.setattr(
+        "verinote.pipeline.query.evaluate_query_candidate_plan", declining
+    )
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert client.calls == 2  # the reinterpretation, then the rescue
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    assert s.questions()[0]["status"] == "translated"
+
+
+def test_repair_reaches_direct_datalog_after_a_truncated_reinterpretation(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    """A re-reading whose own plan truncates must not close the question either.
+
+    Truncation reports no outcome at all, so it is the one member of the
+    disposition domain the outcome parametrization above cannot reach -- it
+    happens before evaluation, so patching the evaluator cannot produce it. The
+    consequence of admitting it is the same as for the others: the truncated
+    result is built with `deterministic_intent_supported=False`, so it carries
+    `allow_direct_datalog_fallback=False` and the question loses its rescue.
+    """
+    from verinote.pipeline.query_planner import (
+        QueryCandidatePlan,
+        plan_query_candidates,
+    )
+
+    real_plan_query_candidates = plan_query_candidates
+    s, qid = _store_with_deterministic_planner_empty(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="born_in"
+        ),
+        query=lambda q, i: f'answer_q{i}(O) :- relation("Sample Person", "born_in", O).',
+    )
+    planned = {"count": 0}
+
+    def truncate_only_the_reinterpretation(intent, snapshot, **kwargs):
+        plan = real_plan_query_candidates(intent, snapshot, **kwargs)
+        planned["count"] += 1
+        if planned["count"] == 1:
+            return plan  # the deterministic pass: a genuinely empty plan
+        return QueryCandidatePlan(
+            qid=plan.qid, candidates=plan.candidates, truncated=True
+        )
+
+    monkeypatch.setattr(
+        "verinote.pipeline.query.plan_query_candidates",
+        truncate_only_the_reinterpretation,
+    )
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert planned["count"] == 2
+    assert client.calls == 2  # the reinterpretation, then the rescue
+    assert results == [{"id": qid, "accepted": True, "reason": ""}]
+    assert s.questions()[0]["status"] == "translated"
+
+
+def test_repair_surfaces_an_engine_error_found_by_the_reinterpretation(
+    tmp_path, fake_client, intent_payload, monkeypatch
+):
+    """An engine or policy error is a failure signal, not a declined reading.
+
+    It is the one non-VALID outcome the re-reading may return in place of the
+    deterministic result, because hiding it behind "no query candidates matched
+    the schema" would report a broken engine as an ordinary miss -- and because
+    spending the direct-Datalog rescue on an engine that is already erroring
+    buys nothing.
+    """
+    from verinote.pipeline.query_candidate_eval import (
+        QueryCandidateSetEvaluation,
+        QueryCandidateSetOutcome,
+    )
+
+    s, _qid = _store_with_deterministic_planner_empty(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(
+        intent=intent_payload(
+            "lookup_object", subject="Sample Person", relation="born_in"
+        )
+    )
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("an erroring engine must not be handed a direct Datalog draft")
+    )
+
+    def engine_error(store, plan):
+        if not plan.candidates:
+            return QueryCandidateSetEvaluation(
+                plan=plan, outcome=QueryCandidateSetOutcome.EMPTY
+            )
+        return QueryCandidateSetEvaluation(
+            plan=plan, outcome=QueryCandidateSetOutcome.ENGINE_POLICY_ERROR
+        )
+
+    monkeypatch.setattr(
+        "verinote.pipeline.query.evaluate_query_candidate_plan", engine_error
+    )
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert client.calls == 1
+    assert results[0]["accepted"] is False
+    assert results[0]["reason"].startswith("engine/policy error:")
+    assert s.questions()[0]["status"] == "review_required"
 
 
 def test_repair_disabled_fallback_keeps_deterministic_planner_empty_under_review(
@@ -352,9 +516,6 @@ def test_repair_disabled_fallback_keeps_deterministic_planner_empty_under_review
     s, qid = _store_with_deterministic_planner_empty(tmp_path)
     s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
     client = fake_client()
-    client.extract_query_intent = lambda **kwargs: (_ for _ in ()).throw(
-        AssertionError("deterministic planner-empty repair must not extract intent")
-    )
     client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
         AssertionError("disabled fallback must not call direct Datalog")
     )
@@ -363,7 +524,9 @@ def test_repair_disabled_fallback_keeps_deterministic_planner_empty_under_review
         s, client, root=tmp_path, allow_direct_datalog_fallback=False
     )
 
-    assert client.calls == 0
+    # The flag scopes the direct-Datalog fallback and nothing else. The
+    # reinterpretation belongs to translation, so it still runs.
+    assert client.calls == 1
     assert results == [
         {
             "id": qid,
@@ -371,6 +534,31 @@ def test_repair_disabled_fallback_keeps_deterministic_planner_empty_under_review
             "reason": "no query candidates matched the schema",
         }
     ]
+    assert s.questions()[0]["status"] == "review_required"
+
+
+def test_repair_provider_error_during_reinterpretation_skips_direct_fallback(
+    tmp_path, fake_client
+):
+    """An outage must not be answered with a second request to the same provider.
+
+    `_prepare_repair_question` consults `allow_direct_datalog_fallback` before it
+    looks at `provider_failed`, so the reinterpretation's failure has to switch
+    that flag off itself or the fallback fires into the same outage.
+    """
+    s, _qid = _store_with_deterministic_planner_empty(tmp_path)
+    s.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    client = fake_client(error=LLMError("synthetic outage"))
+    client.translate_query = lambda **kwargs: (_ for _ in ()).throw(
+        AssertionError("a failed provider must not be called again for this question")
+    )
+
+    results = repair_questions(s, client, root=tmp_path)
+
+    assert client.calls == 1
+    assert results[0]["accepted"] is False
+    assert "no query candidates matched the schema" in results[0]["reason"]
+    assert "synthetic outage" in results[0]["reason"]
     assert s.questions()[0]["status"] == "review_required"
 
 

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -21,7 +21,7 @@ import sqlite3
 import stat
 import tempfile
 import unicodedata
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
 from verinote.engine.terms import Atom, StringLit, render_term
@@ -31,6 +31,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
 )
 from verinote.pipeline.query_intent import (
+    QueryIntent,
     QueryIntentKind,
     deterministic_query_intent,
 )
@@ -40,6 +41,14 @@ from verinote.pipeline.query_schema import (
     build_query_schema_snapshot,
 )
 from verinote.store import Store
+
+if TYPE_CHECKING:
+    # Runtime imports of this module are deliberately kept inside the functions
+    # that need it: query_candidate_eval imports back from here, so a module-level
+    # import would be circular. Annotations are strings under
+    # `from __future__ import annotations`, so the name is only ever needed by a
+    # type checker.
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
 
 # Query draft, relative to the KB root (the db file's directory).
 QUERY_RELPATH = Path("facts") / "query.dl"
@@ -259,8 +268,6 @@ def _schema_aware_query_flow_result(
     question: str,
     llm_error_status: str,
 ) -> _QueryFlowResult:
-    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
-
     snapshot = build_query_schema_snapshot(store)
     intent = deterministic_query_intent(question)
     deterministic_intent_supported = (
@@ -303,6 +310,149 @@ def _schema_aware_query_flow_result(
             allow_direct_datalog_fallback=True,
         )
 
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    result, outcome = _plan_and_evaluate_intent(
+        store,
+        intent,
+        qid=qid,
+        base_snapshot=snapshot,
+        deterministic_intent_supported=deterministic_intent_supported,
+    )
+    # `EMPTY` is the only outcome worth re-reading the question for, and only
+    # when the deterministic parser is the one that read it. The parser is
+    # schema-blind -- it sees the question and nothing else -- so it cannot tell
+    # a relation the KB really holds from a chain of them: `X의 회의 일정은?` and
+    # `X의 담당자의 상사는?` are the same shape to it, and it hands both to the
+    # planner as one relation name. When that subject really does hold a
+    # relation by that name the plan is VALID and nothing here runs; otherwise
+    # the schema has just answered the question the parser was guessing at, and
+    # the model -- which gets the observed relations in its hint -- deserves a
+    # look. The population that reaches here is therefore every deterministic
+    # empty plan, not only chains: a subject with no fact for an otherwise real
+    # relation is re-read too, and pays a provider call to arrive back at the
+    # same place.
+    #
+    # Every other outcome is the engine's own verdict over candidates that were
+    # actually built, and re-reading the question until a verdict changes is how
+    # a system talks itself out of an answer it already has. A truncated plan
+    # reports no outcome at all (`None`), so it cannot reach this either.
+    if (
+        deterministic_intent_supported
+        and outcome == QueryCandidateSetOutcome.EMPTY
+    ):
+        return _reinterpret_empty_plan(
+            store,
+            client,
+            qid=qid,
+            question=question,
+            base_snapshot=snapshot,
+            deterministic_result=result,
+        )
+    return result
+
+
+def _reinterpret_empty_plan(
+    store: Store,
+    client: LLMClient,
+    *,
+    qid: int,
+    question: str,
+    base_snapshot: QuerySchemaSnapshot,
+    deterministic_result: _QueryFlowResult,
+) -> _QueryFlowResult:
+    """Re-read a question the deterministic parser could plan nothing for.
+
+    Only a `VALID` re-reading may replace the deterministic result, plus an
+    engine or policy error, which is a failure signal rather than an answer and
+    must never be hidden behind a stale reason. A model-supplied `no_answer` or
+    `ambiguous` is refused on purpose even though the engine produced it: Ask
+    renders `no_answer` as `VERIFIED — engine (negative)`, the strongest claim
+    the system makes, and both statuses are terminal -- `translate_questions`
+    re-picks only `pending`/`translation_failed` and `repair_questions` only
+    `review_required`, so nothing would ever revisit the question. Keeping the
+    deterministic `review_required` also keeps its
+    `allow_direct_datalog_fallback`, so a declining re-reading costs the
+    question nothing: repair still reaches the direct-Datalog rescue it reaches
+    today.
+
+    An `LLMError` is the one case that returns a *changed* deterministic result:
+    the reason gains the provider error, and the fallback is switched off
+    because `_prepare_repair_question` consults that flag before it looks at
+    `provider_failed`, and would otherwise send a second request to a provider
+    that has just failed.
+    """
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    try:
+        intent = client.extract_query_intent(
+            question=question,
+            schema_hint=query_schema_hint(base_snapshot),
+        )
+    except LLMError as exc:
+        reason = _short_reason(
+            f"{deterministic_result.reason}; schema-aware reinterpretation "
+            f"unavailable: llm error: {exc}"
+        )
+        return _QueryFlowResult(
+            "review_required",
+            f"review_required({_lit(reason)})",
+            reason,
+            allow_direct_datalog_fallback=False,
+            provider_failed=True,
+        )
+
+    if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
+        return deterministic_result
+
+    # `deterministic_intent_supported=False`: this intent came from the model.
+    # The flag only decides the EMPTY branch's fallback permission, and that
+    # branch's result is discarded below in favour of the deterministic one,
+    # which carries the permission the question already had.
+    result, outcome = _plan_and_evaluate_intent(
+        store,
+        intent,
+        qid=qid,
+        base_snapshot=base_snapshot,
+        deterministic_intent_supported=False,
+    )
+    if outcome in {
+        QueryCandidateSetOutcome.VALID,
+        QueryCandidateSetOutcome.ENGINE_POLICY_ERROR,
+    }:
+        return result
+    return deterministic_result
+
+
+def _plan_and_evaluate_intent(
+    store: Store,
+    intent: QueryIntent,
+    *,
+    qid: int,
+    base_snapshot: QuerySchemaSnapshot,
+    deterministic_intent_supported: bool,
+) -> tuple[_QueryFlowResult, QueryCandidateSetOutcome | None]:
+    """Plan one intent's candidates and turn the engine's verdict into a result.
+
+    The outcome is returned beside the result because the two say different
+    things: the result is what the question's lifecycle becomes, while the
+    outcome is *why*. Several outcomes share the `review_required` status, and a
+    caller that needs to tell them apart cannot recover the distinction from the
+    result -- the reason string is human-facing prose, not a discriminator.
+
+    `None` is returned in place of an outcome when the candidate set was
+    truncated, and it is a different state from every `QueryCandidateSetOutcome`
+    including `EMPTY`. Neither reaches the engine -- the evaluator returns for a
+    candidate-less plan before executing anything -- but they mean opposite
+    things: truncated is candidates built and deliberately left unevaluated,
+    while `EMPTY` is no candidates built at all.
+
+    `base_snapshot` is taken by value. The entity-narrowed rebuild below replaces
+    it for planning only, so the caller keeps the unnarrowed snapshot it built.
+    """
+    from verinote.pipeline.query_candidate_eval import QueryCandidateSetOutcome
+
+    snapshot = base_snapshot
     exact_entities = _intent_exact_entities(intent)
     uses_join_facts = intent.kind in {
         QueryIntentKind.CONJUNCTIVE_LOOKUP,
@@ -320,37 +470,58 @@ def _schema_aware_query_flow_result(
     # omitted path could return a different result and evade the ambiguity gate.
     if plan.truncated:
         reason = "too many query candidates matched the schema"
-        return _QueryFlowResult(
-            "review_required", f"review_required({_lit(reason)})", reason
+        return (
+            _QueryFlowResult(
+                "review_required", f"review_required({_lit(reason)})", reason
+            ),
+            None,
         )
     evaluation = evaluate_query_candidate_plan(store, plan)
 
     if evaluation.outcome == QueryCandidateSetOutcome.VALID and evaluation.selected:
-        return _QueryFlowResult("translated", evaluation.selected.query_dl, "")
+        return (
+            _QueryFlowResult("translated", evaluation.selected.query_dl, ""),
+            evaluation.outcome,
+        )
     if evaluation.outcome == QueryCandidateSetOutcome.NO_ANSWER:
         reason = "no confirmed facts match"
-        return _QueryFlowResult("no_answer", f"no_answer({_lit(reason)})", reason)
+        return (
+            _QueryFlowResult("no_answer", f"no_answer({_lit(reason)})", reason),
+            evaluation.outcome,
+        )
     if evaluation.outcome == QueryCandidateSetOutcome.AMBIGUOUS_CONFLICTING:
         reason = "multiple query candidates returned conflicting answers"
-        return _QueryFlowResult("ambiguous", f"ambiguous({_lit(reason)})", reason)
+        return (
+            _QueryFlowResult("ambiguous", f"ambiguous({_lit(reason)})", reason),
+            evaluation.outcome,
+        )
     if evaluation.outcome == QueryCandidateSetOutcome.REVIEW_REQUIRED:
         reason = _short_reason(_evaluation_reason(evaluation))
-        return _QueryFlowResult(
-            "review_required", f"review_required({_lit(reason)})", reason
+        return (
+            _QueryFlowResult(
+                "review_required", f"review_required({_lit(reason)})", reason
+            ),
+            evaluation.outcome,
         )
     if evaluation.outcome == QueryCandidateSetOutcome.EMPTY:
         reason = _short_reason(plan.reason or "no query candidates matched the schema")
-        return _QueryFlowResult(
-            "review_required",
-            f"review_required({_lit(reason)})",
-            reason,
-            allow_direct_datalog_fallback=deterministic_intent_supported,
+        return (
+            _QueryFlowResult(
+                "review_required",
+                f"review_required({_lit(reason)})",
+                reason,
+                allow_direct_datalog_fallback=deterministic_intent_supported,
+            ),
+            evaluation.outcome,
         )
     elif evaluation.outcome == QueryCandidateSetOutcome.ENGINE_POLICY_ERROR:
         reason = _short_reason("engine/policy error: " + _evaluation_reason(evaluation))
     else:
         reason = _short_reason("invalid query: " + _evaluation_reason(evaluation))
-    return _QueryFlowResult("review_required", f"review_required({_lit(reason)})", reason)
+    return (
+        _QueryFlowResult("review_required", f"review_required({_lit(reason)})", reason),
+        evaluation.outcome,
+    )
 
 
 def _intent_exact_entities(intent: object) -> tuple[str, ...]:

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -122,9 +122,15 @@ def repair_questions(
     With `allow_direct_datalog_fallback` (the default), an LLM-confirmed
     unsupported intent costs two provider calls: intent extraction, then the
     direct Datalog fallback. A deterministically supported intent whose planner
-    returns no candidates costs one provider call: the direct Datalog fallback.
-    An intent-extraction LLM error costs one failed call and never retries the
-    provider.
+    returns no candidates costs up to two: the schema-aware reinterpretation of
+    the question, and then the direct Datalog fallback if that reinterpretation
+    declines. It costs one whenever the reinterpretation settles the question --
+    either because it produced an executable query, so the question leaves
+    `review_required`, or because it surfaced an engine or policy error, which
+    replaces the result and withholds the fallback rather than handing a draft
+    to an engine that is already failing. An intent-extraction LLM error costs
+    one failed call and never retries the provider; so does a reinterpretation
+    LLM error, which switches the fallback off for that reason.
     """
     results: list[dict] = []
     for q in store.questions():


### PR DESCRIPTION
Closes #432.

## Problem

`_KOREAN_ATTRIBUTE_QUESTION` claims any `X의 <label>?` question, including ones whose label is itself a chain of relations, and hands the whole chain to the planner as one relation name. Because the deterministic intent kind is "supported", `_schema_aware_query_flow_result` never called `extract_query_intent` — so the model that can read the question as a two-hop lookup was never consulted.

| question | before | after |
|---|---|---|
| `샘플프로젝트의 담당자의 상사는 누구인가?` | UNVERIFIED, candidate `('담당자의 상사',)` | **VERIFIED — engine**, 2 grounding facts |
| `샘플프로젝트의 담당자의상사는 누구인가?` (no space) | UNVERIFIED | **VERIFIED — engine** |
| `샘플프로젝트의 회의 일정은?` (a real relation) | VERIFIED — engine | unchanged, **0 provider calls** |

## Why this is not a parser fix

The parser is schema-blind — it sees the question and nothing else, so `X의 회의 일정은?` and `X의 담당자의 상사는?` are the same shape to it. The markers the issue proposes (`의`/`와`/`과`/`중`) were measured at **13/16 false positives** on ordinary multi-token relation labels (`회의 일정`, `협의 결과` on `의`; `성과 지표`, `결과 보고서` on `과`) and still miss `담당자의상사`, which has no space to anchor on. Narrowing to `의` without the space requirement catches that one but then declines ordinary nouns containing the syllable (`회의실`, `주의사항`, `편의점`).

Only the schema separates them, and it already does so — by planning nothing.

## The change

`_plan_and_evaluate_intent` returns the candidate-set outcome beside the result. A **deterministic** intent whose plan comes back `EMPTY` is re-read once by the model with the observed-relations hint and re-planned through the same helper — re-entering it is what rebuilds the snapshot with join facts for a conjunctive reading.

**Disposition.** Only a `VALID` re-reading may replace the deterministic result, plus an engine/policy error, which is a failure signal rather than an answer. A model-supplied `no_answer`/`ambiguous` is refused even though the engine produced it: Ask renders `no_answer` as `VERIFIED — engine (negative)`, the strongest claim the system makes, on a reading the deterministic layer never understood — and both statuses are terminal, so replacing would take away the direct-Datalog rescue `/repair` uses on these questions today. A truncated plan reports no outcome at all and cannot trigger the re-read.

**No verifying question changes.** A subject that really does hold a relation by that name plans `VALID` and is never reconsidered.

## Honest costs

- Every deterministic empty plan reaches the re-read, **not only chains**. A known subject with no fact for an otherwise real relation pays a provider call to arrive back where it started — the cost #434 would remove.
- The chain population itself is **unmeasured**. The cost is bounded because these questions already spend one call on the UNVERIFIED fallback.
- `repair.py`'s per-question provider budget prose is updated in the same commit; the deterministic-empty branch now costs up to two calls.

English chains are fixed by the same path, by two different routes: `What is the manager of the owner of X?` flattens into the label, `What is X's owner's manager?` flattens into the entity. Both covered.

## Verification

Full suite **2470 passed / 20 skipped** against a frozen tree (digest verified identical before and after the run); baseline on `main` is 2449, so +21 tests and no regressions. Ruff: zero new findings versus baseline, compared by normalising line/column out of both outputs.

Mutation matrix — every mechanism independently falsifiable, verified by three parties on their own copies: remove the retry 15 · trigger on anything-not-VALID 4 · drop the deterministic-support gate 2 · accept NO_ANSWER 1 · accept AMBIGUOUS 1 · accept REVIEW_REQUIRED 1 · accept EMPTY 1 · accept truncated-`None` 1 · drop ENGINE_POLICY_ERROR 1 · keep the fallback on after an LLMError 2 · drop `provider_failed` 1 · truncated reports EMPTY 1 · blank schema hint 1 · wrong qid 4 · re-read reuses the deterministic intent 6 · skip the join-facts rebuild 11 · evaluate despite truncation 1. Remaining survivors are equivalent mutants with no observable difference.

## Follow-ups

- #434 — an empty plan reports one opaque reason for three different causes; structuring it would let the re-read fire only where it can help, and turn "known subject, no such fact" into an honest zero-call negative.
- New: Ask ignores `provider_failed` and calls the fallback LLM after a failed re-read (pre-existing on the LLM-first path, filed separately).

Synthetic fixtures only.