### PR TITLE
test: promote the deterministic contract guards into the default suite (#270)

### DIFF
--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -1,8 +1,9 @@
 <!-- SPDX-License-Identifier: MPL-2.0 -->
 # Provider contract tests (issue #241)
 
-These tests exercise failures that only surface against a **real LLM provider**,
-or that the deterministic suite would otherwise paper over:
+These tests exercise failures the deterministic suite could not see when each was
+written: output from a **real LLM provider** it stubs, an upstream API it never
+calls, and a sync exit code it did not then check.
 
 | Guard | Issue | What it locks |
 |-------|-------|---------------|
@@ -10,13 +11,15 @@ or that the deterministic suite would otherwise paper over:
 | `test_extraction_contract.py` | #238 | A founding-date fact the extractor produces must normalise into the policy's *functional* relation vocabulary, so a two-date contradiction is catchable. |
 | `test_sync_rc_contract.py` | #239 | `verinote sync` must not report success when every extraction chunk fails. |
 | `test_openrouter_catalogue_contract.py` | — | OpenRouter's model catalogue must still carry the `id` and `supported_parameters` fields the settings Model picker is built from, and still declare `structured_outputs`. Needs no key or client; reads the live endpoint. |
-| `test_contract_meta.py` | — | Meta guards on the harness itself (marker registered, fixtures carry provenance, every module has a guard, the skipped-run guard bites). Runs in the default suite. |
+| `test_contract_meta.py` | — | Meta guards on the harness itself (marker registered, fixtures carry provenance, every module has a guard, the skipped-run guard bites, the promoted replays stayed promoted). Runs in the default suite. |
 
 ## Running
 
-The guards are **opt-in**. They self-skip unless you name a provider, so the
-default `pytest tests` stays green (only the meta tests and the deterministic
-positive controls run there). Any invocation path works:
+The guards carrying `@pytest.mark.contract` are **opt-in**: they self-skip unless
+you name a provider. The default `pytest tests` therefore runs the meta tests,
+the deterministic precondition control in `test_query_intent_contract.py`, and
+the replay guards (issue #270), and never reaches a provider. Any invocation path
+works for the opt-in set:
 
 ```bash
 VN_CONTRACT_PROVIDER=claudecli tests/contract/run.sh
@@ -42,7 +45,7 @@ Two rules keep a green run from meaning nothing:
   or naming a path in this directory (`pytest tests/contract`, including
   `--pyargs tests.contract`). The default suite asks in none of those ways —
   `pytest` and `pytest tests` both target `tests`, a parent of this directory —
-  so it is unaffected and the guards keep self-skipping there.
+  so it is unaffected and the marked guards keep self-skipping there.
 
   Asking is not the same as failing: a run that *excludes* the guards on purpose
   (`pytest tests/contract -k meta`, `-m "not contract"`, `--deselect`) is silent,
@@ -83,28 +86,28 @@ VN_CONTRACT_PROVIDER=openai VN_CONTRACT_MODEL=gpt-4o \
 captured from a real provider (`captured_at` records when). The replay tests feed
 the raw string or structured object back through the production parse boundary
 (`parse_query_intent` / `parse_facts`), so they reproduce a captured failure
-deterministically without a provider — while still gated opt-in so the default
-suite stays green. Each provider directory must contain the query-intent and
-extraction pair. The deterministic `sync_all_chunks_failed.json` artifact is the
-only permitted flat fixture.
+deterministically without a provider. Each provider directory must contain the
+query-intent and extraction pair. The deterministic
+`sync_all_chunks_failed.json` artifact is the only permitted flat fixture.
 
-Run the captured query/extraction replays without a provider, credentials, or
-network access with this exact command:
+Since issue #270 the replays carry no marker and no gate, so `pytest tests` runs
+them. To run just those nodes, set nothing at all:
 
 ```bash
-VN_CONTRACT_PROVIDER=replay .venv/bin/pytest -q \
+.venv/bin/pytest -q \
     tests/contract/test_query_intent_contract.py::test_replay_raw_intent_parses_through_production_boundary \
     tests/contract/test_query_intent_contract.py::test_claudecli_replay_retains_reason_regression_shape \
     tests/contract/test_extraction_contract.py::test_replay_founding_relation_normalizes_into_functional_vocab
 ```
 
-The parametrized nodes discover every valid provider fixture pair: the current
-fixture layout runs 3 tests, and each additional provider pair adds 2 more.
-
-`replay` is intentionally not a real provider. It only satisfies
-`require_opt_in` for these deterministic tests; the explicit node IDs exclude
-the live guards. If a live guard is added to this command by mistake, it fails
-at provider validation before an adapter or network request is created.
+The parametrized nodes discover every valid provider fixture pair, so how many
+tests those three targets collect follows the fixtures on disk rather than
+anything written here. `test_contract_meta.py` runs the same three targets in a
+child process with the gate unset and re-derives the expected count from the
+same fixtures, discovered independently, so a replay that quietly takes the gate
+back skips there and reddens the meta suite; a separate static guard reads the
+source for the marker, for the fixture parameter, and for the guard's
+disappearance.
 
 The capture script sends only the fixed synthetic Acme Robotics question and
 source text in `capture.py`. Do not change those inputs to customer, company,

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -22,12 +22,16 @@ Two gates share it:
   provider is unreachable (e.g. the ``claude`` binary is missing) it *fails*,
   never skips — a provider you asked to exercise but that cannot run is a real
   failure, not an absence of coverage (issue #234).
-* :func:`require_opt_in` gates the guards that build no provider client: the
-  replays, the sync exit-code guard, and the OpenRouter catalogue guard. The
-  first two are deterministic; the last reads a live, unauthenticated HTTP
-  endpoint. What they share is that none of them needs a provider client or a
-  key — and that all of them must stay out of the default suite, so they skip on
-  the same unset gate.
+* :func:`require_opt_in` gates the guards that build no provider client and are
+  nonetheless kept out of the default suite: the #239 sync exit-code guard, the
+  DuckDB functional-conflict positive control
+  (``test_extraction_contract.py::test_functional_conflict_fires_on_two_dates``),
+  and the two OpenRouter catalogue guards. What they share is that none of them
+  needs a provider client or a key — not that they are offline, since the
+  OpenRouter pair reads a live, unauthenticated HTTP endpoint. The replay guards
+  were on this list until issue #270 moved them into the default suite, on the
+  ground that a captured response parsed off disk is as deterministic there as it
+  is here; issue #469 asks the same question of the sync and DuckDB guards.
 
 :func:`pytest_sessionfinish` closes the harness's worst failure mode: asking for
 contract tests and getting a green run that exercised nothing. Whenever a run

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -2,8 +2,10 @@
 """Opt-in gate and provider wiring for the issue #241 provider contract tests.
 
 These tests exist to catch failures that *only* show up against a real LLM
-provider (issues #237/#238) or that the deterministic suite would otherwise
-paper over (issue #239).
+provider (issues #237/#238). The #239 sync exit-code guard joined them because
+the deterministic suite papered that failure over at the time; ``7b5ec06`` has
+since pinned the behaviour in ``tests/test_cli.py``, so the guard here is a
+second witness rather than the only one.
 
 The gate lives in a ``VN_CONTRACT_*`` namespace, deliberately *outside* the
 ``VERINOTE_*`` prefix. The root ``tests/conftest.py`` sandbox drops every

--- a/tests/contract/test_contract_meta.py
+++ b/tests/contract/test_contract_meta.py
@@ -2,14 +2,15 @@
 """Meta guards for the #241 contract harness itself — deliberately *not* marked
 ``contract`` so they run in the default suite and stay green.
 
-They catch the ways the harness could rot into a no-op: an unregistered marker
-(so ``-m contract`` silently selects nothing), missing or provenance-less replay
-fixtures, or a contract module that stops declaring any contract-marked test (so
-the opt-in run collects zero guards).
+They catch ways the harness could rot into a no-op: an unregistered marker (so
+``-m contract`` silently selects nothing), missing or provenance-less replay
+fixtures, a contract module that stops declaring any contract-marked test (so
+the opt-in run collects zero guards), and a replay issue #270 promoted slipping
+back out of the default suite.
 
-The last two spawn a real nested pytest to pin the session guard in
-``conftest.py``: asking for contract tests and skipping every one must exit
-non-zero, while a run that never asked must stay green.
+The session guard in ``conftest.py`` is pinned by spawning a real nested pytest:
+asking for contract tests and skipping every one must exit non-zero, while a run
+that never asked must stay green.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from __future__ import annotations
 import ast
 from datetime import date
 import importlib.util
+import inspect
 import json
 import os
 import shutil
@@ -68,12 +70,23 @@ GATE_ONLY_MODULE = "test_sync_rc_contract.py"
 MIXED_MODULE = "test_query_intent_contract.py"
 # A keyword matching exactly one ungated control in this directory and no guard.
 CONTROL_ONLY_KEYWORD = "deterministic_parser"
-REPLAY_ONLY_GATE = "replay"
 REPLAY_ONLY_TARGETS = (
     "tests/contract/test_query_intent_contract.py::test_replay_raw_intent_parses_through_production_boundary",
     "tests/contract/test_query_intent_contract.py::test_claudecli_replay_retains_reason_regression_shape",
     "tests/contract/test_extraction_contract.py::test_replay_founding_relation_normalizes_into_functional_vocab",
 )
+# The same guards, spelled as (module, function) so the promotion #270 made can
+# be asserted at the source level. Listed rather than discovered: a promoted
+# guard that is simply deleted must be as visible as one that is re-gated.
+PROMOTED_REPLAYS = {
+    "test_extraction_contract.py": (
+        "test_replay_founding_relation_normalizes_into_functional_vocab",
+    ),
+    "test_query_intent_contract.py": (
+        "test_replay_raw_intent_parses_through_production_boundary",
+        "test_claudecli_replay_retains_reason_regression_shape",
+    ),
+}
 
 
 def test_contract_marker_is_registered(pytestconfig):
@@ -314,19 +327,76 @@ def test_all_skipped_contract_selection_fails_the_session():
     )
 
 
-def test_replay_only_targets_run_without_a_real_provider():
-    """The documented replay path must not construct a live provider client."""
-    result = _nested_pytest(*REPLAY_ONLY_TARGETS, gate_env={GATE_VAR: REPLAY_ONLY_GATE})
+def test_replay_targets_run_with_no_gate_at_all():
+    """The replays must execute with the gate *unset* — the default suite's case.
+
+    No ``gate_env`` on purpose. Since #270 these carry no ``contract`` marker and
+    no ``require_opt_in``, so an unset gate has to run every one of them. Passing
+    even the inert ``replay`` gate would satisfy a ``require_opt_in`` that crept
+    back onto a single guard: the count below would still read full while that
+    guard skipped in every default run.
+    """
+    result = _nested_pytest(*REPLAY_ONLY_TARGETS)
     assert result.returncode == 0, (
-        "the replay-only command should pass with the non-provider replay gate.\n"
+        "the replay guards should pass with no contract gate set at all.\n"
         f"{result.stdout}\n{result.stderr}"
     )
     expected_count = 2 * len(_valid_live_fixture_pairs()) + 1
     assert f"{expected_count} passed" in result.stdout, (
-        "the replay-only command did not run every discovered provider fixture pair "
+        "the replay guards did not run every discovered provider fixture pair "
         "and the Claude regression assertion.\n"
         f"{result.stdout}\n{result.stderr}"
     )
+
+
+@pytest.mark.parametrize("module_name", sorted(PROMOTED_REPLAYS))
+def test_promoted_replays_carry_neither_the_marker_nor_the_gate(module_name):
+    """#270's promotion must not be undoable without something going red.
+
+    Two of the three reversions read for here cost default-suite coverage
+    outright: ``require_opt_in`` coming back makes the guard skip there, and
+    deleting the guard removes it. The marker is different — a marked test still
+    runs under ``pytest tests`` — but it puts the guard back into the opt-in
+    accounting, where it keeps ``conftest.py``'s all-skipped session guard
+    permanently satisfied. All three are source-level edits, so reading the
+    source catches them without spawning a pytest.
+
+    Not every way is source-readable — let ``LIVE_FIXTURES``' glob stop matching
+    and the parametrized replays collect nothing while their ``def`` still reads
+    correctly here; that one is caught by the count in
+    :func:`test_replay_targets_run_with_no_gate_at_all`.
+
+    ``PROMOTED_REPLAYS`` is written out rather than discovered because of the
+    deletion. A deletion that also tidies away the guard's
+    ``REPLAY_ONLY_TARGETS`` entry and the matching term in
+    :func:`test_replay_targets_run_with_no_gate_at_all`'s count leaves that test
+    green; a second, independent ledger is what still goes red.
+
+    The marker coming back does redden the harness elsewhere, through the meta
+    tests built on an all-skipped run failing. What those report is a run that
+    exited 0 while every guard skipped, or a wrapper that never reached pytest,
+    which points a reader at the gate or at issue #273's wrapper. This test says
+    instead that a promoted replay was re-marked.
+    """
+    module = _load_module(CONTRACT_DIR / module_name)
+    marked = set(_contract_test_names(module))
+    for name in PROMOTED_REPLAYS[module_name]:
+        func = getattr(module, name, None)
+        assert func is not None, (
+            f"{module_name}::{name} is gone; #270 promoted it into the default "
+            "suite, so removing it removes default-suite coverage — drop it from "
+            "PROMOTED_REPLAYS in the same commit if that is deliberate"
+        )
+        assert name not in marked, (
+            f"{module_name}::{name} carries @pytest.mark.contract again. It "
+            "still runs under `pytest tests`, but the marker puts it back into "
+            "the opt-in accounting #270 took it out of, where it keeps "
+            "conftest.py's all-skipped session guard permanently satisfied"
+        )
+        assert "require_opt_in" not in inspect.signature(func).parameters, (
+            f"{module_name}::{name} takes `require_opt_in` again; #270 promoted "
+            "it into the default suite and that fixture skips it there"
+        )
 
 
 def test_targeting_the_contract_directory_fails_when_no_guard_runs():
@@ -500,7 +570,13 @@ def test_documented_api_key_reaches_the_provider_config(monkeypatch, tmp_path):
 
 
 def test_meta_nested_pytest_never_opts_into_a_live_provider():
-    """Default-suite meta tests must not spawn opted-in live contract runs."""
+    """Default-suite meta tests must not spawn opted-in live contract runs.
+
+    Any ``GATE_VAR`` in a ``_nested_pytest`` call is flagged, rather than checked
+    against an allowed value. Until #270 the replay targets were run under an
+    inert ``replay`` gate and had to be exempted; they now need no gate, so no
+    call here sets one and an allow-list would only invite the inert gate back.
+    """
     tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
     live_gate_calls = []
     for node in ast.walk(tree):
@@ -511,24 +587,20 @@ def test_meta_nested_pytest_never_opts_into_a_live_provider():
         for keyword in node.keywords:
             if keyword.arg != "gate_env" or not isinstance(keyword.value, ast.Dict):
                 continue
-            entries = []
-            for key, value in zip(keyword.value.keys, keyword.value.values, strict=True):
+            for key in keyword.value.keys:
                 if isinstance(key, ast.Constant):
                     resolved_key = key.value
                 elif isinstance(key, ast.Name):
                     resolved_key = globals().get(key.id)
                 else:
                     continue
-                if isinstance(value, ast.Constant):
-                    resolved_value = value.value
-                elif isinstance(value, ast.Name):
-                    resolved_value = globals().get(value.id)
-                else:
-                    resolved_value = None
-                entries.append((resolved_key, resolved_value))
-            if any(key == GATE_VAR and value != REPLAY_ONLY_GATE for key, value in entries):
-                live_gate_calls.append(node.lineno)
-    assert live_gate_calls == []
+                if resolved_key == GATE_VAR:
+                    live_gate_calls.append(node.lineno)
+    assert live_gate_calls == [], (
+        f"_nested_pytest at line(s) {live_gate_calls} sets {GATE_VAR}; since "
+        "#270 no meta test needs the contract gate, so any value here is "
+        "flagged rather than checked against an allow-list"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/contract/test_extraction_contract.py
+++ b/tests/contract/test_extraction_contract.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Contract guard for issue #238: a founding-date fact the live extractor produces
+"""Contract guards for issue #238: a founding-date fact the extractor produces
 must normalise into the policy's *functional* relation vocabulary, so the
 functional-conflict check can fire when a source states two different dates.
 
@@ -7,9 +7,14 @@ The functional vocabulary is not hard-coded here: it is parsed from
 ``engine.wirelog.DEFAULT_POLICY``'s ``functional("...")`` declarations, the same
 program the verifier runs. A relation the extractor emits (e.g. ``founded`` /
 ``established``) that does not normalise into that set leaves the conflict check
-blind to the contradiction — the #238 failure. On ``origin/main`` (no #238 fix)
-the live and replay assertions are expected to fail; the differential test is a
-positive control that stays green to prove the check itself works.
+blind to the contradiction — the #238 failure.
+
+The #238 fix is merged, so the replay below runs in the **default** suite: it
+parses a response captured from a real provider off disk, which needs no
+provider, no credentials and no network (issue #270). The live guard keeps
+``@pytest.mark.contract`` and the opt-in gate, as does the DuckDB differential
+positive control that proves the conflict machinery the other two rely on is
+real.
 """
 
 from __future__ import annotations
@@ -75,9 +80,8 @@ def test_live_founding_relation_normalizes_into_functional_vocab(require_live_pr
     )
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize("fixture_path", LIVE_FIXTURES, ids=lambda path: path.parent.name)
-def test_replay_founding_relation_normalizes_into_functional_vocab(require_opt_in, fixture_path):
+def test_replay_founding_relation_normalizes_into_functional_vocab(fixture_path):
     fixture = _fixture(fixture_path)
     facts = parse_facts(fixture["raw_response"])
     # Non-vacuity: the capture must actually contain both founding years, or the

--- a/tests/contract/test_query_intent_contract.py
+++ b/tests/contract/test_query_intent_contract.py
@@ -1,15 +1,28 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Contract guard for issue #237: a role question the deterministic parser cannot
-resolve must still yield a valid query intent through the *live* provider and the
+"""Contract guards for issue #237: a role question the deterministic parser cannot
+resolve must still yield a valid query intent through the provider and the
 production parse boundary.
 
 The deterministic parser deliberately returns ``unknown_or_unsupported`` for a
 "who is the CEO of X" question (asserted below as a precondition), so the only
-thing that can turn it into an executable intent is the LLM. This guard fails on
-any branch where the provider's raw intent is rejected by ``parse_query_intent``
-— for example when the model fills ``reason`` on a ``lookup_object`` intent, the
-schema the parser rejects. On ``origin/main`` (no #237 fix) both the live and the
-replay assertions are expected to fail; that red is the point.
+thing that can turn it into an executable intent is the LLM. A guard that pushes
+a raw intent through ``parse_query_intent`` goes red on any branch where the
+parser rejects it — for example when the model fills ``reason`` on a
+``lookup_object`` intent, the schema the parser rejects.
+
+The #237 fix is merged, so the replays below run in the **default** suite, and
+neither of them needs a provider, credentials or the network (issue #270).
+``test_replay_raw_intent_parses_through_production_boundary`` is the one that
+crosses the boundary: it reads a response captured from a real provider off disk
+and pushes it through ``parse_query_intent``.
+``test_claudecli_replay_retains_reason_regression_shape`` never reaches the
+parser. It is the non-vacuity pin: it asserts the capture still holds the
+populated ``reason`` that made #237 reproduce, without which parsing that
+capture would prove nothing.
+
+``test_live_provider_yields_valid_query_intent`` calls a provider, so it keeps
+``@pytest.mark.contract`` and the opt-in gate; the precondition test and both
+replays carry neither.
 """
 
 from __future__ import annotations
@@ -53,9 +66,8 @@ def test_live_provider_yields_valid_query_intent(require_live_provider):
     assert intent.kind != QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
 
 
-@pytest.mark.contract
 @pytest.mark.parametrize("fixture_path", LIVE_FIXTURES, ids=lambda path: path.parent.name)
-def test_replay_raw_intent_parses_through_production_boundary(require_opt_in, fixture_path):
+def test_replay_raw_intent_parses_through_production_boundary(fixture_path):
     fixture = _fixture(fixture_path)
     raw = fixture["raw_response"]
     decoded = json.loads(raw) if isinstance(raw, str) else raw
@@ -65,8 +77,7 @@ def test_replay_raw_intent_parses_through_production_boundary(require_opt_in, fi
     assert intent.kind != QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
 
 
-@pytest.mark.contract
-def test_claudecli_replay_retains_reason_regression_shape(require_opt_in):
+def test_claudecli_replay_retains_reason_regression_shape():
     """Keep the captured #237 Claude response regression-specific assertion."""
     fixture_path = FIXTURES_DIR / "claudecli" / "query_intent_acme_ceo.json"
     fixture = _fixture(fixture_path)

--- a/tests/contract/test_sync_rc_contract.py
+++ b/tests/contract/test_sync_rc_contract.py
@@ -3,14 +3,12 @@
 every extraction chunk fails.
 
 Deterministic and provider-free — it drives the real chunked-extraction CLI path
-with a stub client that raises on each chunk, so it needs no live provider. It is
-still gated behind the same opt-in signal as the live guards (via
-``require_opt_in``) so the default suite stays green; without that gate a run of
-``pytest tests`` would go red on a bug this branch has not fixed yet.
-
-On ``origin/main`` (no #239 fix) the chunked path swallows every per-chunk
-``LLMError`` and `cmd_sync` returns 0, so both assertions here are expected to
-fail. That red is the point; ``@pytest.mark.contract`` keeps it opt-in.
+with a stub client that raises on each chunk, so it needs no live provider. It
+was written against the unfixed code, where the chunked path swallowed every
+per-chunk ``LLMError`` and `cmd_sync` returned 0; ``7b5ec06`` fixed that, and the
+guard passes against the CLI as it stands. It stays behind ``require_opt_in``
+for scope reasons only — nothing here needs a provider, a key or the network —
+so promoting it into the default suite is tracked as issue #469.
 """
 
 from __future__ import annotations
@@ -51,22 +49,6 @@ class _AllChunksFail:
         raise LLMError(self._reason)
 
 
-class _FirstChunkFails:
-    """Fails only the first chunk, then succeeds — the partial-failure scenario."""
-
-    name = "first-chunk-fails"
-
-    def __init__(self, reason: str) -> None:
-        self._reason = reason
-        self._calls = 0
-
-    def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
-        self._calls += 1
-        if self._calls == 1:
-            raise LLMError(self._reason)
-        return [ExtractedFact("Acme Robotics", "is_a", "company", 0.9)]
-
-
 def _prepare_kb(tmp_path, monkeypatch) -> Path:
     monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
     monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
@@ -91,24 +73,3 @@ def test_sync_fails_when_every_chunk_fails(tmp_path, monkeypatch, capsys, requir
     err = capsys.readouterr().err
     assert rc != 0, "#239 guard: sync must not return success when every chunk failed"
     assert "fail" in err.lower(), "#239 guard: the failure must be reported on stderr"
-
-
-@pytest.mark.contract
-def test_total_failure_differs_from_partial_failure(tmp_path, monkeypatch, capsys, require_opt_in):
-    """Total wipeout and partial failure must not be reported identically (#239)."""
-    reason = _fixture()["failure_reason"]
-
-    _prepare_kb(tmp_path, monkeypatch)
-    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _AllChunksFail(reason))
-    total_rc = cli.main(["sync"])
-    capsys.readouterr()
-
-    _prepare_kb(tmp_path, monkeypatch)
-    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _FirstChunkFails(reason))
-    partial_rc = cli.main(["sync"])
-    capsys.readouterr()
-
-    assert total_rc != partial_rc, (
-        "#239 guard: a total extraction wipeout must be distinguishable from a "
-        f"partial failure, but both returned rc={total_rc}"
-    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,6 +419,57 @@ def test_sync_total_chunk_failure_exits_nonzero(
     assert "sync complete" not in captured.out
 
 
+def test_sync_total_multi_chunk_wipeout_counts_every_failed_chunk(
+    tmp_path, monkeypatch, capsys
+):
+    """A multi-chunk wipeout must report the real chunk numbers.
+
+    The single-chunk total-failure test above asserts neither the failed count
+    nor the total, and its one-chunk source could not separate a per-chunk count
+    from a per-source one anyway, since both are 1 there. Here a source that
+    splits into several chunks loses every one of them, so both numbers have to
+    be that chunk count. The count is read back off the stub client rather than
+    written down here, so the assertion tracks the split instead of a number
+    that would have to be updated with it.
+    """
+    _env(monkeypatch, tmp_path)
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "40")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+    src = tmp_path / "note.txt"
+    src.write_text(
+        "alpha beta gamma delta epsilon\n\nzeta eta theta iota kappa\n\n"
+        "lambda mu nu xi omicron\n\npi rho sigma tau upsilon",
+        encoding="utf-8",
+    )
+    assert cli.main(["ingest", str(src)]) == 0
+
+    class _EveryChunkFails:
+        def __init__(self):
+            self.calls = 0
+
+        def extract_facts(self, *, source_text, schema_hint=""):
+            self.calls += 1
+            raise LLMError("provider down")
+
+    client = _EveryChunkFails()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+
+    rc = cli.main(["sync"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    # Non-vacuity: at one chunk the failed count below stops discriminating.
+    assert client.calls > 1, (
+        f"the source did not split ({client.calls} chunk); a per-source count "
+        "would satisfy the failed count below too"
+    )
+    assert (
+        f"{client.calls} chunk(s) failed, 0/{client.calls} complete" in captured.err
+    )
+    assert "sync failed" in captured.err
+    assert "sync incomplete" not in captured.err
+
+
 def test_sync_partial_chunk_failure_exits_nonzero(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
     monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "40")


### PR DESCRIPTION
Two commits for #270. **The issue stays open** — the provider lane still needs a
human-supplied `OPENAI_API_KEY` in the `provider-contract` environment, and
`gh secret list` is empty at both repository and environment scope.

**1. `fix: drop a sync exit-code assertion no CLI has ever satisfied`** — the
#239 guard asserted `total_rc != partial_rc`, which has never held: the deleted
test was run from each commit's own tree at `86a2ea3` and every one of the 132
later commits touching `verinote/`, 133 runs, zero passes. It would have failed
the lane on its first real run whatever the provider did. Its one unique
assertion — a multi-chunk `0/T` tally, caught by nothing else in the suite —
moves into `tests/test_cli.py`.

**2. `test: run the deterministic replay guards in the default suite`** — five
replay guards need no provider, key or network (measured under a socket blocker
with a biting control), so both the marker and the `require_opt_in` parameter
come off. Two detectors land with them: a plain promotion has **three** silently
green reversions, and without both detectors the promotion can be undone with no
red anywhere.

**Gates.** Architect, Critic and Reviewer measured each frozen candidate
independently. Suite 2856 passed / 14 skipped (2849/19 before Part 1, 2848/20 at
`4c4502b`); `run.sh` with the gate unset still exits 1; ruff 0.15.18 clean.

Two docstrings claiming the replays are "expected to fail" on main were stale in
both files — the #237 and #238 fixes are ancestors of the commit that added the
guards, so the red they describe was impossible from birth.

Refs #469. Verified against synthetic fixtures only.