### PR TITLE
fix: offer both readings of a trailing josa syllable (#431)

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1211,10 +1211,12 @@ def test_known_entity_with_no_such_fact_is_reported_as_neither_half_missing(
     results = translate_questions(s, client, root=tmp_path)
 
     assert results[0]["status"] == "review_required"
-    # The single requested label resolved, so nothing was substituted and no
-    # reading is singled out.
+    # The question also carries its un-stripped josa reading (#431), which no KB
+    # holds, so `any_unmatched` fires and the resolved reading is named. It is
+    # the user's own word, so the message stays true -- but see #441: the
+    # "a word was substituted" signal is now close to always-on for this shape.
     assert results[0]["reason"] == (
-        'entity "샘플조직" is in the knowledge base and the requested relation '
+        'entity "샘플조직" is in the knowledge base and relation "목적" '
         "resolved, but no confirmed fact joins them"
     )
 

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -403,7 +403,17 @@ def test_generic_attribute_questions_become_lookup_object_intents():
 
     for intent in (korean, korean_explicit, english_possessive, english_of):
         assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
-        assert intent.relation_candidates == PURPOSE_RELATION_CANDIDATES
+        # The Korean forms also carry their un-stripped josa reading (#431);
+        # English has no josa, so those stay exactly the synonym set.
+        assert intent.relation_candidates[: len(PURPOSE_RELATION_CANDIDATES)] == (
+            PURPOSE_RELATION_CANDIDATES
+        )
+    assert english_possessive.relation_candidates == PURPOSE_RELATION_CANDIDATES
+    assert english_of.relation_candidates == PURPOSE_RELATION_CANDIDATES
+    assert korean.relation_candidates == PURPOSE_RELATION_CANDIDATES + ("목적은",)
+    assert korean_explicit.relation_candidates == PURPOSE_RELATION_CANDIDATES + (
+        "목적은",
+    )
     assert korean.subject == IntentTarget("entity", "샘플프로젝트")
     assert english_possessive.subject == IntentTarget("entity", "Sample Project")
     assert english_of.subject == IntentTarget("entity", "Sample Project")
@@ -420,11 +430,15 @@ def test_generic_korean_attribute_requires_question_shape():
 # A hand-list drifts: with `이에요` written out for one stem only, dropping it
 # from the other three fails no test, because the stem that still carries it
 # masks them.
+# The second entry of each pair is the un-stripped josa reading, offered
+# alongside the stripped one because nothing here can tell a josa from a
+# label's own last syllable (#431). It never matches for these labels; the
+# stripped reading is the one the KB holds.
 _KOREAN_INTERROGATIVE_STEMS = (
-    ("샘플프로젝트의 담당자는 누구", ("담당자",)),
-    ("샘플제품의 가격은 얼마", ("가격",)),
-    ("샘플조직의 본사는 어디", ("본사",)),
-    ("샘플프로젝트의 착수일은 언제", ("착수일",)),
+    ("샘플프로젝트의 담당자는 누구", ("담당자", "담당자는")),
+    ("샘플제품의 가격은 얼마", ("가격", "가격은")),
+    ("샘플조직의 본사는 어디", ("본사", "본사는")),
+    ("샘플프로젝트의 착수일은 언제", ("착수일", "착수일은")),
 )
 _KOREAN_INTERROGATIVE_QUESTION_FORMS = (
     "인가?",
@@ -448,10 +462,10 @@ _KOREAN_INTERROGATIVE_QUESTION_FORMS = (
     # admits on each of them. They are listed separately because they do not
     # carry the same suffix set as the four added stems.
     + [
-        ("샘플프로젝트의 목적은 무엇인가요?", PURPOSE_RELATION_CANDIDATES),
-        ("샘플프로젝트의 목적이 뭐인가요?", PURPOSE_RELATION_CANDIDATES),
-        ("샘플프로젝트의 목적이 뭐예요?", PURPOSE_RELATION_CANDIDATES),
-        ("샘플문서의 형식은 어떤 것인가요?", ("형식",)),
+        ("샘플프로젝트의 목적은 무엇인가요?", PURPOSE_RELATION_CANDIDATES + ("목적은",)),
+        ("샘플프로젝트의 목적이 뭐인가요?", PURPOSE_RELATION_CANDIDATES + ("목적이",)),
+        ("샘플프로젝트의 목적이 뭐예요?", PURPOSE_RELATION_CANDIDATES + ("목적이",)),
+        ("샘플문서의 형식은 어떤 것인가요?", ("형식", "형식은")),
     ],
 )
 def test_korean_attribute_questions_strip_person_place_time_and_amount_words(
@@ -504,6 +518,7 @@ def test_korean_attribute_label_does_not_strip_a_stemless_politeness_ending():
     # `는` here is a real josa rather than a politeness ending.
     assert deterministic_query_intent("샘플사업의 재인가는?").relation_candidates == (
         "재인가",
+        "재인가는",
     )
 
 
@@ -560,3 +575,90 @@ def test_deterministic_entity_relation_discovery_rejects_generic_what_does_shape
         deterministic_query_intent("What does Sample Entity have?").kind
         == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
     )
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["단가", "물가", "증가", "평가", "나이", "차이", "길이", "넓이", "허가", "기준단가"],
+)
+def test_a_labels_own_last_syllable_survives_as_one_reading(label):
+    """A trailing `은`/`는`/`이`/`가` may belong to the relation, not the grammar.
+
+    Stripping it unconditionally asked the schema for `단`, `길`, `나` -- labels
+    no KB holds -- so a question naming its relation exactly was answered
+    UNVERIFIED. The full spelling is now offered as a reading, and the schema
+    decides which one exists.
+    """
+    intent = deterministic_query_intent(f"샘플대상의 {label}?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert label in intent.relation_candidates
+
+
+@pytest.mark.parametrize(
+    ("question", "label"),
+    [
+        ("샘플대상의 성과 지표은?", "성과 지표"),
+        ("샘플대상의 가격는?", "가격"),
+        ("샘플대상의 담당자은?", "담당자"),
+        ("샘플제품의 길이 얼마인가?", "길이"),
+    ],
+)
+def test_the_stripped_reading_survives_too(question, label):
+    """Keeping the full spelling must not cost the stripped one.
+
+    The first two questions carry a josa that does not agree with the word
+    before it -- `지표은` should be `지표는`, `가격는` should be `가격은` -- which
+    a person mistypes and a caller templating `{relation}은?` produces
+    mechanically. Committing to the full reading there would ask for a relation
+    named `가격는`. Both readings are offered precisely because neither guess is
+    safe on its own.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert label in intent.relation_candidates
+
+
+@pytest.mark.parametrize("question", ["샘플프로젝트의 목적는?", "샘플프로젝트의 목적이?"])
+def test_the_synonym_set_survives_the_second_reading(question):
+    """Adding a second reading must not cost the synonyms the first one carries.
+
+    `목적는` is a mis-typed `목적`, and the stripped reading is the one that
+    resolves to the purpose set. Only that reading is expanded -- the second
+    cannot be a synonym key today -- so this pins that the set still arrives.
+    """
+    intent = deterministic_query_intent(question)
+
+    for synonym in PURPOSE_RELATION_CANDIDATES:
+        assert synonym in intent.relation_candidates
+
+
+def test_a_label_that_is_only_a_josa_is_not_claimed():
+    """`{entity}의 {label}은?` with a blank label is not an attribute question.
+
+    Reading a bare `은` as a relation name would claim a shape this parser has
+    always declined, and then tell the user to add a `policy/relation-aliases.md`
+    entry for a grammatical particle -- advice about their own KB that is simply
+    wrong. Declining sends it to the model instead, which sees the schema hint,
+    so a KB that really does hold a relation named `은` is still reachable.
+    """
+    for question in ("샘플조직의 은?", "샘플조직의 은 무엇인가요?", "샘플조직의 가?"):
+        intent = deterministic_query_intent(question)
+
+        assert intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+        assert intent.relation_candidates == ()
+
+    # Pinned on the function too, not only through the call site's truthiness
+    # check: a label that is only a josa has no readings, rather than a reading
+    # that happens to be the empty string.
+    from verinote.pipeline.query_intent import _korean_attribute_label_readings
+
+    assert _korean_attribute_label_readings("은") == ()
+    assert _korean_attribute_label_readings("가") == ()
+
+    # The boundary: one syllable of label before the josa is a label, so `이는?`
+    # is an ordinary two-reading question rather than a declined one.
+    boundary = deterministic_query_intent("샘플조직의 이는?")
+    assert boundary.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert boundary.relation_candidates == ("이", "이는")

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -568,12 +568,13 @@ def _empty_plan_reason(plan, intent: QueryIntent) -> str:
         and diagnosis.entity_in_kb
         and diagnosis.join_search_complete
     ):
-        # The reading is named only when some requested label did NOT resolve,
-        # because that is the only case where naming it tells the reader
-        # something: one of the words the question carried was substituted for
-        # another. When every label resolved they are aliases of one relation,
-        # and singling one out would put a sibling on screen that the user may
-        # never have typed.
+        # The reading is named only when some requested label did NOT resolve.
+        # That used to mean a word the question carried was substituted for
+        # another; since #431 it usually means the speculative josa reading did
+        # not match, and the label named is the user's own word. It can still be
+        # a sibling they never typed -- `목표는?` names `목적`, the synonym set's
+        # leading spelling -- so the message is true but no longer selective.
+        # #441 is where that distinction gets restored.
         if diagnosis.any_unmatched and diagnosis.matched_relations:
             resolved = ", ".join(f'"{value}"' for value in diagnosis.matched_relations)
             return (

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -488,7 +488,7 @@ def deterministic_query_intent(question: str) -> QueryIntent:
             return QueryIntent(
                 kind=QueryIntentKind.LOOKUP_OBJECT,
                 subject=IntentTarget("entity", entity),
-                relation_candidates=_attribute_relation_candidates(label),
+                relation_candidates=_korean_attribute_relation_candidates(raw_label),
             )
 
     match = _ENGLISH_POSSESSIVE_ATTRIBUTE_QUESTION.match(text)
@@ -601,11 +601,56 @@ _KOREAN_ATTRIBUTE_LABEL_TAIL = re.compile(
 _KOREAN_ATTRIBUTE_LABEL_JOSA = re.compile(r"(?:은|는|이|가)\s*$")
 
 
-def _clean_korean_attribute_label(value: str) -> str:
+def _korean_attribute_label_readings(value: str) -> tuple[str, ...]:
+    """Both ways to read a label whose last syllable might be a josa.
+
+    A trailing `은`/`는`/`이`/`가` is genuinely ambiguous and no rule available
+    here settles it. Stripping it -- what this did unconditionally -- turns the
+    relation `단가` into `단` and `길이` into `길`. Keeping it turns a mis-typed
+    `가격는?` into a relation named `가격는`, which no KB holds. Both are single
+    guesses, each with its own failure class, and the evidence that decides
+    between them is the schema: only it knows whether `단가` or `단` is a
+    relation. So both readings are offered and the planner picks whichever the
+    KB has, the same reasoning that kept the multi-hop guard out of the parser.
+
+    Korean phonology narrows which reading is *likelier* -- `은`/`이` follow a
+    syllable with a 받침, `는`/`가` follow one without, so the `가` in `단가`
+    cannot be a josa -- but not which is *right*: `가격는` is exactly that
+    impossible spelling and is still a mis-typed `가격`. Ordering by that rule
+    is a reporting refinement, not part of this decision.
+
+    The stripped reading comes first, preserving the reading this has always
+    proposed; the un-stripped one is added, never substituted, so the candidate
+    set is a superset of what this asked for before -- no relation the KB holds
+    is dropped from the request. That is weaker than "nothing can stop
+    resolving": a second reading that *also* names a real relation reaches the
+    conflict gate, so a KB holding both `평` and `평가` on one subject turns
+    `평가?` from an answer into an ambiguity report. That is the honest outcome
+    for a question the KB genuinely does not disambiguate.
+
+    The interrogative tail is stripped before any of this and is still a single
+    guess: `재인가?` loses `인가` and asks only for `재`, so a KB holding
+    `재인가` is not covered by this change. See #443.
+    """
     label = " ".join(value.strip().split())
     label = _KOREAN_ATTRIBUTE_LABEL_TAIL.sub("", label).strip()
-    label = _KOREAN_ATTRIBUTE_LABEL_JOSA.sub("", label).strip()
-    return label
+    stripped = _KOREAN_ATTRIBUTE_LABEL_JOSA.sub("", label).strip()
+    if not stripped:
+        # The whole label is a josa. Reading it as a relation name would claim
+        # a shape this parser has always declined -- `{entity}의 {label}은?`
+        # with a blank label lands here -- and then advise adding a policy
+        # alias for a grammatical particle. A KB that really does hold a
+        # relation named `은` is still reachable through the model, which sees
+        # it in the schema hint.
+        return ()
+    if stripped == label:
+        return (label,)
+    return (stripped, label)
+
+
+def _clean_korean_attribute_label(value: str) -> str:
+    readings = _korean_attribute_label_readings(value)
+    return readings[0] if readings else ""
 
 
 def _looks_like_korean_attribute_question(raw_label: str, question: str) -> bool:
@@ -634,6 +679,26 @@ def _looks_like_korean_attribute_question(raw_label: str, question: str) -> bool
 def _clean_english_attribute_label(value: str) -> str:
     label = " ".join(value.strip().split())
     return label.removeprefix("the ").strip()
+
+
+def _korean_attribute_relation_candidates(raw_label: str) -> tuple[str, ...]:
+    """Relation candidates for a Korean attribute label, both josa readings.
+
+    Only the leading reading is expanded through `_attribute_relation_candidates`.
+    The stripped reading leads, and today it is the only one that can be a
+    synonym key: no key in that function's set ends in `은`/`는`/`이`/`가`,
+    while the second reading ends in one by construction. So expanding it too
+    is a branch nothing can currently reach.
+
+    That is a fact about the key set, not a law. Add a key like `평가` -- which
+    ends in a josa syllable and is in this issue's own list -- and `평가?` would
+    need the second reading expanded to keep its synonyms, because the leading
+    `평` is not a key. Expand both if that day comes.
+    """
+    readings = _korean_attribute_label_readings(raw_label)
+    candidates = list(_attribute_relation_candidates(readings[0]))
+    candidates.extend(readings[1:])
+    return tuple(dict.fromkeys(candidates))
 
 
 def _attribute_relation_candidates(label: str) -> tuple[str, ...]:

--- a/verinote/pipeline/query_planner.py
+++ b/verinote/pipeline/query_planner.py
@@ -133,13 +133,21 @@ class EmptyPlanDiagnosis:
     any_unmatched: bool = False
     """Whether some requested label failed to resolve.
 
-    A question asks for every label `_relation_requests` collects, and when all
-    of them resolve they are aliases of one relation -- always so for the sets
-    the deterministic parser invents, which are alias-closed by construction. In
-    that case no reading was substituted and singling one label out would show
-    the user a sibling they may never have typed. Only a partial match, which
-    needs an LLM-supplied candidate that is not an alias sibling, means the
-    question was answered about a different word than one it carried.
+    A question asks for every label `_relation_requests` collects. When all of
+    them resolve they are aliases of one relation -- true of the *synonym* sets
+    the deterministic parser invents, which mirror the default alias policy --
+    so nothing was substituted and singling one label out would show the user a
+    sibling they may never have typed.
+
+    A partial match means some requested label was not used, but no longer that
+    the question was answered about a different word. Since #431 the parser also
+    offers both readings of a trailing josa syllable, and those are deliberately
+    not alias siblings: `단가?` asks for `단` and `단가`, only one of which any
+    KB holds. So this fires for nearly every Korean attribute question, and the
+    label it leads the renderer to name is usually the user's own word rather
+    than a substitution. The message stays true; the signal is duller than it
+    was. Separating a requested label from a speculative reading would sharpen
+    it again -- see #441.
     """
 
 


### PR DESCRIPTION
Closes #431.

## Problem

`_clean_korean_attribute_label` stripped a trailing `은`/`는`/`이`/`가` as a josa. When the syllable belongs to the relation, it ate it:

| question | before | after |
|---|---|---|
| `샘플제품의 단가?` | `('단',)` → UNVERIFIED | `('단', '단가')` → **VERIFIED** |
| `샘플제품의 길이?` | `('길',)` | `('길', '길이')` |
| `샘플인물의 나이?` | `('나',)` | `('나', '나이')` |

Also `물가`, `증가`, `평가`, `차이`, `넓이`, `허가`, `기준단가`.

## Why no rule decides it

Korean phonology narrows which reading is *likelier* — `은`/`이` follow a syllable with a 받침, `는`/`가` follow one without, so the `가` in `단가` cannot be a josa — but not which is *right*. `가격는` is exactly that impossible spelling and is still a mis-typed `가격`.

Three designs were tried and each was refuted by evidence before this one survived:

1. **Decide by phonology.** Necessary but not sufficient — it cannot fix `길이`/`넓이`/`높이`/`깊이`, where `이` after a 받침 *is* a legal josa.
2. **Phonology plus a second reading gated on "no interrogative tail was stripped".** The gate was fitted to the existing suite (0/36 churn) and broke the target class: `샘플제품의 길이 얼마인가?` strips the tail and yields `('길',)`.
3. **Phonology alone.** Implemented, and found by running it to be *not* strictly narrowing — it removes tolerance for a mis-typed josa. `가격는?`, `담당자은?`, `목적는?`, `성과 지표은?` all resolve on `main` and stopped. A test caught it; the fixture was not edited to pass.

So there is no phonology in the shipped change. Both readings are offered and the schema decides — the same reasoning that kept the multi-hop guard out of the parser in #432.

## The property this rests on

The stripped reading leads and the un-stripped one is **added, never substituted**, so the candidate set is a superset of what was asked for before: no relation the KB holds is dropped from the request. Verified independently by two reviewers — a 1748-question cross-product (48 labels × 18 tails × 2 connectors) and a 960-question sweep, both against pristine `main`: **0 non-superset cases, 0 kind changes, 0 order changes**, and 3 newly resolving questions, which are the issue's population.

That is weaker than "nothing can stop resolving", and the docstring says so: a second reading that also names a real relation reaches the conflict gate, so a KB holding both `평` and `평가` on one subject turns `평가?` into an ambiguity report — the honest outcome for a question the KB does not disambiguate.

A label that is **only** a josa yields no readings. Reading a bare `은` as a relation name would claim a shape this parser has always declined — the string a caller emits when its label is blank — and then advise adding a relation alias for a grammatical particle. This restores `main`'s behaviour for that class.

## #434 claims this falsifies, corrected here

The parser's candidate sets are no longer alias-closed, so `any_unmatched` fires for nearly every Korean attribute question and its "a word was substituted" reading no longer holds. Both the field's docstring and the comment at the site that renders it now say what is true; #441 carries the refinement that would make the signal selective again.

## Verification

Full suite **2502 passed / 20 skipped** against a frozen tree (digest identical before and after); baseline on `main` is 2485. Ruff: finding profile identical to base, verified independently.

Mutations, all killed: stripped-reading-only (46) · full-reading-only (41) · order swapped (34) · revert the josa-only guard (M-G) · `(label,)` for a bare josa (M-H) · drop the second reading when the first is a synonym key (M-I). One mutation survived and was acted on rather than tested around: expanding synonyms on *both* readings is unreachable under stripped-first ordering, so that branch was deleted and the docstring claiming otherwise corrected.

## Follow-ups

- #443 — the interrogative tail strip is still a single guess (`재인가?` → `재`). Stated in the docstring rather than left implied.
- #441 — `any_unmatched` cannot tell a speculative reading from a substituted word; extended with the synonym-ordering case (`goal은?` naming `목적`).
- Known, non-blocking: `_korean_attribute_relation_candidates` computes the readings a second time and would raise on an empty tuple, which the call-site guard makes unreachable. Passing the readings in would remove both the duplicate work and the implicit precondition.

Synthetic fixtures only.