### PR TITLE
fix: read a number the suppression scan could not spell (#451)

### DIFF
--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1672,6 +1672,12 @@ def test_a_full_width_number_states_no_quantity():
     The silence is specifically the digits: a non-breaking space between the
     number and the unit is folded by nothing and needs no folding, because
     `\\s` already admits it.
+
+    Since #451 the `[0-9]` sentence is true of `_VALUE_MEASUREMENT` alone. The
+    suppression scan reads `\\d` and does see this number, which is why
+    `３년 30주` no longer names the weeks;
+    `test_the_suppression_scan_reads_any_unicode_decimal_digit` is the other
+    side.
     """
     from verinote.pipeline.query_intent import (
         _value_measure_units,
@@ -1690,10 +1696,15 @@ def test_a_full_width_number_states_no_quantity():
     [
         ("샘플계약의 마감일은 몇 개월인가?", "15일 마감", ("개월", "일"), "a deadline on the 15th"),
         ("샘플계약의 기간은 몇 개월인가?", "03/15일", ("개월", "일"), "March 15th, no year"),
-        ("샘플사업의 가격은 몇 원인가?", "2천만원 (15,000달러)", ("원", "달러"), "20 million won"),
-        ("샘플사업의 가격은 몇 원인가?", "1억5천만원 및 20,000달러", ("원", "달러"), "150 million won"),
+        ("샘플사업의 가격은 몇 원인가?", "이천만원 (15,000달러)", ("원", "달러"),
+         "20 million won, in Sino-Korean numerals"),
+        ("샘플사업의 기간은 몇 년인가?", "20여년 3주", ("년", "주"), "twenty-odd years"),
+        ("샘플사업의 가격은 몇 원인가?", "3만여원 (15,000달러)", ("원", "달러"),
+         "thirty-odd thousand won"),
+        ("샘플작업의 소요시간은 몇 시간인가?", "한 시간 30분", ("시간", "분"),
+         "an hour and a half, in its ordinary spelling"),
+        ("샘플사업의 기간은 몇 년인가?", "반년 3주", ("년", "주"), "half a year"),
         ("샘플사업의 기간은 몇 년인가?", "5개년 계획 3주", ("년", "주"), "a five-year plan"),
-        ("샘플사업의 기간은 몇 년인가?", "３년 30주", ("년", "주"), "three years, full-width"),
         ("샘플사업의 기간은 몇 개월인가?", "6월 및 30주", ("개월", "주"), "June, or six months"),
         ("샘플사업의 기간은 몇 개월인가?", "21년", ("개월", "년"), "the year 2021, or 21 years"),
         ("샘플사업의 소요는 몇 분인가?", "2 second review", ("분", "second"), "a second review"),
@@ -1716,7 +1727,28 @@ def test_known_false_unit_statements_are_recorded_not_fixed(
 
     These are the wrong sentences that have been found, not all the ones that
     exist -- every round of review on #445 added to the list, #450 removed the
-    ones its point-in-time guard reached, and #452 added to it again. So this
+    ones its point-in-time guard reached, #452 added to it again, and #451
+    removed the three whose asked-unit quantity was a number the suppression
+    scan could not spell while adding one it still cannot. What is left of that
+    cause is what `_VALUE_MEASUREMENT_RELAXED` states as a rule rather than a
+    list: SOME decimal digit must stand before the asked unit with nothing
+    between them but digits, separators, class magnitudes and whitespace. Some
+    DIGIT and not every digit -- `1경5천조원` is read on its `5` though its `1`
+    is blocked, so a value is out of reach ON THIS CONDITION only when every
+    digit in it fails -- it may still go unread for one of the two reasons
+    `_VALUE_MEASUREMENT_RELAXED` names, which satisfy the condition and are not
+    this cause. Ranged over
+    occurrences of the spelling instead the same words would be false, which is
+    why the noun is in the sentence and not left to the witness. `이천만원`,
+    `한 시간 30분` and `반년 3주` have no digit before the unit at all -- the
+    last has no numeral in it either, which is why the condition is not "a
+    numeral the scan cannot spell" -- while `20여년` and `3만여원` have one
+    whose gap is blocked. All five are older than #451 and untouched by it;
+    successive drafts of this docstring named one class, then two, and the
+    rows are here so the third cannot be left out silently again. Beside them
+    sit the rows whose asked-unit SPELLING the
+    table excludes on purpose, which is a different cause and is argued in
+    `_MEASUREMENT_UNIT_SPELLINGS`. So this
     is a record, not a boundary, and it deliberately claims no shared cause: the
     two-digit year is not a lexical ambiguity and `second` is not Korean, so any
     argument of the form "the known ones are all X, therefore a non-X input is
@@ -1973,11 +2005,12 @@ def test_the_suppression_scan_sees_everything_the_value_scan_sees():
     )
 
     # The number set carries a magnitude word deliberately. Without one, the
-    # relaxed pattern could lose `[만억천조]?` and this property would still
-    # hold, which is how `3만 원, 5달러` reached `('원', '원')` unnoticed.
+    # relaxed pattern could lose its magnitude run and this property would still
+    # hold, which is how `3만 원, 5달러` reached `('원', '원')` unnoticed. The
+    # last three are the range #451 added to that run and to the digit class.
     values = [
         f"{number}{spelling}{tail}"
-        for number in ("1", "3", "1000", "3만", "1억", "2천")
+        for number in ("1", "3", "1000", "3만", "1억", "2천", "2천만", "2백", "１")
         for spelling in _MEASUREMENT_UNIT_SPELLINGS
         for tail in ("", " ", "차", "5", "의", "간", "러", "s")
     ]
@@ -2068,32 +2101,462 @@ def test_the_year_month_branch_is_bounded_above_and_on_the_left():
     )
 
 
-def test_the_suppression_scan_reads_only_one_magnitude_word():
-    """`2천만원` is invisible to both scans, and that is what turns it wrong.
+def _relaxed_pattern_from(number):
+    """The shipped relaxed pattern with its number replaced, for the mutants.
 
-    `[만억천조]?` is one character rather than a run, so a number stacking
-    magnitudes states nothing either pattern can see. On its own that is a
-    silence. Beside a unit the reporting scan CAN read it becomes a wrong
-    sentence: the caveat names the dollars and the reader's answer leads with
-    won.
+    Built from the live spellings table and the live sort, so a mutant differs
+    from the shipped pattern in its number and in nothing else.
+    """
+    import re
 
-    `1억원` is the control -- one magnitude word, read by both scans, suppressed.
-    Recorded, not fixed: widening to `[만억천조]*` is a coverage change with its
-    own sweep to run, and #445 asks for the caveat rather than for every Korean
-    number format.
+    from verinote.pipeline.query_intent import _MEASUREMENT_UNIT_SPELLINGS
+
+    return re.compile(
+        number
+        + r"(?P<unit>"
+        + "|".join(
+            re.escape(s) for s in sorted(_MEASUREMENT_UNIT_SPELLINGS, key=len, reverse=True)
+        )
+        + r")"
+    )
+
+
+_HEAD_RELAXED_NUMBER = r"[0-9][0-9,.]*\s*[만억천조]?\s*"
+"""The relaxed number as it stood before #451, for the tests that compare.
+
+Written out rather than derived, because what it is for is to be the OTHER
+pattern: deriving it from `_RELAXED_QUANTITY_NUMBER` would make it follow the
+live constant and the comparisons below would compare a thing with itself.
+"""
+
+
+def test_an_unreadable_asked_unit_number_no_longer_names_the_neighbour():
+    """#451: the four witnesses whose asked-unit number the scan could not spell.
+
+    Each was told the value states a neighbouring unit while its own leading
+    figure was exactly what the question asked for. The neighbour assertion is
+    the non-vacuity half: without it a value that stopped stating anything at
+    all -- because the reporting scan went blind rather than because the
+    suppression scan learned to read -- would pass this test.
+
+    `1억원 (15,000달러)` is the control. It was already silent, through the one
+    magnitude word both patterns have always read, so its staying silent shows
+    the fix did not arrive by breaking that path.
     """
     from verinote.pipeline.query_intent import (
+        _value_measure_units,
+        korean_measure_unit_mismatch,
+    )
+
+    for question, value, neighbour in [
+        ("샘플사업의 가격은 몇 원인가?", "2천만원 (15,000달러)", "달러"),
+        ("샘플사업의 가격은 몇 원인가?", "1억5천만원 및 20,000달러", "달러"),
+        ("샘플사업의 가격은 몇 원인가?", "2백만원 (15,000달러)", "달러"),
+        ("샘플사업의 기간은 몇 년인가?", "３년 30주", "주"),
+    ]:
+        assert korean_measure_unit_mismatch(question, value) is None, value
+        assert neighbour in {s for _, s in _value_measure_units(value)}, value
+
+    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "1억원 (15,000달러)") is None
+
+
+def test_the_suppression_scan_reads_a_run_of_magnitude_words(monkeypatch):
+    """`2천만원` stacks two magnitudes, and the scan reads through both.
+
+    The killer is derived from the live constant rather than retyped: turn the
+    run back into the single optional character it was before #451 and both
+    stacked witnesses name the dollars again.
+
+    Both are asserted because the issue reports both, not because either is an
+    independent killer -- they are not. `1억5천만원` ends in `5천만원`, so no
+    magnitude class or run length separates the two: under every widening
+    tried, they move together. The second row is a record of what #451 was
+    filed on, and the test says so rather than implying a discrimination it
+    does not make.
+
+    The reporting scan is deliberately left where it was, so `2천만원` still
+    STATES nothing -- what changed is only whether the value is read as already
+    carrying the unit that was asked for.
+    """
+    import verinote.pipeline.query_intent as query_intent
+    from verinote.pipeline.query_intent import (
+        _RELAXED_QUANTITY_NUMBER,
         _value_measure_units,
         _value_states_asked_unit,
         korean_measure_unit_mismatch,
     )
 
