### PR TITLE
feat: say which half of a question the knowledge base does not have (#434)

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -651,7 +651,10 @@ def test_planner_no_candidates_requires_review(tmp_path, fake_client, intent_pay
 
     assert results[0]["id"] == qid
     assert results[0]["status"] == "review_required"
-    assert results[0]["reason"] == "no query candidates matched the schema"
+    # The relation `is_a` exists; the subject does not. The reason says which,
+    # because "no query candidates matched the schema" sent the reader looking
+    # for a missing relation that is right there.
+    assert results[0]["reason"] == 'entity "Missing Subject" is not in the knowledge base'
     assert load_query(s) == ""
 
 
@@ -1042,7 +1045,9 @@ def test_llm_first_path_makes_exactly_one_intent_call(
     results = translate_questions(s, client, root=tmp_path)
 
     assert results[0]["status"] == "review_required"
-    assert results[0]["reason"] == "no query candidates matched the schema"
+    assert results[0]["reason"] == (
+        'relation "missing_relation" is not in the schema or its aliases (a policy/relation-aliases.md entry would map it)'
+    )
     assert client.calls == 1
 
 
@@ -1068,7 +1073,427 @@ def test_reinterpretation_llm_error_declines_the_direct_datalog_fallback(
     )
 
     assert flow.status == "review_required"
-    assert "no query candidates matched the schema" in flow.reason
+    assert 'relation "birth place" is not in the schema or its aliases (a policy/relation-aliases.md entry would map it)' in flow.reason
     assert "synthetic outage" in flow.reason
     assert flow.provider_failed is True
     assert flow.allow_direct_datalog_fallback is False
+
+
+def _diagnosis_store(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("샘플프로젝트", "purpose", "샘플목표", status="confirmed")
+    s.add_fact("샘플조직", "is_a", "조직", status="confirmed")
+    return s
+
+
+def _plan_for(store, *, subject, relation, qid=1):
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import plan_query_candidates
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", subject),
+        relation=IntentTarget("relation", relation),
+    )
+    snapshot = build_query_schema_snapshot(store, exact_entities=(subject,))
+    return plan_query_candidates(intent, snapshot, qid=qid)
+
+
+@pytest.mark.parametrize(
+    ("subject", "relation", "relation_in_schema", "entity_in_kb"),
+    [
+        ("샘플프로젝트", "담당자", False, True),   # (a) relation absent
+        ("없는조직", "purpose", True, False),      # (b) entity absent
+        ("없는조직", "담당자", False, False),      # (a+b) both absent
+        ("샘플조직", "purpose", True, True),       # (c) both known, no fact joins them
+    ],
+)
+def test_empty_lookup_plan_reports_which_half_is_missing(
+    tmp_path, subject, relation, relation_in_schema, entity_in_kb
+):
+    """One empty plan, three remedies -- so it has to say which one applies.
+
+    (a+b) is listed because it is a real case, not a corner: the parser can
+    mis-split a question so that neither half survives, and a diagnosis that
+    picked one winner would send the user to fix half the problem.
+    """
+    plan = _plan_for(_diagnosis_store(tmp_path), subject=subject, relation=relation)
+
+    assert plan.candidates == ()
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.relation_in_schema is relation_in_schema
+    assert plan.diagnosis.entity_in_kb is entity_in_kb
+
+
+def test_relation_membership_is_read_from_the_complete_label_set(tmp_path):
+    """Membership must not be answered from the bounded, rendered relation list.
+
+    `snapshot.relations` is capped at `max_relations` because it is rendered
+    into the model's hint and into candidate generation. Answering "does this
+    relation exist?" from that cap reports a relation the KB holds as absent,
+    which would tell the user to add an alias for something already there --
+    and, once the re-read is gated on this field, would spend a provider call
+    on it too.
+    """
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    for index in range(120):
+        s.add_fact("샘플주체", f"관계{index:03d}", f"값{index:03d}", status="confirmed")
+    snapshot = build_query_schema_snapshot(s, exact_entities=("없는주체",))
+    assert snapshot.relations_truncated  # the rendered list really is capped
+
+    # A relation past the cap, asked about with a subject that does not hold it.
+    plan = _plan_for(s, subject="없는주체", relation="관계119")
+
+    assert plan.candidates == ()
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.relation_in_schema is True
+    assert plan.diagnosis.entity_in_kb is False
+
+
+def test_diagnosis_is_skipped_when_the_snapshot_carries_no_membership_sets(tmp_path):
+    """Absence is unknown, not false, when the sets were never built.
+
+    A snapshot assembled by hand has no complete membership data. Treating that
+    as "nothing exists" would emit a confidently wrong reason; the planner
+    reports no diagnosis instead and the caller keeps its old wording.
+    """
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import plan_query_candidates
+    from verinote.pipeline.query_schema import QuerySchemaSnapshot
+
+    bare = QuerySchemaSnapshot(
+        relations=(),
+        relations_truncated=False,
+        relation_aliases=(),
+        typed_relations=(),
+        exact_entity_facts=(),
+        exact_entity_facts_truncated=False,
+        fact_count=0,
+    )
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "샘플조직"),
+        relation=IntentTarget("relation", "purpose"),
+    )
+
+    plan = plan_query_candidates(intent, bare, qid=1)
+
+    assert plan.candidates == ()
+    assert plan.diagnosis is None
+
+
+def test_known_entity_with_no_such_fact_is_reported_as_neither_half_missing(
+    tmp_path, fake_client, intent_payload
+):
+    """Case (c) reads differently from the two absences, because nothing is wrong.
+
+    The user has no alias to add and no spelling to fix; the KB simply does not
+    hold the fact. Saying so is the difference between an instruction and a
+    dead end.
+    """
+    s = _diagnosis_store(tmp_path)
+    s.add_question("샘플조직의 목적은?")
+    client = fake_client(
+        intent=intent_payload("lookup_object", subject="샘플조직", relation="purpose")
+    )
+
+    results = translate_questions(s, client, root=tmp_path)
+
+    assert results[0]["status"] == "review_required"
+    # The single requested label resolved, so nothing was substituted and no
+    # reading is singled out.
+    assert results[0]["reason"] == (
+        'entity "샘플조직" is in the knowledge base and the requested relation '
+        "resolved, but no confirmed fact joins them"
+    )
+
+
+def test_reason_names_only_the_endpoint_the_knowledge_base_is_missing(tmp_path):
+    """A question naming two entities must not accuse the one the KB holds.
+
+    `entity_in_kb` is a single bool over both endpoints, so "how are A and B
+    related?" with only B misspelled makes it False for the pair. Rendering that
+    as "entity A, B is not in the knowledge base" states something false about
+    A -- in the very message added to stop the reason being unhelpful. The
+    diagnosis therefore carries the absent endpoints, not just the verdict.
+    """
+    from verinote.pipeline.query import _empty_plan_reason
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import plan_query_candidates
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    s.add_fact("샘플조직", "is_a", "조직", status="confirmed")
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_RELATION,
+        subject=IntentTarget("entity", "샘플조직"),
+        object=IntentTarget("entity", "없는것"),
+    )
+    snapshot = build_query_schema_snapshot(s, exact_entities=("샘플조직", "없는것"))
+
+    plan = plan_query_candidates(intent, snapshot, qid=1)
+
+    assert plan.candidates == ()
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.entity_in_kb is False
+    assert plan.diagnosis.absent_entities == ("없는것",)
+    reason = _empty_plan_reason(plan, intent)
+    assert reason == 'entity "없는것" is not in the knowledge base'
+    assert "샘플조직" not in reason
+
+
+def test_a_typed_relation_alias_counts_as_being_in_the_schema(tmp_path):
+    """The planner matches a typed alias, so membership must see it too.
+
+    `_relation_matches_any` observes a relation's typed-spec name and alias,
+    which are declared in `policy/typed-relations.md` and appear in no fact. A
+    membership set built from facts alone calls such an alias absent, and the
+    reason then tells the user to add it to `policy/relation-aliases.md` -- a
+    remedy for a problem they do not have, prescribed about a relation the
+    planner can already match.
+    """
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import (
+        _matching_relations,
+        _requested_relations_in_schema,
+    )
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    (tmp_path / "policy").mkdir(exist_ok=True)
+    (tmp_path / "policy" / "typed-relations.md").write_text(
+        "- `가격`: amount as price (원=1)\n", encoding="utf-8"
+    )
+    s.add_fact("샘플제품", "가격", "1000", status="confirmed")
+    snapshot = build_query_schema_snapshot(s, exact_entities=("다른제품",))
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "다른제품"),
+        relation=IntentTarget("relation", "price"),
+    )
+
+    # The planner does match it; membership must not disagree.
+    assert _matching_relations(intent, snapshot)
+    assert _requested_relations_in_schema(("price",), snapshot) == (("price",), False)
+
+
+def test_an_entity_seen_only_as_an_object_is_in_the_knowledge_base(tmp_path):
+    """Being in the KB is not the same as being some relation's subject.
+
+    `entity_in_kb` exists to catch a name the KB has never heard of. An entity
+    that appears only on the object side has been heard of, so calling it absent
+    would report a spelling problem for a correctly spelled name -- and the real
+    finding, that this subject has no such fact, would be lost.
+    """
+    plan = _plan_for(
+        _kb_with_object_only_entity(tmp_path), subject="김철수", relation="owner"
+    )
+
+    assert plan.candidates == ()
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.entity_in_kb is True
+    assert plan.diagnosis.absent_entities == ()
+
+
+def _kb_with_object_only_entity(tmp_path):
+    s = _store(tmp_path)
+    s.add_fact("프로젝트A", "owner", "김철수", status="confirmed")
+    return s
+
+
+def test_membership_sets_carry_every_spelling_the_matcher_compares_against(tmp_path):
+    """The sets must mirror the matcher's spellings, not a convenient subset.
+
+    `_matching_entities` compares an intent's value against a term's `display`,
+    `executable` and `key`, and `_relation_matches_any` does the same for a
+    relation. A membership set holding only the displayed surface therefore says
+    "absent" for a spelling the planner would have matched -- the divergence
+    that made a typed alias read as missing. Pinning the spellings keeps the two
+    from drifting apart again.
+    """
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    s.add_fact("샘플조직", "is_a", "조직", status="confirmed")
+    snapshot = build_query_schema_snapshot(s)
+    relation = snapshot.relations[0].relation
+    subject = snapshot.relations[0].subjects[0]
+
+    assert snapshot.all_relation_labels is not None
+    assert {relation.display, relation.executable, relation.key} <= snapshot.all_relation_labels
+    assert snapshot.all_entity_surfaces is not None
+    assert {subject.display, subject.executable, subject.key} <= snapshot.all_entity_surfaces
+    # The three really are different spellings, or this test would pass vacuously.
+    assert len({relation.display, relation.executable, relation.key}) == 3
+
+
+def _kb_where_the_join_search_truncates(tmp_path):
+    """A hub relation and a busy entity, so both bounded views are capped."""
+    s = _store(tmp_path)
+    for index in range(150):  # past max_entities_per_side on purpose.subjects
+        s.add_fact(f"주체{index:03d}", "purpose", f"목표{index:03d}", status="confirmed")
+    for index in range(60):  # past max_exact_entity_facts, sorting before "purpose"
+        s.add_fact("힣타겟", f"aaa{index:03d}", f"값{index:03d}", status="confirmed")
+    s.add_fact("힣타겟", "purpose", "진짜목표", status="confirmed")
+    return s
+
+
+def test_no_fact_joins_them_is_not_claimed_when_the_search_was_truncated(tmp_path):
+    """Emptiness is read from bounded views, so it cannot always be trusted.
+
+    Membership comes from complete sets, but candidate generation does not: a
+    relation's subject list and the exact-fact list are both capped. On a hub
+    relation the joining fact can sit just past a cap, and the planner comes up
+    empty while the fact exists. Saying "no confirmed fact joins them" there is
+    a false statement about the KB's own contents -- worse than the vague string
+    it replaced, which was at least true.
+    """
+    from verinote.pipeline.query import _empty_plan_reason
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import plan_query_candidates
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _kb_where_the_join_search_truncates(tmp_path)
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "힣타겟"),
+        relation=IntentTarget("relation", "purpose"),
+    )
+    snapshot = build_query_schema_snapshot(s, exact_entities=("힣타겟",))
+    # The fixture really does truncate, or this test proves nothing.
+    assert snapshot.exact_entity_facts_truncated
+    plan = plan_query_candidates(intent, snapshot, qid=1)
+    assert plan.candidates == ()
+    # ...and the fact it would have to have found is really there.
+    assert any(
+        row["subject"] == "힣타겟" and row["relation"] == "purpose"
+        for row in s.facts(statuses=["confirmed"])
+    )
+
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.join_search_complete is False
+    assert _empty_plan_reason(plan, intent) == "no query candidates matched the schema"
+
+
+def test_no_fact_joins_them_is_claimed_when_the_search_was_complete(tmp_path):
+    """The guard must not swallow the case it was built to report.
+
+    On a KB small enough for every view to be whole, emptiness really does prove
+    the fact is absent, and that is the one reading of the three that tells the
+    user nothing needs fixing.
+    """
+    plan = _plan_for(_diagnosis_store(tmp_path), subject="샘플조직", relation="purpose")
+
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.join_search_complete is True
+
+
+def test_case_c_names_the_reading_only_when_a_requested_label_was_dropped(tmp_path):
+    """Name the substitution when there is one, and stay quiet when there is not.
+
+    `_relation_requests` merges `intent.relation` with `relation_candidates`, and
+    an LLM-supplied candidate need not be an alias sibling of the relation it
+    accompanies. When only the sibling resolves, "the requested relation
+    resolved" hides that the question was read as a different word. When every
+    label resolves they are one relation under alias policy -- always so for the
+    sets the deterministic parser invents -- and singling one out would show the
+    user a word they may never have typed.
+    """
+    from verinote.pipeline.query import _empty_plan_reason
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import plan_query_candidates
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    s.add_fact("홍길동", "purpose", "샘플목표", status="confirmed")
+    s.add_fact("샘플조직", "is_a", "조직", status="confirmed")
+    partial = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "샘플조직"),
+        relation=IntentTarget("relation", "담당자"),
+        # `목적` resolves to the `purpose` relation, so its canonical differs
+        # from its spelling -- which is what makes the display rule testable.
+        relation_candidates=("목적",),
+    )
+    snapshot = build_query_schema_snapshot(s, exact_entities=("샘플조직",))
+
+    plan = plan_query_candidates(partial, snapshot, qid=1)
+
+    assert plan.candidates == ()
+    assert plan.diagnosis is not None
+    # `담당자` is absent and `목적` resolved, so the reading is disclosed --
+    # spelled as the question spelled it, not as `purpose`, which is neither the
+    # requested word nor a label this KB would show for it.
+    assert plan.diagnosis.any_unmatched is True
+    assert plan.diagnosis.matched_relations == ("목적",)
+    assert _empty_plan_reason(plan, partial) == (
+        'entity "샘플조직" is in the knowledge base and relation "목적" '
+        "resolved, but no confirmed fact joins them"
+    )
+
+
+def test_no_fact_joins_them_needs_evidence_not_merely_an_untruncated_list(tmp_path):
+    """An empty exact-fact list is not a completed search; it is no search.
+
+    `not truncated` is also true of a list that was never populated, so a
+    snapshot built without `exact_entities` would report the join search as
+    exhaustive with no backstop behind it and claim a fact absent on no
+    evidence. A diagnosed entity that is in the KB has at least one fact, so an
+    empty list here means the snapshot was built for something else.
+    """
+    from verinote.pipeline.query import _empty_plan_reason
+    from verinote.pipeline.query_intent import (
+        IntentTarget,
+        QueryIntent,
+        QueryIntentKind,
+    )
+    from verinote.pipeline.query_planner import plan_query_candidates
+    from verinote.pipeline.query_schema import build_query_schema_snapshot
+
+    s = _store(tmp_path)
+    s.add_fact("샘플주체", "관계000", "값000", status="confirmed")
+    s.add_fact("다른주체", "관계001", "값001", status="confirmed")
+    # 샘플주체 is in the KB and 관계001 is in the schema, but they do not join --
+    # the (c) shape, which is the one that needs evidence.
+    intent = QueryIntent(
+        kind=QueryIntentKind.LOOKUP_OBJECT,
+        subject=IntentTarget("entity", "샘플주체"),
+        relation=IntentTarget("relation", "관계001"),
+    )
+    # Built WITHOUT exact_entities: the list is empty and un-truncated.
+    snapshot = build_query_schema_snapshot(s)
+    assert snapshot.exact_entity_facts == ()
+    assert snapshot.exact_entity_facts_truncated is False
+
+    plan = plan_query_candidates(intent, snapshot, qid=1)
+
+    assert plan.diagnosis is not None
+    assert plan.diagnosis.join_search_complete is False
+    assert "no confirmed fact joins them" not in _empty_plan_reason(plan, intent)

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -531,7 +531,9 @@ def test_repair_disabled_fallback_keeps_deterministic_planner_empty_under_review
         {
             "id": qid,
             "accepted": False,
-            "reason": "no query candidates matched the schema",
+            "reason": (
+                'relation "birth place" is not in the schema or its aliases (a policy/relation-aliases.md entry would map it)'
+            ),
         }
     ]
     assert s.questions()[0]["status"] == "review_required"
