### PR TITLE
fix(ingest): 추출기가 매핑 못 한 NUL 을 U+FFFD 로 치환하고 몇 자를 잃었는지 기록한다

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -16,7 +16,7 @@ recompiled from your questions, and `policy/logic-policy.dl` can be re-scaffolde
 | `kb.sqlite` | facts, sources, questions | it records **every accept/reject decision and the full audit log** |
 | `facts.duckdb` | the canonical logical fact terms | see below — it is **not** rebuildable from `kb.sqlite` |
 | `sources/` | the documents you ingested, byte for byte | verinote never re-downloads them |
-| `artifacts/` | the extracted text of each source | `kb.sqlite` stores only its path and checksum, not the text. Re-derivable by re-ingesting — but only while `sources/` survives |
+| `artifacts/` | the extracted text of each source | `kb.sqlite` stores only its path, its checksum, and how many characters the extractor could not read — not the text. Re-derivable by re-ingesting — but only while `sources/` survives |
 | `policy/logic-policy.dl` | your review rules | scaffolded by `init`; `policy reset` only restores the default, never your edits |
 | `policy/relation-aliases.md` | raw → canonical relation names | written by hand or by the Settings UI |
 | `policy/typed-relations.md` | typed relation declarations | hand-written; nothing in verinote writes it |

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -499,12 +499,22 @@ _RE_UPLOAD_ONLY_NOTE = "; re-upload to fix</span>"
 def _block_the_extraction_worker(monkeypatch) -> list[int]:
     """Let the upload route queue its job, and let no worker touch the KB.
 
-    `ExtractionJobBusyError` is the one outcome the worker answers by writing
-    nothing at all -- every other exit runs `fail_extraction_job` -- so raising
-    it keeps a background thread from racing the assertions below over the same
-    sqlite file. `get_client` is patched too because it runs FIRST: left real,
-    it would raise on this key-less config and reach the generic handler, which
-    does write. Returns the list of job ids the worker was asked for.
+    `ExtractionJobBusyError` is the exit that fits a test stub. It is not the
+    only silent one -- `PolicyMissingError` and the corrupt-config pair write
+    nothing either, and a job that simply succeeds writes no failure -- but it
+    is the only one meaning "another worker owns this", so it leaves behind
+    neither a KB write nor a logged fault. `fail_extraction_job` is reached
+    from `LLMError` and the generic handler, and those are what a stub has to
+    stay out of.
+
+    Patching `get_client` is defence, not necessity: measured, this file's web
+    tests pass without it, because `get_client` on this config returns an
+    adapter rather than raising -- constructing one needs no key. It stays so
+    that a provider which does demand a key, or a future check placed ahead of
+    the worker's call, yields a stub client here instead of a real
+    `fail_extraction_job` write.
+
+    Returns the list of job ids the worker was asked for.
     """
     from verinote.pipeline import ExtractionJobBusyError
     from verinote.web import app as webapp
@@ -520,17 +530,27 @@ def _block_the_extraction_worker(monkeypatch) -> list[int]:
     return asked
 
 
-def _join_extraction_workers() -> None:
-    """Wait out the threads the upload route starts, by their given name.
+def _join_extraction_worker(store: Store) -> None:
+    """Wait out the worker thread belonging to the job the last upload queued.
 
-    The thread is started synchronously inside the POST, so by the time the
-    response is in hand it is already enumerable -- no window to miss one.
-    Joining rather than sleeping is what makes the row assertions deterministic.
+    Scoped to one job id, read from the store, rather than to every live
+    `verinote-source-extract-*` thread: with a name prefix, a thread another
+    test leaked would be joined here and, if it outlasted the timeout, fail
+    THIS test for it. The id comes from the store and not from the stub's
+    record because the stub runs inside the thread -- reading its list from
+    here would race the very thread being waited for.
+
+    Defence rather than a load-bearing step, and measured as such: with both
+    calls removed the assertions still pass 10/10, since the stub raises before
+    touching anything. It earns its keep the moment that stub does real work.
     """
+    jobs = store.source_extraction_jobs()
+    assert jobs, "the upload queued no extraction job, so nothing was stubbed out"
+    name = f"verinote-source-extract-{int(jobs[0]['id'])}"
     for thread in threading.enumerate():
-        if thread.name.startswith("verinote-source-extract-"):
+        if thread.name == name:
             thread.join(timeout=5.0)
-            assert not thread.is_alive(), f"{thread.name} outlived its join"
+            assert not thread.is_alive(), f"{name} outlived its join"
 
 
 def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_note(
@@ -582,7 +602,7 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
     # watch it fail to clear anything for THIS population.
     response = client.post("/sources", files=upload, follow_redirects=False)
     assert response.status_code == 303
-    _join_extraction_workers()
+    _join_extraction_worker(store)
 
     rows = store.source_artifacts(source_id)
     assert [row["unreadable_chars"] for row in rows] == [None, 7], (
@@ -608,7 +628,7 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
     assert not legacy_file.exists()
     response = client.post("/sources", files=upload, follow_redirects=False)
     assert response.status_code == 303
-    _join_extraction_workers()
+    _join_extraction_worker(store)
 
     html = client.get("/sources").text
     assert "not checked for unreadable characters" not in html
@@ -657,7 +677,7 @@ def test_a_re_upload_clears_the_note_when_the_old_extraction_held_no_nul(
         follow_redirects=False,
     )
     assert response.status_code == 303
-    _join_extraction_workers()
+    _join_extraction_worker(store)
 
     # One row, not two: the digest was reproducible, so the upload updated this
     # artifact instead of sitting a measured sibling next to it.

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -351,3 +351,46 @@ def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx
     assert "unreadable characters not checked" in html
     assert html.count("unreadable character(s)") == 1
     assert html.count("unreadable characters not checked") == 1
+
+
+def _cli_env(monkeypatch, tmp_path):
+    """Point `cli.main` at a fresh KB under tmp_path, as tests/test_cli.py does."""
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+
+
+def test_cli_ingest_warns_how_many_characters_it_could_not_read(
+    tmp_path, monkeypatch, capsys, nulx
+):
+    from verinote import cli
+
+    _cli_env(monkeypatch, tmp_path)
+    src = tmp_path / "lossy.nulx"
+    src.write_bytes("a\x00b\x00c\x00d".encode("utf-8"))
+
+    rc = cli.main(["ingest", str(src)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "3" in captured.err
+    assert "could not be read" in captured.err
+    # The warning is an aside; the citation line stdout already promised stays.
+    assert "ingested" in captured.out and "-> sources/" in captured.out
+
+
+def test_cli_ingest_says_nothing_when_every_character_was_readable(
+    tmp_path, monkeypatch, capsys, nulx
+):
+    """The other half: a warning printed unconditionally would be no warning."""
+    from verinote import cli
+
+    _cli_env(monkeypatch, tmp_path)
+    src = tmp_path / "fine.nulx"
+    src.write_bytes("abcd".encode("utf-8"))
+
+    rc = cli.main(["ingest", str(src)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "could not be read" not in captured.err
+    assert "ingested" in captured.out and "-> sources/" in captured.out

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -24,6 +24,7 @@ from verinote.pipeline.ingest import (
     store_source,
 )
 from verinote.store import Store
+from verinote.text import nfc
 
 
 @pytest.fixture
@@ -106,7 +107,7 @@ def test_every_sink_of_one_ingest_sees_the_same_sanitized_text(tmp_path, nulx):
     it, or the chunks fed to a provider would still carry NUL while the file on
     disk looked clean.
 
-    The job call mirrors `verinote/web/app.py:1937-1946` -- same function, same
+    The job call mirrors `verinote/web/app.py:1936-1945` -- same function, same
     argument order, `source_text=result["text"]` -- so the chunk assertion is
     about the path the uploader actually takes.
     """
@@ -269,6 +270,101 @@ def test_re_registering_without_a_count_keeps_the_one_already_recorded(tmp_path)
 
     assert again == artifact_id
     assert _artifact_count(store, artifact_id) == 7