+    assert _value_states_asked_unit("2천만원", "KRW") is True
+    assert _value_states_asked_unit("1억5천만원", "KRW") is True
     assert _value_measure_units("2천만원") == ()
-    assert _value_states_asked_unit("2천만원", "KRW") is False
-    # One magnitude word is read by both, so this one suppresses.
-    assert _value_measure_units("1억원") == (("KRW", "원"),)
-    assert _value_states_asked_unit("1억원", "KRW") is True
-    assert korean_measure_unit_mismatch("샘플사업의 가격은 몇 원인가?", "1억원 (15,000달러)") is None
+
+    one_magnitude = _RELAXED_QUANTITY_NUMBER.replace(r")*", r")?")
+    assert one_magnitude != _RELAXED_QUANTITY_NUMBER, "the mutation did not apply"
+    monkeypatch.setattr(
+        query_intent, "_VALUE_MEASUREMENT_RELAXED", _relaxed_pattern_from(one_magnitude)
+    )
+    question = "샘플사업의 가격은 몇 원인가?"
+    assert korean_measure_unit_mismatch(question, "2천만원 (15,000달러)") == ("원", "달러")
+    assert korean_measure_unit_mismatch(question, "1억5천만원 및 20,000달러") == ("원", "달러")
+
+
+def test_the_suppression_scan_reads_any_unicode_decimal_digit(monkeypatch):
+    """`３년` is a number, and the suppression scan admits any Unicode decimal digit.
+
+    `\\d` rather than a listed range, which is the claim the Arabic-Indic and
+    Devanagari assertions make -- the first two below: a `[0-9０-９]` would
+    satisfy the full-width witness and fail those. The reporting scan is
+    unchanged and still reads ASCII digits only.
+
+    Decimal digit and not numeral: `\\d` is the Nd category, so `一년` is no more
+    readable here than `이천만원` is, and the numeral axis stays where
+    `korean_measure_unit_mismatch` records it.
+
+    The killer narrows the class back to ASCII, and does it by replacing the
+    head as one substring -- replacing `\\d` alone would leave the nested set
+    `[[0-9],.]` and a `FutureWarning` rather than the pattern intended.
+    """
+    import verinote.pipeline.query_intent as query_intent
+    from verinote.pipeline.query_intent import (
+        _RELAXED_QUANTITY_NUMBER,
+        _value_measure_units,
+        _value_states_asked_unit,
+        korean_measure_unit_mismatch,
+    )
+
+    assert _value_states_asked_unit("٣년", "YEAR") is True
+    assert _value_states_asked_unit("३년", "YEAR") is True
+    assert _value_measure_units("３년") == ()
+
+    ascii_only = _RELAXED_QUANTITY_NUMBER.replace(r"\d[\d,.]*", r"[0-9][0-9,.]*")
+    assert ascii_only != _RELAXED_QUANTITY_NUMBER and "\\d" not in ascii_only
+    monkeypatch.setattr(
+        query_intent, "_VALUE_MEASUREMENT_RELAXED", _relaxed_pattern_from(ascii_only)
+    )
+    assert korean_measure_unit_mismatch("샘플사업의 기간은 몇 년인가?", "３년 30주") == (
+        "년",
+        "주",
+    )
+
+
+def test_the_widened_number_can_only_silence(monkeypatch):
+    """Reading more here ends caveats and cannot start one, premise and outcome.
+
+    The premise is the load-bearing half, and it is a tripwire rather than a
+    sample: `korean_measure_unit_mismatch` returns None when this scan is true
+    and is otherwise a function of `_value_measure_units` alone, so the only way
+    a wider number changes an answer is by reading FEWER units. It cannot,
+    because no unit spelling begins with a character the number itself admits --
+    so no spelling occurrence can start inside a number, no number can extend
+    across one, and at every start where the narrower pattern matched the wider
+    one matches the same span and unit. Add a spelling that opens with a digit,
+    a comma, a dot, whitespace or a magnitude word and the argument fails here
+    rather than silently.
+
+    The premise is asserted in two halves because a literal set cannot state
+    it. `[\\s\\d]` is the number's own two open classes, and neither is
+    enumerable by hand: `\\d` is every Unicode decimal digit rather than the
+    ASCII ten, and `\\s` reaches `\\r`, `\\f`, `\\v` and the non-breaking space,
+    which a hand-typed `" \\t\\n"` would miss. The literal half is the closed
+    part -- the comma, the dot, and the magnitude class read live.
+
+    The outcome half sweeps the two patterns against each other through
+    `_value_states_asked_unit` itself rather than a copy of it. The corpus
+    carries the shapes where a longer match could hide a later one, since
+    `finditer` resumes from a match's end.
+    """
+    import re
+
+    import verinote.pipeline.query_intent as query_intent
+    from verinote.pipeline.query_intent import (
+        _MEASUREMENT_FAMILY,
+        _MEASUREMENT_UNIT_SPELLINGS,
+        _SINO_KOREAN_MAGNITUDES,
+        _value_states_asked_unit,
+    )
+
+    literal_prefix_chars = set(",.") | set(_SINO_KOREAN_MAGNITUDES)
+    assert [
+        s for s in _MEASUREMENT_UNIT_SPELLINGS if s[0] in literal_prefix_chars
+    ] == []
+    assert [
+        s for s in _MEASUREMENT_UNIT_SPELLINGS if re.fullmatch(r"[\s\d]", s[0])
+    ] == []
+
+    corpus = [
+        f"{number}{spelling}{tail}"
+        for number in ("3", "1000", "3만", "2천만", "1억5천만", "2백", "5십", "３", "１，０００")
+        for spelling in _MEASUREMENT_UNIT_SPELLINGS
+        for tail in ("", " ", "차", "5", "의", "간", "러", "s", " 3주", "2주")
+    ] + [
+        # The swallow shapes: a longer match here could end past a unit the
+        # narrower pattern reached on its own.
+        "1억 2주", "3만 5년6주", "2천 3주", "3만 5천원", "1억 2년 3주", "3만 원, 5달러",
+        "1조5천억원 3달러", "2백 3주", "5십 2년", "3천조억만원 2주", "1경5천조원 3달러",
+        "２천만원 (15,000달러)", "1억5천만원 및 20,000달러", "3시간30분", "２분기 실적, 2시간 소요",
+    ]
+    units = sorted(set(_MEASUREMENT_FAMILY))
+
+    def sweep():
+        return [
+            [_value_states_asked_unit(value, unit) for unit in units]
+            for value in corpus
+        ]
+
+    shipped = sweep()
+    monkeypatch.setattr(
+        query_intent,
+        "_VALUE_MEASUREMENT_RELAXED",
+        _relaxed_pattern_from(_HEAD_RELAXED_NUMBER),
+    )
+    head = sweep()
+
+    lost = [
+        (value, unit)
+        for value, head_row, shipped_row in zip(corpus, head, shipped)
+        for unit, before, after in zip(units, head_row, shipped_row)
+        if before and not after
+    ]
+    assert lost == []
+    gained = sum(
+        1
+        for head_row, shipped_row in zip(head, shipped)
+        for before, after in zip(head_row, shipped_row)
+        if after and not before
+    )
+    assert gained > 0, "the shipped scan must read strictly more somewhere"
+
+
+def test_the_magnitude_run_needs_no_inner_digits():
+    """The declined alternative reads the same units, measured rather than assumed.
+
+    `(?:[...]\\s*[\\d,.]*\\s*)*` reads `1억5천만원` from the `1` where the shipped
+    run reads it from the `5`, and both reach the same unit: a stacked number is
+    a digit run, then magnitude words possibly separated by further digit runs,
+    then the unit, so the shipped form starts at the last inner run and the
+    region the longer form swallows holds no unit to hide.
+
+    That last clause is the premise, and it is re-derived from the live table
+    and the live class rather than restated, so adding `경` to
+    `_SINO_KOREAN_MAGNITUDES` re-derives it too. Written with `startswith` and
+    not by indexing, which raises rather than answers if the table ever holds
+    an empty key.
+
+    The two patterns really are different, which the match starts show. Without
+    that check the equality could hold because the mutation did nothing.
+    """
+    from verinote.pipeline.query_intent import (
+        _MEASUREMENT_UNIT_SPELLINGS,
+        _SINO_KOREAN_MAGNITUDES,
+        _VALUE_MEASUREMENT_RELAXED,
+    )
+
+    assert [
+        s
+        for s in _MEASUREMENT_UNIT_SPELLINGS
+        if s.startswith(tuple(_SINO_KOREAN_MAGNITUDES))
+    ] == []
+
+    inner_digits = _relaxed_pattern_from(
+        r"\d[\d,.]*\s*(?:[" + _SINO_KOREAN_MAGNITUDES + r"]\s*[\d,.]*\s*)*"
+    )
+    assert inner_digits.pattern != _VALUE_MEASUREMENT_RELAXED.pattern
+    corpus = [
+        f"{number}{spelling}{tail}"
+        for number in ("1억5천만", "3만 5천", "2억 5,000만", "2백만", "3천5백만", "5백50만", "1경5천조")
+        for spelling in _MEASUREMENT_UNIT_SPELLINGS
+        for tail in ("", " ", " 3주", "5", "차")
+    ]
+    starts_differ = 0
+    for value in corpus:
+        assert [m.group("unit") for m in inner_digits.finditer(value)] == [
+            m.group("unit") for m in _VALUE_MEASUREMENT_RELAXED.finditer(value)
+        ], value
+        if [m.start() for m in inner_digits.finditer(value)] != [
+            m.start() for m in _VALUE_MEASUREMENT_RELAXED.finditer(value)
+        ]:
+            starts_differ += 1
+    assert starts_differ > 0, "the two patterns must differ, or the equality is vacuous"
+
+
+def test_the_magnitude_class_is_a_series_and_this_is_where_it_stops():
+    """The residue of `_SINO_KOREAN_MAGNITUDES`, re-derived rather than restated.
+
+    `백` is in, so `2백만원` and `3천5백만원` suppress -- and note that neither
+    of those demonstrates `십`, which is the pairing this docstring made when it
+    was first written. A stated member illustrated by a value that does not
+    contain it is a member with no evidence behind it, and `십` could be deleted
+    with the whole suite green until the per-member block below was added. Its
+    own values are `5십원` and `2백5십원`.
+
+    `경` is the known next member and is out, so a sum written with it flush
+    against the unit is still told it states the dollars. Add `경` to the class
+    and the `1경원` assertion fails, which is what forces the boundary in that
+    constant's docstring to be corrected with the code -- the tripwire is the
+    whole protection here, because an unrecognised magnitude on this scan leaves
+    a wrong sentence standing rather than costing a caveat.
+
+    The last two rows are what makes the residue statable rather than open, and
+    they are the pair a reader is likeliest to get wrong. The run starts at the
+    LAST digit run and must reach the unit without interruption, so
+    `1경5천조원` is read -- its last digit run is the `5`, and only `천` and `조`
+    follow -- while `1천경원` is not, even though its `천` is in the class. What
+    decides is the whole gap between the final digit and the unit, not whether
+    some member of it is known.
+
+    Every member of the class carries its own row, because a stated member
+    nothing pins is a member that can be deleted with the suite green -- which
+    `십` was until this test was written. The values are chosen so that removing
+    one character from `_SINO_KOREAN_MAGNITUDES` fails a row naming it and no
+    other: `5십원` needs `십` and nothing else, `2백원` needs `백`, `3천원`
+    `천`, `3만원` `만`, `1억원` `억`, `1조원` `조`. Verified as a diagonal, one
+    deletion at a time.
+
+    `2백5십원` is the shape a sum below ten thousand is actually written in, and
+    it is here as a reading rather than as a seventh killer: it is lost by
+    dropping `십` and NOT by dropping `백`, because the run reads from the last
+    magnitude it knows and the `5십` is reachable on its own. That is the same
+    mechanism the `1경5천조원` row above turns on, which is why one value cannot
+    stand for two members.
+    """
+    from verinote.pipeline.query_intent import (
+        _SINO_KOREAN_MAGNITUDES,
+        korean_measure_unit_mismatch,
+    )
+
+    question = "샘플사업의 가격은 몇 원인가?"
+    assert korean_measure_unit_mismatch(question, "2백만원 (15,000달러)") is None
+    assert korean_measure_unit_mismatch(question, "3천5백만원 (15,000달러)") is None
+    assert korean_measure_unit_mismatch(question, "1경원 (15,000달러)") == ("원", "달러")
+    assert korean_measure_unit_mismatch(question, "1경5천조원 (15,000달러)") is None
+    assert korean_measure_unit_mismatch(question, "1천경원 (15,000달러)") == ("원", "달러")
+
+    # One value per member, so no member rides free. Derived from the live
+    # constant rather than listed, so a member added without a value here fails
+    # for want of a fixture instead of passing unpinned.
+    per_member = {
+        "십": "5십원 (15,000달러)",
+        "백": "2백원 (15,000달러)",
+        "천": "3천원 (15,000달러)",
+        "만": "3만원 (15,000달러)",
+        "억": "1억원 (15,000달러)",
+        "조": "1조원 (15,000달러)",
+    }
+    assert set(per_member) == set(_SINO_KOREAN_MAGNITUDES)
+    for member, value in per_member.items():
+        assert korean_measure_unit_mismatch(question, value) is None, member
+    assert korean_measure_unit_mismatch(question, "2백5십원 (15,000달러)") is None
+
+
+def test_the_reporting_scans_magnitude_bound_has_two_halves_and_both_are_pinned():
+    """`[만억천조]?` says "at most one" AND "only these four"; pin each separately.
+
+    `korean_measure_unit_mismatch` states both halves in one sentence, and one
+    fixture cannot hold them. The obvious choice is vacuous: `2백만원` needs the
+    run AND the class, so it stays unreadable under a mutation that supplies
+    only one, and a test resting on it would pass while either half rotted.
+
+    The diagonal below is the whole point. `2천만원` needs only the run, so it
+    moves under the run mutation and not the class one; `2백원` and `5십원` need
+    only the class, so they move under the class mutation and not the run one.
+    Each half therefore has a value that fails for it alone. `2백만원` is
+    asserted too, but as the conjunction it names rather than as a killer.
+
+    #451 sits on the class half: the SUPPRESSION scan gained `십백` and this one
+    did not, which is why `2백원` asked in won is silent here and suppresses
+    there.
+    """
+    import re
+
+    from verinote.pipeline.query_intent import _VALUE_MEASUREMENT, _value_measure_units
+
+    for value in ["2천만원", "2백원", "5십원", "2백5십원", "2백만원"]:
+        assert _value_measure_units(value) == (), value
+    # The control: one magnitude from the four is read, so the silences above
+    # are the bound and not a blind pattern.
+    assert _value_measure_units("3만원") == (("KRW", "원"),)
+
+    live = _VALUE_MEASUREMENT.pattern
+    bound = "[만억천조]?"
+    assert bound in live, "the bound moved; this test hardcodes only its text"
+    wider_class = re.compile(live.replace(bound, "[십백천만억조]?"))
+    longer_run = re.compile(live.replace(bound, "[만억천조]*"))
+
+    def reads(pattern, value):
+        return [m.group("unit") for m in pattern.finditer(value)]
+
+    # Widening the class reaches the sub-myriad values and not the stacked one.
+    assert reads(wider_class, "2백원") == ["원"]
+    assert reads(wider_class, "5십원") == ["원"]
+    assert reads(wider_class, "2천만원") == []
+    # Allowing a run reaches the stacked value and not the sub-myriad ones.
+    assert reads(longer_run, "2천만원") == ["원"]
+    assert reads(longer_run, "2백원") == []
+    assert reads(longer_run, "5십원") == []
+    # And the conjunction really is one: neither mutation alone reads it.
+    assert reads(wider_class, "2백만원") == []
+    assert reads(longer_run, "2백만원") == []
+
+
+def test_a_separator_is_admitted_only_inside_the_leading_digit_run(monkeypatch):
+    """`2천만,년` states nothing, and that is the number's shape, not luck.
+
+    `_RELAXED_QUANTITY_NUMBER` is `\\d[\\d,.]*` followed by a run of magnitude
+    words, so the comma and the dot are admitted inside the leading digit run
+    and nowhere else. A separator standing AFTER a magnitude word ends the
+    match, which is why `2천만,년` is not read as years -- even though a digit
+    stands before the `년` with only digits, separators and magnitudes between
+    them, and so the value satisfies the rule
+    `_VALUE_MEASUREMENT_RELAXED` states.
+
+    That is the whole reason this test exists. That rule is stated as necessary
+    and not sufficient, and it names two classes where the converse fails; this
+    is the second of them. Until this fixture, nothing held it: admitting
+    `[,.]` after the magnitude group left the entire file green, so the
+    disclosure was a reading of the constant rather than a claim anything would
+    notice losing. The other class has
+    `test_달러_is_the_only_prefix_pair_that_crosses_canonical_units`; this is
+    the matching tripwire.
+
+    The killer is derived from the live constant rather than retyped, so it
+    follows the number if the number moves.
+    """
+    import verinote.pipeline.query_intent as query_intent
+    from verinote.pipeline.query_intent import (
+        _RELAXED_QUANTITY_NUMBER,
+        _VALUE_MEASUREMENT_RELAXED,
+        _value_states_asked_unit,
+        korean_measure_unit_mismatch,
+    )
+
+    question = "샘플사업의 기간은 몇 년인가?"
+    assert _value_states_asked_unit("2천만,년", "YEAR") is False
+    assert _value_states_asked_unit("2천만.년", "YEAR") is False
+    assert korean_measure_unit_mismatch(question, "2천만,년 3주") == ("년", "주")
+    # The minimal pair: this differs from the row above it by the comma alone,
+    # so the two together fail when the POSITION moves and not when the value
+    # stops being read for some other cause. On its own the `False` above would
+    # also go green if `년` ever left the spellings table, and the pin would
+    # survive having stopped meaning anything.
+    assert _value_states_asked_unit("2천만년", "YEAR") is True
+    # The control, and the half of the claim that is about POSITION. Asserted on
+    # the match and not on the boolean: drop `[,.]` from the leading run and
+    # `1,000년` is still read, because the scan resumes and finds `000년`, so no
+    # `_value_states_asked_unit` assertion here could notice. The span is what
+    # moves -- `1,000년` becomes `000년`.
+    assert _VALUE_MEASUREMENT_RELAXED.search("1,000년").group(0) == "1,000년"
+    assert _value_states_asked_unit("1,000년", "YEAR") is True
+    assert korean_measure_unit_mismatch(question, "1,000년 3주") is None
+
+    after_magnitudes = _RELAXED_QUANTITY_NUMBER.replace(r"]\s*)*", r"]\s*[,.]*\s*)*")
+    assert after_magnitudes != _RELAXED_QUANTITY_NUMBER, "the mutation did not apply"
+    monkeypatch.setattr(
+        query_intent,
+        "_VALUE_MEASUREMENT_RELAXED",
+        _relaxed_pattern_from(after_magnitudes),
+    )
+    assert _value_states_asked_unit("2천만,년", "YEAR") is True
+    assert korean_measure_unit_mismatch(question, "2천만,년 3주") is None
 
 
 @pytest.mark.parametrize("value", ["3월 15일", "3월  15일", "3월\t15일", "3월15일"])