@@ -557,7 +559,7 @@ def test_repair_provider_error_during_reinterpretation_skips_direct_fallback(
 
     assert client.calls == 1
     assert results[0]["accepted"] is False
-    assert "no query candidates matched the schema" in results[0]["reason"]
+    assert 'relation "birth place" is not in the schema or its aliases (a policy/relation-aliases.md entry would map it)' in results[0]["reason"]
     assert "synthetic outage" in results[0]["reason"]
     assert s.questions()[0]["status"] == "review_required"
 
@@ -583,7 +585,9 @@ def test_repair_llm_supported_planner_empty_does_not_call_direct_fallback(
         {
             "id": qid,
             "accepted": False,
-            "reason": "no query candidates matched the schema",
+            "reason": (
+                'relation "missing_relation" is not in the schema or its aliases (a policy/relation-aliases.md entry would map it)'
+            ),
         }
     ]
     assert s.questions()[0]["status"] == "review_required"

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -504,7 +504,7 @@ def _plan_and_evaluate_intent(
             evaluation.outcome,
         )
     if evaluation.outcome == QueryCandidateSetOutcome.EMPTY:
-        reason = _short_reason(plan.reason or "no query candidates matched the schema")
+        reason = _short_reason(_empty_plan_reason(plan, intent))
         return (
             _QueryFlowResult(
                 "review_required",
@@ -522,6 +522,75 @@ def _plan_and_evaluate_intent(
         _QueryFlowResult("review_required", f"review_required({_lit(reason)})", reason),
         evaluation.outcome,
     )
+
+
+def _empty_plan_reason(plan, intent: QueryIntent) -> str:
+    """Say which half of the question the KB does not have, and name it.
+
+    "No query candidates matched the schema" is true of three situations whose
+    remedies differ -- add a relation alias, fix the entity's spelling, or
+    accept that the fact is simply absent -- so on its own it tells a user only
+    that something did not work. The planner has already established which one
+    it was; this turns that into the sentence the user acts on.
+
+    Falls back to the planner's own reason whenever the diagnosis is absent,
+    which is every kind whose emptiness does not reduce to one relation and one
+    entity. Those kinds carry more specific messages already.
+    """
+    diagnosis = plan.diagnosis
+    if diagnosis is None:
+        return plan.reason or "no query candidates matched the schema"
+
+    relation = ", ".join(
+        f'"{value}"' for value in _intent_relation_labels(intent)
+    )
+    entities = ", ".join(
+        f'"{target.value}"'
+        for target in (intent.subject, intent.object)
+        if target is not None
+    )
+    missing: list[str] = []
+    if diagnosis.relation_in_schema is False and relation:
+        missing.append(
+            f"relation {relation} is not in the schema or its aliases "
+            "(a policy/relation-aliases.md entry would map it)"
+        )
+    if diagnosis.absent_entities:
+        # Only the endpoints that are actually missing. A question naming two
+        # entities can have one the KB holds and one it does not, and saying
+        # "entity A, B is not in the knowledge base" would be false about A.
+        absent = ", ".join(f'"{value}"' for value in diagnosis.absent_entities)
+        missing.append(f"entity {absent} is not in the knowledge base")
+    if missing:
+        return "; ".join(missing)
+    if (
+        diagnosis.relation_in_schema
+        and diagnosis.entity_in_kb
+        and diagnosis.join_search_complete
+    ):
+        # The reading is named only when some requested label did NOT resolve,
+        # because that is the only case where naming it tells the reader
+        # something: one of the words the question carried was substituted for
+        # another. When every label resolved they are aliases of one relation,
+        # and singling one out would put a sibling on screen that the user may
+        # never have typed.
+        if diagnosis.any_unmatched and diagnosis.matched_relations:
+            resolved = ", ".join(f'"{value}"' for value in diagnosis.matched_relations)
+            return (
+                f"entity {entities} is in the knowledge base and relation "
+                f"{resolved} resolved, but no confirmed fact joins them"
+            )
+        return (
+            f"entity {entities} is in the knowledge base and the requested "
+            "relation resolved, but no confirmed fact joins them"
+        )
+    return plan.reason or "no query candidates matched the schema"
+
+
+def _intent_relation_labels(intent: QueryIntent) -> tuple[str, ...]:
+    values = [intent.relation.value] if intent.relation is not None else []
+    values.extend(intent.relation_candidates)
+    return tuple(dict.fromkeys(values))
 
 
 def _intent_exact_entities(intent: object) -> tuple[str, ...]:

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -70,12 +70,87 @@ class QueryCandidate:
 
 
 @dataclass(frozen=True)
+class EmptyPlanDiagnosis:
+    """Why a lookup produced no candidates, in the two terms a user can act on.
+
+    An empty plan has one message today -- "no query candidates matched the
+    schema" -- for situations with different remedies: a relation the KB does
+    not have (add an alias), an entity spelled differently from the stored one
+    (fix the spelling), and a known entity that simply has no such fact (nothing
+    to fix). Naming which one occurred is the difference between a shrug and an
+    instruction.
+
+    The two verdicts are plain booleans because they are answered from the
+    snapshot's complete, untruncated membership sets. `None` means only that the
+    question does not arise for this intent kind -- `lookup_relation` requests
+    no particular relation, so `relation_in_schema` has nothing to report --
+    never that it could not be determined.
+
+    The two are independent and both are reported: a question can name a
+    relation the KB lacks *and* an entity it lacks, and fixing one of them still
+    yields no answer.
+    """
+
+    relation_in_schema: bool | None
+    entity_in_kb: bool | None
+    join_search_complete: bool = False
+    """Whether the search that found no candidates covered the whole KB.
+
+    The two membership verdicts are read from complete sets, but *emptiness*
+    is not: candidates are generated from the bounded views -- a relation's
+    subject and object lists (`max_entities_per_side`) and the exact-fact list
+    (`max_exact_entity_facts`). So on a hub relation or a busy entity the
+    planner can come up empty while the joining fact exists just past a cap.
+
+    Only the "both known, nothing joins them" reading depends on that search
+    having been exhaustive; the two absence readings rest on the complete sets
+    and are unaffected. When this is False, a caller must not claim the fact is
+    missing -- vague and true beats specific and false.
+    """
+    absent_entities: tuple[str, ...] = ()
+    """Exactly the named endpoints the KB does not hold.
+
+    `entity_in_kb` is one bool over possibly two endpoints, and a question like
+    "how are A and B related?" can name one the KB has and one it does not. A
+    caller with only the bool has to accuse both, which puts a false statement
+    about the KB's own contents in the reason -- the opposite of what this
+    diagnosis exists for. Naming them is the only way the message can be about
+    the endpoint that is actually missing.
+    """
+    matched_relations: tuple[str, ...] = ()
+    """Every requested label that resolved, one per relation it resolved to.
+
+    Verbatim as requested, like `absent_entities`, and deduplicated by canonical
+    form so a set of aliases for one relation is reported once rather than five
+    times. The requested spelling is kept rather than the canonical, because a
+    reader can compare their own word against it while a canonical such as
+    `role` is often neither their word nor any label the KB holds.
+
+    This is a fact, not a decision: it lists what resolved whether or not
+    anything else failed to. Whether naming it *tells the reader anything* is
+    `any_unmatched`, and the renderer -- not this field -- makes that call.
+    """
+    any_unmatched: bool = False
+    """Whether some requested label failed to resolve.
+
+    A question asks for every label `_relation_requests` collects, and when all
+    of them resolve they are aliases of one relation -- always so for the sets
+    the deterministic parser invents, which are alias-closed by construction. In
+    that case no reading was substituted and singling one label out would show
+    the user a sibling they may never have typed. Only a partial match, which
+    needs an LLM-supplied candidate that is not an alias sibling, means the
+    question was answered about a different word than one it carried.
+    """
+
+
+@dataclass(frozen=True)
 class QueryCandidatePlan:
     qid: int
     candidates: tuple[QueryCandidate, ...]
     truncated: bool = False
     reason: str | None = None
     no_answer: bool = False
+    diagnosis: EmptyPlanDiagnosis | None = None
 
 
 def plan_query_candidates(
@@ -151,7 +226,135 @@ def plan_query_candidates(
         candidates = ()
         reason = f"unsupported intent kind: {intent.kind.value}"
 
-    return _bounded_plan(qid, candidates, bounds, reason=reason)
+    return _bounded_plan(
+        qid,
+        candidates,
+        bounds,
+        reason=reason,
+        diagnosis=None if candidates else _diagnose_empty_lookup(intent, snapshot),
+    )
+
+
+_DIAGNOSED_KINDS = frozenset(
+    {
+        QueryIntentKind.LOOKUP_OBJECT,
+        QueryIntentKind.LOOKUP_SUBJECT,
+        QueryIntentKind.LOOKUP_RELATION,
+        QueryIntentKind.DISCOVER_ENTITY_RELATIONS,
+    }
+)
+"""The kinds whose emptiness reduces to one relation and one entity.
+
+The conjunctive and typed-comparison kinds are left out because each carries
+several relations and endpoints, so "the relation" and "the entity" are not
+single things and a per-hop taxonomy is a different design. They return their
+own plan before this runs, so the check is a statement of scope rather than a
+gate anything reaches today -- keep it, but do not read it as protecting their
+specific reasons ("no two-hop relation path matched the schema" and its
+siblings); the early return does that.
+"""
+
+
+def _diagnose_empty_lookup(
+    intent: QueryIntent, snapshot: QuerySchemaSnapshot
+) -> EmptyPlanDiagnosis | None:
+    """Say which half of a lookup the KB does not have, if either."""
+    if intent.kind not in _DIAGNOSED_KINDS:
+        return None
+    if snapshot.all_relation_labels is None or snapshot.all_entity_surfaces is None:
+        # A hand-built snapshot with no membership sets. Absence is unknown, and
+        # reporting it as false would tell a user to add a relation they have.
+        return None
+    requested = _relation_requests(intent)
+    entities = _diagnosed_entities(intent)
+    absent = tuple(
+        value for value in entities if _nfc(value) not in snapshot.all_entity_surfaces
+    )
+    matched, any_unmatched = _requested_relations_in_schema(requested, snapshot)
+    return EmptyPlanDiagnosis(
+        relation_in_schema=bool(matched) if requested else None,
+        entity_in_kb=(not absent) if entities else None,
+        join_search_complete=_join_search_was_complete(snapshot),
+        absent_entities=absent,
+        matched_relations=matched,
+        any_unmatched=any_unmatched,
+    )
+
+
+def _join_search_was_complete(snapshot: QuerySchemaSnapshot) -> bool:
+    """Whether an empty plan proves the joining fact is absent.
+
+    Only the exact-fact list has to be whole. Every diagnosed kind generates
+    candidates from it as well as from the relation views
+    (`_lookup_object_exact_fact_candidates` and its siblings), and when it was
+    built for the intent's entities it holds every fact touching them. So a
+    complete list turns an empty plan into a proof that the entity has no fact
+    with that relation, whatever the relation views dropped.
+
+    Both halves are required, and the non-empty check is the interesting one.
+    "Not truncated" is also true of a list that was never populated -- a
+    snapshot built without `exact_entities` -- and that list is not a whole
+    search but no search, so reading it as proof would assert the fact is absent
+    on no evidence. A diagnosed entity that is in the KB has at least one fact,
+    so an empty list here means the snapshot was built for something else.
+
+    Checking `relations_truncated` or a relation's `subjects_truncated` too
+    would read as extra safety and be neither: with the exact-fact list whole
+    they cannot change the verdict, so they would be branches no test could ever
+    kill. That holds because every stored term is currently a `StringLit`, so
+    `_entity_matches` and the membership sets agree on the displayed surface.
+    """
+    return bool(snapshot.exact_entity_facts) and not snapshot.exact_entity_facts_truncated
+
+
+def _diagnosed_entities(intent: QueryIntent) -> tuple[str, ...]:
+    """The intent's named endpoints, whichever roles this kind puts them in."""
+    return tuple(
+        target.value
+        for target in (intent.subject, intent.object)
+        if target is not None
+    )
+
+
+def _requested_relations_in_schema(
+    requested: tuple[str, ...], snapshot: QuerySchemaSnapshot
+) -> tuple[tuple[str, ...], bool]:
+    """Which requested labels name a relation the KB holds, and whether any did not.
+
+    Returns the labels rather than only a verdict, because *which* one resolved
+    is load-bearing for the message. `_relation_requests` includes the candidates
+    the deterministic parser invents -- asking for `역할` also asks for `직책`
+    and `직위` -- so "one of them resolved" can be true of a word the user never
+    typed, and reporting that as "the requested relation resolved" would tell
+    them nothing needs fixing when the remedy is an alias for the word they did
+    type.
+
+    Read against the complete label set rather than `snapshot.relations`, which
+    is capped: a relation past the cap is one the KB has, and calling it absent
+    would send the user to add an alias for something already there.
+    """
+    aliases = {entry.alias: entry.canonical for entry in snapshot.relation_aliases}
+    observed_labels = snapshot.all_relation_labels or frozenset()
+    # One entry per relation resolved to, spelled as the question spelled it.
+    #
+    # Deduplication is by canonical form because asking for `목적` also asks for
+    # `목표`, `purpose`, `objective` and `goal`, and when those are aliases of
+    # one relation, listing five names describes the attempt rather than the
+    # reading. The name kept is the requested one, not the canonical: a reader
+    # can compare "relation `목적` resolved" against the word they typed, while a
+    # canonical such as `role` is often neither their word nor any label in the
+    # KB, so it gives them nothing to compare and states a name no fact carries.
+    matched: dict[str, str] = {}
+    unmatched = False
+    for value in requested:
+        if any(
+            relation_label_matches(observed, value, aliases)
+            for observed in observed_labels
+        ):
+            matched.setdefault(_nfc(canonical_relation(value, aliases)), value)
+        else:
+            unmatched = True
+    return tuple(matched.values()), unmatched
 
 
 _EXACT_NUMBER = re.compile(r"^-?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?$")
@@ -1118,6 +1321,7 @@ def _bounded_plan(
     *,
     no_answer: bool = False,
     reason: str | None,
+    diagnosis: EmptyPlanDiagnosis | None = None,
 ) -> QueryCandidatePlan:
     bounded = candidates[: bounds.max_candidates]
     return QueryCandidatePlan(
@@ -1126,6 +1330,10 @@ def _bounded_plan(
         truncated=len(candidates) > bounds.max_candidates,
         no_answer=no_answer and not bounded,
         reason=reason,
+        # No `not bounded` guard here, unlike `no_answer`: the only caller that
+        # passes a diagnosis already withholds it when candidates survive, so a
+        # second gate would be a branch no test could reach.
+        diagnosis=diagnosis,
     )
 
 

--- a/verinote/pipeline/query_schema.py
+++ b/verinote/pipeline/query_schema.py
@@ -127,6 +127,30 @@ class QuerySchemaSnapshot:
     join_facts: tuple[SnapshotFact, ...] = ()
     """Complete engine-input fact rows used only for bounded join planning."""
     join_facts_truncated: bool = False
+    all_relation_labels: frozenset[str] | None = None
+    """Every relation surface in the KB, NFC-folded and *not* truncated.
+
+    The lists above are bounded because they are rendered -- into the model's
+    schema hint and into candidate generation -- so a large KB must not blow
+    either up. Membership is a different question: answering "does this label
+    exist at all?" from a list capped at `max_relations` reports a relation the
+    KB holds as absent, which is worse than not answering. These sets are
+    derived from the same complete fact list the bounded views are taken from
+    (`_engine_facts` reads every engine-status fact), so they cost no extra
+    query and carry no truncation.
+
+    `None` means the snapshot was built without them -- by a caller constructing
+    one directly rather than through `build_query_schema_snapshot` -- and
+    absence is then unknown rather than false. Diagnosis is skipped instead of
+    guessed.
+    """
+    all_entity_surfaces: frozenset[str] | None = None
+    """Every subject and object surface in the KB, NFC-folded and not truncated.
+
+    Carries each term's `display`, `executable` and `key` spellings, because
+    that is the set `_matching_entities` compares an intent's entity against.
+    See `all_relation_labels` for why this is unbounded and what `None` means.
+    """
 
 
 @dataclass(frozen=True)
@@ -176,6 +200,8 @@ def build_query_schema_snapshot(
         fact_count=len(facts),
         join_facts=join_rows,
         join_facts_truncated=include_join_facts and len(facts) > bounds.max_join_facts,
+        all_relation_labels=_all_relation_labels(facts, typed_entries),
+        all_entity_surfaces=_all_entity_surfaces(facts),
     )
 
 
@@ -385,6 +411,45 @@ def _typed_entry(relation: str, spec: TypedRelationSpec) -> TypedRelationEntry:
         type=spec.type,
         alias=spec.alias,
         units=units,
+    )
+
+
+def _all_relation_labels(
+    facts: Iterable[_Fact], typed: Iterable[TypedRelationEntry]
+) -> frozenset[str]:
+    """Every spelling by which a relation can be requested, for membership only.
+
+    Facts are not the whole story. `_relation_matches_any` also observes a
+    relation's typed-spec name and its alias, and those live in
+    `policy/typed-relations.md` rather than in any fact -- so a set built from
+    facts alone reports a typed alias the planner does match as absent, and the
+    reason built on it tells the user to declare something they have declared.
+    """
+    labels = {
+        _nfc(surface)
+        for fact in facts
+        for surface in (fact.relation.display, fact.relation.executable, fact.relation.key)
+    }
+    for entry in typed:
+        labels.add(_nfc(entry.relation))
+        if entry.alias:
+            labels.add(_nfc(entry.alias))
+    return frozenset(labels)
+
+
+def _all_entity_surfaces(facts: Iterable[_Fact]) -> frozenset[str]:
+    """Every spelling of every subject and object in the KB.
+
+    Both endpoints are collected, not just subjects: this answers "is this a
+    real entity in this KB?", and an entity sighted only as an object is just as
+    real. What it must never be read as is "this entity can be the subject of
+    that relation" -- that is what the absence of a planned candidate says.
+    """
+    return frozenset(
+        _nfc(surface)
+        for fact in facts
+        for ref in (fact.subject, fact.object)
+        for surface in (ref.display, ref.executable, ref.key)
     )
 
 


### PR DESCRIPTION
Closes #434.

## Problem

An empty query plan reported one string for three situations whose remedies differ:

| situation | remedy | old reason |
|---|---|---|
| the relation is not in the schema or its aliases | add a `policy/relation-aliases.md` entry | `no query candidates matched the schema` |
| the entity surface matches no stored subject/object | fix the spelling | *same* |
| known entity, resolved relation, no fact joins them | nothing to fix | *same* |

True, and useless — it named neither the problem nor the fix.

## The change

`QueryCandidatePlan` carries an `EmptyPlanDiagnosis`, derived inside the planner from the same predicates that produced the emptiness, and the reason says which case it was:

```
relation "담당자" is not in the schema or its aliases (a policy/relation-aliases.md entry would map it)
entity "없는조직" is not in the knowledge base
entity "샘플조직" is in the knowledge base and the requested relation resolved, but no confirmed fact joins them
```

**Membership is read from complete, untruncated sets.** `build_query_schema_snapshot` already materialises every engine-status fact (`store.facts()` has no LIMIT); the caps apply only to the views rendered into the model hint and candidate generation. Deriving membership from that same list costs no extra query and means a relation past `max_relations` is never called absent — which would have told a user to declare something they already had.

## Each strong claim is guarded by what it actually rests on

Three defects of one class — a false statement about the KB's own contents — were found during review and fixed:

- **Only the absent endpoints are named.** `entity_in_kb` is one bool over possibly two, so "how are A and B related?" with only B misspelled said A was missing too.
- **Membership covers typed-spec names and aliases**, which the planner matches and no fact spells. Without them a typed alias read as absent and the reason prescribed the wrong policy file.
- **"No confirmed fact joins them" additionally requires the exact-fact list to be populated and un-truncated.** Emptiness is still computed from the bounded views, so on a hub relation the joining fact can sit past a cap and the claim was confidently false. When completeness cannot be shown, the vague-but-true string is used instead.

**The reading is named only on a partial match.** The sets the deterministic parser invents are alias-closed, so when every requested label resolves nothing was substituted and singling one out would show a sibling the user never typed. Only an LLM-supplied non-sibling candidate produces a partial match — and there the word is shown, spelled as the question spelled it.

## Deliberately not included

Both are from #434's own follow-up list, and both need their own decision:

- **Case (c) is diagnosed but not converted to `VERIFIED — engine (negative)`.** Today such a question splits into a terminal subset and one that stays recoverable when the repair model declares rather than writes; making all of it terminal would remove a rescue.
- **#432's re-read is not gated on the diagnosis.** The obvious gate — relation-unknown — would withhold it from questions a model demonstrably rescues: `우리 샘플조직의 대표는?` matches its relation exactly and still mis-splits the entity.

## Verification

Full suite **2485 passed / 20 skipped** against a frozen tree (digest identical before and after the run); baseline on `main` is 2470. Ruff: zero new findings versus baseline by normalised diff.

Mutation matrix, reproduced independently by three parties: membership from the truncated list · dropping the fail-safe · reporting only the relation half · only the entity half · subjects-only surfaces · display-only spellings · dropping typed labels · accusing every endpoint · the join guard as a whole and each conjunct separately · disclosing when nothing was dropped · never disclosing · displaying the canonical instead of the requested spelling · consulting only the first requested label. All killed.

## Follow-up

- #439 — `lookup_relation` cannot reach the no-such-fact reading, since it requests no relation. Semantically the same case, needing a different claim and a different completeness argument.

Synthetic fixtures only.