### PR TITLE
feat: say when a verified value is stated in a different unit (#445)

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -897,3 +897,275 @@ def test_ask_grounding_table_shows_a_comma_answer_in_its_source_form(tmp_path):
     # is the source's value: no report-join escape reaches this screen.
     assert fact.answer == "검토자, 팀장"
     assert fact.object == "검토자, 팀장"
+
+
+# --- the measure-unit caveat (#445) ----------------------------------------
+
+_UNIT_WARNING = (
+    "the question's counter is 개월; the verified value states 년. verinote "
+    "shows stored values as recorded and applies no unit conversion"
+)
+
+
+class TwoHopMeasureIntentClient:
+    """Reads `X의 <label>의 <label>은 몇 <counter>인가?` as two hops.
+
+    The deterministic parser flattens the chain into one relation name, plans no
+    candidates, and the empty plan is re-read by the model -- the same route
+    `test_ask_answers_a_korean_chain_question_by_reinterpreting_an_empty_plan`
+    pins, here with a measure tail on the end.
+    """
+
+    name = "two-hop-measure-intent"
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        from verinote.pipeline.query_intent import parse_query_intent
+
+        return parse_query_intent(
+            {
+                "kind": "conjunctive_lookup",
+                "subject": None,
+                "relation": None,
+                "object": None,
+                "relation_candidates": None,
+                "operator": None,
+                "value_type": None,
+                "value": None,
+                "reason": None,
+                "hops": [
+                    {
+                        "subject": {"kind": "entity", "value": "샘플사업"},
+                        "relation": {"kind": "relation", "value": "하위단계"},
+                        "object": {"kind": "var", "value": "M"},
+                    },
+                    {
+                        "subject": {"kind": "var", "value": "M"},
+                        "relation": {"kind": "relation", "value": "기간"},
+                        "object": {"kind": "var", "value": "A"},
+                    },
+                ],
+                "conditions": None,
+                "answer_var": "A",
+            }
+        )
+
+    def translate_query(self, **kwargs):
+        raise AssertionError("Ask must not call direct Datalog translation")
+
+    def answer_question(self, **kwargs):
+        raise AssertionError("a verified chain answer must not call the fallback LLM")
+
+
+def test_ask_warns_beside_a_verified_answer_stated_in_another_unit(tmp_path):
+    """#445: the answer stands, and a caveat is shown beside it.
+
+    `샘플사업의 기간은 몇 개월인가?` against a KB holding `(샘플사업, 기간, 2년)`
+    has been answered `VERIFIED — engine` with `2년` since #442, which moved the
+    whole measure-question family onto the engine. None of that changes here: the
+    route, label, answer and reason are exactly what they were, and only the
+    caveat is new. The assertion is on the whole sentence, because a caveat that
+    named `MONTH` instead of `개월` would be worse than none.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "기간", "2년", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 기간은 몇 개월인가?",
+    )
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert result.status == "translated"
+    assert result.reason == "deterministic query matched confirmed/accepted facts"
+    assert result.answer == "샘플사업, 기간, 2년\n    ← sources/sample-plan.txt"
+    assert result.warning == _UNIT_WARNING
+    # ask.html renders this slot as text, so the sentence carries no markup.
+    assert "`" not in result.warning
+    assert "*" not in result.warning
+
+
+def test_ask_does_not_warn_when_the_verified_value_is_in_the_asked_unit(tmp_path):
+    """The same question and the same shape of fact, stated in months."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "기간", "24개월", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 기간은 몇 개월인가?",
+    )
+
+    assert result.label == "VERIFIED — engine"
+    assert result.warning is None
+
+
+def test_ask_warns_on_the_answering_fact_of_a_two_hop_proof(tmp_path):
+    """A two-hop proof lists an intermediate fact whose object is not the answer.
+
+    Here the first fact's object is `샘플단계` and the second's is `2년`. Reading
+    the caveat off the first fact in the trace would find no unit in `샘플단계`
+    and go silent, so this pins the `_fold(object) == _fold(answer)` filter.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "하위단계", "샘플단계", status="confirmed", source_id=source_id)
+    store.add_fact("샘플단계", "기간", "2년", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        TwoHopMeasureIntentClient(),
+        root=tmp_path,
+        question="샘플사업의 하위단계의 기간은 몇 개월인가?",
+    )
+
+    assert result.label == "VERIFIED — engine"
+    assert [fact.object for fact in result.grounding_facts] == ["샘플단계", "2년"]
+    assert result.warning == _UNIT_WARNING
+
+
+def test_ask_keeps_the_trace_warning_for_a_multi_valued_answer(tmp_path):
+    """Two facts on one relation are answered, and produce no source trace.
+
+    That is not an unreachable state -- the question is answered and verified --
+    so the caveat slot is already taken by the standing "no source trace" one,
+    which wins because the unit caveat needs the trace to find the answering
+    fact. This pins that the new branch did not displace it.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "기간", "2년", status="confirmed", source_id=source_id)
+    store.add_fact("샘플사업", "기간", "18개월", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 기간은 몇 개월인가?",
+    )
+
+    assert result.label == "VERIFIED — engine"
+    assert result.grounding_facts == ()
+    assert result.warning == "source trace unavailable for this verified query shape"
+
+
+def test_ask_warns_on_a_value_the_store_holds_in_decomposed_form(tmp_path):
+    """The two sides of the answering-fact test arrive by different routes.
+
+    `Store.add_fact` keeps the `object` column exactly as written, so a
+    decomposed `2년` stays four code points there, while the trace composes the
+    answer it renders through NFC. Without `_fold` on both sides no fact matches
+    and this caveat silently never fires.
+    """
+    import unicodedata
+
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    decomposed = unicodedata.normalize("NFD", "2년")
+    store.add_fact("샘플사업", "기간", decomposed, status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 기간은 몇 개월인가?",
+    )
+
+    fact = result.grounding_facts[0]
+    assert len(fact.object) == 4
+    assert len(fact.answer) == 2
+    assert fact.object != fact.answer
+    assert result.warning == _UNIT_WARNING
+
+
+def test_ask_is_silent_when_the_rendered_answer_escapes_the_stored_value(tmp_path):
+    """Folding normalises; it does not un-escape, and the caveat fails silent.
+
+    A stored `2년<TAB>` reaches the trace as object `'2년\\t'` and answer
+    `'2년\\\\t'`, and NFC-plus-casefold does not reconcile those. No fact passes
+    the answering-fact test, so no caveat is shown -- silence beside a correct
+    answer, never a sentence about the wrong fact.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "기간", "2년\t", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 기간은 몇 개월인가?",
+    )
+
+    fact = result.grounding_facts[0]
+    assert (fact.object, fact.answer) == ("2년\t", "2년\\t")
+    assert result.label == "VERIFIED — engine"
+    assert result.warning is None
+
+
+def test_ask_does_not_warn_for_a_relation_literally_named_with_a_counter(tmp_path):
+    """A KB may hold a relation named `몇 년`, and this question asks for it."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "몇 년", "24개월", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 몇 년인가?",
+    )
+
+    assert result.label == "VERIFIED — engine"
+    assert result.answer == "샘플사업, 몇 년, 24개월\n    ← sources/sample-plan.txt"
+    assert result.warning is None
+
+
+def test_ask_does_not_warn_for_a_question_that_asked_in_no_unit(tmp_path):
+    """An ordinary attribute question is untouched, whatever its value states."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플인물", "역할", "2년", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store, DeterministicOnlyClient(), root=tmp_path, question="샘플인물의 역할은 무엇인가?"
+    )
+
+    assert result.label == "VERIFIED — engine"
+    assert result.warning is None
+
+
+def test_ask_warns_on_a_value_whose_case_differs_from_the_rendered_answer(tmp_path):
+    """`_fold` is load-bearing on the ANSWER side too, not only the object side.
+
+    The decomposed-value test above pins only half of it. There the object is
+    NFD and the answer NFC, so folding the object alone is enough to make them
+    meet -- drop the fold from the answer side and that test still passes.
+
+    A mixed-case Latin value separates them: `3 Weeks` needs casefolding on
+    whichever side is left unfolded, so this fails if either call goes. The
+    caveat reports the folded spelling, which is why it says `weeks`.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample-plan.txt")
+    store.add_fact("샘플사업", "기간", "3 Weeks", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="샘플사업의 기간은 몇 개월인가?",
+    )
+
+    fact = result.grounding_facts[0]
+    assert (fact.object, fact.answer) == ("3 Weeks", "3 Weeks")
+    assert result.label == "VERIFIED — engine"
+    assert result.warning == (
+        "the question's counter is 개월; the verified value states weeks. "
+        "verinote shows stored values as recorded and applies no unit conversion"
+    )

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -993,3 +993,1290 @@ def test_a_label_that_is_only_a_josa_is_not_claimed():
     boundary = deterministic_query_intent("샘플조직의 이는?")
     assert boundary.kind == QueryIntentKind.LOOKUP_OBJECT
     assert boundary.relation_candidates == ("이", "이는")
