### PR TITLE
fix: stop asking a provider that just failed (#438)

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1169,3 +1169,186 @@ def test_ask_warns_on_a_value_whose_case_differs_from_the_rendered_answer(tmp_pa
         "the question's counter is 개월; the verified value states weeks. "
         "verinote shows stored values as recorded and applies no unit conversion"
     )
+
+
+# --- the fallback body names only sections the page renders (#438) ----------
+
+
+def test_ask_fallback_body_promises_nothing_when_there_is_no_evidence(tmp_path):
+    """With neither excerpt nor grounding fact, the body says so.
+
+    `ask.html` gates the `Source excerpts` section on `result.excerpts`, so the
+    old unconditional "Source excerpts are shown below." pointed at a section
+    that was not on the page.
+
+    The assertion is on the whole sentence rather than on the absence of the
+    old one. `"Source excerpts" not in result.answer` would hold here for the
+    right reason, but it would hold just as well on a regression that called
+    the model and got prose back -- a check that cannot tell the fix from the
+    bug. Naming the expected sentence can.
+    """
+    store = _store(tmp_path)
+    client = FallbackClient(error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert result.route == "fallback"
+    assert result.excerpts == ()
+    assert result.grounding_facts == ()
+    assert result.answer == (
+        "The deterministic engine could not answer, and no source excerpt or "
+        "verified grounding fact is shown below."
+    )
+
+
+def test_ask_fallback_body_names_the_grounding_table_when_no_excerpt_renders(tmp_path):
+    """Grounding facts and no excerpt -- the row that was false before #438.
+
+    The source row is registered but its file is absent from disk, so
+    `search_source_excerpts` skips it and the page renders the
+    `Verified grounding facts` table with no excerpts section beneath. The body
+    must name the table that is there rather than the section that is not.
+
+    A failed schema-aware re-read (#438) makes the fallback *route* common; it
+    does not make this shape common -- whether an excerpt renders turns on the
+    sources, independently of why the route was taken. What the two together
+    mean is that the route reaches this shape more often, not that the shape
+    follows from the failure.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed", source_id=source_id)
+    client = FallbackClient(error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직 설명해줘")
+
+    assert result.route == "fallback"
+    assert result.excerpts == ()
+    assert result.grounding_facts
+    assert result.answer == (
+        "The deterministic engine could not answer. Verified grounding facts "
+        "are shown below."
+    )
+
+
+def test_ask_fallback_body_still_names_the_excerpts_when_both_render(tmp_path):
+    """Both collections populated: the sentence this route has always shown.
+
+    Naming one present section is enough, and excerpts win. Swapping the
+    helper's branch order would make this row name the grounding table while
+    the excerpts section renders below it -- true of the page, but a needless
+    change to text that was never false.
+
+    **An unchanged-row pin: this passes on the parent commit by design.** The
+    old sentence was already true wherever an excerpt renders, so this row is
+    here to fail a fix that rewrites text it had no reason to touch, not to
+    demonstrate one. Measured: swapping the helper's branch order fails this
+    test and nothing else in the suite -- the render tripwire in
+    `tests/test_ask_verdict.py` accepts either present section by design.
+    """
+    source = tmp_path / "sources" / "sample.txt"
+    source.parent.mkdir()
+    source.write_text("샘플조직은 샘플서비스를 제공한다.", encoding="utf-8")
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed", source_id=source_id)
+    client = FallbackClient(error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직 설명해줘")
+
+    assert result.route == "fallback"
+    assert result.excerpts
+    assert result.grounding_facts
+    assert result.answer == (
+        "The deterministic engine could not answer. Source excerpts are shown below."
+    )
+
+
+def test_ask_fallback_body_names_the_grounding_table_when_the_model_returns_nothing(
+    tmp_path,
+):
+    """The empty-answer guard is a second writer of this sentence.
+
+    `_fallback_answer` substitutes the body twice -- once when
+    `answer_question` raises and once when it returns an empty string. Reverting
+    either call site alone reintroduces the false promise on that site's own
+    population, and only this test covers the empty-string site: here the
+    provider was consulted and answered with nothing, so `warning` stays unset.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed", source_id=source_id)
+    client = FallbackClient(answer="")
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직 설명해줘")
+
+    assert result.route == "fallback"
+    assert result.warning is None
+    assert result.excerpts == ()
+    assert result.grounding_facts
+    assert result.answer == (
+        "The deterministic engine could not answer. Verified grounding facts "
+        "are shown below."
+    )
+
+
+# The docstring on `_fallback_answer_body` argues from what `ask.html` renders and
+# from what `search_source_excerpts` declines to read. The rendering half is
+# re-derived in tests/test_ask_verdict.py, which already renders `ask.html`; this
+# module keeps the half that needs no template.
+
+
+def test_search_source_excerpts_compares_nothing_from_a_missing_or_undecodable_source(
+    tmp_path, monkeypatch
+):
+    """The absent excerpt in the body's last branch is not a failed comparison.
+
+    `search_source_excerpts` passes over a registered source whose file is gone
+    and one whose bytes are not UTF-8, so `_best_excerpt` -- the only thing that
+    compares source text against the question -- never sees them. That is why
+    the last branch says what the page shows rather than "nothing matched".
+
+    The spy would sit at zero for a vacuous reason if the question produced no
+    patterns, so the control at the end stores the same sentence as UTF-8 and
+    requires exactly one comparison to happen.
+
+    **This is a tripwire on a docstring claim, not coverage of a fix.** It
+    passes on the parent commit by design: it guards `_fallback_answer_body`'s
+    reasoning about *why* an excerpt can be absent, and that reasoning rests on
+    behaviour no change here touches. Read a green run on the parent as the
+    intended result, not as a test that pins nothing.
+
+    It goes red when the skipping stops. Measured: the undecodable half falls to
+    dropping `except UnicodeDecodeError` on its own; the missing-file half needs
+    both the `is_file()` guard and `except OSError` gone, because either one
+    alone still keeps the read away from `_best_excerpt`.
+    """
+    compared: list[str] = []
+    real_best_excerpt = ask_module._best_excerpt
+
+    def spy(text, patterns):
+        compared.append(text)
+        return real_best_excerpt(text, patterns)
+
+    monkeypatch.setattr(ask_module, "_best_excerpt", spy)
+
+    store = _store(tmp_path)
+    (tmp_path / "sources").mkdir()
+    store.add_source("sources/gone.txt")
+    (tmp_path / "sources" / "euckr.txt").write_bytes(
+        "샘플조직은 샘플서비스를 제공한다.".encode("euc-kr")
+    )
+    store.add_source("sources/euckr.txt")
+
+    assert search_source_excerpts(store, root=tmp_path, question="샘플조직 설명해줘") == []
+    assert compared == []
+
+    (tmp_path / "sources" / "readable.txt").write_text(
+        "샘플조직은 샘플서비스를 제공한다.", encoding="utf-8"
+    )
+    store.add_source("sources/readable.txt")
+
+    excerpts = search_source_excerpts(store, root=tmp_path, question="샘플조직 설명해줘")
+
+    assert [item.path for item in excerpts] == ["sources/readable.txt"]
+    assert len(compared) == 1

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -5,8 +5,9 @@ import pytest
 import verinote.pipeline.ask as ask_module
 from verinote.llm.base import LLMError
 from verinote.pipeline.ask import ask_question, search_source_excerpts
-from verinote.pipeline.query import query_path
+from verinote.pipeline.query import _QueryFlowResult, query_path
 from verinote.store import Store
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
 
 
 class DeterministicOnlyClient:
@@ -792,8 +793,8 @@ def test_ask_verified_negative_only_for_explicit_no_answer_flow(tmp_path, monkey
     store.add_fact("샘플인물", "역할", "후보역할", status="candidate")
     monkeypatch.setattr(
         ask_module,
-        "schema_aware_query_flow",
-        lambda *args, **kwargs: (
+        "_schema_aware_query_flow_result",
+        lambda *args, **kwargs: _QueryFlowResult(
             "no_answer",
             'no_answer("no confirmed facts match")',
             "no confirmed facts match",
@@ -1352,3 +1353,254 @@ def test_search_source_excerpts_compares_nothing_from_a_missing_or_undecodable_s
 
     assert [item.path for item in excerpts] == ["sources/readable.txt"]
     assert len(compared) == 1
+
+
+# --- Ask does not re-request a provider that just failed (#438) -------------
+
+
+class RecordingClient:
+    """Records the provider methods it is asked for, in order.
+
+    The suppression under test is invisible to an answer-level assertion: a
+    fallback answer built after a failed `answer_question` and one built without
+    calling it at all can render identically, and `_fallback_answer` swallows
+    `LLMError`. Only the call list distinguishes them, so these tests assert on
+    it rather than on the result.
+    """
+
+    name = "recording"
+
+    def __init__(self, *, intent_error=None, answer_error=None, answer="샘플 모델 답변"):
+        self.calls: list[str] = []
+        self.intent_error = intent_error
+        self.answer_error = answer_error
+        self.answer = answer
+
+    def extract_query_intent(self, *, question: str, schema_hint: str = ""):
+        from verinote.pipeline.query_intent import parse_query_intent
+
+        self.calls.append("extract_query_intent")
+        if self.intent_error is not None:
+            raise self.intent_error
+        return parse_query_intent(
+            {
+                "kind": "unknown_or_unsupported",
+                "subject": None,
+                "relation": None,
+                "object": None,
+                "relation_candidates": None,
+                "operator": None,
+                "value_type": None,
+                "value": None,
+                "reason": "unsupported synthetic question",
+            }
+        )
+
+    def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
+        self.calls.append("translate_query")
+        raise AssertionError("Ask must not call direct Datalog translation")
+
+    def answer_question(self, *, question: str, context: str) -> str:
+        self.calls.append("answer_question")
+        if self.answer_error is not None:
+            raise self.answer_error
+        return self.answer
+
+
+def _seed_rich(tmp_path):
+    """A confirmed fact whose source text answers the question."""
+    source = tmp_path / "sources" / "sample.txt"
+    source.parent.mkdir()
+    source.write_text(
+        "샘플조직은 샘플서비스를 운영하며 샘플조직의 역할 논의가 진행 중이다.", encoding="utf-8"
+    )
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed", source_id=source_id)
+    return store
+
+
+def _seed_grounding_only(tmp_path):
+    """A confirmed fact whose source text does not answer the question."""
+    source = tmp_path / "sources" / "sample.txt"
+    source.parent.mkdir()
+    source.write_text("샘플조직은 샘플서비스를 제공한다.", encoding="utf-8")
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("샘플조직", "is_a", "조직", status="confirmed", source_id=source_id)
+    return store
+
+
+def test_ask_sends_one_request_when_intent_extraction_fails(tmp_path):
+    """T1 -- the shape #438 reports: one failed call, not two.
+
+    The deterministic parser does not support this question, so the flow asks
+    the provider to read it; that call raises, the flow reports
+    `provider_failed`, and Ask must not then ask the same provider to compose an
+    answer. Asserted on the call list because the rendered answer is the same
+    either way.
+    """
+    store = _store(tmp_path)
+    client = RecordingClient(intent_error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert client.calls == ["extract_query_intent"]
+    assert result.route == "fallback"
+
+
+def test_ask_sends_one_request_when_reinterpretation_fails_and_keeps_the_evidence(tmp_path):
+    """T2 -- the other reachable site, and the evidence survives the skip.
+
+    Here the deterministic parser supports the question but plans nothing, so
+    the flow asks the provider to re-read it; that is a different construction
+    site from T1's with the same verdict. The excerpts and grounding facts are
+    built without a model, so suppressing the request must not cost them.
+    """
+    store = _seed_rich(tmp_path)
+    client = RecordingClient(intent_error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직의 역할은 무엇인가?")
+
+    assert client.calls == ["extract_query_intent"]
+    assert result.excerpts
+    assert result.grounding_facts
+
+
+@pytest.mark.parametrize("status", ["review_required", "ambiguous", "translated"])
+def test_ask_suppresses_on_the_flag_and_not_on_the_status(tmp_path, monkeypatch, status):
+    """T3 -- consumer-side tripwire: the guard reads the flag, nothing else.
+
+    Ask suppresses on `provider_failed` alone. Conjoining a status would let a
+    future construction site with a different one fall through to a second
+    request, so these rows inject statuses the flag does not naturally pair
+    with and require the suppression to hold anyway. That is also why they are
+    injected: among the constructions that carry a literal status, the flag
+    pairs only with `review_required` and `translation_failed` today.
+
+    This pins the consumer half only. The producer half -- that every
+    provider-failure exit sets the flag -- is pinned in tests/test_query.py.
+    """
+    store = _store(tmp_path)
+    client = RecordingClient()
+    monkeypatch.setattr(
+        ask_module,
+        "_schema_aware_query_flow_result",
+        lambda *args, **kwargs: _QueryFlowResult(
+            status, None, "llm error: synthetic outage", False, True
+        ),
+    )
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert client.calls == []
+    assert result.route == "fallback"
+
+
+def test_ask_says_no_usable_reading_rather_than_that_the_provider_failed(tmp_path):
+    """T4 -- the warning is true on both halves of the flag, and unformatted.
+
+    `provider_failed` covers a request that failed *and* a request that
+    succeeded with an unusable payload, so the notice claims only that no usable
+    reading arrived. The literal is spelled out here rather than imported: a
+    test that imports the constant it asserts cannot fail when the constant is
+    reworded.
+    """
+    store = _store(tmp_path)
+    client = RecordingClient(intent_error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert result.warning == (
+        "verinote did not get a usable reading of the question from the provider "
+        "and did not send it another request, so no model-composed answer is shown"
+    )
+    # ask.html renders this slot as text, so the sentence carries no markup.
+    assert "`" not in result.warning
+    assert "*" not in result.warning
+
+
+def test_ask_still_reports_a_consulted_provider_as_consulted(tmp_path):
+    """T5 -- over-reach guard; passes on the parent commit by design.
+
+    Here the provider read the question successfully and only the *answering*
+    call failed, so there is no provider-failure verdict and the fallback model
+    was rightly asked. It exists to fail a suppression that fires too widely,
+    not to demonstrate one: make the skip unconditional and both assertions go.
+    """
+    store = _store(tmp_path)
+    client = RecordingClient(answer_error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert client.calls == ["extract_query_intent", "answer_question"]
+    assert result.warning == "synthetic outage"
+
+
+def test_ask_does_not_treat_a_fact_term_error_as_a_provider_failure(tmp_path, monkeypatch):
+    """T6 -- over-reach guard: a flow that raised is not a provider failure.
+
+    When the flow itself raises, it reported nothing at all -- including no
+    verdict about the provider, which was never asked. The fallback model is
+    still worth asking, so this path must keep calling it.
+
+    **There is no parent-commit run of this to compare against**: it patches
+    `_schema_aware_query_flow_result`, the name `ask.py` binds only from this
+    commit, so on the parent the patch target does not exist and the test errors
+    rather than reporting on behaviour. It earns its place against over-reach,
+    not absence -- passing `provider_skipped=True` at this call site is caught
+    here and, measured, nowhere else.
+    """
+    store = _store(tmp_path)
+    client = RecordingClient()
+
+    def _raise(*args, **kwargs):
+        raise DuckDBFactTermStoreError("synthetic fact-term failure")
+
+    monkeypatch.setattr(ask_module, "_schema_aware_query_flow_result", _raise)
+
+    ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert client.calls == ["answer_question"]
+
+
+def test_ask_names_the_grounding_table_on_the_skipped_path(tmp_path):
+    """T7 -- the body stays true on the shape this fix makes common.
+
+    Suppressing the model makes the no-prose body the usual outcome rather than
+    a rare one, so the sentence commit 1 fixed has to be right here too.
+    """
+    store = _seed_grounding_only(tmp_path)
+    client = RecordingClient(intent_error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="샘플조직의 역할은 무엇인가?")
+
+    assert client.calls == ["extract_query_intent"]
+    assert result.excerpts == ()
+    assert result.grounding_facts
+    assert result.answer == (
+        "The deterministic engine could not answer. Verified grounding facts "
+        "are shown below."
+    )
+
+
+def test_ask_keeps_the_provider_error_in_the_reason_when_it_skips(tmp_path):
+    """T8 -- the specific error is still reachable, one line below the notice.
+
+    The notice deliberately does not name the failure, so `reason` is the only
+    place the actual provider error survives; `ask.html` renders it directly
+    beneath the warning.
+
+    **This passes on the parent commit**, and that is not a defect in it: the
+    reason is composed by the flow and is the same whether or not Ask goes on to
+    ask the model, so no assertion about it can separate the two. What it guards
+    is the new branch not substituting something of its own -- measured, it is
+    the only test that catches a constant reason on the skipped path.
+    """
+    store = _store(tmp_path)
+    client = RecordingClient(intent_error=LLMError("synthetic outage"))
+
+    result = ask_question(store, client, root=tmp_path, question="지원하지 않는 질문")
+
+    assert "llm error" in result.reason
+    assert "synthetic outage" in result.reason

--- a/tests/test_ask_verdict.py
+++ b/tests/test_ask_verdict.py
@@ -36,7 +36,12 @@ from pathlib import Path
 import pytest
 from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
 
-from verinote.pipeline.ask import AskResult
+from verinote.pipeline.ask import (
+    AskExcerpt,
+    AskGroundingFact,
+    AskResult,
+    _fallback_answer_body,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 TEMPLATES = ROOT / "verinote" / "web" / "templates"
@@ -499,3 +504,190 @@ def test_the_answer_body_separates_verified_from_unverified() -> None:
         "an unverified answer body renders like a verified one once the colour is "
         "stripped -- the LLM's excerpt-built answer wears the engine's tone"
     )
+
+
+# --- the fallback body names only sections this page renders (#438) ---------
+#
+# `_fallback_answer_body` reasons about which sections `ask.html` will carry, and
+# a sentence about rendering that drifted from what renders is the defect #438's
+# first commit removes. The tripwire lives here because this module already owns
+# the `ask.html` renders and the overlay they go through; putting it in
+# `tests/test_ask.py` meant a second copy of `TEMPLATES`, `STUB_BASE` and
+# `_render` a few hundred lines away from these.
+
+# The `<h2>` each section renders under, and which of them each sentence
+# `_fallback_answer_body` can return points the reader at. Keyed by the whole
+# sentence, not by a fragment of it: a substring test would read a reworded
+# sentence as naming nothing, which is indistinguishable from the empty case.
+# An unrecognised sentence is an error here rather than an empty set.
+SECTION_HEADINGS = ("Source excerpts", "Verified grounding facts")
+SECTIONS_NAMED_BY_SENTENCE = {
+    "The deterministic engine could not answer. Source excerpts are shown below.": frozenset(
+        {"Source excerpts"}
+    ),
+    "The deterministic engine could not answer. Verified grounding facts "
+    "are shown below.": frozenset({"Verified grounding facts"}),
+    "The deterministic engine could not answer, and no source excerpt or "
+    "verified grounding fact is shown below.": frozenset(),
+}
+
+_EXCERPT = AskExcerpt(
+    path="sources/sample.txt", excerpt="샘플조직은 샘플서비스를 제공한다.", score=1
+)
+_GROUNDING = AskGroundingFact(
+    answer="",
+    subject="샘플조직",
+    relation="is_a",
+    object="조직",
+    source="sources/sample.txt",
+)
+
+# All four evidence shapes a fallback result can carry -- the domain is one
+# boolean per collection, so leaving any row out leaves a quarter of it untested.
+# Each is reachable from `ask_question`, measured: nothing; a grounding fact
+# whose source file yielded no excerpt; an ingested source with nothing yet
+# confirmed; and both.
+BODY_SHAPES = {
+    "none": ((), ()),
+    "grounding-only": ((), (_GROUNDING,)),
+    "excerpt-only": ((_EXCERPT,), ()),
+    "both": ((_EXCERPT,), (_GROUNDING,)),
+}
+BODY_SECTIONS_ON_PAGE = {
+    "none": frozenset(),
+    "grounding-only": frozenset({"Verified grounding facts"}),
+    "excerpt-only": frozenset({"Source excerpts"}),
+    "both": frozenset({"Verified grounding facts", "Source excerpts"}),
+}
+
+
+def _fallback_result(shape: str) -> AskResult:
+    """A fallback `AskResult` whose body is what the shipped helper writes.
+
+    The body is not spelled out here -- it comes from `_fallback_answer_body`
+    itself, so a change to the helper reaches this render. What this cannot see
+    is whether `ask_question` hands the same two collections to the helper and
+    to the result; `tests/test_ask.py` pins that end to end by asserting both
+    the sentence and the collections from real runs.
+    """
+    excerpts, grounding = BODY_SHAPES[shape]
+    return AskResult(
+        route="fallback",
+        label="UNVERIFIED — source exploration",
+        question="샘플조직 설명해줘",
+        status="fallback",
+        answer=_fallback_answer_body(excerpts, grounding),
+        query_dl=None,
+        engine_answers=(),
+        reason="r",
+        excerpts=excerpts,
+        grounding_facts=grounding,
+    )
+
+
+def _heading_match(html: str, name: str) -> re.Match[str] | None:
+    # Attribute-tolerant: `<h2 class="...">` is still that heading, and matching
+    # a bare `<h2>` would report "the section is gone" for a styling change.
+    return re.search(rf"<h2\b[^>]*>\s*{re.escape(name)}\s*</h2>", html)
+
+
+def _sections_on_page(html: str) -> frozenset[str]:
+    return frozenset(name for name in SECTION_HEADINGS if _heading_match(html, name))
+
+
+def _sections_named(answer: str) -> frozenset[str]:
+    assert answer in SECTIONS_NAMED_BY_SENTENCE, (
+        f"`_fallback_answer_body` returned a sentence this test does not know: "
+        f"{answer!r}. Add it to SECTIONS_NAMED_BY_SENTENCE with the sections it "
+        f"names, so a reworded body cannot pass as one that names nothing."
+    )
+    return SECTIONS_NAMED_BY_SENTENCE[answer]
+
+
+@pytest.mark.parametrize("shape", sorted(BODY_SHAPES))
+def test_fallback_body_names_only_sections_the_rendered_page_carries(shape: str) -> None:
+    """Render `ask.html` and compare its `<h2>`s against the body sentence.
+
+    `_fallback_answer_body` reasons about which sections the page will carry.
+    Asserting that reasoning in a docstring is what went wrong before, so this
+    pins it against a real render of the template.
+
+    The rows are the whole domain -- one boolean per collection, four shapes --
+    because a test named for a universal over a domain missing a quarter of
+    itself is worth less than its name promises.
+
+    Six ways this goes red, each checked to fire: gate the excerpts section or
+    the grounding table on something true for an empty collection (the `none`
+    row then finds a heading it must not have); rename either `<h2>` (the page
+    then carries a heading set no row expects, and for the sentence that named
+    the renamed one, it now names a section that is not there); narrow the
+    helper's first branch to `if excerpts and grounding` (the `excerpt-only`
+    row then denies an excerpt the page is rendering); and swap the two blocks
+    in `ask.html` (the `both` row's headings then come in the wrong order).
+    The last two are each invisible to every other test in the suite.
+
+    The order pin is not incidental to this test, and nothing else holds it.
+    Neither `docs/architecture.md:57`'s "Ask output order" nor `README.md:56`'s
+    "The evidence block always comes first" says more than that the answer
+    block precedes everything else. The architecture doc's list of what the
+    answer precedes, "route reasons, query details, source tables, or
+    excerpts", does run in `ask.html`'s page order, but a list of what one
+    block precedes fixes no order among the listed items -- and it omits the
+    warning line, which renders between the answer and the reason. A document
+    setting out the page's sections in order would not leave one out. So
+    nothing states that the grounding table comes before the excerpts, and no
+    other test holds it either; that is why the allowance in the body below
+    cannot rest on it unpinned.
+
+    **There is no parent-commit run of this test to compare against**: it calls
+    `_fallback_answer_body`, which the parent does not have, so the module does
+    not import there. It guards the helper and the template agreeing, not the
+    behaviour change itself. The behaviour change is pinned end to end in
+    `tests/test_ask.py`, where the `none` and `grounding-only` shapes run
+    through `ask_question` and fail on the parent, and `both` runs there and
+    passes.
+
+    What the two excerpt-bearing rows pin, measured against the whole suite
+    rather than asserted: they are its only catchers for a renamed
+    `Source excerpts` heading, and `excerpt-only` is its only catcher for a
+    narrowed first branch. They are unchanged-row pins only in the narrow sense
+    that their sentence was already true before this change -- **they do not
+    catch a swap of the helper's branch order.** On the `both` row that names
+    the grounding table, which is also on the page, so `named <= on_page` holds
+    and the row stays green; on `excerpt-only` grounding is empty, so
+    grounding-first falls through and the sentence does not move at all.
+    Forbidding that needless rewording is
+    `test_ask_fallback_body_still_names_the_excerpts_when_both_render`'s job in
+    `tests/test_ask.py`, and it is the whole suite's only catcher for it.
+    """
+    result = _fallback_result(shape)
+    html = _render(result)
+
+    on_page = _sections_on_page(html)
+
+    assert on_page == BODY_SECTIONS_ON_PAGE[shape]
+    if len(on_page) == 2:
+        # Both sections render, so their order is observable -- pin it. The
+        # allowance below rests on the grounding table coming first, and
+        # nothing else in the suite holds that.
+        #
+        # Anchored on the headings, not on the bare phrase: `Source excerpts`
+        # occurs twice on this page and the earlier hit is the body sentence
+        # inside `<pre>`, above every heading -- so `html.index(...)` compares
+        # the sentence against a heading and is False on correct code.
+        grounding = _heading_match(html, "Verified grounding facts")
+        excerpts = _heading_match(html, "Source excerpts")
+        assert grounding.start() < excerpts.start(), (
+            "ask.html must keep the grounding table above the source excerpts"
+        )
+    named = _sections_named(result.answer)
+    # Never name a section that is not there...
+    assert named <= on_page
+    # ...and name one that is, whenever there is one to name. Equality is
+    # deliberately not demanded. On the both-populated row the sentence names
+    # only the excerpts, and the grounding table renders *above* them (pinned
+    # just above) -- so the unnamed section sits between the answer and the
+    # named one and cannot be missed. The sentence points past it, not away
+    # from it, and the claim the body must not make is a false one, not an
+    # incomplete one.
+    assert bool(named) == bool(on_page)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
+import ast
 import unicodedata
 import os
 import stat
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -1499,3 +1501,61 @@ def test_no_fact_joins_them_needs_evidence_not_merely_an_untruncated_list(tmp_pa
     assert plan.diagnosis is not None
     assert plan.diagnosis.join_search_complete is False
     assert "no confirmed fact joins them" not in _empty_plan_reason(plan, intent)
+
+
+def test_every_provider_failure_exit_reports_the_provider_failed():
+    """Producer-side tripwire for `provider_failed` (#438).
+
+    Ask suppresses its fallback request on this flag, so a handler that builds a
+    `_QueryFlowResult` after an `LLMError` and forgets the keyword silently
+    re-opens the defect: the dataclass defaults it to `False`, and the consumer
+    cannot tell a provider that did not fail from one nobody reported. The
+    consumer half -- that Ask reads the flag and does not condition on status --
+    is pinned in tests/test_ask.py.
+
+    The offender set is re-derived from the AST on every run rather than
+    compared against a list of known sites, so this carries no count and a new
+    module or handler is covered the day it is written. It swept the whole
+    package deliberately: `_QueryFlowResult` lives in one module today, and a
+    second one importing the private name is exactly the drift worth catching.
+
+    What would make this vacuous: no construction inside any `except LLMError:`
+    handler, so the loop finds nothing to judge. The companion assertion below
+    requires the sweep to have examined at least one.
+    """
+    package = Path(__file__).resolve().parent.parent / "verinote"
+    offenders = []
+    examined = []
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            caught = node.type
+            names = caught.elts if isinstance(caught, ast.Tuple) else [caught]
+            if not any(getattr(n, "id", getattr(n, "attr", None)) == "LLMError" for n in names):
+                continue
+            for child in ast.walk(node):
+                if not (
+                    isinstance(child, ast.Call)
+                    and getattr(child.func, "id", None) == "_QueryFlowResult"
+                ):
+                    continue
+                examined.append(f"{path.name}:{child.lineno}")
+                flagged = any(
+                    kw.arg == "provider_failed"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is True
+                    for kw in child.keywords
+                )
+                if not flagged:
+                    offenders.append(f"{path.name}:{child.lineno}")
+
+    assert examined, (
+        "no `_QueryFlowResult` was built inside an `except LLMError:` handler, so "
+        "this sweep judged nothing -- it has been made vacuous, not satisfied"
+    )
+    assert offenders == [], (
+        "these provider-failure exits build a flow result without "
+        f"provider_failed=True, so Ask cannot tell they failed: {offenders}"
+    )

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -389,6 +389,48 @@ def _render_engine_answer_body(
     return "\n".join(strip_answer_line_prefix(line, ASK_QID) for line in answers)
 
 
+def _fallback_answer_body(
+    excerpts: tuple[AskExcerpt, ...],
+    grounding: tuple[AskGroundingFact, ...],
+) -> str:
+    """Describe what this answer has below it, naming only what is there.
+
+    `ask.html` puts the `Source excerpts` section on the page only when
+    `result.excerpts` is non-empty, and the grounding table only when
+    `result.grounding_facts` is, heading that table `Verified grounding facts`
+    on the `fallback` route this helper serves. A body sentence naming a
+    section built from an empty collection therefore points at nothing on the
+    page, which is what the unconditional "Source excerpts are shown below."
+    did on a fallback result carrying grounding facts and no excerpt.
+
+    Each branch points at only the collection it has just found non-empty; the
+    last points at neither and says so. Naming one present section is enough,
+    so a result carrying both keeps the excerpt sentence it has today.
+
+    The last branch reports what the page shows rather than why. An excerpt is
+    also absent when the source file is missing from disk or is not UTF-8:
+    `search_source_excerpts` passes over both before any comparison against the
+    question runs, so "nothing matched the question" would be a claim about
+    text that was never read.
+
+    Neither the rendering claim nor the skipping one is left as prose a later
+    edit could quietly falsify: `tests/test_ask_verdict.py` re-derives the first
+    from a render of `ask.html`, and `tests/test_ask.py` re-derives the second
+    from `search_source_excerpts` itself.
+    """
+    if excerpts:
+        return "The deterministic engine could not answer. Source excerpts are shown below."
+    if grounding:
+        return (
+            "The deterministic engine could not answer. Verified grounding facts "
+            "are shown below."
+        )
+    return (
+        "The deterministic engine could not answer, and no source excerpt or "
+        "verified grounding fact is shown below."
+    )
+
+
 def _fallback_answer(
     store: Store,
     client: LLMClient,
@@ -405,9 +447,9 @@ def _fallback_answer(
         answer = client.answer_question(question=question, context=context)
     except LLMError as exc:
         warning = _short_reason(exc)
-        answer = "The deterministic engine could not answer. Source excerpts are shown below."
+        answer = _fallback_answer_body(excerpts, grounding)
     if not answer:
-        answer = "The deterministic engine could not answer. Source excerpts are shown below."
+        answer = _fallback_answer_body(excerpts, grounding)
     return AskResult(
         route="fallback",
         label="UNVERIFIED — source exploration",

--- a/verinote/pipeline/ask.py
+++ b/verinote/pipeline/ask.py
@@ -22,7 +22,10 @@ from verinote.engine.wirelog import strip_answer_line_prefix
 from verinote.llm.base import LLMClient, LLMError
 from verinote.pipeline.corroboration import CorroborationPolicyError, store_relation_aliases
 from verinote.pipeline.engine_input import engine_relation_rows
-from verinote.pipeline.query import expand_query_relation_aliases, schema_aware_query_flow
+from verinote.pipeline.query import (
+    _schema_aware_query_flow_result,
+    expand_query_relation_aliases,
+)
 from verinote.pipeline.query_candidate_eval import RELATION_DECL
 from verinote.pipeline.query_intent import korean_measure_unit_mismatch
 from verinote.pipeline.report_trace import trace_query_answers
@@ -35,6 +38,25 @@ MAX_EXCERPTS = 8
 MAX_GROUNDING_FACTS = 8
 _TOKEN = re.compile(r"[A-Za-z0-9_]{2,}|[가-힣一-龥ぁ-んァ-ン]{1,}")
 _RELATION_DECL = ".decl relation(subject: symbol, rel: symbol, object: symbol)\n"
+
+# Shown when the flow reports `provider_failed`, so Ask sends no second request.
+#
+# It deliberately does not say the provider failed. `provider_failed` is set by
+# the `except LLMError` handlers around the flow's provider calls, and an
+# `LLMError` also arrives from a request that succeeded: the
+# `"anthropic response contained no tool_use block"` raise sits outside the block
+# that normalises transport errors, so it is reachable only once
+# `messages.create` has returned. On that shape "the provider failed" would be
+# printed directly above a `reason` line reporting the provider's own output as
+# unusable -- the confusion `query_intent.py` refuses to create one level down,
+# where it keeps a local wiring bug out of the parse path rather than let it be
+# reported as "the provider violated the schema".
+#
+# `ask.html` renders the warning slot as text, so this carries no markup.
+_PROVIDER_SKIPPED_WARNING = (
+    "verinote did not get a usable reading of the question from the provider and "
+    "did not send it another request, so no model-composed answer is shown"
+)
 
 
 @dataclass(frozen=True)
@@ -99,7 +121,7 @@ def ask_question(
         )
 
     try:
-        status, query_dl, reason = schema_aware_query_flow(
+        flow = _schema_aware_query_flow_result(
             store,
             client,
             qid=ASK_QID,
@@ -107,6 +129,9 @@ def ask_question(
             llm_error_status="review_required",
         )
     except DuckDBFactTermStoreError as exc:
+        # The flow raised, so it reported nothing -- including no provider
+        # verdict. `provider_skipped` stays False here: a fact-term error is
+        # not a provider failure, and the fallback model is still worth asking.
         return _fallback_answer(
             store,
             client,
@@ -114,6 +139,10 @@ def ask_question(
             question=question,
             reason=f"engine fact-term error: {_short_reason(exc)}",
         )
+    status, query_dl, reason = flow.status, flow.query_dl, flow.reason
+    # Read once, here, rather than re-deriving it per branch: every downstream
+    # `_fallback_answer` gets the same verdict about the same flow.
+    provider_skipped = flow.provider_failed
     if status == "translated" and query_dl:
         report, expanded_query, snapshot = _run_engine_query(store, query_dl)
         if report.engine_available and report.ok and not report.errors:
@@ -135,12 +164,17 @@ def ask_question(
                 if _is_three_hop_answer_query(expanded_query) and not _has_complete_three_hop_trace(
                     answers, traces
                 ):
+                    # Unexercisable today: no _QueryFlowResult pairs
+                    # provider_failed with "translated", and this branch needs
+                    # that status. Wired so a future site that does is
+                    # suppressed by default rather than silently re-requesting.
                     return _fallback_answer(
                         store,
                         client,
                         root=root,
                         question=question,
                         reason="three-hop query source trace is incomplete",
+                        provider_skipped=provider_skipped,
                     )
                 source_facts = tuple(_grounding_facts_from_traces(traces))
                 return AskResult(
@@ -166,7 +200,17 @@ def ask_question(
                 reason="no confirmed facts match",
             )
         reason = _short_reason("; ".join(report.findings) or report.text)
-        return _fallback_answer(store, client, root=root, question=question, reason=reason)
+        # Unexercisable today, for the same reason as the three-hop site above:
+        # reaching here requires status "translated", which no construction
+        # pairs with provider_failed. Wired for the same default-safe reason.
+        return _fallback_answer(
+            store,
+            client,
+            root=root,
+            question=question,
+            reason=reason,
+            provider_skipped=provider_skipped,
+        )
 
     if status == "no_answer":
         return AskResult(
@@ -186,6 +230,7 @@ def ask_question(
         root=root,
         question=question,
         reason=reason or f"deterministic query status: {status}",
+        provider_skipped=provider_skipped,
     )
 
 
@@ -220,8 +265,8 @@ def _engine_answer_warning(
 
     The sentence carries no backticks or other markup: `ask.html` renders this
     slot as text, and no warning text this module writes uses any. (The fallback
-    path also puts a provider error message in this slot; that text is not
-    written here.)
+    path also writes to this slot -- either a provider error message or the
+    provider-skipped notice; neither is written here.)
     """
     if not source_facts:
         return "source trace unavailable for this verified query shape"
@@ -438,18 +483,37 @@ def _fallback_answer(
     root: Path,
     question: str,
     reason: str,
+    provider_skipped: bool = False,
 ) -> AskResult:
+    """Assemble the unverified answer, asking the model unless it just failed.
+
+    `provider_skipped` is the flow's `provider_failed` verdict. When it is set,
+    the provider has already been asked to read this question and produced
+    nothing usable, so asking it again would double the failed requests for one
+    question -- the whole of #438. Everything the page shows apart from the
+    model's prose is built here without a model, which is why the skipped path
+    still returns excerpts, grounding facts, route, label, status and reason.
+
+    Default `False` so a caller that has no verdict cannot accidentally suppress
+    a healthy provider; the callers that do have one pass it explicitly.
+    """
     excerpts = tuple(search_source_excerpts(store, root=root, question=question))
     grounding = tuple(grounding_facts(store, question=question))
-    context = _fallback_context(excerpts, grounding)
-    warning = None
-    try:
-        answer = client.answer_question(question=question, context=context)
-    except LLMError as exc:
-        warning = _short_reason(exc)
+    if provider_skipped:
+        # No context is built: nothing consumes it on this path, and composing a
+        # prompt for a request that is not sent would only invite one later.
+        warning = _PROVIDER_SKIPPED_WARNING
         answer = _fallback_answer_body(excerpts, grounding)
-    if not answer:
-        answer = _fallback_answer_body(excerpts, grounding)
+    else:
+        context = _fallback_context(excerpts, grounding)
+        warning = None
+        try:
+            answer = client.answer_question(question=question, context=context)
+        except LLMError as exc:
+            warning = _short_reason(exc)
+            answer = _fallback_answer_body(excerpts, grounding)
+        if not answer:
+            answer = _fallback_answer_body(excerpts, grounding)
     return AskResult(
         route="fallback",
         label="UNVERIFIED — source exploration",

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -241,25 +241,6 @@ def classify_query_draft(store: Store, qid: int, query_dl: str) -> tuple[str, st
     return "review_required", f"review_required({_lit(reason)})", reason
 
 
-def schema_aware_query_flow(
-    store: Store,
-    client: LLMClient,
-    *,
-    qid: int,
-    question: str,
-    llm_error_status: str,
-) -> tuple[str, str | None, str]:
-    """Translate one question through intent extraction, planning, and dry-run evaluation."""
-    result = _schema_aware_query_flow_result(
-        store,
-        client,
-        qid=qid,
-        question=question,
-        llm_error_status=llm_error_status,
-    )
-    return result.status, result.query_dl, result.reason
-
-
 def _schema_aware_query_flow_result(
     store: Store,
     client: LLMClient,
@@ -282,7 +263,18 @@ def _schema_aware_query_flow_result(
         except LLMError as exc:
             reason = _short_reason(exc)
             if llm_error_status == "translation_failed":
-                return _QueryFlowResult("translation_failed", None, reason)
+                # Flagged like the sibling exits of this handler even though
+                # nothing reads it here: `translate_questions` is the only
+                # caller that passes this status, and it reads status, query_dl
+                # and reason and never the flag. The invariant is that every
+                # provider-failure exit sets it, and an exemption is exactly the
+                # shape the tripwire in tests/test_query.py exists to forbid.
+                return _QueryFlowResult(
+                    "translation_failed",
+                    None,
+                    reason,
+                    provider_failed=True,
+                )
             reason = _short_reason(f"llm error: {exc}")
             # No fallback here. The direct-Datalog fallback answers "planning
             # reports it cannot support this question"; an LLMError reports


### PR DESCRIPTION
Closes #438. Two commits, each standing alone.

**1. `fix: say which evidence section the page carries`** — `_fallback_answer`
closed both of its bodies with "Source excerpts are shown below", false
whenever the fallback route produced no excerpt. A helper now names only
sections the page carries, over all four evidence shapes, pinned by a test that
**renders** `ask.html` rather than parsing it — and by an order assertion, since
the partiality allowance rests on the grounding table rendering above the
excerpts and nothing held that.

**2. `fix: stop asking a provider that just failed`** — `ask_question` called
the three-tuple adapter, which discards `provider_failed`, so a question whose
intent call failed sent a second request to the same provider. Measured on a
counting stub: both reachable flag sites go 2 → 1. The notice does not say the
provider *failed*, because the flag also fires after a request the provider
answered whose payload was unusable. An AST tripwire now fails on any
`_QueryFlowResult` built inside an `except LLMError:` handler that omits the
flag — the producer side defaulted unsafe.

**Gates.** Architect, Critic and Reviewer measured each frozen candidate
independently; commit 1 took eleven revisions, every blocking finding a
sentence rather than a mechanism. Suite 2868 passed / 20 skipped (baseline
2848/20 at `4c4502b`), ruff 0.15.18 clean.

Disclosed, not fixed, and carried in the commit messages: `_fallback_context`'s
prompt string makes the same over-claim on its excerpts half — commit 2 shrinks
its population without removing it. Related: #468.

Verified against synthetic fixtures only.