+    store.close()
+
+
+def _legacy_text_artifact(store: Store, root, citation: str, text: str) -> str:
+    """A row as a pre-#473 verinote left it: no count, digest of raw text.
+
+    The digest is the load-bearing part. Back then nothing sanitized, so the
+    checksum names the text the extractor produced -- NUL and all -- which is
+    what decides whether a later measuring ingest conflicts with this row or
+    sits down beside it. Returns the checksum.
+    """
+    source_id = store.add_source(citation, kind="binary")
+    digest = hashlib.sha256(nfc(text).encode("utf-8")).hexdigest()
+    relpath = f"artifacts/sources/{source_id}/{digest}.txt"
+    artifact_file = root / relpath
+    artifact_file.parent.mkdir(parents=True, exist_ok=True)
+    artifact_file.write_text(text, encoding="utf-8")
+    store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path=relpath,
+        checksum=digest,
+    )
+    return digest
+
+
+def test_a_pre_column_row_that_held_nul_gains_a_second_row_not_a_backfill(
+    tmp_path, nulx
+):
+    """The narrow precondition on that backfill, made executable.
+
+    Re-registering fills in a missing count only for the SAME checksum, and a
+    pre-column row was hashed from unsanitized text. Where that text held NUL,
+    sanitizing moves the digest, so the measuring re-ingest never reaches the
+    conflict target: it INSERTs a second row with the count and the first keeps
+    its NULL for good.
+
+    Documentation that runs, not a mutation guard, and it does not claim to be
+    one: the change it accompanies is prose, and this stays green under
+    `DO UPDATE` -> `DO NOTHING` because nothing here ever conflicts.
+    `test_re_registering_with_a_count_fills_in_one_never_measured` owns that
+    kill, and `test_every_sink_of_one_ingest_sees_the_same_sanitized_text` owns
+    the one for hashing before sanitizing. Its worth is that the claim in
+    `Store.add_source_artifact`'s docstring is now checked by something that
+    executes, instead of by a reader.
+    """
+    store = _store(tmp_path)
+    legacy_digest = _legacy_text_artifact(
+        store, tmp_path, "sources/plan.nulx", _DIRTY
+    )
+    src = tmp_path / "plan.nulx"
+    src.write_bytes(_DIRTY.encode("utf-8"))
+
+    result = ingest_file(store, src, root=tmp_path)
+
+    # Same source: it is the one path, re-ingested, so this is the row the
+    # count would have to land on for a backfill to be possible at all.
+    source_id = int(result["source_id"])
+    rows = store.source_artifacts(source_id)
+    assert len(rows) == 2
+    assert [row["unreadable_chars"] for row in rows] == [None, 7]
+    # The mechanism, spelled out: the digests differ because one is taken over
+    # the NULs and the other over their replacements.
+    clean_digest = hashlib.sha256(_CLEAN.encode("utf-8")).hexdigest()
+    assert legacy_digest != clean_digest
+    assert [row["checksum"] for row in rows] == [legacy_digest, clean_digest]
+    assert int(result["artifact_id"]) == int(rows[1]["id"])
+    store.close()
+
+
+def test_a_pre_column_row_that_held_no_nul_is_backfilled_by_a_re_ingest(
+    tmp_path, nulx
+):
+    """The other side of that precondition: nothing to sanitize, digest holds.
+
+    An unmeasured row over text with no NUL is the case the backfill does
+    reach, and the count it gains is 0 -- the only count such a row could ever
+    have had. Same standing as the test above: it pins the docstring's claim,
+    not a clause, and shares its kills with the re-registration tests.
+    """
+    store = _store(tmp_path)
+    readable = "every character here was readable"
+    legacy_digest = _legacy_text_artifact(
+        store, tmp_path, "sources/plan.nulx", readable
+    )
+    src = tmp_path / "plan.nulx"
+    src.write_bytes(readable.encode("utf-8"))
+
+    result = ingest_file(store, src, root=tmp_path)
+
+    rows = store.source_artifacts(int(result["source_id"]))
+    assert len(rows) == 1, "the digest is unchanged, so this is an update"
+    assert rows[0]["checksum"] == legacy_digest
+    # 0 rather than None: the re-ingest measured, and found nothing lost.
+    assert rows[0]["unreadable_chars"] == 0
     store.close()
 
 

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -53,9 +53,10 @@ def _store(tmp_path) -> Store:
         ("a\x00b", "a�b", 1),
         # Runs and edges, so a count that only looks at the interior fails.
         ("\x00a\x00b\x00c\x00d\x00", "�a�b�c�d�", 5),
-        # The shape from the bug report: `F-13` arrived as `F\x0013`. Deleting
-        # the NUL would silently manufacture the fact `F13`.
-        ("F\x0013", "F�13", 1),
+        # The shape from the bug report, with a placeholder identifier: a hyphen
+        # between two runs of digits arrives as `A\x0001`. Deleting the NUL would
+        # silently manufacture the fact `A01`.
+        ("A\x0001", "A�01", 1),
         # Non-ASCII neighbours: the replacement is per character, not per byte.
         ("가\x00나", "가�나", 1),
         # A replacement character the input already carried is not this
@@ -90,10 +91,11 @@ def test_sanitize_leaves_decomposed_text_decomposed():
     assert result.unreadable_chars == 1
 
 
-# Seven NULs, shaped like the report: a hyphen, a tilde and a run of glyphs the
-# extractor could not map.
-_DIRTY = "F\x0013\nF\x0018\n07/27 \x00 08/02\n가\x00나\x00다\x00라\x00마"
-_CLEAN = "F�13\nF�18\n07/27 � 08/02\n가�나�다�라�마"
+# Seven NULs in the shape the report describes -- a hyphen, a tilde and a run
+# of glyphs the extractor could not map -- over placeholder content. The shape
+# is what the assertions turn on, so nothing is lost by not being the document.
+_DIRTY = "A\x0001\nA\x0002\n01/01 \x00 01/07\n가\x00나\x00다\x00라\x00마"
+_CLEAN = "A�01\nA�02\n01/01 � 01/07\n가�나�다�라�마"
 
 
 def test_every_sink_of_one_ingest_sees_the_same_sanitized_text(tmp_path, nulx):

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -369,9 +369,16 @@ def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx
     # 7 rather than 1: it collides with no other number on the page, so
     # rendering the artifact count, the source id or a literal all fail here.
     assert "7 unreadable character(s)" in html
-    assert "unreadable characters not checked" in html
+    assert "not checked for unreadable characters" in html
+    # Warning colour on the count. Without `.warn-inline` it is the same grey
+    # pill as the `extracted_text` badge beside it, and a real loss would read
+    # lighter than the benign "N pending" further along the row.
+    assert '<span class="badge warn-inline">7 unreadable character(s)</span>' in html
+    # Neither phrase is a substring of the other -- "unreadable character(s)"
+    # carries the parenthesised plural, the note does not -- so these two counts
+    # stay independent.
     assert html.count("unreadable character(s)") == 1
-    assert html.count("unreadable characters not checked") == 1
+    assert html.count("not checked for unreadable characters") == 1
 
 
 def _cli_env(monkeypatch, tmp_path):

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -11,6 +11,7 @@ PDF and never a real filename.
 
 import hashlib
 import sqlite3
+import threading
 import unicodedata
 
 import pytest
@@ -483,6 +484,124 @@ def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx
     # stay independent.
     assert html.count("unreadable character(s)") == 1
     assert html.count("not checked for unreadable characters") == 1
+
+
+_UNMEASURED_NOTE = (
+    '<span class="badge src">not checked for unreadable characters — some may '
+    "remain; delete the source and upload it again to fix</span>"
+)
+
+
+def _block_the_extraction_worker(monkeypatch) -> list[int]:
+    """Let the upload route queue its job, and let no worker touch the KB.
+
+    `ExtractionJobBusyError` is the one outcome the worker answers by writing
+    nothing at all -- every other exit runs `fail_extraction_job` -- so raising
+    it keeps a background thread from racing the assertions below over the same
+    sqlite file. `get_client` is patched too because it runs FIRST: left real,
+    it would raise on this key-less config and reach the generic handler, which
+    does write. Returns the list of job ids the worker was asked for.
+    """
+    from verinote.pipeline import ExtractionJobBusyError
+    from verinote.web import app as webapp
+
+    asked: list[int] = []
+
+    def refuse(_store, _client, *, job_id, **_kwargs):
+        asked.append(job_id)
+        raise ExtractionJobBusyError(f"job {job_id} is not analysed in this test")
+
+    monkeypatch.setattr(webapp, "get_client", lambda _cfg: object())
+    monkeypatch.setattr(webapp, "process_extraction_job", refuse)
+    return asked
+
+
+def _join_extraction_workers() -> None:
+    """Wait out the threads the upload route starts, by their given name.
+
+    The thread is started synchronously inside the POST, so by the time the
+    response is in hand it is already enumerable -- no window to miss one.
+    Joining rather than sleeping is what makes the row assertions deterministic.
+    """
+    for thread in threading.enumerate():
+        if thread.name.startswith("verinote-source-extract-"):
+            thread.join(timeout=5.0)
+            assert not thread.is_alive(), f"{thread.name} outlived its join"
+
+
+def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_note(
+    tmp_path, monkeypatch, nulx
+):
+    """The note has to name something that works, so all three legs run for real.
+
+    A note reading "re-upload to fix" was wrong: an unmeasured row's checksum is
+    over unsanitized text, so the upload adds a measured row instead of filling
+    that one in, and the page keeps rendering both. Leg 2 performs the old
+    wording and shows the note surviving it; leg 3 performs the new one and
+    shows the note gone. Asserting the rendered string alone would not tell
+    those two apart -- either wording renders fine.
+    """
+    asked = _block_the_extraction_worker(monkeypatch)
+    client = _sources_client(tmp_path)
+    store = client.app.state.store
+
+    # A source as a pre-#473 verinote left it: the original file, an artifact
+    # hashed over text that still holds its NULs, and no count.
+    upload = {"file": ("plan.nulx", _DIRTY.encode("utf-8"), "application/octet-stream")}
+    source_dir = tmp_path / "sources"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "plan.nulx").write_bytes(_DIRTY.encode("utf-8"))
+    legacy_digest = _legacy_text_artifact(
+        store, tmp_path, "sources/plan.nulx", _DIRTY
+    )
+    source_id = int(store.get_source_by_path("sources/plan.nulx")["id"])
+    legacy_file = tmp_path / f"artifacts/sources/{source_id}/{legacy_digest}.txt"
+
+    # Leg 1: the wording, whole, as the browser receives it. The `.badge src`
+    # class and the em dash are inside the assertion because the reviewer's
+    # earlier assertions couple to them; a substring of the sentence would let
+    # the chip quietly become plain text.
+    html = client.get("/sources").text
+    assert _UNMEASURED_NOTE in html
+    assert "; re-upload to fix" not in html
+    assert html.count("not checked for unreadable characters") == 1
+
+    # Leg 2: do exactly what the old wording asked -- upload the same bytes
+    # again -- and watch it fail to clear anything.
+    response = client.post("/sources", files=upload, follow_redirects=False)
+    assert response.status_code == 303
+    _join_extraction_workers()
+
+    rows = store.source_artifacts(source_id)
+    assert [row["unreadable_chars"] for row in rows] == [None, 7], (
+        "the re-upload sanitized, so it hashed differently and INSERTed; the "
+        "unmeasured row is untouched"
+    )
+    html = client.get("/sources").text
+    assert html.count("not checked for unreadable characters") == 1
+    assert "7 unreadable character(s)" in html, (
+        "both rows render: this is the side-by-side state the comment warns is "
+        "a trap, the stale note above a correct count"
+    )
+
+    # Leg 3: do what the new wording asks. Delete takes the row and its file,
+    # and the upload that follows leaves one measured artifact behind.
+    # Asserted before as well as after: `not exists()` is true of a path that
+    # was never right, and would pass this leg without a delete happening.
+    assert legacy_file.exists()
+    response = client.post(f"/sources/{source_id}/delete", follow_redirects=False)
+    assert response.status_code == 303
+    assert not legacy_file.exists()
+    response = client.post("/sources", files=upload, follow_redirects=False)
+    assert response.status_code == 303
+    _join_extraction_workers()
+
+    html = client.get("/sources").text
+    assert "not checked for unreadable characters" not in html
+    assert "7 unreadable character(s)" in html
+    # Both uploads queued a job and neither was analysed, so nothing above came
+    # from a worker write -- and the stub really did stand in the way.
+    assert len(asked) == 2
 
 
 def _cli_env(monkeypatch, tmp_path):

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -377,10 +377,11 @@ def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx
     # rendering the artifact count, the source id or a literal all fail here.
     assert "7 unreadable character(s)" in html
     assert "not checked for unreadable characters" in html