@@ -2114,8 +2577,11 @@ def test_the_suppression_scan_keeps_the_digit_head_of_the_strict_pattern():
     """The relaxed pattern's twin of "the whole precision of this rule".
 
     `_VALUE_MEASUREMENT`'s leading `[0-9]` is pinned by a 637-pair prose sweep,
-    and the relaxed pattern was built with the same head and nothing guarding
-    it. Drop it there and the bare `원` inside `지원` counts as a quantity in
+    and the relaxed pattern requires a digit in the same position with nothing
+    guarding it. The two heads differ in their digit CLASS and in nothing else,
+    `\\d` there against `[0-9]` here; what differs elsewhere in the two numbers
+    is the magnitude group, which is not what this test is about.
+    Drop the head there and the bare `원` inside `지원` counts as a quantity in
     won, so this value stops warning about its dollars -- the same prose-noise
     hazard, arriving through the suppression side instead.
     """
@@ -2131,15 +2597,20 @@ def test_the_suppression_scan_keeps_the_digit_head_of_the_strict_pattern():
     )
 
 
-def test_the_suppression_scan_reads_the_same_magnitude_word_as_the_value_scan():
-    """The two scans must agree on what a quantity looks like, or the caveat lies.
+def test_the_suppression_scan_reads_at_least_the_value_scans_magnitude_word():
+    """The relaxed scan must read at least what the value scan does, or it lies.
 
