### PR TITLE
feat: read a measure question as the relation it names (#442)

### DIFF
--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -522,6 +522,337 @@ def test_korean_attribute_label_does_not_strip_a_stemless_politeness_ending():
     )
 
 
+# Two lists, not one, and not only for grammaticality (`개이야` is not Korean).
+# The halves pin different alternatives: the vowel counters are the only thing
+# here that pins the bare `야`, whereas `이야` is pinned redundantly -- these
+# counters, the counterless `몇이야?` below and the spaced-off `몇 살 이야?`
+# each kill its removal. A single merged list would let one mask the other.
+_KOREAN_MEASURE_BATCHIM_COUNTERS = ("살", "명", "건", "년", "원", "시간")
+_KOREAN_MEASURE_BATCHIM_FORMS = ("인가?", "인가요?", "입니까?", "이야?", "이에요?", "?")
+_KOREAN_MEASURE_VOWEL_COUNTERS = ("개", "차", "배", "가지", "퍼센트", "회")
+_KOREAN_MEASURE_VOWEL_FORMS = ("인가?", "인가요?", "입니까?", "야?", "예요?", "?")
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        f"샘플인물의 나이는 몇 {counter}{form}"
+        for counter in _KOREAN_MEASURE_BATCHIM_COUNTERS
+        for form in _KOREAN_MEASURE_BATCHIM_FORMS
+    ],
+)
+def test_a_counted_measure_question_asks_for_the_relation_it_names(question):
+    """`몇` plus a counter noun is the question, not part of the relation.
+
+    `샘플인물의 나이는 몇 살인가?` asked the schema for a relation named
+    `나이는 몇 살`, which no schema holds, so a question naming its relation
+    exactly was answered UNVERIFIED. Built as a real cross-product so that one
+    counter carrying a form cannot mask that form's absence on the others.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("나이", "나이는")
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        f"샘플인물의 나이는 몇 {counter}{form}"
+        for counter in _KOREAN_MEASURE_VOWEL_COUNTERS
+        for form in _KOREAN_MEASURE_VOWEL_FORMS
+    ],
+)
+def test_a_vowel_final_counter_takes_the_vowel_final_predicates(question):
+    """The same rule, on the counters that take `야`/`예요` rather than `이야`.
+
+    These cells are the only ones that pin the bare `야` alternative; the
+    받침 counters pin `이야`. Asserting both sets on one counter list would
+    put ungrammatical Korean (`개이야`) in the fixture.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("나이", "나이는")
+
+
+@pytest.mark.parametrize("question", ["샘플인물의 나이는 몇인가?", "샘플인물의 나이는 몇이야?", "샘플인물의 나이는 몇?"])
+def test_a_measure_question_needs_no_counter(question):
+    """`몇` alone is a measure question -- the counter is optional.
+
+    Requiring one would leave `나이는 몇` as the relation candidate, the same
+    label no schema holds that the counted forms already fail on.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("나이", "나이는")
+
+
+def test_a_measure_question_may_omit_the_space_before_the_counter():
+    """`몇살인가?` is how the form is commonly typed.
+
+    The space is optional between the interrogative and its counter. After a
+    Hangul syllable it is not optional before the interrogative itself -- see
+    the word-boundary tests.
+    """
+    intent = deterministic_query_intent("샘플인물의 나이는 몇살인가?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("나이", "나이는")
+
+
+@pytest.mark.parametrize(
+    ("question", "candidates"),
+    [
+        ("샘플인물의 나이는 몇 살 인가?", ("나이", "나이는")),
+        ("샘플인물의 나이는 몇 살 이야?", ("나이", "나이는")),
+        ("샘플대상의 수량은 몇 개 인가요?", ("수량", "수량은")),
+        ("샘플사업의 기간은 몇 년 입니까?", ("기간", "기간은")),
+    ],
+)
+def test_a_measure_question_may_space_the_predicate_off_the_counter(
+    question, candidates
+):
+    """The space *after* the counter is optional too, and separately so.
+
+    Its sibling above pins the space before the counter. Nothing else pins this
+    one: without it the measure tail stops reaching the end anchor on every one
+    of these, and each falls back to naming a relation that still carries its
+    counter -- `나이는 몇 살`, `수량은 몇 개 인가요` -- which is the defect this
+    rule exists to fix, in the spelling a writer gets by putting a space where
+    Korean allows one.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "샘플사업의 기간은 얼마나 되나요?",
+        "샘플사업의 기간은 얼마나 됩니까?",
+        "샘플사업의 기간은 얼마나 길어?",
+        "샘플사업의 기간은 얼마나 걸리나요?",
+    ],
+)
+def test_an_amount_measure_question_strips_its_open_class_predicate(question):
+    """`얼마나` complements a conjugated predicate, which is an open class.
+
+    A closed verb list would be a losing game -- `되나요`, `됩니까`, `길어`,
+    `걸리나요` are four spellings of the same question -- so the bound is the
+    literal `얼마나` plus a capped wildcard rather than an enumeration.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("기간", "기간은")
+
+
+@pytest.mark.parametrize(
+    "question", ["샘플사업의 기간은 얼마나?", "샘플사업의 기간은 얼마나 오래 걸리나요?"]
+)
+def test_the_amount_predicate_may_be_absent_or_two_words(question):
+    """Both ends of the wildcard's word count are load-bearing.
+
+    `얼마나?` carries no predicate at all and `얼마나 오래 걸리나요?` carries
+    two words, so a cap of one word in either direction drops one of them.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("기간", "기간은")
+
+
+@pytest.mark.parametrize(
+    ("question", "candidates"),
+    [
+        ("샘플사업의 기간은 얼마나 3개월?", ("기간은 얼마나 3개월",)),
+        ("샘플사업의 기간은 얼마나 A?", ("기간은 얼마나 A",)),
+        ("샘플사업의 기간은 얼마나 오래-걸리나요?", ("기간은 얼마나 오래-걸리나요",)),
+    ],
+)
+def test_the_amount_wildcard_spans_hangul_only(question, candidates):
+    """The wildcard is Hangul syllables, not any non-space run.
+
+    A conjugated Korean predicate is written in Hangul, so a digit, a Latin
+    letter or a hyphen means the tail is not the conjugation this rule claims to
+    recognise. Widened to `\\S` all three lose everything from `얼마나` rightward
+    and ask for `기간` instead of the words the question spelled -- and nothing
+    else here notices, because every other amount fixture is pure Hangul.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+@pytest.mark.parametrize(
+    ("predicate", "candidates"),
+    [
+        # One word, where a run may end mid-word, so two runs reach twelve.
+        ("소요되겠습니까", ("기간", "기간은")),  # 7
+        ("가나다라마바사아자차카타", ("기간", "기간은")),  # 12, the ceiling
+        ("가나다라마바사아자차카타파", ("기간은 얼마나 가나다라마바사아자차카타파",)),  # 13
+        # Two words: neither run may cross the space, so each word costs one.
+        ("가나다라마바 사아자차카타", ("기간", "기간은")),  # 6+6, the ceiling again
+        ("가나다 라마바사아자", ("기간", "기간은")),  # 3+6
+        ("가나 다라마바사아자", ("기간은 얼마나 가나 다라마바사아자",)),  # 2+7
+    ],
+)
+def test_the_amount_wildcard_caps_each_run_and_not_only_the_total(
+    predicate, candidates
+):
+    """Twelve syllables, in at most two runs of at most six.
+
+    Nothing else pins those numbers -- widening each run from six to twelve, or
+    to ten, leaves every other test here passing. The last two rows are what
+    makes the per-run half falsifiable: `3+6` is stripped and the shorter `2+7`
+    is not, because one run is spent on the first word and six cannot cover the
+    second. A cap on the total alone would take both, or neither.
+    """
+    intent = deterministic_query_intent(f"샘플사업의 기간은 얼마나 {predicate}?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+def test_the_measure_interrogative_must_begin_a_word():
+    """`몇몇` is an ordinary Korean determiner, not `몇` plus a stray syllable.
+
+    Without the word-boundary guard the second syllable matched the bare-`몇`
+    form and cut the label to `몇` -- the `개요`->`개` hazard, one constant over.
+    Only the bare spelling exercises the guard: behind a josa the rule cannot fire
+    at all -- the trailing `은` of `몇몇은` is neither a counter nor a
+    predicate, so nothing reaches the end anchor -- and `몇몇은?` would pass
+    with the guard removed.
+    """
+    intent = deterministic_query_intent("샘플대상의 몇몇?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("몇몇",)
+
+
+def test_the_counter_list_stays_closed():
+    """The closed counter list is otherwise pinned by nothing.
+
+    Its two siblings mask it: opening the list to any Hangul word takes the
+    whole of `몇몇?` and the whole of `몇분야?`, and a label the strip empties is
+    read whole, so both still name themselves. Only here does the wildcard leave
+    something behind -- it eats `몇몇` and asks for `최근` -- so this is the only
+    test that fails when the counter list becomes a wildcard, which is why it
+    survives despite `최근 몇몇` being a marginal relation name.
+    """
+    intent = deterministic_query_intent("샘플대상의 최근 몇몇?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("최근 몇몇",)
+
+
+@pytest.mark.parametrize(
+    ("question", "candidates"),
+    [
+        ("샘플대상의 가격은얼마나?", ("가격은얼마나",)),
+        ("샘플사업의 기간은얼마나 길어?", ("기간은얼마나 길어",)),
+        ("샘플대상의 비용은얼마나 되나요?", ("비용은얼마나 되나요",)),
+    ],
+)
+def test_the_amount_interrogative_must_begin_a_word_too(question, candidates):
+    """The word-boundary guard on `얼마나`, which its sibling does not pin.
+
+    Splitting the guard per interrogative shows that dropping it from `얼마나`
+    alone survives every other test here -- `몇몇?` only exercises the `몇` half.
+    Without it these labels lose everything from `얼마나` rightward and ask for
+    `가격`, `기간`, `비용` instead of the words the question spelled.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+def test_the_measure_tail_matches_only_at_the_end_of_the_label():
+    """`몇` inside a label is not a tail.
+
+    Unanchored, the rule ate forward from the `몇` and left `째 심사` -- a
+    fragment of the relation the question named.
+    """
+    intent = deterministic_query_intent("샘플사업의 몇 번째 심사는?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("몇 번째 심사", "몇 번째 심사는")
+
+
+@pytest.mark.parametrize(
+    ("question", "candidates"),
+    [
+        ("샘플대상의 몇 개?", ("몇 개",)),
+        ("샘플대상의 얼마나 많은 인원?", ("얼마나 많은 인원",)),
+        ("샘플문서의 몇분야?", ("몇분야",)),
+    ],
+)
+def test_a_label_the_measure_strip_would_empty_is_read_whole(question, candidates):
+    """The tail is the whole label here, so the label is read whole instead.
+
+    Declining a whole-label measure question is worse than claiming it: an
+    emptied label is declined, which routes the question past
+    `_reinterpret_empty_plan` -- the gate that refuses a model `no_answer`,
+    the reading Ask renders as `VERIFIED — engine (negative)`. Should the model
+    then return an intent that itself plans empty, that plan loses the
+    direct-Datalog fallback too. These stay exactly where they are without this
+    change.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+@pytest.mark.parametrize(
+    ("question", "candidates"),
+    [
+        ("샘플제품의 이 몇 개인가?", ("이 몇 개",)),
+        ("샘플광산의 은 몇 개인가?", ("은 몇 개",)),
+        ("샘플대상의 가 몇 개?", ("가 몇 개",)),
+        ("샘플모임의 누구 몇 명인가?", ("누구 몇 명",)),
+    ],
+)
+def test_a_label_the_later_strips_would_empty_is_read_whole(question, candidates):
+    """Not emptying a label takes more than not letting *this* strip empty it.
+
+    Two more strips run after the measure tail, and what the measure tail leaves
+    behind is exactly what they are built to remove: a lone josa syllable, or an
+    interrogative. Guarding on the measure strip's own output lets those finish
+    the job and decline the question anyway, which is the harm the guard exists
+    to prevent. Guarding on the finished readings is what actually holds these
+    where they were, so the measure rule adds nothing to the declined class.
+    """
+    intent = deterministic_query_intent(question)
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == candidates
+
+
+@pytest.mark.parametrize(
+    "question", ["샘플인물의 나이는 몇 살이야", "샘플사업의 기간은 얼마나 되나요"]
+)
+def test_a_measure_question_without_a_question_mark_is_still_declined(question):
+    """The measure tails are added to the label cleaner, not to the shape check.
+
+    `_looks_like_korean_attribute_question` decides whether the flat attribute
+    shape is claimed at all, and only for a question with no `?`. Widening it
+    with the measure predicates would claim these, but would also flatten a
+    no-`?` multi-hop question the model can read as two hops -- the trade its
+    own comment records declining. Nothing here changes that.
+    """
+    assert (
+        deterministic_query_intent(question).kind
+        == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
+    )
+
+
 def test_deterministic_entity_relation_discovery_questions_are_generic():
     english = deterministic_query_intent("How is Sample Entity related?")
     connected = deterministic_query_intent(

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -574,6 +574,12 @@ _KOREAN_INTERROGATIVE_TAIL = (
 )
 """The interrogative tails `_clean_korean_attribute_label` strips.
 
+Every alternative is an interrogative stem with an optional copula suffix,
+except the two bare endings `인가`/`입니까` discussed below.
+`_KOREAN_MEASURE_QUESTION_TAIL` carries the tails this alternation cannot
+express, the ones with a counter noun or a conjugated predicate inside them
+(`몇 살인가`, `얼마나 되나요`).
+
 `누구` and `얼마` are how Korean asks for a person and an amount, and stripping
 only `무엇` left `프로젝트A의 담당자는 누구인가?` asking for a relation literally
 named `담당자는 누구` -- a label no schema can hold, so the planner built no
@@ -599,6 +605,69 @@ _KOREAN_ATTRIBUTE_LABEL_TAIL = re.compile(
     rf"\s*(?:{_KOREAN_INTERROGATIVE_TAIL})\s*$"
 )
 _KOREAN_ATTRIBUTE_LABEL_JOSA = re.compile(r"(?:은|는|이|가)\s*$")
+
+_KOREAN_MEASURE_COUNTER = (
+    r"살|명|개|건|년|개월|달|주|일|시간|분|초|번|회|차|가지|종류|종|"
+    r"퍼센트|프로|원|점|위|권|장|쪽|편|배|층"
+)
+_KOREAN_MEASURE_PREDICATE = r"인가요?|입니까|이에요|이야|예요|야"
+_KOREAN_MEASURE_QUESTION_TAIL = (
+    rf"(?<![가-힣])몇\s*(?:{_KOREAN_MEASURE_COUNTER})?\s*(?:{_KOREAN_MEASURE_PREDICATE})?"
+    r"|(?<![가-힣])얼마나(?:\s*[가-힣]{1,6}){0,2}"
+)
+"""The measure-question tails `_clean_korean_attribute_label` strips.
+
+`샘플인물의 나이는 몇 살인가?` asked the schema for a relation named
+`나이는 몇 살`. No schema holds that, so a question naming its relation exactly
+was answered UNVERIFIED -- the same defect `누구`/`얼마` had, in a different
+shape: a counter noun sits between the interrogative and the predicate, which
+`_KOREAN_INTERROGATIVE_TAIL`'s stem-and-suffix alternatives cannot express. That
+is why this is a separate pattern rather than two more stems there.
+
+The two halves are bounded differently because they complement different word
+classes. `몇` takes a counter noun, an enumerable class, so the counters are
+listed. `얼마나` takes a conjugated predicate, which is open, so it takes a
+bounded wildcard: Hangul syllables only, in at most two runs of at most six,
+anchored to the end of the label. A run may end mid-word but may never cross a
+space, so where the space falls decides: `얼마나 소요되겠습니까?` is one word of
+seven and is stripped, two runs covering it between them, while
+`얼마나 가나 다라마바사아자` is nine and is not: one run is spent on the first
+word, leaving the second word's seven syllables to a single run of six. Twelve
+syllables is the ceiling -- one word of twelve, or two words of six.
+
+Both interrogatives carry `(?<![가-힣])`, so neither may follow a Hangul
+syllable. `몇몇` is an ordinary Korean determiner, and without that guard its
+second syllable matched the bare-`몇` form and cut `몇몇` down to `몇`. What the
+guard buys for the bare `야`/`예요` predicates is narrower than safety: inside a
+Hangul label they are reachable only bound to a word-initial `몇`, so this rule
+cannot cut a word in half the way a stemless `야` would leave `분야` as `분` --
+it takes whole words. The guard names Hangul only, so any non-Hangul character
+before the interrogative -- punctuation as much as another script -- falls
+outside that reasoning, and there the rule does leave a fragment:
+`샘플대상의 가격-몇 개?` asks for `가격-`. A label whose tail really is `몇` +
+counter + `야` still loses that phrase: `샘플대상의 최근 몇 주야?` asks only for
+`최근`. That is the "several" case below, not a truncation.
+
+The guard is on the interrogative, not on the counter, so `몇살인가?` is still
+read; the spaces on either side of the counter are both optional, so
+`몇 살 인가?` is read too. What falls outside is any label with no space before
+the interrogative -- `나이는몇살인가?` and `가격은얼마나?` alike.
+
+`몇` also means "several" non-interrogatively and nothing here settles which it
+is: `샘플기간의 최근 몇 년?` loses its `몇 년` and asks only for `최근`. That is
+an accepted cost, weighed against `최근 몇 년` being an implausible relation
+name, not a case this handles.
+
+Not covered, and stated rather than implied: a counter outside the list
+(`몇 톤인가?`), a non-Hangul unit (`몇 %인가?`), an ordinal (`몇 번째인가?`), the
+`-나` particle (`몇 개나 되나요?`). Past forms such as `몇 살이었나요?` are
+untouched by this rule, the same gap `_KOREAN_INTERROGATIVE_TAIL` records for
+`누구였나요?`.
+"""
+
+_KOREAN_ATTRIBUTE_LABEL_MEASURE_TAIL = re.compile(
+    rf"\s*(?:{_KOREAN_MEASURE_QUESTION_TAIL})\s*$"
+)
 
 
 def _korean_attribute_label_readings(value: str) -> tuple[str, ...]:
@@ -628,11 +697,46 @@ def _korean_attribute_label_readings(value: str) -> tuple[str, ...]:
     `평가?` from an answer into an ambiguity report. That is the honest outcome
     for a question the KB genuinely does not disambiguate.
 
-    The interrogative tail is stripped before any of this and is still a single
-    guess: `재인가?` loses `인가` and asks only for `재`, so a KB holding
-    `재인가` is not covered by this change. See #443.
+    Two tails are stripped before any of this and both are single guesses: the
+    interrogative tail (`재인가?` loses `인가` and asks only for `재` -- see
+    #443) and the measure tail. They differ in whether they may leave a label
+    with nothing to ask for. The interrogative tail may, which is how
+    `샘플사업의 인가?` loses its whole label and is declined. The measure tail
+    may not, and what enforces that is not the strip but the readings it leads
+    to: the measure reading is adopted only when it yields readings, and
+    otherwise the label is read whole, exactly as it would be read without this
+    rule. So this change declines no question that was not already declined.
+    Unlike the josa, a measure tail is not a spelling of a relation name the way
+    `단가` is, so there is no second reading for the schema to choose between;
+    the one narrow case where it could be, `몇` read as "several", is named in
+    `_KOREAN_MEASURE_QUESTION_TAIL`'s docstring.
     """
     label = " ".join(value.strip().split())
+    # Adopting the measure reading is conditional on it surviving the rest of
+    # the cleaning, because declining is not neutral: `샘플대상의 몇 개?` would
+    # stop reaching `_reinterpret_empty_plan`, the gate that refuses a model
+    # `no_answer` -- the reading Ask renders as `VERIFIED — engine (negative)`,
+    # its strongest claim -- for a question the deterministic parser could plan
+    # nothing for. Should the model then return an intent that itself plans
+    # empty, that plan would also lose the direct-Datalog fallback a
+    # deterministic intent keeps. Testing the finished readings rather than this
+    # strip's own output is what covers the labels the two later strips would
+    # empty, which `measured` alone does not see.
+    measured = _KOREAN_ATTRIBUTE_LABEL_MEASURE_TAIL.sub("", label).strip()
+    if measured != label:
+        readings = _label_readings_after_measure(measured)
+        if readings:
+            return readings
+    return _label_readings_after_measure(label)
+
+
+def _label_readings_after_measure(label: str) -> tuple[str, ...]:
+    """The rest of the cleaning: the interrogative tail, then the josa reading.
+
+    Returns no readings at all when the label cleans away to nothing. That empty
+    result is the signal the caller reads: a measure reading that cleans away is
+    dropped in favour of reading the whole label.
+    """
     label = _KOREAN_ATTRIBUTE_LABEL_TAIL.sub("", label).strip()
     stripped = _KOREAN_ATTRIBUTE_LABEL_JOSA.sub("", label).strip()
     if not stripped:


### PR DESCRIPTION
Closes #442.

`샘플인물의 나이는 몇 살인가?` asked the schema for a relation named `나이는 몇 살` — a label no schema holds — so a question naming its relation exactly was answered `UNVERIFIED — source exploration`. Measured over a synthetic question population before the change: counted measure forms resolved **0 of 64**, while plain Korean attribute questions resolved **112 of 112**. That is why this issue was picked over the other open Ask gaps.

## What changed

A new `_KOREAN_MEASURE_QUESTION_TAIL` beside the existing interrogative tail, rather than more stems inside it. A measure tail is a different shape — a counter noun sits between the interrogative and the predicate — which a stem-plus-suffix alternation cannot express. Its two halves are bounded asymmetrically because they complement different word classes: `몇` takes a counter noun, an enumerable class, so the counters are listed; `얼마나` takes a conjugated predicate, which is open, so it takes a capped Hangul wildcard.

End to end, against a store holding `(샘플인물, 나이, 30)` and a client that raises on every provider entry point, all eight measure forms now return `VERIFIED — engine` with **zero provider calls**: `몇 살인가?`, `몇 살이야?`, `몇살인가?`, `몇인가?`, `얼마나 되나요?`, `얼마나?`, `얼마나 오래 걸리나요?`, `몇 개예요?`. On `main` they do not reach the engine at all.

## Two properties worth calling out

**The strip never moves a question into the declined class.** It is applied only when what is left still reads as a relation, and the fallback is `main`'s body on the original label — so the declined set is identical to `main`'s by construction, not by inspection. This matters because declining is not neutral: it routes a question past `_reinterpret_empty_plan`, the gate that refuses a model `no_answer`, the reading Ask renders as `VERIFIED — engine (negative)`. Verified over generated label corpora of 4,273 / 11,464 / 57,912 labels by three independent reviewers: zero newly declined, zero newly claimed.

**Both interrogatives carry a word-boundary guard.** `몇몇` is an ordinary Korean determiner; without the guard the rule cut it down to `몇`.

## Accepted costs, named in the docstring rather than left to be discovered

`몇` also means "several", so `샘플기간의 최근 몇 년?` asks only for `최근`. The guard is Hangul-only, so `샘플대상의 가격-몇 개?` gives `('가격-',)`. The counter list is closed. Follow-ups filed: #446, #447, #448 — and **#445**, the sharpest, where a measure question is answered in whatever unit the KB stores rather than the one it asked in. #445 is the only case in this family that turns an `UNVERIFIED` into a *confident* answer rather than leaving a question unanswered.

## Validation

- `pytest`: **2612 passed, 20 skipped** (`main` at b98efd3: 2502/20, measured in a clean worktree). `tests/test_query_intent.py` 71 → 181.
- ruff 0.15.18, the version CI pins: clean.
- Mutation matrix over every mechanism the change claims: **all mutants killed, no vacuous test**. Each of `counter_wildcard`, `no_lb_much`, `no_mid_space`, `much_nonspace`, `syl_1_12`, `cap_6_to_10`, `guard_on_measured` and `shape_widen` is killed by exactly one test.

## Review

Three rounds through independent Architect / Critic / Reviewer gates on a frozen candidate, which found and fixed one code defect and nine false prose claims — including one where the guard was placed so that the change did add ~170 labels to the declined class, and two where the fix for a false claim introduced a new one. Every docstring example in the final diff was run and reproduces.