-    # Warning colour on the count. Without `.warn-inline` it is the same grey
-    # pill as the `extracted_text` badge beside it, and a real loss would read
-    # lighter than the benign "N pending" further along the row.
-    assert '<span class="badge warn-inline">7 unreadable character(s)</span>' in html
+    # The class is the signal -- colour is how this row grades severity -- so it
+    # is worth coupling to. Bare `.warn-inline`, like the "N pending" span
+    # further along the row: with `.badge` added it would be a chip, the same
+    # shape as the `extracted_text` badge beside it, differing only in hue.
+    assert '<span class="warn-inline">7 unreadable character(s)</span>' in html
     # Neither phrase is a substring of the other -- "unreadable character(s)"
     # carries the parenthesised plural, the note does not -- so these two counts
     # stay independent.

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -10,6 +10,7 @@ PDF and never a real filename.
 """
 
 import hashlib
+import sqlite3
 import unicodedata
 
 import pytest
@@ -170,3 +171,126 @@ def test_store_source_sanitizes_text_uploads_too(tmp_path):
     # extraction, and the file a fact cites must stay what was uploaded.
     assert (tmp_path / "sources" / "notes.txt").read_bytes() == b"a\x00b"
     store.close()
+
+
+def _artifact_count(store: Store, artifact_id: int):
+    """The stored `unreadable_chars`, read straight off the row.
+
+    Read from the DB rather than the returned dict on purpose: sanitizing the
+    text correctly and never persisting the count is exactly the half-done
+    state the display layer would then be unable to report.
+    """
+    return store.get_source_artifact(artifact_id)["unreadable_chars"]
+
+
+def test_ingest_persists_the_count_on_the_artifact_row(tmp_path, nulx):
+    store = _store(tmp_path)
+    dirty = tmp_path / "dirty.nulx"
+    dirty.write_bytes(_DIRTY.encode("utf-8"))
+    clean = tmp_path / "clean.nulx"
+    clean.write_bytes("all of this is readable".encode("utf-8"))
+
+    dirty_result = ingest_file(store, dirty, root=tmp_path)
+    clean_result = ingest_file(store, clean, root=tmp_path)
+
+    assert _artifact_count(store, int(dirty_result["artifact_id"])) == 7
+    # 0, not NULL: this extraction was measured and lost nothing.
+    assert _artifact_count(store, int(clean_result["artifact_id"])) == 0
+    store.close()
+
+
+def test_an_artifact_registered_without_a_count_stays_unmeasured(tmp_path):
+    """A caller that does not measure must not be recorded as having found zero."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/legacy.txt", kind="text")
+
+    artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path="artifacts/sources/1/abc.txt",
+        checksum="abc",
+    )
+
+    assert _artifact_count(store, artifact_id) is None
+    store.close()
+
+
+def test_re_registering_without_a_count_keeps_the_one_already_recorded(tmp_path):
+    """Re-ingesting identical text must not erase a count with a missing one.
+
+    Same (source, kind, checksum) is the conflict the insert already tolerated;
+    the count now rides along, so the clause has to prefer a real number on
+    either side over the None a non-measuring caller passes.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/doc.txt", kind="text")
+    artifact_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path="artifacts/sources/1/abc.txt",
+        checksum="abc",
+        unreadable_chars=7,
+    )
+
+    again = store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path="artifacts/sources/1/abc.txt",
+        checksum="abc",
+    )
+
+    assert again == artifact_id
+    assert _artifact_count(store, artifact_id) == 7
+    store.close()
+
+
+def test_a_kb_written_before_the_column_existed_gains_it_on_open(tmp_path):
+    """The only guard on the migration: schema.sql cannot fix an existing table.
+
+    `init_schema()` runs schema.sql before `_ensure_schema_migrations()`, and
+    that script's `CREATE TABLE IF NOT EXISTS` does nothing to a table that is
+    already there. So deleting the column from the canonical DDL would leave
+    this passing, while deleting the ALTER breaks every KB that predates #473.
+
+    Column existence alone is not enough to assert -- a column nothing can read
+    or write is not a migration -- so this also round-trips a value through it.
+    """
+    db_path = tmp_path / "kb.sqlite"
+    store = Store(db_path)
+    store.init_schema()
+    source_id = store.add_source("sources/old.txt", kind="text")
+    legacy_id = store.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path="artifacts/sources/1/old.txt",
+        checksum="old",
+        unreadable_chars=4,
+    )
+    store.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("ALTER TABLE source_artifacts DROP COLUMN unreadable_chars")
+    conn.commit()
+    conn.close()
+
+    reopened = Store(db_path)
+    reopened.init_schema()
+
+    columns = {
+        row["name"]
+        for row in reopened._conn.execute("PRAGMA table_info(source_artifacts)")
+    }
+    assert "unreadable_chars" in columns
+    # The pre-existing row comes back unmeasured, not zero: the count it once
+    # had went with the column, and inventing one here would be a lie.
+    assert _artifact_count(reopened, legacy_id) is None
+
+    fresh_id = reopened.add_source_artifact(
+        source_id=source_id,
+        kind="extracted_text",
+        path="artifacts/sources/1/new.txt",
+        checksum="new",
+        unreadable_chars=3,
+    )
+    assert _artifact_count(reopened, fresh_id) == 3
+    reopened.close()

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -126,13 +126,20 @@ def test_every_sink_of_one_ingest_sees_the_same_sanitized_text(tmp_path, nulx):
         chunk_overlap_chars=None,
     )
 
+    # Every NUL-absence check below is paired with the exact expected string,
+    # and with the length: replacement preserves it, deletion would lose seven.
+    # NUL-absence on its own passes for `replace("\x00", "")` -- the silent
+    # removal the issue rejected as option (a).
     artifact_text = (tmp_path / result["artifact_path"]).read_text(encoding="utf-8")
     assert "\x00" not in artifact_text
     assert artifact_text == _CLEAN
+    assert len(artifact_text) == len(_DIRTY)
 
     chunks = store.source_chunks(job_id)
-    assert chunks, "the job must have produced chunks for this assertion to mean anything"
-    assert all("\x00" not in chunk["text"] for chunk in chunks)
+    assert [chunk["text"] for chunk in chunks] == [_CLEAN], (
+        "the fixture is far shorter than one chunk, so the chunk table is the "
+        "sanitized text exactly once -- NUL-free is not enough to assert here"
+    )
 
     digest = hashlib.sha256(_CLEAN.encode("utf-8")).hexdigest()
     artifact = store.get_source_artifact(int(result["artifact_id"]))

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -294,3 +294,60 @@ def test_a_kb_written_before_the_column_existed_gains_it_on_open(tmp_path):
     )
     assert _artifact_count(reopened, fresh_id) == 3
     reopened.close()
+
+
+def _sources_client(tmp_path):
+    """A local TestClient, deliberately not `tests/test_web.py`'s shared `_client`.
+
+    Local so this file's rows cannot collide with another lane's fixtures, and a
+    real client rather than a hand-built dict because `web/app.py:1425` is what
+    turns each artifact row into the mapping the template indexes -- rendering a
+    dict made here would skip exactly that step.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from verinote.config import Config
+    from verinote.web import create_app
+
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    return TestClient(create_app(cfg))
+
+
+def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx):
+    """Three rows, one GET: a lossy artifact, a clean one, and a legacy NULL one."""
+    client = _sources_client(tmp_path)
+    store = client.app.state.store
+
+    dirty = tmp_path / "dirty.nulx"
+    dirty.write_bytes(_DIRTY.encode("utf-8"))
+    ingest_file(store, dirty, root=tmp_path)
+
+    clean = tmp_path / "clean.nulx"
+    clean.write_bytes("every character here was readable".encode("utf-8"))
+    ingest_file(store, clean, root=tmp_path)
+
+    # A row as an older verinote wrote it: registered without a count.
+    legacy_id = store.add_source("sources/legacy.txt", kind="text")
+    store.add_source_artifact(
+        source_id=legacy_id,
+        kind="extracted_text",
+        path=f"artifacts/sources/{legacy_id}/legacy.txt",
+        checksum="legacy",
+    )
+
+    html = client.get("/sources").text
+
+    # 7 rather than 1: it collides with no other number on the page, so
+    # rendering the artifact count, the source id or a literal all fail here.
+    assert "7 unreadable character(s)" in html
+    assert "unreadable characters not checked" in html
+    assert html.count("unreadable character(s)") == 1
+    assert html.count("unreadable characters not checked") == 1

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -215,6 +215,36 @@ def test_an_artifact_registered_without_a_count_stays_unmeasured(tmp_path):
     store.close()
 
 