-    Drop `[만억천조]?` from the relaxed pattern only, and the two disagree about
-    `3만 원`: the reporting scan reads won, the suppression scan does not, so
-    nothing suppresses and the first same-family unit reported is the won
-    itself. The caveat then renders as "the question's counter is 원; the
-    verified value states 원" -- a sentence that contradicts itself in front of
-    the reader.
+    Since #451 the two do not read the same magnitude word, nor the same
+    magnitude class: the relaxed number is a run over
+    `_SINO_KOREAN_MAGNITUDES` and `_VALUE_MEASUREMENT` still takes one
+    `[만억천조]`. What is required is the inequality, not the equality. Drop the
+    magnitude run from the relaxed pattern and the two disagree about `3만 원`
+    in the unsafe direction: the reporting scan reads won, the suppression scan
+    does not, so nothing suppresses and the first same-family unit reported is
+    the won itself. The caveat then renders as "the question's counter is 원;
+    the verified value states 원" -- a sentence that contradicts itself in front
+    of the reader. The other direction is safe by construction, and
+    `test_the_widened_number_can_only_silence` is where it is argued.
     """
     from verinote.pipeline.query_intent import (
         _value_measure_units,
@@ -2159,6 +2630,12 @@ def test_the_suppression_scan_reads_the_same_magnitude_word_as_the_value_scan():
         ("샘플사업의 기간은 몇 주인가?", "1주년 기념, 3개월 준비", "개월"),
         ("샘플사업의 기간은 몇 년인가?", "80년대 후반, 3개월", "개월"),
         ("샘플사업의 소요는 몇 초인가?", "3 secondary reviews, 2 minutes", "minutes"),
+        ("샘플사업의 소요는 몇 분인가?", "２분기 실적, 2시간 소요", "시간"),
+        ("샘플사업의 기간은 몇 주인가?", "１주년 기념, 3개월 준비", "개월"),
+        ("샘플사업의 기간은 몇 년인가?", "８０년대 후반, 3개월", "개월"),
+        ("샘플사업의 기간은 몇 주인가?", "2천만주 보유, 3개월 준비", "개월"),
+        ("샘플사업의 기간은 몇 주인가?", "3천만 주주, 3개월", "개월"),
+        ("샘플사업의 기간은 몇 주인가?", "3백주 보유, 3개월 준비", "개월"),
     ],
 )
 def test_caveats_lost_to_the_suppression_scan_are_recorded_not_fixed(
@@ -2177,6 +2654,26 @@ def test_caveats_lost_to_the_suppression_scan_are_recorded_not_fixed(
     the paragraph in `_VALUE_MEASUREMENT_RELAXED` to be corrected with the code.
     The trade is accepted because the alternative was a wrong sentence on
     `3시간30분`, not because the cost is small.
+
+    The last six arrived with #451, which widened the number into three
+    notations: a magnitude RUN, a magnitude CLASS reaching below the myriad, and
+    a non-ASCII decimal digit. Three are the full-width twins of the three
+    Korean rows above them. The rest are the other lost-caveat shape reaching a
+    scale the old number could not spell: `2천만주` is twenty million shares,
+    the `100주` `test_known_false_unit_statements_are_recorded_not_fixed`
+    records, and `3천만 주주` is shareholders, where the `주` is a syllable of a
+    longer word as in the first three.
+
+    `3백주 보유, 3개월 준비` is the row that keeps the count of notations honest,
+    and it is here for that and not for variety. Three hundred shares beside a
+    genuine three months, in ASCII digits, with a magnitude run of length one --
+    so neither the run nor the digit class explains it, and a docstring saying
+    "two notations" would price every value except the ones the third reaches.
+    Drop `백` from `_SINO_KOREAN_MAGNITUDES` and this row alone fires.
+
+    Read the list as an illustration of a product and not as a set: every
+    reading this scan already makes now reaches into all three notations, so a
+    count here would be a count of an open class.
     """
     from verinote.pipeline.query_intent import (
         _value_measure_units,
@@ -2188,6 +2685,42 @@ def test_caveats_lost_to_the_suppression_scan_are_recorded_not_fixed(
     assert unit_the_caveat_used_to_name in {
         spelling for _, spelling in _value_measure_units(value)
     }
+
+
+def test_a_point_in_time_silence_travels_into_the_new_notations():
+    """#451's second cost, which is not the lost-caveat class above it.
+
+    `_value_states_asked_unit` does not consult `_TIME_POINT` -- that pattern's
+    own docstring says so -- so a point-in-time component the suppression scan
+    reads as a quantity suppresses in whatever notation it is written. Widening
+    the number therefore carried every point-in-time silence into the new
+    notations too, and filing that under the lost-caveat class would be a false
+    claim about the code: nothing here is a unit spelling hiding inside another
+    word.
+
+    Each row is asserted beside its ASCII twin, which is silent as well. That
+    pairing is what makes this an extension of an accepted silence rather than a
+    new misreading -- and it is also the falsifier, since a row whose twin was
+    caveated would belong somewhere else. These are real losses judged as
+    Korean: `２０２１년 착수, 총 3주` asked in years carries no duration in years
+    and the caveat naming the weeks was true.
+
+    One reading went the other way with them, and it is the defect this scan
+    exists to fix: `３시간30분` asked in hours was told it states minutes.
+    """
+    from verinote.pipeline.query_intent import korean_measure_unit_mismatch
+
+    for question, wide, ascii_twin in [
+        ("샘플사업의 기간은 몇 년인가?", "２０２１년 착수, 총 3주", "2021년 착수, 총 3주"),
+        ("샘플계약의 마감일은 몇 일인가?", "１５일 마감, 3주", "15일 마감, 3주"),
+        ("샘플계약의 마감일은 몇 일인가?", "３월 １５일, 3주", "3월 15일, 3주"),
+        ("샘플사업의 소요는 몇 분인가?", "３시 ３０분 회의, 2시간", "3시 30분 회의, 2시간"),
+        ("샘플사업의 기간은 몇 년인가?", "２１년, 3개월", "21년, 3개월"),
+    ]:
+        assert korean_measure_unit_mismatch(question, wide) is None, wide
+        assert korean_measure_unit_mismatch(question, ascii_twin) is None, ascii_twin
+
+    assert korean_measure_unit_mismatch("샘플작업의 소요시간은 몇 시간인가?", "３시간30분") is None
 
 
 def test_only_the_달러_before_달_constraint_decides_the_suppression_ordering():
@@ -2208,6 +2741,7 @@ def test_only_the_달러_before_달_constraint_decides_the_suppression_ordering(
 
     from verinote.pipeline.query_intent import (
         _MEASUREMENT_UNIT_SPELLINGS,
+        _RELAXED_QUANTITY_NUMBER,
         _VALUE_MEASUREMENT_RELAXED,
     )
 
@@ -2220,19 +2754,38 @@ def test_only_the_달러_before_달_constraint_decides_the_suppression_ordering(
         "alphabetical": sorted(spellings),
         "reverse-alphabetical": sorted(spellings, reverse=True),
     }
-    probes = ["3달러", "2주일", "3만 원", "1000달러", "3달", "2주", "30 seconds", "5달러 및 3달"]
+    # The last two probes are the range the number gained in #451. Without them
+    # every probe is ASCII with at most one magnitude word, so the copy of the
+    # number this test used to carry could not be told apart from the live one
+    # and substituting the constant would stop the copy drifting while leaving
+    # the probes blind at the level above.
+    probes = [
+        "3달러", "2주일", "3만 원", "1000달러", "3달", "2주", "30 seconds", "5달러 및 3달",
+        "2천만달러 및 3달", "３달러",
+    ]
 
     def reads(pattern):
         return [[m.group("unit") for m in pattern.finditer(v)] for v in probes]
 
     def compiled(order):
         return re.compile(
-            r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+            _RELAXED_QUANTITY_NUMBER
+            + r"(?P<unit>"
             + "|".join(re.escape(s) for s in order)
             + r")"
         )
 
     shipped = reads(_VALUE_MEASUREMENT_RELAXED)
+    # The probes really do exercise the number, and not only the alternation:
+    # the pre-#451 number reads them differently. Without this the two added
+    # probes could be inert and nothing here would say so.
+    before_451 = re.compile(
+        r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+        + "|".join(re.escape(s) for s in candidates["longest-first"])
+        + r")"
+    )
+    assert reads(before_451) != shipped, "the probes cannot see the number"
+
     satisfying = {n: o for n, o in candidates.items() if o.index("달러") < o.index("달")}
     violating = {n: o for n, o in candidates.items() if o.index("달러") > o.index("달")}
     assert satisfying, candidates
@@ -2324,6 +2877,7 @@ def test_a_unit_suffix_would_be_inert_here():
 
     from verinote.pipeline.query_intent import (
         _MEASUREMENT_UNIT_SPELLINGS,
+        _RELAXED_QUANTITY_NUMBER,
         _UNIT_SUFFIX,
         _UNIT_SUFFIX_MEMBERS,
         _VALUE_MEASUREMENT_RELAXED,
@@ -2351,7 +2905,8 @@ def test_a_unit_suffix_would_be_inert_here():
     # non-vacuity guard below would fire on a mutation that breaks nothing. The
     # claim is about these character sets, not about today's pattern text.
     quantity = (
-        r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+        _RELAXED_QUANTITY_NUMBER
+        + r"(?P<unit>"
         + "|".join(
             re.escape(s) for s in sorted(_MEASUREMENT_UNIT_SPELLINGS, key=len, reverse=True)
         )
@@ -2361,7 +2916,11 @@ def test_a_unit_suffix_would_be_inert_here():
     with_suffix = re.compile(quantity + _UNIT_SUFFIX)
     corpus = [
         f"{number}{magnitude}{spelling}{tail}"
-        for number in ("3", "1000")
+        # The last three numbers are the three notations #451 added: a
+        # magnitude run, a magnitude outside `[만억천조]`, and a non-ASCII
+        # digit. Without them the corpus stays inside the pre-#451 number and
+        # this test cannot see the pattern it is built from.
+        for number in ("3", "1000", "2천만", "2백", "３")
         for magnitude in ("", "만")
         for spelling in _MEASUREMENT_UNIT_SPELLINGS
         # The last four are the distinguishing shape: something follows the
@@ -2961,11 +3520,11 @@ def test_whether_a_withdrawn_cover_becomes_a_caveat_depends_on_the_question():
     # has no negative candidate that could fire -- which is exactly how it went
     # unnoticed while the list was being called complete.
     _MONEY = "샘플사업의 가격은 몇 원인가?"
-    assert korean_measure_unit_mismatch(_MONEY, "2021년, 2천만원 (15,000달러)") == (
+    assert korean_measure_unit_mismatch(_MONEY, "2021년, 15,000달러 계약") == (
         "원",
         "달러",
     )
-    assert korean_measure_unit_mismatch(_MONTH, "2021년, 2천만원 (15,000달러)") is None
+    assert korean_measure_unit_mismatch(_MONTH, "2021년, 15,000달러 계약") is None
     # The reverse pairing, and the witness `_TIME_POINT` cites: a DAY reported
     # and outside every span, passed over because the question asks in won.
     assert korean_measure_unit_mismatch(_MONEY, "2021년, 15일 마감") is None

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -724,6 +724,18 @@ Absent on purpose, each for its own reason:
   judgement between two. `_TIME_POINT` does read digits run into `월`, but as a
   month term inside a longer shape rather than as a unit, so the two do not
   disagree.
+  The exclusion is live on the suppression scan too, which is what makes
+  `6월 및 30주` asked in months name the weeks. Admitting `월` there was measured
+  against #451 and declined: it silences `3월 15일간`, `3월 내 15일 소요`,
+  `3월 계약 15일 소요` and their siblings, values whose duration other tests
+  assert is caveated, and it reaches the `N월 ..., N주` shape at large, where
+  the `3월` is the month of the year far more often than a count of them.
+  The reach is the DIGIT month only -- `전월 대비 3일 단축` and `매월 15일간`
+  keep their caveats, since the scan needs a digit in front of the `월` --
+  which narrows the cost without
+  changing the verdict. Declining a `월` that falls inside a `_TIME_POINT` span
+  does not rescue the narrower cases either: `2년 3월` and `10000년 3월` match no
+  branch of that pattern.
 * `일` is present, unlike `월`: `3일` is three days far more often than it is
   the third of the month. That is a judgement about which reading is commoner,
   not a guarantee that the other one is caught. What catches the other reading
@@ -733,10 +745,22 @@ Absent on purpose, each for its own reason:
   `korean_measure_unit_mismatch`.
 * `개년`. It fired on `5개년 계획`, which is the name of a plan rather than a
   duration.
+  Live on the suppression scan too, so `5개년 계획 3주` asked in years names the
+  weeks -- a wrong sentence #451 records. Fixing it means reading `5개년` as
+  possibly stating years after all, which is the judgement this row was excluded
+  for, so the two cannot both stand.
 * `$`, `₩`, `€`. Every quantity here begins at a digit, and these precede their
   number, so no row in this table could reach them. `%` is read because it
   follows the number. That asymmetry is by construction; it is not an omission
   a row would restore.
+  What #451 adds is not a reason to restore one but a name for what the
+  omission costs. A symbol-led sum states no unit on either scan, so where a
+  readable same-family unit stands beside it the caveat names that one:
+  `₩20,000,000 (15,000달러)` asked in won reports `달러`, before this change and
+  after. That is the general form `korean_measure_unit_mismatch`'s last bullet
+  states -- an accepted silence with a readable neighbour is a latent wrong
+  sentence -- reached by a cause that is neither the number nor a missing row,
+  but the side the symbol sits on.
 """
 
 _UNIT_SUFFIX_MEMBERS = ("간", "가량", "정도", "쯤", "짜리")
@@ -806,11 +830,18 @@ _VALUE_MEASUREMENT = re.compile(
     + "|".join(re.escape(s) for s in _MEASUREMENT_UNIT_SPELLINGS)
     + r")" + _UNIT_SUFFIX + r"(?![가-힣0-9A-Za-z])"
 )
-"""One quantity stated inside a value: digits, at most one Korean magnitude
-word, and a unit spelling.
+"""One quantity stated inside a value: ASCII digits, at most one of four Korean
+magnitude words, and a unit spelling.
 
 `[만억천조]?` is one character, not a run, so `3만원` is read and `2천만원` is
-not -- a number that stacks magnitudes states nothing this pattern can see.
+not; it is those four and no others, so `2백만원` is not either; and the digits
+are `[0-9]` rather than `\\d`, so `３년` is not. All three bounds are narrower
+than `_VALUE_MEASUREMENT_RELAXED`'s, and the asymmetry has a direction. This
+pattern decides what a value STATES and its output is put in front of a reader,
+so widening it ADDS sentences and needs a sweep of its own; the relaxed one
+decides only whether to stay silent. #451 widened the relaxed number and left
+this one where it was, which is why those three are silent here and suppress
+there.
 
 Requiring the digits is the whole precision of this rule. Ordinary Korean prose
 is full of syllables that are also unit spellings -- `지원`, `내년`, `일정`,
@@ -988,7 +1019,7 @@ time, and span-local withdraws that from all of them at once.
 `2021년 계약, 15일 마감` is now told it states `일`, `2021년 착수, 21년` that
 it states `년`, `2021년 계약, 2 second review` that it states `second`,
 `2021년 기준, 6월 및 30주` that it states `주`, and
-`2021년 계약, 2천만원 (15,000달러)` that it states `달러` -- one witness per
+`2021년 계약, 15,000달러` that it states `달러` -- one witness per
 entry would just be the list of entries again. None of them is a new
 misreading: each value reads the same way standing alone and has since before
 #450. What changed is the reach, and it changed for the whole list rather
@@ -1312,8 +1343,65 @@ picks the date one.
 """
 
 
+_SINO_KOREAN_MAGNITUDES = "십백천만억조"
+"""The magnitude words `_VALUE_MEASUREMENT_RELAXED`'s number may run through.
+
+The Sino-Korean magnitudes as far as documents use them. This is TWO series
+joined, and the join is worth naming because only one of them continues: the
+sub-myriad steps 십 백 천, which are 10^1 to 10^3 and stop there because 10^4
+has its own word, and the myriad steps 만 억 조, which are 10^4, 10^8 and 10^12
+and go on to `경`. Both are enumerable with a defining property rather than
+open lexical classes like `_MONTH_WORD_MEMBERS`, so naming them is one decision
+rather than a list that grows each round. Reading the six as one run is what
+makes the boundary hard to see: it invites looking for a next member after
+`조` by the same step that got from `십` to `백`, when what actually continues
+is the myriad half, at `경`. `경` is out because a sum of 10^16 has not been
+seen in this data; that boundary is stated here so it can be argued with, and
+`test_the_magnitude_class_is_a_series_and_this_is_where_it_stops` re-derives
+what it costs rather than restating this sentence.
+
+What it costs is narrow, and narrow for a structural reason: the run has to
+reach from a digit to the unit without interruption, so it starts at the LAST
+digit run and a number escapes when a magnitude outside the class stands
+anywhere between that run and the unit. `1경5천조원` is read, because its last
+digit run is the `5` and only `천` and `조` stand after it. `1경원`, `1천경원`
+and `1억경원` are not, and the `천` in the second of those is in the class and
+does not help -- what decides is the whole gap, not any one member of it.
+
+`_DAY_DURATION_SUFFIXES` says an open-ended class needs a safe default and a
+tripwire. Only the tripwire is available here, and that is worth saying plainly
+because it inverts the usual argument in this file: on THIS scan an
+unrecognised member does not cost a caveat, it leaves a wrong sentence
+standing, since failing to read the asked unit is what #451 is. There is no
+consolation in the default, so the tripwire carries the whole load.
+
+`[만억천조]` was what shipped for #445 -- the myriad steps plus `천`, which is
+neither a full series nor a closed one -- and `2백만원`, two million won and as
+ordinary in a Korean document as `2천만원`, was told it states `달러` for
+exactly that reason. Adding `십` and `백` is what makes the sub-myriad half
+complete rather than partial, and completing it is the decision; `십` on its
+own buys `5십원` and `2백5십원`, which
+`test_the_magnitude_class_is_a_series_and_this_is_where_it_stops` pins so the
+member cannot be dropped with the suite green.
+"""
+
+_RELAXED_QUANTITY_NUMBER = (
+    r"\d[\d,.]*\s*(?:[" + _SINO_KOREAN_MAGNITUDES + r"]\s*)*"
+)
+"""The number `_VALUE_MEASUREMENT_RELAXED` reads, named so the tests can rebuild
+the pattern instead of restating it.
+
+Two of them opened with a copy of this text, and a copy of a pattern is a claim
+about the pattern that nothing checks: both went on passing when the number
+changed under them for #451, because their probes happened not to distinguish
+the old shape from the new one. Naming it is the same remedy
+`_UNIT_SUFFIX_MEMBERS` and `_MONTH_WORD_MEMBERS` get, and the probes were
+widened at the same time.
+"""
+
 _VALUE_MEASUREMENT_RELAXED = re.compile(
-    r"[0-9][0-9,.]*\s*[만억천조]?\s*(?P<unit>"
+    _RELAXED_QUANTITY_NUMBER
+    + r"(?P<unit>"
     + "|".join(
         re.escape(s) for s in sorted(_MEASUREMENT_UNIT_SPELLINGS, key=len, reverse=True)
     )
@@ -1329,7 +1417,8 @@ _VALUE_MEASUREMENT_RELAXED = re.compile(
     # over the live tuple, the moving ends, the unchanged readings -- are
     # re-derived by `test_a_unit_suffix_would_be_inert_here`, not quoted here.
 )
-"""`_VALUE_MEASUREMENT` without the trailing lookahead, for the suppression test.
+"""`_VALUE_MEASUREMENT` with a wider number and no trailing lookahead, for the
+suppression test.
 
 The lookahead is right for deciding what a value STATES -- `2년차` is a second
 year of service, not two years -- but wrong for deciding whether the value
@@ -1338,6 +1427,140 @@ the caveat fire anyway: `3시간30분` answering `몇 시간인가?` was told th
 states minutes and that no conversion is applied, when the leading quantity is
 exactly the hours asked for. A single space changed the outcome, because
 `3시간 30분` passes the lookahead and `3시간30분` does not.
+
+The number is wider in three ways, and #451 is what made them necessary. They
+are three and not two, which matters below: the magnitude group is a RUN rather
+than one character, its CLASS is `_SINO_KOREAN_MAGNITUDES` rather than
+`[만억천조]`, and these are independent -- `2천만원` needs only the run, `2백원`
+needs only the class, and `2백만원` needs both. So `2천만원`, `1억5천만원`,
+`2백만원` and `2백원` are read -- `X천만원`, `X억Y천만원`, `X백만원` and `X백원`
+are how a Korean document writes a sum, and `원` is a live question counter, so
+a `몇 원인가?` answered any of them was told the value states `달러` beside an
+answer whose leading figure is won. The digit class is `\\d`, every Unicode
+decimal digit rather than a listed range, because naming a range would leave the
+next script out; `verinote.text.nfc` is not `nfkc` and folding compatibility
+forms would have this rule compare a value differently from every other
+comparison made on it, but admitting the characters in a class local to this
+pattern normalizes nothing, so the one-normalizer rule is not in play.
+
+What is still out of reach is stated as a rule and not as a list, because a
+list here has been wrong every time it has been written -- three times, each
+time by leaving out a class the next reader found. The rule is about a unit
+spelling and not about a value, and it is ONE existential condition with two
+ways to fail:
+
+    this scan reads a given unit ONLY WHERE SOME DECIMAL DIGIT stands
+    before that unit's spelling with nothing between them but digits,
+    separators, magnitude words from `_SINO_KOREAN_MAGNITUDES`, and
+    whitespace.
+
+Only where, and not wherever. The condition is what every match must satisfy,
+so failing it at every digit is what puts a value out of reach -- which is the
+whole of the account below, and that direction is exact: every match this
+pattern makes begins at a decimal digit and reaches its spelling through those
+four character classes and nothing else. It does not run the other way.
+`3달러` has a digit before its `달` and an empty gap between them, and is still
+not read as months, because the alternation takes `달러` first.
+`test_only_the_달러_before_달_constraint_decides_the_suppression_ordering` is
+where that constraint lives, and it is the one thing a reader cannot get from
+the condition above.
+
+That is a mechanism with a bound rather than a case that happened to be found,
+and the bound is what keeps this from being a list. A prefix pair can only bite
+when the two spellings CROSS CANONICAL UNITS, because the converse asks whether
+the unit was read and not which spelling read it: `3주일` satisfies the
+condition on its `주` and the alternation takes `주일`, and nothing is lost,
+since both are WEEK. `달`/`달러` is the only cross-family prefix pair in the
+table, and
+`test_달러_is_the_only_prefix_pair_that_crosses_canonical_units` fails the day a
+row creates a second one -- so a new spelling cannot quietly widen this
+exception.
+
+The other way it does not run is narrower and worth a clause rather than a
+paragraph: a separator is admitted only inside the leading digit run and never
+after a magnitude word, so `2천만,년` satisfies the condition as worded and is
+read as nothing. `_RELAXED_QUANTITY_NUMBER` is the shape, and
+`test_a_separator_is_admitted_only_inside_the_leading_digit_run` is the
+tripwire: it was written because admitting `[,.]` after the magnitude group
+left the whole suite green, so this exception was a reading of the constant
+rather than a claim anything would notice losing. Both classes are held now,
+which is what makes naming two of them a bound rather than a count.
+
+SOME DIGIT and not EVERY DIGIT, and the difference is the whole sentence.
+`1경5천조원` qualifies on its `5`, whose gap to the `원` is `천조`, and does not
+qualify on its `1`, whose gap holds the `경`; the scan resumes from the next
+start rather than giving up at the first, so the value is read. A reader who
+takes the gap clause distributively gets that value wrong -- which is the
+mistake an earlier draft of this paragraph made in the code, saying "the FIRST
+digit" while a test in the same commit asserted the `5`. Existential is the
+property; "reads from the last digit run" is a consequence of the run being
+greedy, not the rule.
+
+Say DIGIT and not just "some", because the quantifier has a second axis and
+only one of them is this rule. Ranged over OCCURRENCES OF THE SPELLING it
+would say every `원` in the value must be reachable, and that is false:
+`2천만원 지원 (15,000달러)` holds two, of which only the first is, and the
+value is read. `1경5천조원` cannot catch that mistake -- it has one `원` and
+comes out true either way -- so the witness does not substitute for naming the
+noun. `지원` is this file's own standing example for why the digit requirement
+exists, which is how ordinary the wrong axis is.
+
+Failing that condition at every digit puts a unit out of reach, and the groups
+below are the ways it is failed. Read that direction only: the groups account
+for what the condition excludes, not for everything this scan declines, since
+the two classes above are declined while satisfying it. What the direction does
+buy is the thing four drafts of this paragraph kept getting wrong -- a cause
+that fails the condition needs no new entry here, because the condition already
+covers it.
+
+FAILING THE DIGIT. No decimal digit stands before the asked unit, so there is
+nothing for the scan to start from. A Sino-Korean numeral (`이천만원`) is the
+case this file has recorded longest, but the reachable ones are the native
+Korean numerals -- `한 시간 30분` asked in hours, `두 달 3주`, `이틀 3주` --
+and the quantities that carry no numeral at all: `반년`, `수개월`, `수십억원`,
+`여러 달`. `반년` is why the condition cannot be phrased as "a numeral the scan
+cannot spell": there is no numeral in it to fail to spell. `한 시간 30분` is
+the most reachable of all of them, since `일 시간` is not Korean and an hour
+and a half is ordinarily written that way -- though `1시간 30분` and `1.5시간`
+are read, so what is out of reach is the notation and not the quantity.
+
+FAILING THE GAP. Digits do stand before the unit, and EVERY one of them has
+something in its gap: a magnitude outside the class (`1경원`, and `1천경원`,
+whose in-class `천` does not save it -- there is no later digit to start from),
+or an approximator (`3천만여원`, `20여년`). This is where the quantifier earns
+its keep: one blocked digit proves nothing, since `1경5천조원` has a blocked
+`1` and is read anyway. Position and not vocabulary -- the same `여` AFTER the
+unit spelling never enters a gap, so `3개월여` and `2년여` read normally.
+
+All of these are pre-existing rather than introduced by #451. That change
+widened the gap condition, and it widened the digits themselves from `[0-9]`
+to every Unicode decimal digit; what it left alone is the requirement that
+there be a decimal digit at all, which is the whole of the first group.
+`korean_measure_unit_mismatch` records what they cost.
+
+The run takes no digits between its magnitude words, and that is measured rather
+than assumed. `(?:[...]\\s*[\\d,.]*\\s*)*` reads `1억5천만원` from the `1` where
+this reads it from the `5`, and both report KRW: a stacked number is a digit
+run, then magnitude words possibly separated by further digit runs, then the
+unit, so where there are inner runs this pattern starts at the last of them and
+reaches the same unit. What that rests on is that no spelling in
+`_MEASUREMENT_UNIT_SPELLINGS` begins with a magnitude character, so the region
+the longer form swallows holds no unit to hide.
+`test_the_magnitude_run_needs_no_inner_digits` re-derives the premise from the
+live table and the equality from a corpus, and shows the two patterns really do
+differ, since their match starts do.
+
+Neither widening can put a unit in front of a reader, and that is a theorem
+rather than a corpus result. This pattern's one caller is
+`_value_states_asked_unit`, whose one output is the early return in
+`korean_measure_unit_mismatch`, so the only way a wider number changes an answer
+is by reading FEWER units. It cannot: the number's own language is
+`[\\d,.\\s십백천만억조]` and no spelling begins with a character in it, so no
+spelling can start inside a number and no number can extend across one, and at
+every start where the narrower pattern matched this one matches the same span
+and unit. `test_the_widened_number_can_only_silence` asserts that premise as
+well as the outcome, so the argument degrades loudly rather than silently if the
+table ever gains such a spelling.
 
 Suppression can only ever produce silence, so reading generously here is
 safety-increasing in a way that reading generously in `_value_measure_units`
@@ -1374,15 +1597,53 @@ before this scan existed and says nothing now, and the same goes for
 These are lost caveats, not near-misses, and this is the noisier half of the
 rule. The trade is deliberate: a lost caveat beats the wrong sentence the strict
 reading produced on `3시간30분`. It is still a trade.
+
+#451 widened the number and thereby widened this class, and it widened every
+other silence this scan already makes; that is the cost of the change rather
+than a separate defect. What reaches further is not a list of values but the
+three notations named above -- a magnitude run, a sub-myriad magnitude, and a
+non-ASCII decimal digit -- so anything this scan already read wrongly it now
+reads wrongly in those too. Three and not two: the sub-myriad magnitude reaches
+values with ASCII digits and a run of length one, which neither of the other
+two describes, and `3백주 보유, 3개월 준비` asked in weeks is a lost caveat of
+this very class that only that notation explains -- three hundred shares beside
+a genuine three months. `２분기 실적, 2시간 소요` asked in minutes is the
+full-width twin of `3분기`, `１주년 기념, 3개월 준비` and `８０년대 후반, 3개월`
+are the twins of the two named above, and `3백주 보유, 3개월 준비`,
+`2천만주 보유, 3개월 준비` and `3천만 주주, 3개월` asked in weeks are the `100주`
+shares reading at a scale the old number could not spell. A holding really is
+written `2천만주`, so that one is the most reachable. The point-in-time silences
+travel the same way, since this scan does not consult `_TIME_POINT`:
+`２０２１년 착수, 총 3주` asked in years and `１５일 마감, 3주` asked in days are
+silent now, where their ASCII spellings were already silent, and
+`test_a_point_in_time_silence_travels_into_the_new_notations` holds that half
+because it is not this class. Read none of these as a set. The rule is that the
+three notations join every reading this scan already makes, and a count here
+would be a count of an open class -- which is what the earlier draft of this
+paragraph got wrong by saying two, since a rule that omits a notation prices
+none of the values only that notation reaches.
+
+One reading in the other direction arrived with them: `３시간30분` asked in
+`몇 시간인가?` was told it states minutes and is silent now, which is the defect
+of the paragraph above this one, reaching a notation it could not before.
 """
 
 
 def _value_states_asked_unit(value: str, asked_unit: str) -> bool:
     """Whether the value carries a quantity in the unit the question asked for.
 
-    Read with `_VALUE_MEASUREMENT_RELAXED`, which is a strict superset of what
-    `_value_measure_units` finds, so every unit that function reports is caught
-    here too and this subsumes the plain equality test it replaced.
+    Read with `_VALUE_MEASUREMENT_RELAXED`, which reads more than
+    `_value_measure_units` does in four ways -- no trailing lookahead, a run of
+    magnitude words rather than one, a wider magnitude class, and any Unicode
+    decimal digit rather than ASCII -- so every unit that function reports is
+    caught here too and this subsumes the plain equality test it replaced.
+
+    That it reads MORE and never less is argued from the character sets rather
+    than sampled; the argument is in `_VALUE_MEASUREMENT_RELAXED` and its premise
+    is asserted by `test_the_widened_number_can_only_silence`. It is worth
+    knowing which of the two the tests are doing, because `finditer` resumes
+    from a match's end and a longer match could in principle hide a later one:
+    the premise closes that, and the corpus sweep confirms it.
     """
     folded = nfc(value).casefold()
     return any(
@@ -1477,21 +1738,51 @@ def korean_measure_unit_mismatch(question: str, value: str) -> tuple[str, str] |
 
     Both halves are what a pattern reads, not what the value contains, and the
     sentence has to be put that way round: `_value_states_asked_unit` re-reads
-    the value for the asked unit with the same quantity shape minus the
-    lookahead, and anything that scan cannot see is not suppressed on. It reads
-    `6개월` in `2년 6개월`, so a `몇 개월인가?` is suppressed. It does not read
-    the won in `2천만원 (15,000달러)`, because the quantity shape admits one
-    magnitude word and that number stacks two, so a `몇 원인가?` there is
-    caveated with `달러` beside an answer whose leading figure is won.
+    the value for the asked unit with a wider quantity shape and no lookahead,
+    and anything that scan cannot see is not suppressed on. It reads `6개월` in
+    `2년 6개월`, so a `몇 개월인가?` is suppressed, and since #451 it reads the
+    won in `2천만원 (15,000달러)` and `2백만원 (15,000달러)` and the years in
+    `３년 30주` as well.
+
+    What it still cannot see is given as a rule in
+    `_VALUE_MEASUREMENT_RELAXED`, and the rule is the thing to read, because
+    every attempt to write the residue as a list has left something out. The
+    scan reads a unit ONLY where SOME decimal digit stands before that
+    unit's spelling with nothing between them but digits, separators, class
+    magnitudes and whitespace -- necessary and not sufficient, since the
+    alternation taking `달러` before `달` can refuse a unit that satisfies it.
+    Some DIGIT and not every digit, or `1경5천조원`
+    reads wrong: it qualifies on its `5` and not on its `1`. The noun is worth
+    repeating because ranged over occurrences of the SPELLING the same words
+    say something false -- `2천만원 지원` holds two `원` and is read on the
+    first. So `한 시간 30분` and `반년 3주`
+    fail for want of any digit -- as `이천만원` does, and the native-numeral and
+    no-numeral forms are the reachable members of that class rather than the
+    Sino-Korean one -- while `1경원`, `3천만여원` and `20여년` have digits whose
+    gaps are all blocked. The other half of the residue is a spelling
+    `_MEASUREMENT_UNIT_SPELLINGS` leaves out on purpose: the `개년` in
+    `5개년 계획 3주` and the bare `월` in `6월 및 30주`. #451 widened what may
+    stand in a gap, and widened which characters count as digits; the
+    requirement that there be a digit at all is older than it and survives it,
+    and the bullet below is where the survivors live.
 
     The two halves are read by different patterns, and that is deliberate rather
     than an oversight. What the value STATES comes from `_value_measure_units`,
-    which refuses a unit run into the next character. Whether the value CARRIES
-    the asked unit comes from `_value_states_asked_unit`, which does not -- with
-    one pattern doing both, the same lookahead that correctly declines to read
-    `2년차` as two years also hid the asked unit in `3시간30분` and `2년6개월`,
-    and the caveat fired on a value whose leading quantity was exactly what the
-    question asked for. Spacing decided it, which no reader would predict.
+    which refuses a unit run into the next character and reads ASCII digits and
+    at most one of `[만억천조]`. Whether the value CARRIES the asked unit comes from
+    `_value_states_asked_unit`, which refuses none of those. With one pattern
+    doing both, the same lookahead that correctly declines to read `2년차` as two
+    years also hid the asked unit in `3시간30분` and `2년6개월`, and the caveat
+    fired on a value whose leading quantity was exactly what the question asked
+    for. Spacing decided it, which no reader would predict; #451 was the same
+    defect one layer down, where the notation the number was written in decided
+    it instead.
+
+    The divergence runs one way and may only run that way. The relaxed pattern
+    feeds a single early return here, so reading more with it ends caveats and
+    cannot start one; `_value_measure_units` is what a reader is shown, so
+    reading more with THAT adds sentences and is a separate change with a sweep
+    of its own.
 
     The first same-family unit is reported, not the first unit. `30% 완료, 3주`
     asked in months states a ratio first and a duration second, and the duration
@@ -1501,14 +1792,24 @@ def korean_measure_unit_mismatch(question: str, value: str) -> tuple[str, str] |
     stating no number; a unit run into the next syllable (`2년차`); a quantity
     that overlaps a point in time (`매월 15일`); a spelling outside the
     table; a suffix outside `_UNIT_SUFFIX`;
-    a number that stacks magnitude words (`2천만원`), since the quantity shape
-    admits at most one; and a number written in full-width digits (`３년`), which
-    `[0-9]` does not admit and `nfc` does not fold away. `nfkc` would fold it, but
-    `verinote.text.nfc` is the one normalizer the rest of the codebase compares
-    through, and folding compatibility forms here alone would have this rule read
-    a value differently from every other comparison made on it. A non-breaking
-    space between the number and the unit is fine (`3<NBSP>년` states years), so
-    this silence is specifically the digits. An earlier cross-family quantity
+    a number that stacks magnitude words (`2천만원`) or uses one outside
+    `[만억천조]` (`2백원`), since `_VALUE_MEASUREMENT` admits at most one and
+    only from those four -- `2백만원` needs both allowances and is silent for
+    either reason; and a number written in full-width digits (`３년`),
+    which its `[0-9]` does not admit and `nfc` does not fold away. `nfkc` would
+    fold it, but `verinote.text.nfc` is the one normalizer the rest of the
+    codebase compares through, and folding compatibility forms here alone would
+    have this rule read a value differently from every other comparison made on
+    it. A non-breaking space between the number and the unit is fine
+    (`3<NBSP>년` states years), so
+    this silence is specifically the digits. Those last two are silences on the
+    REPORTING side only since #451. The suppression scan reads all three
+    notations, so where the ASKED unit is the one written that way the whole rule
+    now says nothing instead of naming a neighbour: `2천만원 (15,000달러)` asked
+    in won, `３년 30주` asked in years. Asked in some other unit of the family the
+    quantity is still unreported and a neighbour can still be named --
+    `３년 30주` asked in months says `주` -- which is the reporting silence doing
+    what it has always done. An earlier cross-family quantity
     does not silence a later same-family one.
 
     One silence is worth separating from those, because it is the only one where
@@ -1545,13 +1846,68 @@ def korean_measure_unit_mismatch(question: str, value: str) -> tuple[str, str] |
       and `50/15일 3주` lost a genuine caveat. A dotted form is worse, since
       `1.5일` is a decimal duration with the same shape, and a dashed one collides
       with the range `10-15일`.
-    * A value whose asked-unit quantity no pattern here can read, beside a
-      same-family unit that one can. The suppression scan misses the first and
-      the reporting scan finds the second, so the caveat names the second:
-      `2천만원 (15,000달러)` asked in won reports `달러`, `5개년 계획 3주` and
-      `３년 30주` asked in years report `주`, and `6월 및 30주` asked in months
-      reports `주`. Each is a silence cause from the list above turned into a
-      wrong sentence by a readable unit standing next to it.
+    * A value whose asked-unit quantity the suppression scan cannot read, beside
+      a same-family unit the reporting scan can, so the caveat names the second.
+      What makes the two kinds below worth telling apart is that one is a
+      pattern's reach and the other is a table's contents; the split is not a
+      claim that there are two of anything, and the NUMBER side is itself given
+      as a rule rather than a list, for the reason
+      `_VALUE_MEASUREMENT_RELAXED` gives.
+
+      The NUMBER, in the two ways `_VALUE_MEASUREMENT_RELAXED`'s rule can
+      fail. That rule is existential -- SOME digit before the unit with a clean
+      gap -- so both failures below are failures at every digit, not at one.
+      These are the values the rule EXCLUDES; the rule holds only in that
+      direction, and the two classes it declines while satisfying are recorded
+      with it rather than here.
+
+      No DIGIT at all before the asked unit, so the scan has nothing to start
+      from. `이천만원 (15,000달러)` asked in won reports `달러`, and so do
+      `한 시간 30분` asked in hours, `두 달 3주` and `이틀 3주` asked in their
+      own units, and `반년 3주`, `수개월 3주` and `수십억원 (15,000달러)`,
+      which carry no numeral to spell at all. `한 시간 30분` is the one to
+      weigh: it is the very sentence this scan exists to prevent, on the way an
+      hour and a half is ordinarily written, since `일 시간` is not Korean.
+      Notation and not quantity -- `1시간 30분` and `1.5시간` say the same thing
+      and are both silent -- which is what makes it a spelling defect rather
+      than a limit on what can be asked.
+
+      Something in the GAP between that digit and the unit. A magnitude outside
+      `_SINO_KOREAN_MAGNITUDES` (`1경원 (15,000달러)`), or an approximator
+      (`3천만여원 (15,000달러)`, `20여년 3주`) -- position and not vocabulary,
+      since the same `여` after the unit is harmless.
+
+      #451 moved the gap condition and part of the digit one: it widened what
+      magnitudes may stand in the gap, and widened the digits themselves from
+      `[0-9]` to every Unicode decimal digit. What it did not touch is the
+      requirement that the starting character be a DECIMAL DIGIT at all, which
+      is why the whole first group above is older than #451 and survives it. It
+      retired `2천만원 (15,000달러)` and `３년 30주` from this bullet, which is
+      what it listed before; `1억5천만원 및 20,000달러` was in the test table
+      rather than here, and `2백만원 (15,000달러)` was in neither, since this
+      change is what found it.
+
+      The SPELLING: a row `_MEASUREMENT_UNIT_SPELLINGS` excludes on purpose.
+      `5개년 계획 3주` asked in years reports `주`, and `6월 및 30주` asked in
+      months reports `주`, for the reasons given beside those exclusions.
+      Reading either on the suppression side was measured against #451 and
+      declined. Bare `월` silences `3월 15일간`, `3월 내 15일 소요` and
+      `3월 계약 15일 소요` among others, each of which states a duration some
+      test asserts is caveated -- the word-month forms beside them,
+      `전월 대비 3일 단축` and `매월 15일간`, are untouched, since no digit
+      stands before their `월` -- and declining a `월` inside a `_TIME_POINT`
+      span does not even reach the two
+      the year+month branch's bounds are placed for, since neither `2년 3월` nor
+      `10000년 3월` matches that pattern at all. `개년` silences a `5개년` the
+      table calls the name of a plan rather than a duration, which is the
+      judgement the row was excluded for.
+
+      #451 states the general form these are instances of: an accepted silence
+      here is a latent wrong sentence, and a readable same-family unit standing
+      beside it is what turns it into one. The form reaches past this bullet --
+      `₩20,000,000 (15,000달러)` asked in won reports `달러` for a third reason
+      again, the symbol standing where no row in `_MEASUREMENT_UNIT_SPELLINGS`
+      can reach it.
     * A bare two-digit year. `21년 3월` is read as a date and so is `'21년`, but
       `21년` alone is left reading YEAR, so `몇 개월인가?` answered `21년` is told
       it states years. Twenty-one years is a real duration, and without the


### PR DESCRIPTION
Closes #451.

The measure-unit caveat suppresses itself when the value carries a quantity in the unit the question asked. That check reads the value with `_VALUE_MEASUREMENT_RELAXED`, so a quantity the pattern cannot parse is invisible to it — and when a *readable* same-family unit stands next to it, the caveat fires and names the wrong one.

| question | value | parent | this PR |
|---|---|---|---|
| `몇 원인가?` | `2천만원 (15,000달러)` | states `달러` | silent |
| `몇 원인가?` | `1억5천만원 및 20,000달러` | states `달러` | silent |
| `몇 원인가?` | `2백만원 (15,000달러)` | states `달러` | silent |
| `몇 년인가?` | `３년 30주` | states `주` | silent |
| control `몇 원인가?` | `1억원 (15,000달러)` | silent | silent |

`_VALUE_MEASUREMENT_RELAXED`'s number now reads a **run** of Sino-Korean magnitudes and **any Unicode decimal digit** — on the suppression scan only. That scan feeds one early return, so reading more can only remove a caveat, never invent or rename one, and this is a property of the code's shape rather than a corpus result: no unit spelling begins with a character the number admits, so the widened scan matches the same spans as the narrow one and more.

Suite **2848 passed, 20 skipped** (2832/20 at the parent). One behavioural edit — the pattern and two constants — then prose, three parametrize rows and one new test function.

## Deliberately not fixed

`5개년 계획 3주` and `6월 및 30주` still reproduce. Both need a spelling `_MEASUREMENT_UNIT_SPELLINGS` excludes on purpose, and admitting a bare `월` to the suppression side silences `2년 3월` and `10000년 3월` — the values the year+month branch's bounds exist to keep caveated — for 17 failures across 7 other test functions.

The issue's own preferred direction was **rejected with numbers**: "suppress whenever the value carries a numeral the scan cannot fully parse", read literally, silences 7,777 of 13,914 firing pairs and takes out three of #452's four headline witnesses, because a contract number, a version triple and an ISO date are unreadable by design. A bounded reading fixes all five of #451's witnesses and keeps all four of #452's — and is still refused, because 84% of its silences fire on a Hangul token the unit table cannot spell. The trigger is **the complement of the unit table within Korean counter vocabulary**, which does not shrink as the table improves.

## The disclosure is a rule, not a list

A list here was wrong every time it was written. The shipped rule: *the scan reads a given unit **only where** SOME decimal digit stands before that unit's spelling with nothing between them but digits, separators, class magnitudes and whitespace.* **Necessity only** — the converse is false, in two classes, each now held by a test: a unit spelling that is a prefix of a longer one (`3달러`; `달`/`달러` is the only cross-family pair) and a separator after a magnitude word (`2천만,년`).

Filed from this review: **#463** (the two scans read different numbers), **#464** (an approximator between number and unit), **#465** (native-Korean numerals, and quantities with no numeral at all — `한 시간 30분` asked in hours is #445's defect verbatim in the only natural spelling).

## Note on the evidence

Eight candidate revisions, three gates, fourteen blocking findings — **none of them about the code**, which has not moved since the first revision. Every one was a claim the prose made about the code. Four of them were introduced by the correction to the previous one.

Several instruments in the review record could not have failed, and the agents that built them said so:

- a completeness harness whose `OUTSIDE` arm was jointly unsatisfiable, and which reimplemented the function it certified — replacing that function with `lambda *_: None` left every bucket byte-identical;
- a classifier that filtered to non-caveat rows and then reported 0 from an arm that only fires on caveat rows;
- a reviewer's predicate that implemented the rule's **intent** rather than its **text**, and reported the agreement as evidence for the text;
- an acceptance contract ("noun **or** witness") kept after the reviewer's own measurement had retired the second disjunct;
- a test control that reasoned distributively about a scan that resumes — no boolean assertion could have caught its mutation, only the match span.

**So counts from that record should not be cited as support.** What carries the shipped sentences is structural: the AST-derived exit enumeration, the prefix-language argument for the theorem, and the two tripwires named above.

The rule that came out of it, above the specific fixes: **when a rule is stated in more than one place, diff the statements against each other, not just each against the code** — three of this issue's false claims were one rule corrected in some of its copies and not others.

Verified against synthetic fixtures only.