+
+
+# --- the measure-unit caveat (#445) ----------------------------------------
+#
+# `korean_measure_unit_mismatch` decides whether a verified answer is shown with
+# a caveat saying it is stated in a different unit from the one the question
+# asked in. Every assertion here is on the exact pair or on None: a mutation that
+# returned the family key instead of the spelling would print "the verified value
+# states MONTH" to a Korean reader, and only an exact comparison catches that.
+
+_PROSE_VALUES = (
+    "샘플부서 연간 계획 수립",
+    "연내 완료 예정",
+    "주간 보고 체계 운영",
+    "일정 조율 진행 중",
+    "분기별 실적 검토",
+    "시간제 근무 허용",
+    "초기 검토 단계",
+    "원격 근무 원칙",
+    "달성 여부 미정",
+    "내년 상반기 착수",
+    "지원 대상 아님",
+    "분야별 담당 지정",
+    "개요 작성 완료",
+    "일반 관리 대상",
+    "주요 위험 식별",
+    "초안 검토 요청",
+    "연구 개발 과제",
+    "세부 항목 없음",
+    "배포 준비 완료",
+    "유로존 시장 조사",
+    "엔진 점검 필요",
+    "달력 기준 산정",
+    "세금 계산 제외",
+    "살균 처리 완료",
+    "프로세스 표준화",
+    "퍼센트 표기 통일",
+    "제3자 검토 필요",
+    "2단계 진행 중",
+    "3차 회의 예정",
+    "제1분기 마감",
+    "5개년 계획 수립",
+    "1순위 과제",
+    "샘플문서 v2 초안",
+    "2년차 담당자 배정",
+    "3일간의 일정 확정",
+    "3주간격 점검",
+    "6월 착수 예정",
+    "2021년 기준",
+    "second review pending",
+    "yearly summary drafted",
+    "monthly report archived",
+    "weekly sync scheduled",
+    "daily standup held",
+    "hourly rate undisclosed",
+    "minute taking assigned",
+    "percentage not disclosed",
+    "dollar cost averaging",
+    "3 secondary reviews",
+    "2 daylight sessions",
+)
+"""Synthetic values a KB could plausibly hold that state no quantity.
+
+Each one contains a syllable or word that *is* a unit spelling -- `연간`,
+`주간`, `일정`, `분기`, `시간제`, `초기`, `원격`, `달성`, `내년`, `지원`,
+`분야`, `세금`, `살균`, `프로세스`, `second`, `weekly` -- with no number in
+front of it. Fourteen of them do carry a digit, as near-misses: an ordinal
+(`제3자`), a stage number (`2단계`), a sequence number (`3차`), a quarter
+(`제1분기`), a plan title (`5개년`), a rank (`1순위`), a version (`v2`), a unit
+run into the next syllable (`2년차`), two suffixes outside the closed set
+(`3일간의`, `3주간격`), a bare month (`6월`), a calendar year (`2021년`), and two
+Latin words that begin with a unit spelling (`3 secondary`, `2 daylight`).
+"""
+
+
+def _unit_bearing_counters() -> tuple[str, ...]:
+    """The counters a question can ask in that also name a unit.
+
+    Derived from the two tables rather than listed, so the sweep below covers
+    every counter that can reach the caveat as the table stands.
+    """
+    from verinote.pipeline.query_intent import (
+        _KOREAN_MEASURE_COUNTER,
+        _MEASUREMENT_UNIT_SPELLINGS,
+    )
+
+    return tuple(
+        counter
+        for counter in _KOREAN_MEASURE_COUNTER.split("|")
+        if counter in _MEASUREMENT_UNIT_SPELLINGS
+    )
+
+
+def test_a_measure_question_answered_in_another_unit_names_both_spellings():
+    """The headline case from #445, at the level that decides it.
+
+    `샘플사업의 기간은 몇 개월인가?` against a KB holding `2년` is answered `2년`
+    and verified, and that stays true -- this only supplies the pair the caveat
+    beside it is worded from.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "2년") == (
+        "개월",
+        "년",
+    )
+
+
+@pytest.mark.parametrize(
+    ("question", "value"),
+    [
+        ("샘플사업의 기간은 몇 개월인가?", "6개월"),
+        ("샘플사업의 기간은 몇 개월인가?", "2년 6개월"),
+        ("샘플사업의 기간은 몇 달인가?", "6개월"),
+        ("샘플사업의 비율은 몇 퍼센트인가?", "30%"),
+        ("샘플인물의 나이는 몇 살인가?", "30세"),
+    ],
+)
+def test_the_asked_unit_stated_anywhere_in_the_value_suppresses_the_caveat(question, value):
+    """A value that does state the asked unit has nothing to caveat.
+
+    `2년 6개월` answers `몇 개월인가?` in months among other things, so the
+    earlier `년` must not fire.
+
+    The last three pin THIS suppression and nothing else. Their asked counter is
+    a table row (`달`, `퍼센트`, `살`) whose value-side spelling is a different
+    row of the same canonical unit, so deleting the row under test silences the
+    *question* side too and the case stays green -- it cannot pin the row. The
+    rows are pinned one-sidedly by the test below.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) is None
+
+
+@pytest.mark.parametrize(
+    ("question", "value", "expected"),
+    [
+        ("샘플사업의 기간은 몇 년인가?", "6달", ("년", "달")),
+        ("샘플사업의 증가율은 몇 배인가?", "30%", ("배", "%")),
+        ("샘플인물의 나이는 몇 살인가?", "24개월", ("살", "개월")),
+    ],
+)
+def test_a_spellings_row_is_pinned_by_a_question_asked_in_a_different_row(
+    question, value, expected
+):
+    """One row of `_MEASUREMENT_UNIT_SPELLINGS` per case, from one side only.
+
+    The table serves both the question and the value, so a case whose asked
+    counter is the row under test cannot pin it. Each case here asks in one row
+    and is answered in the row being pinned: delete `달` and `6달` states no unit
+    at all, delete `%` and `30%` states none, delete `살` and the question names
+    no unit. Every one of the three goes silent, and none of them is masked by
+    the same-unit suppression.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) == expected
+
+
+@pytest.mark.parametrize(
+    ("question", "value"),
+    [
+        ("샘플사업의 항목은 몇 개인가?", "2년"),
+        ("샘플사업의 기간은 얼마나 되나요?", "2년"),
+    ],
+)
+def test_a_tail_naming_no_unit_is_silent(question, value):
+    """`몇 개` and `얼마나` reach the same answer by different routes.
+
+    `개` is a counter `_KOREAN_MEASURE_COUNTER` lists and
+    `_MEASUREMENT_UNIT_SPELLINGS` does not, so no unit is derived from it and the
+    family table is never consulted. The `얼마나` branch captures no counter at
+    all, so the lookup is handed None. Both land on the same `.get` returning
+    None rather than on a branch apiece.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) is None
+
+
+def test_a_relation_literally_named_with_a_counter_is_not_a_measure_question():
+    """`샘플사업의 몇 년인가?` asks *for* `몇 년`, not *in* years.
+
+    The measure tail is the whole label, so nothing is left in front of it to
+    read as a relation -- and `_korean_attribute_label_readings` correspondingly
+    reads the label whole and asks the KB for a relation named `몇 년`. A KB that
+    holds one answers it, and telling that reader the value is in the wrong unit
+    would be nonsense.
+    """
+    from verinote.pipeline.query_intent import (
+        _korean_attribute_label_readings,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _korean_attribute_label_readings("몇 년") == ("몇 년",)
+    assert korean_measure_unit_mismatch("샘플사업의 몇 년인가?", "24개월") is None
+
+
+@pytest.mark.parametrize(
+    ("question", "value"),
+    [
+        ("샘플인물의 역할은 무엇인가?", "2년"),
+        ("샘플기간의 최근 몇 년인가?", "재검토"),
+        ("샘플행사의 참석자는 몇 분인가?", "5"),
+        ("샘플사업의 주기는 몇 시간인가?", "일 단위 관리"),
+        ("샘플사업의 가격은 몇 원인가?", "지원 없음"),
+    ],
+)
+def test_a_question_or_value_with_nothing_to_compare_is_silent(question, value):
+    """Nothing to compare on one side or the other.
+
+    `역할은 무엇인가?` has no measure tail. The other four have one and a value
+    that states no quantity.
+
+    `참석자는 몇 분인가?` answered `5` is a labelled contract regression rather
+    than a pinned mechanism: the value engages no value-side machinery at all, so
+    no mutation of this rule can make it fire, and it is kept to record that a
+    bare number is never caveated.
+
+    `지원 없음` is likewise carried by the sweep rather than by itself: the bare
+    `원` inside `지원` is the unit the question asked in, so the same-unit
+    suppression would silence it even with the digit requirement removed. The
+    one-sided case for that requirement is in the test below.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) is None
+
+
+def test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat(monkeypatch):
+    """Every unit-bearing counter against a corpus of prose values, all silent.
+
+    This is what the leading `[0-9]` in `_VALUE_MEASUREMENT` buys, and the sweep
+    rather than any single case is what measures it.
+
+    The mutant count is BUILT AND MEASURED here rather than quoted in prose. It
+    was quoted once, as 55, and went stale the moment the suppression scan got
+    its own pattern: with one pattern serving both halves, mutating
+    `_VALUE_MEASUREMENT` mutated suppression too, and 13 of the fires that
+    number counted are now suppressed by `_VALUE_MEASUREMENT_RELAXED` instead.
+    A figure in a docstring cannot notice that; this assertion can.
+
+    A one-sided case for the requirement, not masked by the same-unit
+    suppression: `몇 개월인가?` answered `내년 착수` is silent as written and
+    fires `(개월, 년)` without the digit prefix.
+    """
+    import re
+
+    import verinote.pipeline.query_intent as query_intent
+    from verinote.pipeline.query_intent import (
+        _VALUE_MEASUREMENT,
+        korean_measure_unit_mismatch,
+    )
+
+    counters = _unit_bearing_counters()
+    assert len(counters) == 13
+    questions = [f"샘플대상의 지표는 몇 {counter}인가?" for counter in counters]
+    pairs = [(question, value) for question in questions for value in _PROSE_VALUES]
+    assert len(pairs) == len(counters) * len(_PROSE_VALUES)
+
+    for question, value in pairs:
+        assert korean_measure_unit_mismatch(question, value) is None, (question, value)
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "내년 착수") is None
+
+    # The mutation the sentence above names: the reporting pattern only, with
+    # the suppression pattern left alone. Mutating both instead gives 55, which
+    # is what the stale figure was measuring.
+    #
+    # Sliced off the live pattern rather than rebuilt from parts, so the mutant
+    # is this pattern minus its digit head and nothing else. A hand-built copy
+    # would drift from the source silently, and asserting text equality against
+    # one would fail whenever the alternation is legitimately reordered -- the
+    # `startswith` is the tie, and it is the only thing this hardcodes.
+    digit_head = r"[0-9][0-9,.]*"
+    assert _VALUE_MEASUREMENT.pattern.startswith(digit_head)
+    without_digits = re.compile(_VALUE_MEASUREMENT.pattern[len(digit_head):])
+    monkeypatch.setattr(query_intent, "_VALUE_MEASUREMENT", without_digits)
+    fires = sum(
+        1 for question, value in pairs
+        if korean_measure_unit_mismatch(question, value) is not None
+    )
+    assert fires == 68
+
+
+def test_a_cross_family_unit_is_not_a_unit_mismatch():
+    """`몇 원인가?` answered `2년` is not a money value in the wrong currency.
+
+    Money and time are not convertible, so "no unit conversion is applied" would
+    be the wrong thing to say about it. Within a family the caveat is right:
+    `1000달러` answering `몇 원인가?` is the same quantity in another currency.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "2년") is None
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "1000달러") == (
+        "원",
+        "달러",
+    )
+
+
+@pytest.mark.parametrize(
+    ("question", "value", "expected"),
+    [
+        ("샘플사업의 기간은 몇 개월인가?", "30% 완료, 3주", ("개월", "주")),
+        ("샘플사업의 가격은 몇 원인가?", "30% 할인, 3달러", ("원", "달러")),
+        ("샘플사업의 기간은 몇 개월인가?", "2배 증가, 3주 소요", ("개월", "주")),
+    ],
+)
+def test_the_first_same_family_unit_is_reported_not_the_first_unit(
+    question, value, expected
+):
+    """An earlier cross-family quantity does not silence a later same-family one.
+
+    Each value states a ratio first and the quantity the question was about
+    second. Reporting the first unit found would name a percentage or a multiple
+    beside a question about months or won, and reverting the selection to the
+    first unit makes all three go silent instead, because the ratio is in the
+    wrong family.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) == expected
+
+
+def test_a_calendar_date_silences_the_whole_value():
+    """A date is a point in time, not a quantity of it -- at the cost named here.
+
+    `2021년` must not be reported as stating years. The guard is on the whole
+    value rather than on the matched span, so a value containing a calendar date
+    reports no units at all, including a genuine mismatch stated elsewhere in the
+    same value. Both costs below are real and accepted.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "2021년") is None
+    assert (
+        korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "2021년 착수, 총 3주")
+        is None
+    )
+    assert (
+        korean_measure_unit_mismatch("샘플회의의 시간은 몇 시간인가?", "2021년 기준 30분")
+        is None
+    )
+
+
+def test_a_longer_digit_run_is_not_read_as_a_calendar_year():
+    """The left-hand `(?<![0-9])`: without it, `10000년` matches on `0000년`.
+
+    A genuine ten-thousand-year value would then be read as a calendar date and
+    silenced. The right-hand bound is pinned separately below. `1500년` and
+    `2000년간` stay on the date side; both spellings are really used for
+    durations too, so that reading is ambiguous and this rule picks the date one.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "10000년") == (
+        "개월",
+        "년",
+    )
+    assert _value_measure_units("1500년") == ()
+    assert _value_measure_units("2000년간") == ()
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["2년차", "3일간의 일정", "3주간격", "제1분기", "3 secondary reviews"],
+)
+def test_a_unit_continued_by_another_letter_is_not_read(value):
+    """The trailing lookahead: a unit run into Hangul, a digit, or Latin is not one.
+
+    `2년차` is a second year of service, `3일간의 일정` and `3주간격` carry
+    suffixes outside the closed set, `제1분기` is a quarter, and
+    `3 secondary reviews` begins with `second` and continues in Latin. Each is
+    asked in a *different* unit of the same family, so none of them is masked by
+    the same-unit suppression -- `몇 초인가?` would have masked the last one.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", value) is None
+
+
+def test_a_suffix_inside_the_closed_set_still_reads_the_unit():
+    """`2년간` states two years; the suffix does not hide the unit."""
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "2년간") == (
+        "개월",
+        "년",
+    )
+
+
+def test_a_longer_spelling_is_reached_by_backtracking_past_a_shorter_one():
+    """`주일` and `달러` are read even though `주` and `달` are tried first.
+
+    The alternation is in table order, so `주` and `달` match first and are then
+    rejected by the lookahead, which sees the Hangul that follows them; the
+    engine backtracks into the longer row. That mechanism, not the ordering, is
+    what makes these read -- every prefix pair in the table today is extended by
+    a Hangul or Latin character, both inside the lookahead's class.
+    """
+    from verinote.pipeline.query_intent import _value_measure_units
+
+    assert _value_measure_units("2주일") == (("WEEK", "주일"),)
+    assert _value_measure_units("3달러") == (("USD", "달러"),)
+
+
+def test_bare_월_is_a_month_of_the_year_and_is_not_read():
+    """`3월` is March and `6월` is June, so neither states a month-count.
+
+    `개월` is the counter for a month-count and is in the table; bare `월` is
+    deliberately not. `일` is in the table because `3일` is three days far more
+    often than it is the third of the month, and a day-of-month arrives with its
+    month beside it, which `_CALENDAR_DATE` catches.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 일인가?", "3월 착수") is None
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "6월") is None
+    assert _value_measure_units("3일") == (("DAY", "일"),)
+
+
+def test_a_prefix_currency_symbol_is_out_of_reach_by_construction():
+    """`$`, `₩` and `€` precede their number, and every quantity starts at a digit.
+
+    Their absence from the table is therefore not a row that could be restored:
+    no row spelled that way would ever be reached. `%` is read because it follows
+    the number.
+    """
+    from verinote.pipeline.query_intent import _value_measure_units
+
+    assert _value_measure_units("$1000") == ()
+    assert _value_measure_units("₩1000") == ()
+    assert _value_measure_units("€1000") == ()
+    assert _value_measure_units("30%") == (("PERCENT", "%"),)
+
+
+@pytest.mark.parametrize(
+    ("question", "value", "expected"),
+    [
+        ("샘플사업의 기간은 몇 개월인가?", "30세", ("개월", "세")),
+        ("샘플사업의 증가율은 몇 배인가?", "120퍼센트", ("배", "퍼센트")),
+    ],
+)
+def test_further_rows_report_the_spelling_the_value_used(question, value, expected):
+    """The stated spelling is reported, never the canonical unit.
+
+    `30세` states `세`, not `YEAR`, and `120퍼센트` states `퍼센트`, not
+    `PERCENT`. A caveat naming the family key would print an English identifier
+    to a Korean reader.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) == expected
+
+
+def test_a_value_written_in_nfd_states_its_unit():
+    """The value is composed before it is read.
+
+    `Store.add_fact` keeps the `object` column as written, so a decomposed `2년`
+    reaches this rule as four code points while the alternation is composed. Drop
+    the `nfc` call and this value states nothing.
+    """
+    import unicodedata
+
+    from verinote.pipeline.query_intent import _value_measure_units
+
+    decomposed = unicodedata.normalize("NFD", "2년")
+    assert len(decomposed) == 4
+    assert _value_measure_units(decomposed) == (("YEAR", "년"),)
+
+
+_ROW_FIXTURES = {
+    "년": "2년", "연": "3연", "살": "30살", "세": "30세",
+    "year": "1 year", "years": "2 years",
+    "개월": "6개월", "달": "6달", "month": "1 month", "months": "2 months",
+    "주": "3주", "주일": "2주일", "week": "1 week", "weeks": "2 weeks",
+    "일": "3일", "day": "1 day", "days": "2 days",
+    "시간": "5시간", "hour": "1 hour", "hours": "2 hours",
+    "분": "30분", "minute": "1 minute", "minutes": "2 minutes",
+    "초": "10초", "second": "1 second", "seconds": "2 seconds",
+    "퍼센트": "30퍼센트", "프로": "30프로", "%": "30%", "percent": "30 percent",
+    "배": "2배",
+    "원": "1000원", "won": "1000 won",
+    "달러": "3달러", "dollar": "1 dollar", "dollars": "2 dollars",
+    "엔": "1000엔", "yen": "1000 yen",
+    "유로": "500유로", "euro": "500 euro",
+}
+"""One value per row of `_MEASUREMENT_UNIT_SPELLINGS`, stating that row's unit.
+
+`_value_measure_units` reads only the value, so a fixture here is one-sided by
+construction: deleting the row it exercises leaves its value stating nothing,
+whatever the question. That is what the mismatch-level cases cannot do for a row
+whose only counter is the row itself -- `won` has no second money counter to ask
+in, since `원` is the only money spelling `_KOREAN_MEASURE_COUNTER` lists.
+
+`3연` is the one contrived value: `연` means a year but is not used as a counter
+after a number in ordinary Korean, so this pins the row's reachability rather
+than a spelling a KB would hold.
+"""
+
+
+def test_every_spellings_row_has_a_value_that_states_it():
+    """Each row read back one-sidedly, and no row left without a fixture.
+
+    The equality on `_ROW_FIXTURES`' key set is the half that keeps this honest:
+    a row added to the table with no value exercising it fails here rather than
+    joining silently.
+    """
+    from verinote.pipeline.query_intent import (
+        _MEASUREMENT_UNIT_SPELLINGS,
+        _value_measure_units,
+    )
+
+    assert set(_ROW_FIXTURES) == set(_MEASUREMENT_UNIT_SPELLINGS)
+    for spelling, value in _ROW_FIXTURES.items():
+        assert _value_measure_units(value) == (
+            (_MEASUREMENT_UNIT_SPELLINGS[spelling], spelling),
+        ), (spelling, value)
+
+
+def test_a_korean_magnitude_word_between_the_digits_and_the_unit_is_read():
+    """`3만 달러` is thirty thousand dollars, and the `만` must not break the read.
+
+    Without `[만억천조]?` in `_VALUE_MEASUREMENT` the digits no longer reach the
+    unit and the value states nothing.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_measure_units("3만 달러") == (("USD", "달러"),)
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "3만 달러") == (
+        "원",
+        "달러",
+    )
+
+
+def test_a_latin_spelling_is_matched_and_reported_casefolded():
+    """The value is casefolded before it is read, and that shows in the caveat.
+
+    `3 Weeks` states weeks, and the sentence beside the answer will say the value
+    states `weeks` rather than `Weeks`. Reporting the folded spelling is the
+    accepted cost of matching a table written in lower case.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_measure_units("3 Weeks") == (("WEEK", "weeks"),)
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "3 Weeks") == (
+        "개월",
+        "weeks",
+    )
+
+
+def test_a_four_digit_year_run_into_more_digits_is_not_a_calendar_year():
+    """The right-hand `(?![0-9])` of the year branch, pinned on its own.
+
+    The left-hand `(?<![0-9])` is what `10000년` needs; this is the other half,
+    and the value that separates them is contrived: `2021년12개월` is not a
+    spelling a KB would plausibly hold, but without the right-hand bound it is
+    read as a calendar year and its genuine `12개월` is silenced with it.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    # This first assertion is the pin: without the right-hand bound the value is
+    # a calendar date and states nothing at all.
+    assert _value_measure_units("2021년12개월") == (("MONTH", "개월"),)
+    # Asked in weeks rather than years, because the value does carry a quantity
+    # in years -- `2021년` -- and `_value_states_asked_unit` correctly suppresses
+    # a years question on it however the year branch is bounded.
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 주인가?", "2021년12개월") == (
+        "주",
+        "개월",
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "branch", "unit_it_would_wrongly_state"),
+    [
+        ("3월 15일 착수", "digit month and day", "일"),
+        ("21년 3월 ~ 22년 2월", "year and month", "년"),
+        ("2021년 착수, 총 3주", "four-digit year", "년"),
+        ("2021.03.15 일", "ISO-style date", "일"),
+    ],
+)
+def test_each_calendar_date_branch_is_needed_by_one_of_these_values(
+    value, branch, unit_it_would_wrongly_state
+):
+    """One value per alternative of `_CALENDAR_DATE`, so no branch rides free.
+
+    A guard with four alternatives needs four killers. Pinning only the
+    four-digit-year branch left the other three deletable with the suite green,
+    which is the same defect as a spellings row with no fixture: one covered
+    alternative makes the whole guard look covered.
+
+    Deleting the branch each value exercises makes exactly that value fire, and
+    only that value -- the deletion matrix over the four branches is a clean
+    diagonal, so none is masking another. The last parameter records what the
+    caveat would then wrongly say the value states.
+
+    The ISO value is the one that justifies its branch rather than merely
+    exercising it. A bare `2021-03-15` states no unit, so the branch does nothing
+    for it; what the branch is for is a unit spelling run onto the end of a date,
+    which is read as days without it. That branch also costs real caveats
+    (`2024/01/02 3주` states a genuine duration and is silenced), and it is kept
+    anyway because a wrong sentence is worse than a missing one.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플계약의 기간은 몇 개월인가?", value) is None
+
+
+def test_a_full_width_number_states_no_quantity():
+    """`[0-9]` is ASCII, and `nfc` is not `nfkc`, so `３년` states nothing.
+
+    The silence is specifically the digits: a non-breaking space between the
+    number and the unit is folded by nothing and needs no folding, because
+    `\\s` already admits it.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_measure_units("３년") == ()
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "３년") is None
+    # Written as the escape rather than pasted, so the non-breaking space
+    # cannot be mistaken for -- or reflowed into -- an ordinary one.
+    assert _value_measure_units("3\xa0년") == (("YEAR", "년"),)
+
+
+@pytest.mark.parametrize(
+    ("question", "value", "wrong_output", "what_the_value_really_says"),
+    [
+        ("샘플계약의 정산일은 몇 개월인가?", "매월 15일", ("개월", "일"), "the 15th of each month"),
+        ("샘플계약의 마감일은 몇 개월인가?", "15일 마감", ("개월", "일"), "a deadline on the 15th"),
+        ("샘플회의의 시간은 몇 시간인가?", "3시 30분", ("시간", "분"), "half past three"),
+        ("샘플회의의 시간은 몇 시간인가?", "오후 2시 15분", ("시간", "분"), "a quarter past two"),
+        ("샘플계약의 기간은 몇 개월인가?", "3월 중 15일", ("개월", "일"), "the 15th, within March"),
+        ("샘플계약의 기간은 몇 개월인가?", "3월의 15일", ("개월", "일"), "the 15th of March"),
+        ("샘플계약의 기간은 몇 개월인가?", "3월 말 15일", ("개월", "일"), "the 15th, late March"),
+        ("샘플계약의 기간은 몇 개월인가?", "03/15일", ("개월", "일"), "March 15th, no year"),
+        ("샘플사업의 가격은 몇 원인가?", "2천만원 (15,000달러)", ("원", "달러"), "20 million won"),
+        ("샘플사업의 가격은 몇 원인가?", "1억5천만원 및 20,000달러", ("원", "달러"), "150 million won"),
+        ("샘플사업의 기간은 몇 년인가?", "5개년 계획 3주", ("년", "주"), "a five-year plan"),
+        ("샘플사업의 기간은 몇 년인가?", "３년 30주", ("년", "주"), "three years, full-width"),
+        ("샘플사업의 기간은 몇 개월인가?", "6월 및 30주", ("개월", "주"), "June, or six months"),
+        ("샘플사업의 기간은 몇 개월인가?", "21년", ("개월", "년"), "the year 2021, or 21 years"),
+        ("샘플사업의 소요는 몇 분인가?", "2 second review", ("분", "second"), "a second review"),
+        ("샘플사업의 기간은 몇 년인가?", "100주", ("년", "주"), "one hundred shares"),
+        ("샘플회의의 시간은 몇 시간인가?", "5분", ("시간", "분"), "five people, honorific"),
+    ],
+)
+def test_known_false_unit_statements_are_recorded_not_fixed(
+    question, value, wrong_output, what_the_value_really_says
+):
+    """The caveat is wrong on these, and this records it rather than hiding it.
+
+    These are the wrong sentences that have been found, not all the ones that
+    exist -- every round of review on #445 has added to the list, and each
+    addition was a case an earlier round's reasoning had ruled out. So this is a
+    record, not a boundary, and it deliberately claims no shared cause: the
+    two-digit year is not a lexical ambiguity and `second` is not Korean, so any
+    argument of the form "the known ones are all X, therefore a non-X input is
+    safe" is unsound on its face.
+
+    What is true of the individual entries. Day-of-month and time-of-day are
+    points in time, not quantities of time: `_CALENDAR_DATE` reaches a day of the
+    month only through a digit month, so `매월 15일` is not a date to it, and the
+    guard has no time-of-day branch at all -- `시` is outside the spellings table
+    while `분` is in it. Neither needs a strained question; `시간` asked in
+    `몇 시간` is the most on-point relation there is. `21년` is left reading YEAR
+    because twenty-one years is a real duration -- the year+month branch takes
+    `21년 3월`, and nothing here separates the bare form. `2 second review` is an
+    English ordinal sitting on a unit row that pays for itself elsewhere
+    (`30 seconds` asked in `몇 분`). Only `100주` and `5분` need a question asked
+    in a unit the relation does not really measure.
+
+    None of this is fixed here; #445 asks that a verified answer in another unit
+    be caveated, not that every ambiguity be resolved. Asserting the wrong output
+    is deliberate: if a later change fixes one of these, this test fails and the
+    disclosure in `korean_measure_unit_mismatch` has to be corrected with it,
+    instead of quietly going stale.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) == wrong_output
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["21년 3월 ~ 22년 2월", "25년 12월 착수", "12년 6월", "2021년 3월"],
+)
+def test_a_year_followed_by_a_month_is_a_date_at_any_year_width(value):
+    """Two-digit years are ordinary Korean notation, and were read as durations.
+
+    `기간` asked in `몇 개월` is the issue's own headline question, so this needed
+    no strained relation: a `기간` holding `21년 3월 ~ 22년 2월` was told "the
+    verified value states 년", of a value that names no duration at all. The
+    year+month branch reads it as the date it is.
+
+    Delete that branch and every value here fires `(개월, 년)`.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", value) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("21년", ("개월", "년")),
+        ("21년 계약", ("개월", "년")),
+        ("10000년", ("개월", "년")),
+    ],
+)
+def test_a_year_with_no_month_beside_it_still_reads_as_a_duration(value, expected):
+    """The other half of the year+month branch: what it deliberately does NOT take.
+
+    Widening the four-digit year branch to `[0-9]{2,4}` would silence all of
+    these, and nothing in the diff used to notice. `21년` on its own really can
+    be twenty-one years, so it keeps reading YEAR and is disclosed as a wrong
+    sentence when it is not; that is the trade, and this is the assertion that
+    makes reversing it fail rather than pass.
+
+    `10000년` is here for a second reason: it also pins that the year+month
+    branch did not acquire a way to match a five-digit run.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", value) == expected
+
+
+@pytest.mark.parametrize("value", ["12년 6개월", "2년 3개월", "1년 6개월"])
+def test_a_duration_written_with_개월_is_not_swallowed_by_the_year_month_branch(value):
+    """The counter is what separates a duration from a date, not the number.
+
+    `12년 6개월` is twelve years and six months and has the same digits as a date
+    would; what makes it a duration is `개월` rather than bare `월`. All three
+    state months, so the same-unit suppression is what silences them -- if the
+    year+month branch had swallowed them they would be silent for the wrong
+    reason, which the unit list below the assertion distinguishes.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", value) is None
+    assert ("MONTH", "개월") in _value_measure_units(value)
+
+
+def test_the_iso_branch_silences_true_caveats_as_well_as_false_ones():
+    """The ISO branch's cost, recorded beside the case that justifies it.
+
+    `2021.03.15 일` is a date with a unit spelling on the end, and without the
+    branch it is reported as stating days -- that is what the branch is for. But
+    the guard is whole-value, so the same branch silences a genuine duration
+    stated next to a date. Both values below state a real mismatch with a
+    question asked in months, and both are silent.
+
+    Recorded rather than fixed. Taking the first without the second needs a
+    span-local guard, which is a change of its own; keeping the branch follows
+    this rule's standing preference for a missing sentence over a wrong one.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    question = "샘플계약의 기간은 몇 개월인가?"
+    assert korean_measure_unit_mismatch(question, "2024/01/02 3주") is None
+    assert korean_measure_unit_mismatch(question, "2021-03-15 (3일)") is None
+    # The durations really are there; it is the guard that hides them.
+    assert _value_measure_units("3주") == (("WEEK", "주"),)
+    assert _value_measure_units("(3일)") == (("DAY", "일"),)
+
+
+def test_a_single_digit_year_before_a_month_is_left_alone():
+    """The year+month branch's lower bound, which is a judgement, not a fact.
+
+    `[0-9]{2,4}` takes `21년 3월` and leaves `2년 3월`. Both readings of the
+    latter are rare -- a duration would normally be written `2년 3개월`, and a
+    date `2년 3월` only makes sense in a relative or fiscal year -- so neither
+    side is clearly right and the rule takes the conservative one, changing as
+    little as possible. This records which side that is, so widening the bound
+    to `[0-9]{1,4}` fails here rather than passing quietly.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "2년 3월") == (
+        "개월",
+        "년",
+    )
+
+
+@pytest.mark.parametrize(
+    ("question", "value"),
+    [
+        ("샘플작업의 소요시간은 몇 시간인가?", "3시간30분"),
+        ("샘플작업의 소요시간은 몇 시간인가?", "3시간 30분"),
+        ("샘플사업의 기간은 몇 년인가?", "2년6개월"),
+        ("샘플사업의 기간은 몇 년인가?", "2년 6개월"),
+        ("샘플사업의 기간은 몇 주인가?", "1주2일"),
+        ("샘플사업의 기간은 몇 개월인가?", "2년 6개월의 사업기간"),
+        ("샘플사업의 기간은 몇 개월인가?", "2개월10일"),
+    ],
+)
+def test_a_quantity_in_the_asked_unit_suppresses_the_caveat_however_it_is_spaced(
+    question, value
+):
+    """Spacing must not decide whether a correct answer gets a wrong caveat.
+
+    `_VALUE_MEASUREMENT`'s trailing lookahead refuses a unit run into the next
+    character, which is right for reading what a value states and wrong for
+    asking whether the value already carries the unit the question wanted. It
+    hid the asked unit in every unspaced case here, and the caveat fired: a
+    reader asking `몇 시간인가?` of `3시간30분` was told the value states minutes
+    and that verinote applies no conversion, when the leading quantity is
+    exactly the hours asked for. `3시간 30분`, one space apart, was silent.
+
+    The spaced and unspaced forms are paired deliberately, so a regression that
+    reintroduces the asymmetry fails on the pair rather than on a single case.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch(question, value) is None
+
+
+def test_the_suppression_scan_does_not_read_a_shorter_spelling_inside_a_longer():
+    """Why the suppression scan is longest-first rather than lookahead-free.
+
+    Dropping the lookahead is what lets `3시간30분` suppress, but dropping it
+    without reordering would let a months question find `달` inside `달러` and
+    suppress a caveat the value never earned. The alternation is sorted longest
+    spelling first, so `달러` is taken before `달`.
+
+    The second assertion is the one that would fail under a bare substring test
+    or a per-unit scan with no ordering: the value states dollars and weeks, the
+    question asked months, and the weeks caveat must survive.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_states_asked_unit,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_states_asked_unit("3달러", "MONTH") is False
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "3달러, 2주 소요") == (
+        "개월",
+        "주",
+    )
+    assert _value_states_asked_unit("2주일", "WEEK") is True
+    assert _value_states_asked_unit("3시간30분", "HOUR") is True
+
+
+def test_the_suppression_scan_sees_everything_the_value_scan_sees():
+    """The relaxed scan is a superset, so it subsumes the equality test it replaced.
+
+    If some unit could be read by `_value_measure_units` and missed by
+    `_value_states_asked_unit`, a value stating the asked unit plainly would
+    stop suppressing and the caveat would fire on it. Swept over every spelling
+    against a set of following characters that exercise the lookahead.
+    """
+    from verinote.pipeline.query_intent import (
+        _MEASUREMENT_UNIT_SPELLINGS,
+        _value_measure_units,
+        _value_states_asked_unit,
+    )
+
+    # The number set carries a magnitude word deliberately. Without one, the
+    # relaxed pattern could lose `[만억천조]?` and this property would still
+    # hold, which is how `3만 원, 5달러` reached `('원', '원')` unnoticed.
+    values = [
+        f"{number}{spelling}{tail}"
+        for number in ("1", "3", "1000", "3만", "1억", "2천")
+        for spelling in _MEASUREMENT_UNIT_SPELLINGS
+        for tail in ("", " ", "차", "5", "의", "간", "러", "s")
+    ]
+    for value in values:
+        for unit, _ in _value_measure_units(value):
+            assert _value_states_asked_unit(value, unit), (value, unit)
+
+
+@pytest.mark.parametrize("value", ["21.03.15일", "25-01-15일", "2021.03.15 일"])
+def test_the_iso_branch_reads_a_two_digit_year_like_every_other_branch(value):
+    """The year+month branch takes two-digit years; the ISO branch now does too.
+
+    Holding this branch at four digits while the branch above it accepted two --
+    on the stated grounds that two-digit years are ordinary Korean notation --
+    was the same premise accepted in one place and refused in the next, and
+    `21.03.15일` was read as fifteen days because of it.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", value) is None
+
+
+@pytest.mark.parametrize("value", ["2.03.15일", "12021.03.15일"])
+def test_the_iso_year_is_bounded_below_and_on_the_left(value):
+    """Both new bounds on the ISO year, pinned the way branch 2's are.
+
+    `2.03.15일` has a one-digit year and `12021.03.15일` a five-digit run; widen
+    to `{1,4}` or drop the `(?<![0-9])` and each becomes a date, silencing a
+    value this rule otherwise reads. Both are contrived -- that is the point of
+    a bound -- but an unpinned bound is one a later change removes for free.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", value) == (
+        "개월",
+        "일",
+    )
+
+
+@pytest.mark.parametrize("suffix", ["간", "가량", "정도", "쯤", "짜리"])
+def test_every_unit_suffix_alternative_has_a_value_that_needs_it(suffix):
+    """One value per member of `_UNIT_SUFFIX`, so no member rides free.
+
+    Four of the five were unpinned: dropping `가량`, `정도`, `쯤` or `짜리` left
+    the suite green while changing what values read. Same argument as
+    `_ROW_FIXTURES` two tables over -- an unpinned entry licences a silent
+    deletion -- and the same remedy.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 년인가?", f"3개월{suffix}") == (
+        "년",
+        "개월",
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1000엔", ("원", "엔")), ("1000 yen", ("원", "yen")),
+     ("500유로", ("원", "유로")), ("500 euro", ("원", "euro"))],
+)
+def test_the_yen_and_euro_family_rows_are_pinned(value, expected):
+    """`_MEASUREMENT_FAMILY`'s JPY and EUR rows, the two that were unpinned.
+
+    Eleven of the thirteen rows were already killed by existing fixtures; these
+    two were reachable only through `_ROW_FIXTURES`, which checks
+    `_value_measure_units` and never consults the family table. Remap either to
+    another family and the cross-currency caveat here goes silent.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", value) == expected
+
+
+def test_the_year_month_branch_is_bounded_above_and_on_the_left():
+    """Branch 2's `{2,4}` upper bound and its `(?<![0-9])`, both pinned at once.
+
+    `10000년 3월` is a five-digit run followed by a month. Widen the branch to
+    `{2,}` and it matches outright; drop the left-hand lookbehind and it matches
+    on the inner `0000년 3월`. Either way the value becomes a date and stops
+    being read, so one value covers both bounds.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 개월인가?", "10000년 3월") == (
+        "개월",
+        "년",
+    )
+
+
+def test_the_suppression_scan_reads_only_one_magnitude_word():
+    """`2천만원` is invisible to both scans, and that is what turns it wrong.
+
+    `[만억천조]?` is one character rather than a run, so a number stacking
+    magnitudes states nothing either pattern can see. On its own that is a
+    silence. Beside a unit the reporting scan CAN read it becomes a wrong
+    sentence: the caveat names the dollars and the reader's answer leads with
+    won.
+
+    `1억원` is the control -- one magnitude word, read by both scans, suppressed.
+    Recorded, not fixed: widening to `[만억천조]*` is a coverage change with its
+    own sweep to run, and #445 asks for the caveat rather than for every Korean
+    number format.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        _value_states_asked_unit,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_measure_units("2천만원") == ()
+    assert _value_states_asked_unit("2천만원", "KRW") is False
+    # One magnitude word is read by both, so this one suppresses.
+    assert _value_measure_units("1억원") == (("KRW", "원"),)
+    assert _value_states_asked_unit("1억원", "KRW") is True
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "1억원 (15,000달러)") is None
+
+
+@pytest.mark.parametrize("value", ["3월 15일", "3월  15일", "3월\t15일", "3월15일"])
+def test_whitespace_between_a_digit_month_and_its_day_still_reads_as_a_date(value):
+    """Branch 1 is `\\s*` on both sides, so whitespace does not separate them.
+
+    The bullet describing this said "immediately beside" while its own example
+    carried a space. What ends the match is a word between the two, not a gap:
+    `3월 중 15일` is not a date and is covered in the residue test above.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    assert korean_measure_unit_mismatch("샘플계약의 기간은 몇 개월인가?", value) is None
+
+
+def test_the_suppression_scan_keeps_the_digit_head_of_the_strict_pattern():
+    """The relaxed pattern's twin of "the whole precision of this rule".
+
+    `_VALUE_MEASUREMENT`'s leading `[0-9]` is pinned by a 637-pair prose sweep,
+    and the relaxed pattern was built with the same head and nothing guarding
+    it. Drop it there and the bare `원` inside `지원` counts as a quantity in
+    won, so this value stops warning about its dollars -- the same prose-noise
+    hazard, arriving through the suppression side instead.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_states_asked_unit,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_states_asked_unit("지원 없음, 3달러", "KRW") is False
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "지원 없음, 3달러") == (
+        "원",
+        "달러",
+    )
+
+
+def test_the_suppression_scan_reads_the_same_magnitude_word_as_the_value_scan():
+    """The two scans must agree on what a quantity looks like, or the caveat lies.
+
+    Drop `[만억천조]?` from the relaxed pattern only, and the two disagree about
+    `3만 원`: the reporting scan reads won, the suppression scan does not, so
+    nothing suppresses and the first same-family unit reported is the won
+    itself. The caveat then renders as "the question's counter is 원; the
+    verified value states 원" -- a sentence that contradicts itself in front of
+    the reader.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        _value_states_asked_unit,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_measure_units("3만 원, 5달러") == (("KRW", "원"), ("USD", "달러"))
+    assert _value_states_asked_unit("3만 원, 5달러", "KRW") is True
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "3만 원, 5달러") is None
+
+
+@pytest.mark.parametrize(
+    ("question", "value", "unit_the_caveat_used_to_name"),
+    [
+        ("샘플사업의 소요는 몇 분인가?", "3분기 실적, 2시간 소요", "시간"),
+        ("샘플사업의 기간은 몇 주인가?", "1주년 기념, 3개월 준비", "개월"),
+        ("샘플사업의 기간은 몇 년인가?", "80년대 후반, 3개월", "개월"),
+        ("샘플사업의 소요는 몇 초인가?", "3 secondary reviews, 2 minutes", "minutes"),
+    ],
+)
+def test_caveats_lost_to_the_suppression_scan_are_recorded_not_fixed(
+    question, value, unit_the_caveat_used_to_name
+):
+    """What the generous suppression reading costs, priced rather than implied.
+
+    A unit spelling that is only a syllable of an unrelated word still counts as
+    a quantity in that unit: `3분기` reads MINUTE, `1주년` WEEK, `80년대` YEAR,
+    `3 secondary` SECOND. Each value here states a real same-family mismatch
+    somewhere else and each is silent because of it. The last parameter records
+    the caveat that used to be shown.
+
+    Asserting the silence is deliberate, the same instrument as the wrong-
+    sentence record: narrow the suppression scan later and these fail, forcing
+    the paragraph in `_VALUE_MEASUREMENT_RELAXED` to be corrected with the code.
+    The trade is accepted because the alternative was a wrong sentence on
+    `3시간30분`, not because the cost is small.
+    """
+    from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    assert korean_measure_unit_mismatch(question, value) is None
+    # The mismatch really is in the value; only the suppression scan hides it.
+    assert unit_the_caveat_used_to_name in {
+        spelling for _, spelling in _value_measure_units(value)
+    }
+
+
+def test_only_the_달러_before_달_constraint_decides_the_suppression_ordering():
+    """The ordering requirement is one prefix pair, not the length rule.
+
+    `달`/`달러` is the only prefix pair in the table that crosses canonical
+    units, so it is the only one whose order can change an answer. Longest-first
+    is what ships because it states the intent, but it is not privileged.
+
+    Pinned in both directions, and derived from the table rather than hardcoded
+    so that reordering `_MEASUREMENT_UNIT_SPELLINGS` cannot make this fail for a
+    reason it is not about: every candidate ordering that puts `달러` first reads
+    exactly as the shipped pattern does, and every one that does not reads
+    differently. The two non-empty assertions keep it from passing vacuously if
+    some future table put every candidate on one side.
+    """
+    import re
+
+    from verinote.pipeline.query_intent import (
+        _MEASUREMENT_UNIT_SPELLINGS,
+        _VALUE_MEASUREMENT_RELAXED,
+    )
+
+    spellings = list(_MEASUREMENT_UNIT_SPELLINGS)
+    candidates = {
+        "longest-first": sorted(spellings, key=len, reverse=True),
+        "shortest-first": sorted(spellings, key=len),
+        "table": list(spellings),
+        "reversed-table": list(reversed(spellings)),
+        "alphabetical": sorted(spellings),
+        "reverse-alphabetical": sorted(spellings, reverse=True),
+    }
+    probes = ["3달러", "2주일", "3만 원", "1000달러", "3달", "2주", "30 seconds", "5달러 및 3달"]
+
+    def reads(pattern):
+        return [[m.group("unit") for m in pattern.finditer(v)] for v in probes]
+
+    def compiled(order):
+        return re.compile(
+            r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+            + "|".join(re.escape(s) for s in order)
+            + r")"
+        )
+
+    shipped = reads(_VALUE_MEASUREMENT_RELAXED)
+    satisfying = {n: o for n, o in candidates.items() if o.index("달러") < o.index("달")}
+    violating = {n: o for n, o in candidates.items() if o.index("달러") > o.index("달")}
+    assert satisfying, candidates
+    assert violating, candidates
+    for name, order in satisfying.items():
+        assert reads(compiled(order)) == shipped, name
+    for name, order in violating.items():
+        assert reads(compiled(order)) != shipped, name
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["12.5.3 버전, 3주 소요", "10.1.2 릴리스, 3주", "10.0.0.1 서버, 3주"],
+)
+def test_the_widened_iso_year_also_swallows_version_triples(value):
+    """The third cost of the ISO widening, recorded beside the other two.
+
+    Widening the ISO year to two digits made dotted numeric triples look like
+    dates, so a version number beside a genuine duration now silences it. Each
+    of these was caveated `(개월, 주)` before the widening.
+
+    `1.2.3 버전, 3주` still fires, because a one-digit first component is below
+    the bound -- luck of where the bound fell, not a rule about version numbers,
+    which is why it is asserted here rather than relied on.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    question = "샘플사업의 기간은 몇 개월인가?"
+    assert korean_measure_unit_mismatch(question, value) is None
+    assert korean_measure_unit_mismatch(question, "1.2.3 버전, 3주") == ("개월", "주")
+
+
+def test_달러_is_the_only_prefix_pair_that_crosses_canonical_units():
+    """The premise the suppression ordering rests on, derived from the table.
+
+    `_VALUE_MEASUREMENT_RELAXED` argues that dropping the lookahead is safe
+    because sorting settles the one prefix pair whose order can change an
+    answer. That argument is only as good as the premise, and nothing checked
+    it: the ordering test's probes are chosen values, so a row introducing a
+    second cross-unit prefix pair would falsify the paragraph and leave the
+    suite green.
+
+    Both counts are computed here rather than quoted, for the same reason the
+    digit-prefix figure is.
+    """
+    from verinote.pipeline.query_intent import _MEASUREMENT_UNIT_SPELLINGS as spellings
+
+    prefix_pairs = [
+        (short, long)
+        for short in spellings
+        for long in spellings
+        if short != long and long.startswith(short)
+    ]
+    crossing = [
+        (short, long)
+        for short, long in prefix_pairs
+        if spellings[short] != spellings[long]
+    ]
+    assert len(prefix_pairs) == 10
+    assert crossing == [("달", "달러")]
+
+
+def test_a_unit_suffix_would_be_inert_here():
+    """Why `_UNIT_SUFFIX` is absent from the relaxed pattern, re-derived.
+
+    Not the general claim that a match's end is unread -- it is read, `finditer`
+    resumes from it, and the two-line counterexample below shows an optional
+    trailing group changing what a scan finds. The reason is specific to these
+    character sets: every suffix member is Hangul and every match starts at a
+    digit, so a moved end can never swallow a later match's start.
+
+    Both halves are asserted, because only the pair is the argument: ends really
+    do move, and readings really do not.
+    """
+    import re
+
+    from verinote.pipeline.query_intent import (
+        _MEASUREMENT_UNIT_SPELLINGS,
+        _UNIT_SUFFIX,
+        _UNIT_SUFFIX_MEMBERS,
+        _VALUE_MEASUREMENT_RELAXED,
+    )
+
+    # The general rule this reason is NOT: an optional trailing group does
+    # change later matches when its characters can begin one.
+    assert [m.group("u") for m in re.finditer(r"(?P<u>[ab])", "ab")] == ["a", "b"]
+    assert [m.group("u") for m in re.finditer(r"(?P<u>[ab])(?:b)?", "ab")] == ["a"]
+
+    # The premise, over the LIVE members rather than a copy of them. A literal
+    # here would keep passing if a non-Hangul member were added, which is the
+    # one change that breaks the argument: a digit member makes `3년2주` read
+    # `년` alone, and `몇 주인가?` against it answers "the verified value states
+    # 주". The corpus below carries `<quantity><quantity>` shapes so that the
+    # readings loop sees it too, not only this assertion.
+    assert _UNIT_SUFFIX_MEMBERS, "an empty member set would make this vacuous"
+    for member in _UNIT_SUFFIX_MEMBERS:
+        assert re.fullmatch(r"[가-힣]+", member), member
+
+    # Both patterns are built from parts rather than by appending to the shipped
+    # one. Deriving `with_suffix` from `_VALUE_MEASUREMENT_RELAXED.pattern` made
+    # this test fail if the suffix were ever put back -- it would then be
+    # comparing one suffix against two, the ends would stop moving, and the
+    # non-vacuity guard below would fire on a mutation that breaks nothing. The
+    # claim is about these character sets, not about today's pattern text.
+    quantity = (
+        r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+        + "|".join(
+            re.escape(s) for s in sorted(_MEASUREMENT_UNIT_SPELLINGS, key=len, reverse=True)
+        )
+        + r")"
+    )
+    without_suffix = re.compile(quantity)
+    with_suffix = re.compile(quantity + _UNIT_SUFFIX)
+    corpus = [
+        f"{number}{magnitude}{spelling}{tail}"
+        for number in ("3", "1000")
+        for magnitude in ("", "만")
+        for spelling in _MEASUREMENT_UNIT_SPELLINGS
+        # The last four are the distinguishing shape: something follows the
+        # suffix position, so a member that could begin a match would swallow
+        # it. Without them the loop below cannot see a bad member.
+        for tail in (
+            "", "간", "가량", "정도", "쯤", "짜리", "차", "의", " ", "5", "s", "러",
+            "2주", "간5주", "가량10초", "5초",
+        )
+    ]
+    moved = sum(
+        1 for value in corpus
+        if [m.end() for m in with_suffix.finditer(value)]
+        != [m.end() for m in without_suffix.finditer(value)]
+    )
+    assert moved > 0, "the suffix must actually match somewhere, or this is vacuous"
+    for value in corpus:
+        assert [m.group("unit") for m in with_suffix.finditer(value)] == [
+            m.group("unit") for m in without_suffix.finditer(value)
+        ], value
+
+    # And the shipped pattern is the suffix-free one, which is what the comment
+    # beside it claims. Asserted on readings, not on pattern text, so restoring
+    # the suffix -- inert, per the loop above -- would not fail this.
+    for value in corpus:
+        assert [m.group("unit") for m in _VALUE_MEASUREMENT_RELAXED.finditer(value)] == [
+            m.group("unit") for m in without_suffix.finditer(value)
+        ], value

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -24,6 +24,7 @@ from verinote.pipeline.corroboration import CorroborationPolicyError, store_rela
 from verinote.pipeline.engine_input import engine_relation_rows
 from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_query_flow
 from verinote.pipeline.query_candidate_eval import RELATION_DECL
+from verinote.pipeline.query_intent import korean_measure_unit_mismatch
 from verinote.pipeline.report_trace import trace_query_answers
 from verinote.store import Store, engine_statuses
 from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
@@ -152,11 +153,7 @@ def ask_question(
                     engine_answers=answers,
                     reason="deterministic query matched confirmed/accepted facts",
                     grounding_facts=source_facts,
-                    warning=(
-                        None
-                        if source_facts
-                        else "source trace unavailable for this verified query shape"
-                    ),
+                    warning=_engine_answer_warning(question, source_facts),
                 )
             return AskResult(
                 route="engine",
@@ -189,6 +186,58 @@ def ask_question(
         root=root,
         question=question,
         reason=reason or f"deterministic query status: {status}",
+    )
+
+
+def _engine_answer_warning(
+    question: str, source_facts: tuple[AskGroundingFact, ...]
+) -> str | None:
+    """The caveat shown beside a verified engine answer, if there is one.
+
+    Two unrelated caveats share this slot because the template renders one. The
+    standing one is that there is no source trace, so the answer cannot be shown
+    as facts; it wins when both would apply, because the unit caveat needs the
+    trace to find the fact the answer came from. A multi-valued answer never
+    reaches the unit caveat, and not because it is an unreachable state: it is
+    answered and verified, and it produces no source trace, so it takes that
+    first branch.
+
+    The second says the verified value is in a different unit from the one the
+    question asked in (#445). It declines nothing, converts nothing, and changes
+    no label, route, or reason: `VERIFIED — engine` is a claim about provenance
+    and that claim is still accurate.
+
+    The answering fact is the one whose object is the answer; a two-hop proof
+    also lists its intermediate fact, whose object is not. `_fold` is applied to
+    both sides because the two strings arrive by different routes -- `answer` is
+    composed through NFC by the trace, while `object` is the store's text as
+    written -- so without it an NFD value would fail this test on every fact and
+    the caveat would silently never fire. The comparison is still between a
+    rendered string and a stored one, and rendering escapes more than it
+    normalises: a stored `2년<TAB>` gives object `'2년\\t'` and answer
+    `'2년\\\\t'`, which the fold does not reconcile, so that answer gets no
+    caveat. Silence, never a wrong sentence.
+
+    The sentence carries no backticks or other markup: `ask.html` renders this
+    slot as text, and no warning text this module writes uses any. (The fallback
+    path also puts a provider error message in this slot; that text is not
+    written here.)
+    """
+    if not source_facts:
+        return "source trace unavailable for this verified query shape"
+    answering = next(
+        (f for f in source_facts if _fold(f.object) == _fold(f.answer)), None
+    )
+    if answering is None:
+        return None
+    mismatch = korean_measure_unit_mismatch(question, answering.object)
+    if mismatch is None:
+        return None
+    counter, stated = mismatch
+    return (
+        f"the question's counter is {counter}; the verified value states "
+        f"{stated}. verinote shows stored values as recorded and applies "
+        f"no unit conversion"
     )
 
 

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from verinote.llm.base import LLMError
 from verinote.llm.schema import QUERY_INTENT_SCHEMA
+from verinote.text import nfc
 
 
 # Every derivation below takes its schema as an argument rather than reading
@@ -612,7 +613,7 @@ _KOREAN_MEASURE_COUNTER = (
 )
 _KOREAN_MEASURE_PREDICATE = r"인가요?|입니까|이에요|이야|예요|야"
 _KOREAN_MEASURE_QUESTION_TAIL = (
-    rf"(?<![가-힣])몇\s*(?:{_KOREAN_MEASURE_COUNTER})?\s*(?:{_KOREAN_MEASURE_PREDICATE})?"
+    rf"(?<![가-힣])몇\s*(?:(?P<counter>{_KOREAN_MEASURE_COUNTER}))?\s*(?:{_KOREAN_MEASURE_PREDICATE})?"
     r"|(?<![가-힣])얼마나(?:\s*[가-힣]{1,6}){0,2}"
 )
 """The measure-question tails `_clean_korean_attribute_label` strips.
@@ -663,11 +664,457 @@ Not covered, and stated rather than implied: a counter outside the list
 `-나` particle (`몇 개나 되나요?`). Past forms such as `몇 살이었나요?` are
 untouched by this rule, the same gap `_KOREAN_INTERROGATIVE_TAIL` records for
 `누구였나요?`.
+
+The counter is captured as `counter` so the unit rule below can read the word
+this strip discards -- the strip itself does not consult the group, and naming
+it changed no substitution this pattern makes. On the `얼마나` branch the group
+does not participate, so it reads back as None, which is the right answer:
+`얼마나` names no unit.
 """
 
 _KOREAN_ATTRIBUTE_LABEL_MEASURE_TAIL = re.compile(
     rf"\s*(?:{_KOREAN_MEASURE_QUESTION_TAIL})\s*$"
 )
+
+_MEASUREMENT_FAMILY = {
+    "YEAR": "time", "MONTH": "time", "WEEK": "time", "DAY": "time",
+    "HOUR": "time", "MINUTE": "time", "SECOND": "time",
+    "PERCENT": "ratio", "TIMES": "ratio",
+    "KRW": "money", "USD": "money", "JPY": "money", "EUR": "money",
+}
+"""The quantity each canonical unit measures.
+
+Two units in one family measure the same thing, so asking in one and being
+answered in the other is a mismatch a reader can act on. Two units in different
+families are not comparable at all: `몇 원인가?` answered `2년` is a money
+question answered with a duration, which is a mis-read question or a mis-stored
+fact rather than a unit difference, and saying "no unit conversion is applied"
+would be the wrong thing to tell that reader. So the cross-family case is
+silent.
+"""
+
+_MEASUREMENT_UNIT_SPELLINGS = {
+    "년": "YEAR", "연": "YEAR", "살": "YEAR", "세": "YEAR", "year": "YEAR", "years": "YEAR",
+    "개월": "MONTH", "달": "MONTH", "month": "MONTH", "months": "MONTH",
+    "주": "WEEK", "주일": "WEEK", "week": "WEEK", "weeks": "WEEK",
+    "일": "DAY", "day": "DAY", "days": "DAY",
+    "시간": "HOUR", "hour": "HOUR", "hours": "HOUR",
+    "분": "MINUTE", "minute": "MINUTE", "minutes": "MINUTE",
+    "초": "SECOND", "second": "SECOND", "seconds": "SECOND",
+    "퍼센트": "PERCENT", "프로": "PERCENT", "%": "PERCENT", "percent": "PERCENT",
+    "배": "TIMES",
+    "원": "KRW", "won": "KRW",
+    "달러": "USD", "dollar": "USD", "dollars": "USD",
+    "엔": "JPY", "yen": "JPY",
+    "유로": "EUR", "euro": "EUR",
+}
+"""Every spelling read as a unit, mapped to its canonical unit.
+
+One table serves both sides of the comparison -- the counter a question asks in
+and the unit a value states -- so a row added for one side is live on the other,
+and a test whose asked counter is the row under test cannot pin that row: delete
+the row and the question side goes silent too.
+
+Absent on purpose, each for its own reason:
+
+* bare `월`. `3월` is March, and `개월` is the counter for a month-count and is
+  present. Nothing here reads `월` as a month of the year either, though: the
+  row is absent, so a `6월` that really did mean six months states no unit this
+  rule can see, and is silent for want of any reading rather than by a
+  judgement between two.
+* `일` is present, unlike `월`: `3일` is three days far more often than it is the
+  third of the month. That is a judgement about which reading is commoner, not a
+  guarantee that the other one is caught. `_CALENDAR_DATE` reaches a day of the
+  month only when a digit month stands beside the day with nothing but
+  whitespace between them, so `3월 15일` and `3월15일` are dates while
+  `매월 15일`, `15일 마감`, `3월 중 15일`, `3월의 15일` and `3월 말 15일` are not,
+  and all of those do state `일` -- the last three have the month in digits and
+  are still missed, because a word between the two ends the match. See
+  `korean_measure_unit_mismatch`.
+* `개년`. It fired on `5개년 계획`, which is the name of a plan rather than a
+  duration.
+* `$`, `₩`, `€`. Every quantity here begins at a digit, and these precede their
+  number, so no row in this table could reach them. `%` is read because it
+  follows the number. That asymmetry is by construction; it is not an omission
+  a row would restore.
+"""
+
+_UNIT_SUFFIX_MEMBERS = ("간", "가량", "정도", "쯤", "짜리")
+"""The members of `_UNIT_SUFFIX`, named so a test can assert over the live set.
+
+Every member is Hangul, and `_VALUE_MEASUREMENT_RELAXED` is dropped from that
+pattern on exactly that ground. A test that restated the members as its own
+literal would go on passing if a non-Hangul one were added here, which is the
+case the argument does not survive: a digit member makes `3년2주` read as `년`
+alone and a `몇 주인가?` against it answer "the verified value states 주".
+"""
+
+_UNIT_SUFFIX = r"(?:" + "|".join(_UNIT_SUFFIX_MEMBERS) + r")?"
+"""The particles that may follow a unit and still leave it read as one.
+
+`2년간` states two years. The set is closed, and the lookahead in
+`_VALUE_MEASUREMENT` still applies after it, so `3일간의 일정` and `3주간격`
+state no unit here: with the suffix taken, the next character is Hangul and the
+lookahead refuses it; without it, `간` is Hangul and the lookahead refuses that.
+"""
+
+_VALUE_MEASUREMENT = re.compile(
+    r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+    + "|".join(re.escape(s) for s in _MEASUREMENT_UNIT_SPELLINGS)
+    + r")" + _UNIT_SUFFIX + r"(?![가-힣0-9A-Za-z])"
+)
+"""One quantity stated inside a value: digits, at most one Korean magnitude
+word, and a unit spelling.
+
+`[만억천조]?` is one character, not a run, so `3만원` is read and `2천만원` is
+not -- a number that stacks magnitudes states nothing this pattern can see.
+
+Requiring the digits is the whole precision of this rule. Ordinary Korean prose
+is full of syllables that are also unit spellings -- `지원`, `내년`, `일정`,
+`분야` -- and read without a number in front of them they turn a caveat into
+noise. The prose sweep in the tests is what measures that.
+
+The alternation is built from the spellings table in the table's own order, and
+what reads `3달러` as USD is the trailing lookahead plus backtracking rather
+than that order: `달` is tried first and matches, the lookahead rejects it
+because `러` is Hangul and so inside the lookahead's class, and the engine
+backtracks into `달러`. Every prefix pair in the table today is extended by a
+Hangul or Latin character, both of which that class covers, which is why
+re-sorting the table by length changes no reading. A spelling extended by
+punctuation would sit outside the class, and there the order would decide.
+"""
+
+_CALENDAR_DATE = re.compile(
+    r"[0-9]{1,2}\s*월\s*[0-9]{1,2}\s*일"
+    r"|(?<![0-9])[0-9]{2,4}\s*년\s*[0-9]{1,2}\s*월"
+    r"|(?<![0-9])[0-9]{4}\s*년(?![0-9])"
+    r"|(?<![0-9])[0-9]{2,4}\s*[-./]\s*[0-9]{1,2}\s*[-./]\s*[0-9]{1,2}"
+)
+"""Shapes that make a value a point in time rather than a quantity of one.
+
+`2021년` is a year, not two thousand and twenty-one years, and a question asking
+`몇 개월인가?` must not be told that value states years. The guard is on the
+whole value rather than on the matched span, so a value containing a calendar
+date reports no units at all, including a genuine mismatch stated elsewhere in
+the same value: `2021년 착수, 총 3주` asked in months, and `2021년 기준 30분`
+asked in hours, are both silent though each states a real same-family mismatch.
+
+Four alternatives, each of which some value needs; the tests delete them one at
+a time and every deletion changes an outcome.
+
+A year followed by a month is a date whatever the year's width, which is the
+branch that reads `21년 3월` and `25년 12월` as dates rather than as twenty-one
+and twenty-five years. Two-digit years are ordinary Korean document notation, so
+without it the issue's own headline question -- `기간` asked in `몇 개월` --
+answers a date range with "the verified value states 년". The year is bounded
+below at two digits: `2년 3월` is left alone because one digit is as likely to be
+a duration as a date and nothing here separates them. What distinguishes this
+branch from a real duration is the counter, not the number: `12년 6개월` is
+twelve years and six months and stays a duration, because `개월` is not `월`.
+
+A bare two-digit year is deliberately NOT caught. `21년` on its own really can be
+twenty-one years, so it is left reading YEAR and disclosed in
+`korean_measure_unit_mismatch` instead. Widening the four-digit branch to
+`[0-9]{2,4}` would silence it, and that is the trade this declines.
+
+The four-digit year branch is bounded on both sides, and the two bounds do
+different work. The left-hand `(?<![0-9])` is what stops a genuine `10000년`
+matching on its inner `0000년`. The right-hand `(?![0-9])` stops a four-digit run
+that continues into more digits from being read as a year, which only a
+contrived value reaches (`2021년12개월`).
+
+The ISO branch earns its place narrowly. An ISO date on its own states no unit,
+so the branch does nothing for `2021-03-15`; what it catches is a date with a
+unit spelling run onto the end of it, `2021.03.15 일` and `2021-03-15일`, which
+without it are read as stating days. It is the worst-paying of the four, because
+the same whole-value suppression costs real caveats elsewhere: `2024/01/02 3주`
+and `2021-03-15 (3일)` state genuine durations and go silent. Kept because a
+false sentence is worse than a missing one, which is this rule's standing
+preference; a span-local guard would take both, and that is a change of its own.
+
+Its year is `[0-9]{2,4}` for the same reason the year+month branch's is, and
+holding it at four digits while arguing two-digit years are ordinary notation
+one branch above was the contradiction that got it widened: `21.03.15일` and
+`25-01-15일` are dates by exactly the premise this file already accepts. Bounded
+below at two digits and on the left, so `2.03.15일` and `12021.03.15일` are not
+dates. What the branch still misses is a date with no year at all -- `03/15일`
+needs two separators to be reached and has one -- which is disclosed in
+`korean_measure_unit_mismatch` rather than chased with a fifth alternative.
+
+Widening the year also widened what else looks like a date, and that is a third
+cost on top of the two above: a dotted or dashed numeric triple whose first
+component is two or three digits now reads as one. `12.5.3 버전, 3주 소요`,
+`10.1.2 릴리스, 3주` and `10.0.0.1 서버, 3주` each state a genuine duration and
+are silent, where before the widening they were caveated. A one-digit first
+component still falls outside, so `1.2.3 버전, 3주` is unaffected -- which is
+luck of the bound rather than a rule about version numbers.
+
+`1500년` and `2000년간` are read as calendar years; both spellings are really
+used for durations too, so that reading is honestly ambiguous and this rule
+picks the date one.
+"""
+
+
+_VALUE_MEASUREMENT_RELAXED = re.compile(
+    r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+    + "|".join(
+        re.escape(s) for s in sorted(_MEASUREMENT_UNIT_SPELLINGS, key=len, reverse=True)
+    )
+    + r")"
+    # No `_UNIT_SUFFIX` here, unlike `_VALUE_MEASUREMENT`. NOT because a match's
+    # end is unread -- `finditer` resumes from it, so in general an optional
+    # trailing group does change what is found later: `(?P<u>[ab])` reads "ab"
+    # as a, b and `(?P<u>[ab])(?:b)?` reads it as a alone. It is inert here
+    # because of what the two character sets are: every `_UNIT_SUFFIX_MEMBERS`
+    # entry is Hangul, and every match must begin at a digit, so a start this
+    # scan cares about can never fall inside a suffix that a longer match
+    # swallowed. Ends do move; readings cannot. All three parts -- the premise
+    # over the live tuple, the moving ends, the unchanged readings -- are
+    # re-derived by `test_a_unit_suffix_would_be_inert_here`, not quoted here.
+)
+"""`_VALUE_MEASUREMENT` without the trailing lookahead, for the suppression test.
+
+The lookahead is right for deciding what a value STATES -- `2년차` is a second
+year of service, not two years -- but wrong for deciding whether the value
+already carries the unit that was ASKED for. There it hid the asked unit and let
+the caveat fire anyway: `3시간30분` answering `몇 시간인가?` was told the value
+states minutes and that no conversion is applied, when the leading quantity is
+exactly the hours asked for. A single space changed the outcome, because
+`3시간 30분` passes the lookahead and `3시간30분` does not.
+
+Suppression can only ever produce silence, so reading generously here is
+safety-increasing in a way that reading generously in `_value_measure_units`
+would not be. What it spends is caveats, and it does spend them -- see the last
+paragraph, which is part of the design rather than a caveat about it.
+
+Dropping the lookahead alone would have been wrong for one specific reason: it
+is what makes `3달러` read as USD rather than as `달` plus a stray syllable, so
+without it a question asked in months would find `달` inside `달러` and suppress
+a caveat the value never earned. `달`/`달러` is the only one of the table's ten
+prefix pairs that crosses canonical units; the other nine are two spellings of
+one unit, where which of them matches cannot change any answer. So the whole of
+what the lookahead was doing for THIS scan is discharged by reading `달러`
+before `달`.
+
+The alternation is sorted longest spelling first because that states the
+intent, but length is not the property to preserve -- putting `달러` before `달`
+is. Reversed-table and reverse-alphabetical orderings also satisfy it and read
+identically; table order, shortest-first and alphabetical do not and read
+differently. No count is quoted here on purpose: the numbers in this file have
+rotted once already, so
+`test_only_the_달러_before_달_constraint_decides_the_suppression_ordering`
+partitions the orderings off the live table and asserts both halves instead.
+This is the opposite of `_VALUE_MEASUREMENT`, where the lookahead does the work
+and the order is free.
+
+What no ordering buys, and nothing here does: a unit spelling that is merely a
+syllable of an unrelated Korean word is still read as that unit whenever a digit
+precedes it. `3분기` reads MINUTE, `1주년` reads WEEK, `80년대` reads YEAR,
+`3 secondary` reads SECOND. Each of those suppresses a caveat the value had
+earned, silently -- `몇 분인가?` answered `3분기 실적, 2시간 소요` named `시간`
+before this scan existed and says nothing now, and the same goes for
+`몇 주인가?` on `1주년 기념, 3개월 준비` and `몇 년인가?` on `80년대 후반, 3개월`.
+These are lost caveats, not near-misses, and this is the noisier half of the
+rule. The trade is deliberate: a lost caveat beats the wrong sentence the strict
+reading produced on `3시간30분`. It is still a trade.
+"""
+
+
+def _value_states_asked_unit(value: str, asked_unit: str) -> bool:
+    """Whether the value carries a quantity in the unit the question asked for.
+
+    Read with `_VALUE_MEASUREMENT_RELAXED`, which is a strict superset of what
+    `_value_measure_units` finds, so every unit that function reports is caught
+    here too and this subsumes the plain equality test it replaced.
+    """
+    folded = nfc(value).casefold()
+    return any(
+        _MEASUREMENT_UNIT_SPELLINGS[match.group("unit")] == asked_unit
+        for match in _VALUE_MEASUREMENT_RELAXED.finditer(folded)
+    )
+
+
+def _question_measure_unit(question: str) -> tuple[str, str] | None:
+    """The unit a Korean measure question asked in -- its last, if it names two.
+
+    Returned as (spelling, unit). The singular in a summary line is worth
+    qualifying because a two-counter question falsifies it:
+    `기간은 몇 년 몇 개월인가?` yields `개월`, so against a `2년` value this rule
+    would name a mismatch against a question that did ask in years. That is
+    latent rather than user-visible -- the cleaned label `기간은 몇 년` names no
+    relation an ordinary KB holds, so the question is declined to the model and
+    never reaches a verified answer to be caveated. Only a KB carrying a
+    relation spelled `기간은 몇 년` could surface it.
+
+    None when the question is not the flat attribute shape; when its label has no
+    measure tail; when the tail carries a counter that names no unit
+    (`몇 개인가?`) or no counter at all (`얼마나 되나요?`); or when what stands in
+    front of the tail does not read as a relation.
+
+    That last condition is what keeps a KB holding a relation literally named
+    `몇 년` out of this rule. There the tail is the whole label, nothing is left
+    in front of it, and `_korean_attribute_label_readings` reads the label whole
+    -- the question is asking *for* that relation, not *in* that unit.
+    """
+    match = _KOREAN_ATTRIBUTE_QUESTION.match(question.strip())
+    if match is None:
+        return None
+    label = " ".join(match.group("label").strip().split())
+    tail = _KOREAN_ATTRIBUTE_LABEL_MEASURE_TAIL.search(label)
+    if tail is None:
+        return None
+    spelling = tail.group("counter")
+    # `.get`, so the two ways there is no unit to ask about -- a counter outside
+    # the table and the `얼마나` branch, which captures no counter at all --
+    # arrive at the same answer without a branch apiece.
+    unit = _MEASUREMENT_UNIT_SPELLINGS.get(spelling)
+    if unit is None:
+        return None
+    if not _label_readings_after_measure(label[: tail.start()].strip()):
+        return None
+    return (spelling, unit)
+
+
+def _value_measure_units(value: str) -> tuple[tuple[str, str], ...]:
+    """The units a value states, as this pattern reads them.
+
+    Each is a (unit, spelling) pair, in the order stated.
+
+    "As this pattern reads them" is load-bearing rather than hedging: `3시간30분`
+    states hours and this returns only minutes, because the lookahead refuses a
+    unit followed by a digit. `korean_measure_unit_mismatch` depends on that
+    being the reporting reading and on a second, looser one deciding
+    suppression.
+
+    Empty for a value stating no quantity, and empty for a value carrying a
+    calendar date -- `_CALENDAR_DATE` records what that costs.
+
+    NFC because a value written in NFD spells `년` as two code points while the
+    alternation is composed, and casefold because the Latin spellings in the
+    table are lower-case. One consequence is worth naming: the spelling handed
+    back is the folded one, so a value stating `3 Weeks` is reported as stating
+    `weeks`.
+    """
+    folded = nfc(value).casefold()
+    if _CALENDAR_DATE.search(folded):
+        return ()
+    return tuple(
+        (_MEASUREMENT_UNIT_SPELLINGS[match.group("unit")], match.group("unit"))
+        for match in _VALUE_MEASUREMENT.finditer(folded)
+    )
+
+
+def korean_measure_unit_mismatch(question: str, value: str) -> tuple[str, str] | None:
+    """The (asked counter, stated unit) a unit caveat should name, or None.
+
+    A mismatch only when the value states a unit in the same family as the one
+    asked for and a second scan finds no quantity in the asked unit itself.
+
+    Both halves are what a pattern reads, not what the value contains, and the
+    sentence has to be put that way round: `_value_states_asked_unit` re-reads
+    the value for the asked unit with the same quantity shape minus the
+    lookahead, and anything that scan cannot see is not suppressed on. It reads
+    `6개월` in `2년 6개월`, so a `몇 개월인가?` is suppressed. It does not read
+    the won in `2천만원 (15,000달러)`, because the quantity shape admits one
+    magnitude word and that number stacks two, so a `몇 원인가?` there is
+    caveated with `달러` beside an answer whose leading figure is won.
+
+    The two halves are read by different patterns, and that is deliberate rather
+    than an oversight. What the value STATES comes from `_value_measure_units`,
+    which refuses a unit run into the next character. Whether the value CARRIES
+    the asked unit comes from `_value_states_asked_unit`, which does not -- with
+    one pattern doing both, the same lookahead that correctly declines to read
+    `2년차` as two years also hid the asked unit in `3시간30분` and `2년6개월`,
+    and the caveat fired on a value whose leading quantity was exactly what the
+    question asked for. Spacing decided it, which no reader would predict.
+
+    The first same-family unit is reported, not the first unit. `30% 완료, 3주`
+    asked in months states a ratio first and a duration second, and the duration
+    is the part the question was about.
+
+    The main causes of an accepted silence, rather than all of them: a value
+    stating no number; a unit run into the next syllable (`2년차`); a value
+    carrying a
+    calendar date; a spelling outside the table; a suffix outside `_UNIT_SUFFIX`;
+    a number that stacks magnitude words (`2천만원`), since the quantity shape
+    admits at most one; and a number written in full-width digits (`３년`), which
+    `[0-9]` does not admit and `nfc` does not fold away. `nfkc` would fold it, but
+    `verinote.text.nfc` is the one normalizer the rest of the codebase compares
+    through, and folding compatibility forms here alone would have this rule read
+    a value differently from every other comparison made on it. A non-breaking
+    space between the number and the unit is fine (`3<NBSP>년` states years), so
+    this silence is specifically the digits. An earlier cross-family quantity
+    does not silence a later same-family one.
+
+    One silence is worth separating from those, because it is the only one where
+    the value did earn a caveat and this rule loses it by misreading rather than
+    by not reading. `_value_states_asked_unit` takes a unit spelling that is a
+    syllable of an unrelated word as the asked unit, so `3분기 실적, 2시간 소요`
+    asked in minutes suppresses as though it stated minutes and its real `시간`
+    caveat is dropped; likewise `1주년 기념, 3개월 준비` asked in weeks and
+    `80년대 후반, 3개월` asked in years. `_VALUE_MEASUREMENT_RELAXED` carries the
+    class and the reason it is accepted.
+
+    Wrong sentences this is known to produce. These are the ones that have been
+    found, not a bound on what exists, and each round of review has added to
+    them; read the list as open. They also have no single cause -- a two-digit
+    year is not a lexical ambiguity and `second` is not Korean -- so do not
+    generalise from it to decide whether some new input is safe.
+
+    * A day of the month separated from its month by anything but whitespace.
+      `_CALENDAR_DATE` reads a digit month and a day with nothing but whitespace
+      between them, so `3월 15일`, `3월  15일` and `3월15일` are dates and
+      `3월 중 15일`, `3월의 15일` and `3월 말 15일` are not, though those have a
+      digit month too. `매월 15일` and `15일 마감` have no digit month at all.
+      Every one of the misses is told it states `일` -- fifteen days rather than
+      the fifteenth. A 정산일 or 마감일 relation holding `매월 N일` is ordinary
+      contract data, which makes this the most reachable one found so far.
+    * A date written with no year. The ISO branch needs two separators, so
+      `03/15일` is not a date to it and is reported as stating `일`.
+    * A value whose asked-unit quantity no pattern here can read, beside a
+      same-family unit that one can. The suppression scan misses the first and
+      the reporting scan finds the second, so the caveat names the second:
+      `2천만원 (15,000달러)` asked in won reports `달러`, `5개년 계획 3주` and
+      `３년 30주` asked in years report `주`, and `6월 및 30주` asked in months
+      reports `주`. Each is a silence cause from the list above turned into a
+      wrong sentence by a readable unit standing next to it.
+    * A time of day. The guard has no time-of-day branch, and `시` is outside the
+      spellings table while `분` is in it, so `3시 30분` and `오후 2시 15분` are
+      reported to `몇 시간인가?` as stating `분` -- thirty minutes rather than
+      half past three. Note that this one needs no strained question: `시간`
+      asked in `몇 시간` is exactly the relation the counter names.
+    * A bare two-digit year. `21년 3월` is read as a date, but `21년` alone is
+      left reading YEAR, so `몇 개월인가?` answered `21년` is told it states
+      years. Twenty-one years is a real duration and nothing here separates the
+      two readings.
+    * An English ordinal. `second` is in the spellings table as a unit, so
+      `2 second review` is reported as stating `second`. The neighbouring
+      `3 secondary reviews` is silent for an unrelated reason -- Latin continues
+      past the spelling and the lookahead refuses it -- which does not reach the
+      spaced form. The row stays, because `30 seconds` answering `몇 분인가?` is
+      a real result and the question side can only ask SECOND through `몇 초`.
+    * `몇 년인가?` answered `100주` (one hundred shares), and `몇 시간인가?`
+      answered `5분` (five people, honorific): Korean spellings that mean two
+      things, read here as the unit. These two also need a question asked in a
+      unit the relation does not really measure.
+
+    None of these is fixed here. #445 asks that a verified answer in another unit
+    be caveated, not that every ambiguous spelling be resolved. The first two
+    want a guard for "a point in time" wider than `_CALENDAR_DATE`, which is a
+    change of its own rather than a widening of this one.
+    """
+    asked = _question_measure_unit(question)
+    if asked is None:
+        return None
+    asked_spelling, asked_unit = asked
+    found = _value_measure_units(value)
+    if _value_states_asked_unit(value, asked_unit):
+        return None
+    asked_family = _MEASUREMENT_FAMILY[asked_unit]
+    for unit, spelling in found:
+        if _MEASUREMENT_FAMILY[unit] == asked_family:
+            return (asked_spelling, spelling)
+    return None
 
 
 def _korean_attribute_label_readings(value: str) -> tuple[str, ...]:


### PR DESCRIPTION
Closes #445.

#442 moved 64/64 measure questions onto the engine by stripping `몇` and its counter before the schema sees the label. That discards the unit the question asked in, so a KB holding `(샘플사업, 기간, 2년)` answers `샘플사업의 기간은 몇 개월인가?` with `VERIFIED — engine` and `2년` and **no caveat** — the one case in that family that turns an `UNVERIFIED` into a *confident* answer rather than leaving a question unanswered.

This adds the caveat. It does not decline, convert, or change label, route, status, reason or the answer body.

## Positive evidence, not absence

The first design warned when the value did **not** state the asked unit, on the argument that a substring fact cannot be false. It can:

    "달"    in "6개월"     False   -- but 6개월 states months
    "퍼센트" in "30%"       False   -- but 30% states percent
    "살"    in "만 30세"    False   -- the likely storage for an age
    "개월"  in NFD("6개월") False   -- renders identically on screen

So the rule fires only on **positive evidence**: the value states a unit of the same measurement family as the counter, and none equal to it. A unit counts only attached to a number, which is what keeps prose out — **637 counter/value pairs of synthetic prose produce no caveat, and 68 without that requirement.**

## Two patterns, because the two questions have opposite error costs

What the value **states** decides the sentence, so it is read strictly. Whether the value **carries** the asked unit only ever suppresses, so it is read generously. Without the second, `3시간30분` asked in hours was caveated as stating minutes — a wrong caveat on a correct answer, decided by a single space. A single-pattern alternative was built and refuted: it passes every test and the 637-pair sweep, and changes 66 of 200 probed pairs, all regressions.

## What it does not do is written down beside it

A day of the month, a time of day, a bare two-digit year, an English ordinal, `100주` as shares, and a value whose asked-unit quantity no pattern here can read all still produce a wrong sentence. A unit spelling that is only a syllable of another word (`3분기`, `1주년`, `80년대`) silences a caveat that was earned. **Those are asserted as they are**, so narrowing the rule later forces the list to be corrected with the code. The list is written as open, not counted — three rounds were blocked on prose that promised completeness it did not have.

Follow-ups: #450 #451 #452 #453 #454 #455.

## Validation

- `pytest` **2736 passed / 20 skipped** (base 745d0a5: 2612/20). ruff 0.15.18, the CI pin: clean.
- **120 mutants, 112 killed, 8 survivors** — all equivalent or recorded as live-but-untested by decision, and declared a floor rather than a total.
- **#442 preserved exactly**: 33,408 generated questions parse identically to the parent, and all 29 counters keep route, label, status, reason and answer body byte for byte. Only `warning` is new.
- Direction proven, not argued: across 411,983 question/value pairs the rule adds **zero** caveats over the pre-suppression version and produces **zero** self-contradictory `("X","X")` sentences.

## Review

Eight rounds through independent Architect / Critic / Reviewer gates. They found one code defect and twelve false prose claims; three of those were introduced by the fix for the previous one, and one was a hardcoded number that rotted when the code changed under it. Every hardcoded figure that survives is now re-derived by a test. Later rounds reviewed an immutable `refs/candidates/445` in a separate worktree rather than a working-tree diff, after the tree drifted under a reviewer twice.