+def _artifact_key(source_id: int) -> dict:
+    """One (source_id, kind, checksum) — the conflict target of the insert."""
+    return {
+        "source_id": source_id,
+        "kind": "extracted_text",
+        "path": f"artifacts/sources/{source_id}/abc.txt",
+        "checksum": "abc",
+    }
+
+
+def test_re_registering_with_a_count_fills_in_one_never_measured(tmp_path):
+    """An unmeasured row gains its count when something re-ingests and measures.
+
+    This is the direction `DO UPDATE` adds, and the reason the clause changed.
+    The opposite direction -- a missing count leaving an existing one alone --
+    is a property the old `DO NOTHING` had for free, so a suite that asserted
+    only that would stay green with the clause reverted.
+    """
+    store = _store(tmp_path)
+    key = _artifact_key(store.add_source("sources/doc.txt", kind="text"))
+    artifact_id = store.add_source_artifact(**key)
+    assert _artifact_count(store, artifact_id) is None
+
+    again = store.add_source_artifact(**key, unreadable_chars=7)
+
+    assert again == artifact_id
+    assert _artifact_count(store, artifact_id) == 7
+    store.close()
+
+
 def test_re_registering_without_a_count_keeps_the_one_already_recorded(tmp_path):
     """Re-ingesting identical text must not erase a count with a missing one.
 
@@ -223,21 +253,10 @@ def test_re_registering_without_a_count_keeps_the_one_already_recorded(tmp_path)
     either side over the None a non-measuring caller passes.
     """
     store = _store(tmp_path)
-    source_id = store.add_source("sources/doc.txt", kind="text")
-    artifact_id = store.add_source_artifact(
-        source_id=source_id,
-        kind="extracted_text",
-        path="artifacts/sources/1/abc.txt",
-        checksum="abc",
-        unreadable_chars=7,
-    )
+    key = _artifact_key(store.add_source("sources/doc.txt", kind="text"))
+    artifact_id = store.add_source_artifact(**key, unreadable_chars=7)
 
-    again = store.add_source_artifact(
-        source_id=source_id,
-        kind="extracted_text",
-        path="artifacts/sources/1/abc.txt",
-        checksum="abc",
-    )
+    again = store.add_source_artifact(**key)
 
     assert again == artifact_id
     assert _artifact_count(store, artifact_id) == 7
@@ -372,8 +391,11 @@ def test_cli_ingest_warns_how_many_characters_it_could_not_read(
 
     captured = capsys.readouterr()
     assert rc == 0
-    assert "3" in captured.err
-    assert "could not be read" in captured.err
+    # Anchored on both sides of the number. A bare `"3" in err` passes for any
+    # count, or none, because the warning interpolates `args.path` and a pytest
+    # tmp path supplies stray digits; and without the leading `warning: ` the
+    # phrase is still a suffix of a wrong count like "103 character(s)".
+    assert "warning: 3 character(s) could not be read" in captured.err
     # The warning is an aside; the citation line stdout already promised stays.
     assert "ingested" in captured.out and "-> sources/" in captured.out
 

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MPL-2.0
+"""#473: a NUL the extractor could not map must not enter the KB unremarked.
+
+pypdf emits `\\x00` for a glyph whose font has no ToUnicode map. Those NULs
+reached the artifact file and `source_chunks.text` untouched. Here we pin the
+replacement, the count, and the three places the count has to surface.
+
+All input is synthetic: a `.nulx` converter registered per test, never a real
+PDF and never a real filename.
+"""
+
+import hashlib
+import unicodedata
+
+import pytest
+
+from verinote.pipeline.extract import create_chunked_extraction_job
+from verinote.pipeline.ingest import (
+    _CONVERTERS,
+    ingest_file,
+    register_converter,
+    sanitize_extracted_text,
+    store_source,
+)
+from verinote.store import Store
+
+
+@pytest.fixture
+def nulx():
+    """A converter for a made-up binary extension that passes bytes through.
+
+    Stands in for pypdf without needing a PDF: the point under test is what
+    ingest does with whatever the converter hands back, and a real document
+    would put real data in the repository.
+    """
+    register_converter(".nulx", lambda raw: raw.decode("utf-8"))
+    yield
+    _CONVERTERS.pop(".nulx", None)
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+@pytest.mark.parametrize(
+    "raw, expected_text, expected_count",
+    [
+        # Nothing to do: text without NUL comes back identical and counts zero.
+        ("clean text", "clean text", 0),
+        ("a\x00b", "a�b", 1),
+        # Runs and edges, so a count that only looks at the interior fails.
+        ("\x00a\x00b\x00c\x00d\x00", "�a�b�c�d�", 5),
+        # The shape from the bug report: `F-13` arrived as `F\x0013`. Deleting
+        # the NUL would silently manufacture the fact `F13`.
+        ("F\x0013", "F�13", 1),
+        # Non-ASCII neighbours: the replacement is per character, not per byte.
+        ("가\x00나", "가�나", 1),
+        # A replacement character the input already carried is not this
+        # extraction's loss: two NULs in, three U+FFFD out, count is 2.
+        ("�\x00\x00", "���", 2),
+        # Only NUL. `\x0c` is pdftotext's page separator and the rest are
+        # ordinary whitespace -- widening to Cc would eat all four.
+        ("\t\n\r\x0c", "\t\n\r\x0c", 0),
+    ],
+)
+def test_sanitize_replaces_nul_and_counts_the_input(raw, expected_text, expected_count):
+    result = sanitize_extracted_text(raw)
+
+    assert result.text == expected_text
+    assert result.unreadable_chars == expected_count
+
+
+def test_sanitize_leaves_decomposed_text_decomposed():
+    """Sanitizing is not normalizing: NFD in, NFD out, only the NUL changes.
+
+    `store_source` applies `nfc()` first and then sanitizes; if this function
+    also normalized, the order of those two would stop mattering and a later
+    reordering would go unnoticed.
+    """
+    decomposed = unicodedata.normalize("NFD", "가나")
+    assert decomposed != "가나"
+
+    result = sanitize_extracted_text(decomposed[:2] + "\x00" + decomposed[2:])
+
+    assert result.text == decomposed[:2] + "�" + decomposed[2:]
+    assert unicodedata.normalize("NFC", result.text) == "가�나"
+    assert result.unreadable_chars == 1
+
+
+# Seven NULs, shaped like the report: a hyphen, a tilde and a run of glyphs the
+# extractor could not map.
+_DIRTY = "F\x0013\nF\x0018\n07/27 \x00 08/02\n가\x00나\x00다\x00라\x00마"
+_CLEAN = "F�13\nF�18\n07/27 � 08/02\n가�나�다�라�마"
+
+
+def test_every_sink_of_one_ingest_sees_the_same_sanitized_text(tmp_path, nulx):
+    """Artifact file, chunk rows, checksum and returned count, in one ingest.
+
+    Sanitizing in only some of `store_source`'s sinks is the failure this
+    catches: the digest naming the artifact would stop matching the bytes in
+    it, or the chunks fed to a provider would still carry NUL while the file on
+    disk looked clean.
+
+    The job call mirrors `verinote/web/app.py:1937-1946` -- same function, same
+    argument order, `source_text=result["text"]` -- so the chunk assertion is
+    about the path the uploader actually takes.
+    """
+    store = _store(tmp_path)
+    src = tmp_path / "plan.nulx"
+    src.write_bytes(_DIRTY.encode("utf-8"))
+
+    result = ingest_file(store, src, root=tmp_path)
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=int(result["source_id"]),
+        artifact_id=int(result["artifact_id"]),
+        source_text=result["text"],
+        provider="anthropic",
+        model="m",
+        chunk_chars=None,
+        chunk_overlap_chars=None,
+    )
+
+    artifact_text = (tmp_path / result["artifact_path"]).read_text(encoding="utf-8")
+    assert "\x00" not in artifact_text
+    assert artifact_text == _CLEAN
+
+    chunks = store.source_chunks(job_id)
+    assert chunks, "the job must have produced chunks for this assertion to mean anything"
+    assert all("\x00" not in chunk["text"] for chunk in chunks)
+
+    digest = hashlib.sha256(_CLEAN.encode("utf-8")).hexdigest()
+    artifact = store.get_source_artifact(int(result["artifact_id"]))
+    assert artifact["checksum"] == digest
+    assert result["artifact_path"].endswith(f"{digest}.txt")
+
+    assert result["unreadable_chars"] == 7
+    store.close()
+
+
+def test_a_clean_ingest_reports_zero_not_none(tmp_path, nulx):
+    """0 and None are different answers; an ingest that ran always knows a number."""
+    store = _store(tmp_path)
+    src = tmp_path / "clean.nulx"
+    src.write_bytes("nothing was lost here".encode("utf-8"))
+
+    result = ingest_file(store, src, root=tmp_path)
+
+    assert result["unreadable_chars"] == 0
+    assert result["text"] == "nothing was lost here"
+    store.close()
+
+
+def test_store_source_sanitizes_text_uploads_too(tmp_path):
+    """The single decision point is in `store_source`, not in the pdf converter.
+
+    A `.txt` upload never touches a converter, so if the replacement lived in
+    `_convert_pdf` this text would reach the artifact with its NUL intact.
+    """
+    store = _store(tmp_path)
+
+    result = store_source(store, tmp_path, "notes.txt", b"a\x00b", "a\x00b", "text")
+
+    assert result["text"] == "a�b"
+    assert result["unreadable_chars"] == 1
+    assert (tmp_path / result["artifact_path"]).read_text(encoding="utf-8") == "a�b"
+    # The original upload is kept byte-for-byte: sanitizing is about the
+    # extraction, and the file a fact cites must stay what was uploaded.
+    assert (tmp_path / "sources" / "notes.txt").read_bytes() == b"a\x00b"
+    store.close()

--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -318,9 +318,7 @@ def test_a_pre_column_row_that_held_nul_gains_a_second_row_not_a_backfill(
     executes, instead of by a reader.
     """
     store = _store(tmp_path)
-    legacy_digest = _legacy_text_artifact(
-        store, tmp_path, "sources/plan.nulx", _DIRTY
-    )
+    legacy_digest = _legacy_text_artifact(store, tmp_path, "sources/plan.nulx", _DIRTY)
     src = tmp_path / "plan.nulx"
     src.write_bytes(_DIRTY.encode("utf-8"))
 
@@ -341,9 +339,7 @@ def test_a_pre_column_row_that_held_nul_gains_a_second_row_not_a_backfill(
     store.close()
 
 
-def test_a_pre_column_row_that_held_no_nul_is_backfilled_by_a_re_ingest(
-    tmp_path, nulx
-):
+def test_a_pre_column_row_that_held_no_nul_is_backfilled_by_a_re_ingest(tmp_path, nulx):
     """The other side of that precondition: nothing to sanitize, digest holds.
 
     An unmeasured row over text with no NUL is the case the backfill does
@@ -488,8 +484,16 @@ def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx
 
 _UNMEASURED_NOTE = (
     '<span class="badge src">not checked for unreadable characters — some may '
-    "remain; delete the source and upload it again to fix</span>"
+    "remain; re-upload to fix, or delete the source and upload it again if "
+    "this note stays</span>"
 )
+
+# The wording this replaced, which told every unmeasured row to delete its
+# source -- destructive, and unnecessary for the majority whose extraction held
+# no NUL. `"; re-upload to fix"` on its own is no longer a regression guard: the
+# new note opens with that clause. The closing tag is what pins the old one.
+_DESTRUCTIVE_FIRST_NOTE = "; delete the source and upload it again to fix</span>"
+_RE_UPLOAD_ONLY_NOTE = "; re-upload to fix</span>"
 
 
 def _block_the_extraction_worker(monkeypatch) -> list[int]:
@@ -532,14 +536,19 @@ def _join_extraction_workers() -> None:
 def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_note(
     tmp_path, monkeypatch, nulx
 ):
-    """The note has to name something that works, so all three legs run for real.
+    """This source is the note's harder population, and both of its clauses run.
 
-    A note reading "re-upload to fix" was wrong: an unmeasured row's checksum is
-    over unsanitized text, so the upload adds a measured row instead of filling
-    that one in, and the page keeps rendering both. Leg 2 performs the old
-    wording and shows the note surviving it; leg 3 performs the new one and
-    shows the note gone. Asserting the rendered string alone would not tell
-    those two apart -- either wording renders fine.
+    The note offers re-upload first and deleting the source only "if this note
+    stays". For an artifact whose unsanitized text held NUL, staying is exactly
+    what it does: the sanitized upload hashes differently, INSERTs a measured
+    row rather than filling this one in, and the page renders both. So leg 2
+    performs the first clause and shows it is not enough here, which is what
+    makes the second clause reachable rather than gratuitous; leg 3 performs
+    the second and shows the note gone. Rendering assertions alone would not
+    separate those -- any wording renders.
+
+    `test_a_re_upload_clears_the_note_when_the_old_extraction_held_no_nul`
+    carries the other population, where the first clause is the whole answer.
     """
     asked = _block_the_extraction_worker(monkeypatch)
     client = _sources_client(tmp_path)
@@ -551,9 +560,7 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
     source_dir = tmp_path / "sources"
     source_dir.mkdir(parents=True, exist_ok=True)
     (source_dir / "plan.nulx").write_bytes(_DIRTY.encode("utf-8"))
-    legacy_digest = _legacy_text_artifact(
-        store, tmp_path, "sources/plan.nulx", _DIRTY
-    )
+    legacy_digest = _legacy_text_artifact(store, tmp_path, "sources/plan.nulx", _DIRTY)
     source_id = int(store.get_source_by_path("sources/plan.nulx")["id"])
     legacy_file = tmp_path / f"artifacts/sources/{source_id}/{legacy_digest}.txt"
 
@@ -563,11 +570,16 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
     # the chip quietly become plain text.
     html = client.get("/sources").text
     assert _UNMEASURED_NOTE in html
-    assert "; re-upload to fix" not in html
+    # Both discarded wordings, pinned by their closing tag. A bare
+    # `"; re-upload to fix"` would match the current note's first clause and
+    # guard nothing; ending at `</span>` is what makes each of these the whole
+    # of a note rather than a prefix of one.
+    assert _RE_UPLOAD_ONLY_NOTE not in html
+    assert _DESTRUCTIVE_FIRST_NOTE not in html
     assert html.count("not checked for unreadable characters") == 1
 
-    # Leg 2: do exactly what the old wording asked -- upload the same bytes
-    # again -- and watch it fail to clear anything.
+    # Leg 2: do what the note says first -- upload the same bytes again -- and
+    # watch it fail to clear anything for THIS population.
     response = client.post("/sources", files=upload, follow_redirects=False)
     assert response.status_code == 303
     _join_extraction_workers()
@@ -578,14 +590,16 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
         "unmeasured row is untouched"
     )
     html = client.get("/sources").text
-    assert html.count("not checked for unreadable characters") == 1
+    assert html.count("not checked for unreadable characters") == 1, (
+        "the note stayed, which is the condition its second clause names"
+    )
     assert "7 unreadable character(s)" in html, (
         "both rows render: this is the side-by-side state the comment warns is "
-        "a trap, the stale note above a correct count"
+        "a sharp edge, the stale note above a correct count"
     )
 
-    # Leg 3: do what the new wording asks. Delete takes the row and its file,
-    # and the upload that follows leaves one measured artifact behind.
+    # Leg 3: the note stayed, so follow its second clause. Delete takes the row
+    # and its file, and the upload after it leaves one measured artifact.
     # Asserted before as well as after: `not exists()` is true of a path that
     # was never right, and would pass this leg without a delete happening.
     assert legacy_file.exists()
@@ -602,6 +616,58 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
     # Both uploads queued a job and neither was analysed, so nothing above came
     # from a worker write -- and the stub really did stand in the way.
     assert len(asked) == 2
+
+
+def test_a_re_upload_clears_the_note_when_the_old_extraction_held_no_nul(
+    tmp_path, monkeypatch, nulx
+):
+    """The note's first clause, on the page, for the population it is meant for.
+
+    Most documents contain no NUL, so most unmeasured rows hash the same before
+    and after sanitizing: the re-upload the note asks for first backfills the
+    row with 0 and the note disappears. That is what makes offering the
+    destructive action second, and only conditionally, honest -- these readers
+    never reach it.
+
+    `test_a_pre_column_row_that_held_no_nul_is_backfilled_by_a_re_ingest` shows
+    the same backfill one layer down. This one is at the layer the wording
+    makes a promise about: the reader sees a note, does what it says, and the
+    note is gone.
+    """
+    _block_the_extraction_worker(monkeypatch)
+    client = _sources_client(tmp_path)
+    store = client.app.state.store
+
+    readable = "every character here was readable"
+    source_dir = tmp_path / "sources"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "plan.nulx").write_bytes(readable.encode("utf-8"))
+    _legacy_text_artifact(store, tmp_path, "sources/plan.nulx", readable)
+    source_id = int(store.get_source_by_path("sources/plan.nulx")["id"])
+
+    # Asserted before as well as after: "the note is gone" is also true of a
+    # page that never rendered one, which would pass this while proving nothing.
+    assert _UNMEASURED_NOTE in client.get("/sources").text
+
+    response = client.post(
+        "/sources",
+        files={
+            "file": ("plan.nulx", readable.encode("utf-8"), "application/octet-stream")
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    _join_extraction_workers()
+
+    # One row, not two: the digest was reproducible, so the upload updated this
+    # artifact instead of sitting a measured sibling next to it.
+    rows = store.source_artifacts(source_id)
+    assert [row["unreadable_chars"] for row in rows] == [0]
+    html = client.get("/sources").text
+    assert "not checked for unreadable characters" not in html
+    # And nothing took its place: 0 is measured and lossless, so this row now
+    # reports neither state. A note swapped for a count would not be a fix.
+    assert "unreadable character(s)" not in html
 
 
 def _cli_env(monkeypatch, tmp_path):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1002,6 +1002,19 @@ def cmd_ingest(cfg: Config, args: argparse.Namespace) -> int:
         store.close()
         return 1
     store.close()
+    unreadable = result["unreadable_chars"]
+    if unreadable:
+        # Not a failure -- the source is ingested and usable -- but the text now
+        # holds U+FFFD where the extractor could not map a glyph, and facts
+        # drawn from it will inherit those gaps. Said on stderr so the citation
+        # line on stdout stays pipeable.
+        print(
+            f"warning: {unreadable} character(s) could not be read from "
+            f"{args.path} and were replaced with U+FFFD; extracting a text "
+            "copy another way (e.g. `pdftotext -layout`) and re-ingesting it "
+            "may recover them",
+            file=sys.stderr,
+        )
     print(f"ingested {args.path} -> {result['citation']} ({result['kind']})")
     print("run `verinote sync` to extract candidate facts from it")
     return 0

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -16,6 +16,7 @@ raise a helpful `IngestError` when it is missing — install with
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from typing import Callable
@@ -25,6 +26,14 @@ from verinote.text import nfc
 
 # Stored as-is, no conversion.
 TEXT_SUFFIXES = {".txt", ".md"}
+
+# What an extraction says where it could not say a character. Extractors emit
+# NUL for a glyph they cannot map (pypdf does this for fonts without a
+# ToUnicode map), and a NUL is not "slightly dirty text": it is a value that
+# breaks differently at each downstream boundary -- exec arguments refuse it,
+# SQLite stores it, and the display layer shows nothing at all. U+FFFD is the
+# one character whose job is to say "something was here and could not be read".
+UNREADABLE_CHAR = "�"
 
 
 class IngestError(RuntimeError):
@@ -73,10 +82,34 @@ register_converter(".docx", _convert_docx)
 register_converter(".pdf", _convert_pdf)
 
 
+@dataclass(frozen=True)
+class SanitizedText:
+    """Extraction text with the NULs replaced, and how many there were."""
+
+    text: str
+    unreadable_chars: int
+
+
+def sanitize_extracted_text(text: str) -> SanitizedText:
+    """Replace NULs the extractor could not map with U+FFFD, and count them.
+
+    The count is of NULs *in the input*, not of U+FFFD in the output: text can
+    already contain a legitimate replacement character, and only the NULs are
+    this extraction's loss.
+
+    Only NUL. Not the other control characters -- `\\x0c` in particular is
+    pdftotext's ordinary page separator, and widening this would delete
+    structure nobody reported as broken.
+    """
+    return SanitizedText(text.replace("\x00", UNREADABLE_CHAR), text.count("\x00"))
+
+
 def ingest_bytes(raw: bytes, filename: str) -> tuple[str, str]:
     """Resolve raw upload bytes to ``(text, kind)``; kind is ``text``/``binary``.
 
-    Raises `IngestError` for unsupported suffixes or conversion failures.
+    Returns the converter's text unchanged: sanitizing happens in `store_source`
+    and nowhere else, so every sink sees one value. Raises `IngestError` for
+    unsupported suffixes or conversion failures.
     """
     suffix = Path(filename).suffix.lower()
     if suffix in TEXT_SUFFIXES:
@@ -92,11 +125,17 @@ def ingest_bytes(raw: bytes, filename: str) -> tuple[str, str]:
 def store_source(
     store: Store, root: Path, filename: str, raw: bytes, text: str, kind: str
 ) -> dict:
-    """Persist an original source and its extraction text artifact."""
+    """Persist an original source and its extraction text artifact.
+
+    Sanitizing happens here and nowhere else. The single reassignment below is
+    what makes the digest, the artifact file, and the returned text one value:
+    a second decision point elsewhere would let them drift apart.
+    """
     sources_dir = root / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
     name = nfc(Path(filename).name)
-    text = nfc(text)
+    extracted = sanitize_extracted_text(nfc(text))
+    text = extracted.text
     source_path = sources_dir / name
     source_path.write_bytes(raw)
     citation = f"sources/{name}"
@@ -123,6 +162,9 @@ def store_source(
         "source_id": source_id,
         "artifact_id": artifact_id,
         "artifact_path": artifact_relpath,
+        # Always an int, 0 when nothing was lost. NULL means "never measured"
+        # and that is a property of a stored row, not of an ingest that ran.
+        "unreadable_chars": extracted.unreadable_chars,
     }
 
 

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -154,6 +154,7 @@ def store_source(
         kind="extracted_text",
         path=artifact_relpath,
         checksum=digest,
+        unreadable_chars=extracted.unreadable_chars,
     )
     return {
         "citation": citation,

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -104,6 +104,10 @@ def sanitize_extracted_text(text: str) -> SanitizedText:
     Only NUL. Not the other control characters -- `\\x0c` in particular is
     pdftotext's ordinary page separator, and widening this would delete
     structure nobody reported as broken.
+
+    Called from exactly one place, `store_source`. Sanitizing in two places
+    would make two decision points about what may enter the KB, and two such
+    points drift apart quietly -- which is how the NULs got in (#473).
     """
     return SanitizedText(text.replace("\x00", UNREADABLE_CHAR), text.count("\x00"))
 

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -11,6 +11,10 @@ The converter table is open: `register_converter('.ext', fn)` adds a format.
 The built-in docx/pdf converters import their (optional) library lazily and
 raise a helpful `IngestError` when it is missing — install with
 `pip install verinote[ingest]`.
+
+A converter returns whatever its library handed it, NULs and all. `store_source`
+is the single place that replaces those with U+FFFD and records how many there
+were (#473), so a new converter neither has to sanitize nor is able to skip it.
 """
 
 from __future__ import annotations

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -956,9 +956,17 @@ class Store:
         `unreadable_chars` is how many characters the extraction could not read
         (#473), and `None` means the caller did not measure. Re-registering an
         existing `(source_id, kind, checksum)` is how a count gets filled in
-        after the fact: a row left unmeasured -- which is every row written
-        before that column existed -- gains the number as soon as something
-        re-ingests the same text and does measure it.
+        after the fact: an unmeasured row gains the number as soon as something
+        re-ingests text that hashes to the SAME checksum and does measure it.
+
+        The same checksum is the whole precondition, and for a row written
+        before this column existed it is a narrow one. That row's checksum is
+        the digest of UNSANITIZED text, so a re-ingest reproduces it only when
+        sanitizing changes nothing -- which is exactly the case where the count
+        is 0. A pre-column extraction that did contain NUL hashes differently
+        once sanitized: the re-ingest INSERTs a second row carrying the count
+        and leaves the original NULL, permanently. Deleting the source is what
+        clears it.
 
         `COALESCE` keeps a caller that did not measure (NULL) from erasing a
         count that was measured. It is not a "highest wins" rule: an explicit 0

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -949,14 +949,23 @@ class Store:
         path: str,
         content_type: str = "text/plain",
         checksum: str = "",
+        unreadable_chars: int | None = None,
     ) -> int:
+        """Register an artifact row; re-registering the same checksum is a no-op.
+
+        `unreadable_chars` is how many characters the extraction could not read
+        (#473); `None` means the caller did not measure, and the conflict clause
+        keeps a count already on the row rather than erasing it with that None.
+        """
         with self._lock:
             self._conn.execute(
                 "INSERT INTO source_artifacts("
-                "source_id, kind, path, content_type, checksum"
-                ") VALUES(?,?,?,?,?) "
-                "ON CONFLICT(source_id, kind, checksum) DO NOTHING",
-                (source_id, kind, path, content_type, checksum),
+                "source_id, kind, path, content_type, checksum, unreadable_chars"
+                ") VALUES(?,?,?,?,?,?) "
+                "ON CONFLICT(source_id, kind, checksum) DO UPDATE SET "
+                "unreadable_chars = COALESCE("
+                "excluded.unreadable_chars, source_artifacts.unreadable_chars)",
+                (source_id, kind, path, content_type, checksum, unreadable_chars),
             )
             row = self._conn.execute(
                 "SELECT id FROM source_artifacts "
@@ -3069,6 +3078,16 @@ class Store:
         if "checksum" not in artifact_columns:
             self._conn.execute(
                 "ALTER TABLE source_artifacts ADD COLUMN checksum TEXT NOT NULL DEFAULT ''"
+            )
+        if "unreadable_chars" not in artifact_columns:
+            # #473. This ALTER, not the column in schema.sql, is what gives an
+            # existing KB the column: init_schema() runs that script first, and
+            # its CREATE TABLE IF NOT EXISTS does nothing to a table that already
+            # exists. No default, so every row predating this reads back NULL --
+            # "never measured", rather than a fabricated zero claiming the
+            # extraction was checked and clean.
+            self._conn.execute(
+                "ALTER TABLE source_artifacts ADD COLUMN unreadable_chars INTEGER"
             )
         job_columns = {
             row["name"]

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -958,9 +958,13 @@ class Store:
         existing `(source_id, kind, checksum)` is how a count gets filled in
         after the fact: a row left unmeasured -- which is every row written
         before that column existed -- gains the number as soon as something
-        re-ingests the same text and does measure it. The COALESCE is the other
-        direction of that rule, and the reason this is not a plain assignment:
-        a caller that did not measure must not erase a count already recorded.
+        re-ingests the same text and does measure it.
+
+        `COALESCE` keeps a caller that did not measure (NULL) from erasing a
+        count that was measured. It is not a "highest wins" rule: an explicit 0
+        overwrites an explicit 5. In practice the unique key is the checksum of
+        the sanitized text, so the same row always carries the same count -- a
+        convention, not a constraint.
         """
         with self._lock:
             self._conn.execute(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -951,11 +951,16 @@ class Store:
         checksum: str = "",
         unreadable_chars: int | None = None,
     ) -> int:
-        """Register an artifact row; re-registering the same checksum is a no-op.
+        """Register an artifact row, or update the one this checksum already has.
 
         `unreadable_chars` is how many characters the extraction could not read
-        (#473); `None` means the caller did not measure, and the conflict clause
-        keeps a count already on the row rather than erasing it with that None.
+        (#473), and `None` means the caller did not measure. Re-registering an
+        existing `(source_id, kind, checksum)` is how a count gets filled in
+        after the fact: a row left unmeasured -- which is every row written
+        before that column existed -- gains the number as soon as something
+        re-ingests the same text and does measure it. The COALESCE is the other
+        direction of that rule, and the reason this is not a plain assignment:
+        a caller that did not measure must not erase a count already recorded.
         """
         with self._lock:
             self._conn.execute(

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -39,6 +39,15 @@ CREATE TABLE IF NOT EXISTS source_artifacts (
     content_type TEXT NOT NULL DEFAULT 'text/plain',
     checksum     TEXT NOT NULL DEFAULT '',
     created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    -- How many characters the extraction could not read (#473). Nullable with
+    -- no default on purpose: NULL means "never measured", which is the truth
+    -- about every artifact written before this column existed, and 0 means an
+    -- extraction ran and lost nothing. A DEFAULT 0 would tell those older rows
+    -- they are clean when nobody ever looked. This line keeps the canonical DDL
+    -- honest; the migration for existing KBs is the ALTER in
+    -- `db.py::_ensure_schema_migrations`, since this script only ever CREATEs
+    -- the table on a KB that does not have one.
+    unreadable_chars INTEGER,
     UNIQUE(source_id, kind, checksum)
 );
 

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -82,16 +82,22 @@
                  Re-analyze, which would meet the same characters again. 0 stays
                  silent: a measured, lossless extraction has nothing to report.
 
-                 The count takes `.warn-inline` (colour only, no new CSS) because a
-                 plain `.badge` here is indistinguishable from the `extracted_text`
-                 badge two spans left, which would leave a real loss looking lighter
-                 than the benign, temporary "N pending" further down this row. The
-                 unmeasured note stays `.src`: it is information, not a warning. #}
+                 The count is bare `.warn-inline`, matching the "N pending" signal
+                 further down this row exactly -- same file, same kind of inline
+                 warning, so a chip here and plain text there would be the
+                 inconsistency. Dropping `.badge` also answers what was actually
+                 wrong better: as a chip the count kept the shape of the
+                 `extracted_text` badge two spans left and differed only in hue,
+                 where plain coloured text differs in shape too. And `.warn-inline`
+                 is meant to stay plain text rather than become a chip. The
+                 unmeasured note keeps `.badge src`: a chip is right for
+                 information, and `.artifact-row .badge` already lays one out.
+                 No new CSS either way. #}
               {% set unreadable = artifact["unreadable_chars"] %}
               {% if unreadable is none %}
-                <span class="src">not checked for unreadable characters — some may remain; re-upload to fix</span>
+                <span class="badge src">not checked for unreadable characters — some may remain; re-upload to fix</span>
               {% elif unreadable %}
-                <span class="badge warn-inline">{{ unreadable }} unreadable character(s)</span>
+                <span class="warn-inline">{{ unreadable }} unreadable character(s)</span>
               {% endif %}
             </div>
           {% endfor %}

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -77,10 +77,38 @@
               {# #473: three states, not two. NULL is an artifact extracted before
                  anyone counted, and it may well be full of unreadable glyphs --
                  rendering it the same as a measured 0 would tell the reader it is
-                 clean on the strength of nobody having looked. It also still holds
-                 whatever the extractor produced, so the note names re-upload, not
-                 Re-analyze, which would meet the same characters again. 0 stays
-                 silent: a measured, lossless extraction has nothing to report.
+                 clean on the strength of nobody having looked. 0 stays silent: a
+                 measured, lossless extraction has nothing to report.
+
+                 The note names deleting the source because re-uploading does not
+                 clear this row. `store_source` hashes the SANITIZED text, and an
+                 unmeasured row was hashed before anything sanitized, so where the
+                 old extraction held NUL the digests differ: the upload INSERTs a
+                 second, measured artifact rather than filling this one in (see
+                 `Store.add_source_artifact`). `_source_inspector_rows` renders
+                 every row `store.source_artifacts` returns, so afterwards the
+                 note and the new "N unreadable character(s)" sit side by side
+                 and the note is there for good. Only `store.delete_source` --
+                 and the file sweep in the delete route beside it -- takes the
+                 row away.
+
+                 Re-analyze is worth naming only while this row is the source's
+                 ONLY text artifact: `reanalyze_source` feeds the chunk job with
+                 the artifact file it names, so it re-reads that unsanitized text
+                 and meets the same characters again. Once a re-upload has landed,
+                 `latest_source_text_artifact` and `source_text_inputs` both pick
+                 by MAX(id), so Re-analyze reads the new clean text -- correct
+                 output, with the stale note still on screen above it.
+
+                 The named action is not free, and the badge does not have room to
+                 say so: `store.delete_source` drops every fact from this source,
+                 and unlike `clear_source_analysis` it does not spare `confirmed`
+                 or `accepted` ones. After a re-upload that is a trap -- the note
+                 and the measured count are adjacent, so a reader following the
+                 note deletes facts a human had already confirmed against the
+                 clean re-extraction. Naming an action that works beats naming one
+                 that does not; sizing that warning is a UX question this comment
+                 is only recording, not settling.
 
                  The count is bare `.warn-inline`, matching the "N pending" signal
                  further down this row exactly -- same file, same kind of inline
@@ -95,7 +123,7 @@
                  No new CSS either way. #}
               {% set unreadable = artifact["unreadable_chars"] %}
               {% if unreadable is none %}
-                <span class="badge src">not checked for unreadable characters — some may remain; re-upload to fix</span>
+                <span class="badge src">not checked for unreadable characters — some may remain; delete the source and upload it again to fix</span>
               {% elif unreadable %}
                 <span class="warn-inline">{{ unreadable }} unreadable character(s)</span>
               {% endif %}

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -77,13 +77,21 @@
               {# #473: three states, not two. NULL is an artifact extracted before
                  anyone counted, and it may well be full of unreadable glyphs --
                  rendering it the same as a measured 0 would tell the reader it is
-                 clean on the strength of nobody having looked. 0 stays silent
-                 because a measured, lossless extraction has nothing to report. #}
+                 clean on the strength of nobody having looked. It also still holds
+                 whatever the extractor produced, so the note names re-upload, not
+                 Re-analyze, which would meet the same characters again. 0 stays
+                 silent: a measured, lossless extraction has nothing to report.
+
+                 The count takes `.warn-inline` (colour only, no new CSS) because a
+                 plain `.badge` here is indistinguishable from the `extracted_text`
+                 badge two spans left, which would leave a real loss looking lighter
+                 than the benign, temporary "N pending" further down this row. The
+                 unmeasured note stays `.src`: it is information, not a warning. #}
               {% set unreadable = artifact["unreadable_chars"] %}
               {% if unreadable is none %}
-                <span class="src">unreadable characters not checked — re-upload to measure</span>
+                <span class="src">not checked for unreadable characters — some may remain; re-upload to fix</span>
               {% elif unreadable %}
-                <span class="badge">{{ unreadable }} unreadable character(s)</span>
+                <span class="badge warn-inline">{{ unreadable }} unreadable character(s)</span>
               {% endif %}
             </div>
           {% endfor %}

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -96,13 +96,17 @@
                  `store.delete_source`, with the file sweep beside it in the
                  delete route, is the only thing that ends it.
 
-                 Re-analyze is worth naming only while this row is the source's
-                 ONLY text artifact: `reanalyze_source` feeds the chunk job with
-                 the artifact file it names, so it re-reads that unsanitized text
-                 and meets the same characters again. Once a re-upload has landed,
-                 `latest_source_text_artifact` and `source_text_inputs` both pick
-                 by MAX(id), so Re-analyze reads the new clean text -- correct
-                 output, with the stale note still on screen above it.
+                 Re-analyze is not a third option, and the predicate deciding
+                 that is MAX(id) -- LATEST, not only. `reanalyze_source` feeds
+                 the chunk job whatever `latest_source_text_artifact` returns,
+                 so while the highest-id text artifact is a pre-#473 one it
+                 re-reads unsanitized text and meets the same characters again;
+                 a legacy KB holding two such rows for one source is still in
+                 that state, which "the source's only artifact" would have got
+                 wrong. Only once a sanitized row lands, taking the highest id,
+                 does Re-analyze -- and `source_text_inputs`, same MAX(id) --
+                 read clean text: correct output, with this stale note still on
+                 screen above it.
 
                  Order matters because the second branch is destructive and the
                  badge has no room to price it: `store.delete_source` drops every

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -74,6 +74,17 @@
             <div class="artifact-row">
               <span class="badge">{{ artifact["kind"] }}</span>
               <code class="truncate" title="{{ artifact["path"] }}">{{ artifact["path"] }}</code>
+              {# #473: three states, not two. NULL is an artifact extracted before
+                 anyone counted, and it may well be full of unreadable glyphs --
+                 rendering it the same as a measured 0 would tell the reader it is
+                 clean on the strength of nobody having looked. 0 stays silent
+                 because a measured, lossless extraction has nothing to report. #}
+              {% set unreadable = artifact["unreadable_chars"] %}
+              {% if unreadable is none %}
+                <span class="src">unreadable characters not checked — re-upload to measure</span>
+              {% elif unreadable %}
+                <span class="badge">{{ unreadable }} unreadable character(s)</span>
+              {% endif %}
             </div>
           {% endfor %}
         </div>

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -80,17 +80,21 @@
                  clean on the strength of nobody having looked. 0 stays silent: a
                  measured, lossless extraction has nothing to report.
 
-                 The note names deleting the source because re-uploading does not
-                 clear this row. `store_source` hashes the SANITIZED text, and an
-                 unmeasured row was hashed before anything sanitized, so where the
-                 old extraction held NUL the digests differ: the upload INSERTs a
-                 second, measured artifact rather than filling this one in (see
-                 `Store.add_source_artifact`). `_source_inspector_rows` renders
-                 every row `store.source_artifacts` returns, so afterwards the
-                 note and the new "N unreadable character(s)" sit side by side
-                 and the note is there for good. Only `store.delete_source` --
-                 and the file sweep in the delete route beside it -- takes the
-                 row away.
+                 NULL is two populations, so the note names an action for each,
+                 the cheap one first. Re-uploading suffices whenever the old
+                 digest is reproducible: `store_source` hashes the SANITIZED
+                 text, and an unmeasured row was hashed before anything
+                 sanitized, so for an extraction that held no NUL the two agree,
+                 the upload backfills THIS row with 0, and the note goes away.
+                 That is most sources -- most documents contain no NUL at all.
+                 Where the old extraction did hold NUL the digests differ, so the
+                 upload INSERTs a second, measured artifact instead of filling
+                 this one in (see `Store.add_source_artifact`), and
+                 `_source_inspector_rows` renders every row
+                 `store.source_artifacts` returns -- the note survives, beside
+                 the new count. That is the "if this note stays" branch, and
+                 `store.delete_source`, with the file sweep beside it in the
+                 delete route, is the only thing that ends it.
 
                  Re-analyze is worth naming only while this row is the source's
                  ONLY text artifact: `reanalyze_source` feeds the chunk job with
@@ -100,15 +104,17 @@
                  by MAX(id), so Re-analyze reads the new clean text -- correct
                  output, with the stale note still on screen above it.
 
-                 The named action is not free, and the badge does not have room to
-                 say so: `store.delete_source` drops every fact from this source,
-                 and unlike `clear_source_analysis` it does not spare `confirmed`
-                 or `accepted` ones. After a re-upload that is a trap -- the note
-                 and the measured count are adjacent, so a reader following the
-                 note deletes facts a human had already confirmed against the
-                 clean re-extraction. Naming an action that works beats naming one
-                 that does not; sizing that warning is a UX question this comment
-                 is only recording, not settling.
+                 Order matters because the second branch is destructive and the
+                 badge has no room to price it: `store.delete_source` drops every
+                 fact from this source and, unlike `clear_source_analysis`, does
+                 not spare `confirmed` or `accepted` ones -- and the Delete
+                 button in the Actions cell submits straight away, with no
+                 confirmation step. Naming re-upload first keeps every reader it
+                 does work for away from that entirely. For the rest it is still
+                 a sharp edge: by then this note sits next to a measured count
+                 taken from a clean re-extraction, so deleting can cost facts a
+                 human already confirmed against it. Sizing that warning is a UX
+                 question this comment records rather than settles.
 
                  The count is bare `.warn-inline`, matching the "N pending" signal
                  further down this row exactly -- same file, same kind of inline
@@ -123,7 +129,7 @@
                  No new CSS either way. #}
               {% set unreadable = artifact["unreadable_chars"] %}
               {% if unreadable is none %}
-                <span class="badge src">not checked for unreadable characters — some may remain; delete the source and upload it again to fix</span>
+                <span class="badge src">not checked for unreadable characters — some may remain; re-upload to fix, or delete the source and upload it again if this note stays</span>
               {% elif unreadable %}
                 <span class="warn-inline">{{ unreadable }} unreadable character(s)</span>
               {% endif %}


### PR DESCRIPTION
`Refs #473` — **자동으로 닫지 않는다.** 아래 "범위 한계" 참조.

## 무엇을 고치나

추출기가 매핑하지 못한 글리프를 `\x00` 으로 뱉으면, 그 NUL 이 검사 없이 아티팩트 파일과 `source_chunks.text` 에 저장됐다. 이 PR 은 **`store_source` 한 곳에서** NUL 을 `U+FFFD` 로 치환하고 **몇 개를 치환했는지 기록**해 Sources 에서 보이게 한다.

조용히 지우지 않는다. 손실은 남되 보이게 만드는 것이 요점이다.

## 판정점이 하나인 이유

정제는 `pipeline/ingest.py::store_source` 의 재대입 한 줄에서 일어난다. 그 뒤로 digest·아티팩트 파일 write·반환 dict **세 싱크가 같은 값**을 본다. `register_converter` 로 등록된 모든 변환기와 두 텍스트 확장자가 여기로 합류한다.

두 곳에서 정제하면 "무엇이 KB 에 들어갈 수 있는가"를 결정하는 지점이 둘이 되고, 그런 둘은 조용히 갈라진다. 테스트가 세 싱크를 **한 테스트에서 동시에** 단언해 그 불변식을 못박는다.

## NUL 로 한정한 근거

하류에서 다르게 깨지는 것은 NUL 뿐이다 — execve argv 는 NUL 종단이라 못 나가고(#474), C 문자열은 잘라먹고, SQLite 는 통과시킨다. `\x0c` 는 pdftotext 계열의 정상 페이지 구분자이고 `\t\n\r` 은 본문이라, Cc 전체로 넓히면 Sources 에 뜨는 숫자 자체가 거짓이 된다. `\t\n\r\x0c` 가 그대로 살아남고 개수에 안 잡히는 것을 테스트가 지킨다.

## NULL 과 0 을 나눈 이유

`source_artifacts.unreadable_chars` 는 nullable 이고 DEFAULT 가 없다.

- `NULL` = **측정된 적 없음** (이 변경 이전 아티팩트)
- `0` = 측정했고 손실 없음

이 구분이 UI 까지 살아 있다. 3분기 표시라 **이전 시대의 아티팩트가 "깨끗함"으로 읽히지 않는다.**

## 범위 한계 — 이 수정은 신규 인제스트에만 적용된다

재분석은 `store_source` 를 다시 타지 않고 디스크에 이미 저장된 아티팩트를 그대로 읽는다 (`web/app.py`, `cli.py` 의 `read_text()`). 따라서 **이미 KB 에 들어간 NUL 은 이 PR 로 사라지지 않으며, 이슈 증상란의 재현 절차(기존 소스에 Re-analyze)는 머지 후에도 동일하게 재현된다.** 이슈 재현란의 pypdf 스니펫도 계속 통과한다 — pypdf 는 여전히 NUL 을 뱉고, 우리가 그것을 저장하지 않을 뿐이다.

기존 소스를 고치려면 삭제 후 재업로드해야 한다. 정제 이전에 만들어진 아티팩트는 Sources 에 `not checked for unreadable characters — some may remain; re-upload to fix` 로 표시된다.

**그래서 `Closes` 가 아니라 `Refs` 다.** 자동으로 닫으면 vacuous close 가 된다.

### 덮지 않은 두 번째 경로

`verinote sync` 는 `<root>/sources/*.txt|*.md` 를 변환기 테이블을 거치지 않고 직접 읽어 `extract_source` → `add_fact_evidence(snippet=...)` 로 넣는다. 이 경로에는 아티팩트 행이 없어 손실을 기록할 자리가 없고, 기록 없이 정제하면 이 이슈가 거부한 "조용한 제거"가 된다. 도달성은 낮지만(변환기 미경유, `.txt`/`.md` 한정) 열려 있는 것은 사실이라 후속 이슈로 분리한다.

### Provenance 에 표시하지 않은 이유

`provenance.html` 이 쓰는 `artifact_path` 는 읽기 쿼리 두 곳이 `a.path AS artifact_path` **단일 컬럼**으로 뽑은 값이라(`a.*` 가 아님), Sources 에서 통한 `SELECT *` 전파가 통하지 않는다. 손실은 fact 가 아니라 소스의 성질이므로 이번 범위는 Sources 로 한정한다.

## 마이그레이션

`init_schema()` 가 `schema.sql` 을 `_ensure_schema_migrations()` 보다 먼저 돌리므로 그쪽 CREATE 는 기존 KB 에 재실행되지 않는다. **`PRAGMA table_info` + `ALTER` 분기가 모든 기존 KB 에 컬럼을 붙이는 유일한 코드**이고, 그것을 지키는 유일한 가드가 레거시 KB 테스트(행 심기 → DROP → 재오픈 → `is None` → 새 행 왕복)다.

`schema.sql` 의 컬럼 줄은 정본 DDL 의 정직성용이다 — 지워도 기능이 도는 구조라 그 줄을 죽이는 테스트는 존재할 수 없다. 리뷰가 지킨다.

## 검증

- 커밋 9개, 각각 단독 green. 순서 의존(컬럼 → 템플릿) 준수.
- 워크트리 기준선 `2876 passed, 14 skipped` → `2895 passed, 14 skipped` (신규 19).
- `ruff check` 통과. `app.css` **0줄 변경.**
- 뮤테이션 21종 실행. `schema.sql` 컬럼 줄 삭제 하나만 생존(위 구조적 사유). 단독 가드로 죽는 것들: `ALTER` 분기→레거시 KB 테스트, `DO UPDATE`→`DO NOTHING` 복귀→승격 테스트, `COALESCE` 삭제→back-fill 테스트, 개수를 출력 FFFD 수로→`"�\x00\x00"` 픽스처.
- CLI 개수 단언은 `warning:` 접두까지 앵커해 임시 경로의 숫자와 무관함을 두 종류 basetemp 에서 확인했다.
