### PR TITLE
fix(llm): claude CLI 어댑터의 인코딩·디코딩 실패를 LLMError 로 정규화한다

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -506,6 +506,11 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     # over that cap today and loses its last sentence there; this pins that this
     # constant does not. (`verinote/pipeline/ask.py` keeps a second copy of
     # `_short_reason` with the same cap.)
+    #
+    # Only for THIS prefix, though: `query.py:387` composes a much longer one and
+    # does truncate this message -- mid-word, even when the reason it prepends is
+    # empty. That site is over budget on its own and closing it is a separate
+    # change; what is pinned here is that this constant is not what put it there.
     prefixed = f"llm error: {message}"
     assert _short_reason(prefixed) == prefixed
 

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -254,3 +254,27 @@ def test_claude_cli_surfaces_an_unknown_model_id_instead_of_substituting_one(tmp
 
     with pytest.raises(LLMError, match="claude-nonexistent-9"):
         ClaudeCliAdapter(_cfg(tmp_path, model="claude-nonexistent-9")).extract_facts(source_text="x")
+
+
+# --- one subprocess call site, shared by both command shapes ---
+
+
+def test_claude_cli_routes_every_command_shape_through_one_call_site(tmp_path, monkeypatch):
+    """The bug this refactor precedes (#474) was a missing `except` clause that had
+    to be added twice because the body was copy-pasted twice. A shape that skips
+    `_invoke` would keep its own copy of the clauses and drift again."""
+    seen = []
+
+    def recorder(self, cmd):
+        seen.append(cmd)
+        return '{"facts":[]}'
+
+    monkeypatch.setattr(ClaudeCliAdapter, "_invoke", recorder)
+    adapter = ClaudeCliAdapter(_cfg(tmp_path))
+
+    adapter.extract_facts(source_text="x")  # --json-schema path
+    adapter.answer_question(question="Who?", context="c")  # plain-text path
+
+    assert len(seen) == 2
+    assert "--json-schema" in seen[0]
+    assert "--json-schema" not in seen[1]

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -441,11 +441,14 @@ def test_claude_cli_unsendable_text_says_what_to_do_about_it(tmp_path, monkeypat
 
 @pytest.mark.parametrize("invoke", _INVOCATIONS)
 def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkeypatch, invoke):
-    """`text=True` decodes the CLI's stdout as strict UTF-8, so a mangled *reply*
-    also surfaces as a `ValueError` (`UnicodeDecodeError` is one). Same exception
-    family, opposite direction, opposite advice: nothing is wrong with the source
-    text here, and telling the user to go edit their document would send them
-    hunting for a character that is not there.
+    """`text=True` decodes the CLI's stdout AND its stderr as strict UTF-8, so a
+    mangled byte on *either* stream surfaces as a `ValueError` (`UnicodeDecodeError`
+    is one). Same exception family as the argument clause, opposite direction, and
+    the advice cannot be the argument clause's: this says nothing about which stream
+    carried the bytes, so "go edit your document" would be a claim the code never
+    made. It cannot even promise the answer was lost -- a valid JSON reply on stdout
+    is thrown away just the same when one byte of the log beside it will not decode
+    -- so the message names the operation that failed and stops there.
 
     This clause also may not quote its cause, which is why the absence assertions
     below are as load-bearing as the presence one. `UnicodeDecodeError`'s text is
@@ -468,6 +471,15 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     assert "0xff" not in message  # a byte of the model's output
     assert "position" not in message  # its offset
     assert "codec" not in message  # the decoder's own phrasing, i.e. the raw cause
+
+    # Pinned in full, not by substring: the failure mode this clause has already
+    # shown is a sentence drifting into a claim the code never made. Any edit to
+    # the wording turns this red and makes someone read it again.
+    assert message == (
+        "claude CLI request failed: the CLI's output was not valid UTF-8 and could "
+        "not be read. Reading the CLI's output is what failed, not sending your "
+        "text. If it fails the same way again, check the claude CLI's version."
+    )
 
 
 @pytest.mark.parametrize("invoke", _INVOCATIONS)

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -401,9 +401,12 @@ def test_claude_cli_unpaired_surrogate_in_the_text_is_llm_error(tmp_path, monkey
     from the same call, which the same clause has to cover.
 
     U+D800 specifically, because it is outside the U+DC80..U+DCFF band that
-    surrogateescape round-trips to bytes. `\\udcff` and friends encode fine and
-    would make this test pass against a NUL-only fix (see the test below, which
-    pins that they keep working).
+    surrogateescape round-trips to bytes. A character from inside that band cannot
+    stand in for it: `\\udcff` raises no encoding error at all, so the call runs on
+    and dies at the absent binary `_no_claude_on_path` leaves behind, reporting
+    `claude CLI not found` -- which makes both assertions below false, the second
+    of them by naming the very message it forbids. Round-tripping text is the
+    subject of the test after this one, which pins that it still reaches the CLI.
     """
     _no_claude_on_path(tmp_path, monkeypatch)
 

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import subprocess
+import tempfile
 from types import SimpleNamespace
 
 import pytest
@@ -415,6 +416,15 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     family, opposite direction, opposite advice: nothing is wrong with the source
     text here, and telling the user to go edit their document would send them
     hunting for a character that is not there.
+
+    This clause also may not quote its cause, which is why the absence assertions
+    below are as load-bearing as the presence one. `UnicodeDecodeError`'s text is
+    `'utf-8' codec can't decode byte 0xff in position 0: invalid start byte` -- a
+    byte value and an offset read out of the model's reply, which is derived from
+    the user's document. Interpolating it into a message that travels to a job row
+    and the UI turns an error message into a content oracle. The argument clause
+    interpolates *its* cause (pinned by the test above) precisely because the
+    character it names cannot be document content; here it can be.
     """
     _fake_claude(tmp_path, monkeypatch, r"printf '\xff\xfe'")
 
@@ -425,6 +435,9 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     assert "was not valid UTF-8" in message
     assert "re-ingest" not in message
     assert "Remove it from the source" not in message
+    assert "0xff" not in message  # a byte of the model's output
+    assert "position" not in message  # its offset
+    assert "codec" not in message  # the decoder's own phrasing, i.e. the raw cause
 
 
 @pytest.mark.parametrize("invoke", _INVOCATIONS)
@@ -447,6 +460,79 @@ def test_claude_cli_os_error_is_llm_error(tmp_path, monkeypatch, invoke):
 
     with pytest.raises(LLMError, match="request failed"):
         invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "x")
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_unusable_temp_directory_is_llm_error(tmp_path, monkeypatch, invoke):
+    """The scratch directory the CLI runs in is part of making the call, so failing
+    to create it (a full disk, an unwritable TMPDIR) is a failed LLM call and must
+    arrive as one.
+
+    Not hypothetical: merging the two call sites moved the `with` out of the `try`,
+    and this `OSError` went from `LLMError` to escaping raw -- straight onto the web
+    worker's generic branch as "analysis failed: [Errno 28] ...", the same shape
+    #474 was reported as.
+    """
+    def boom(**kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", boom)
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada")
+
+    assert "request failed" in str(excinfo.value)
+    assert "No space left on device" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_failing_temp_directory_cleanup_is_llm_error(tmp_path, monkeypatch, invoke):
+    """`TemporaryDirectory.__exit__` removes the tree and can fail doing it. The
+    call itself already succeeded, but the exception still comes out of this
+    function, so it is still this function's job to normalise it -- the same reason
+    the creation failure above is caught.
+    """
+    class _CleanupFails:
+        def __enter__(self):
+            return str(tmp_path)
+
+        def __exit__(self, *exc_info):
+            raise OSError(39, "Directory not empty")
+
+    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", lambda **kwargs: _CleanupFails())
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada")
+
+    assert "request failed" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, OSError)
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_only_blames_the_argument_for_the_argument(tmp_path, monkeypatch, invoke):
+    """`except ValueError` is only safe because it wraps `subprocess.run` ALONE.
+
+    `ValueError` is a domain type in this repo -- `CorroborationPolicyError`
+    subclasses it -- so a clause that says "your text contains a character that
+    cannot be sent" would be lying about any other `ValueError` raised anywhere
+    inside the guarded region. Keeping that region one statement wide is the whole
+    defence, and this pins it: a `ValueError` from a *different* statement (temp
+    directory setup) must come out as itself, not relabelled.
+
+    Without this, moving the `with` back inside the shared `try` is invisible.
+    """
+    def boom(**kwargs):
+        raise ValueError("something else entirely")
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", boom)
+
+    # Not `LLMError`: it subclasses RuntimeError, so this would not match.
+    with pytest.raises(ValueError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada")
+
+    assert "cannot travel in a command-line argument" not in str(excinfo.value)
 
 
 def _raise(exc):
@@ -566,9 +652,12 @@ def test_one_unsendable_chunk_fails_alone_and_the_job_keeps_going(tmp_path, monk
 
     job = store.get_extraction_job(job_id)
     assert job["status"] == "failed"
-    # The web worker's `except LLMError` branch is what produces this wording; the
-    # generic `except Exception` branch says "analysis failed: <python error>"
-    # instead, which is the symptom #474 was reported as.
+    # Written by `_refresh_extraction_job` (`store/db.py:3336`), NOT by the web
+    # worker: with the fix in place the `LLMError` never leaves
+    # `process_extraction_job` (`extract.py:459-461` swallows it per chunk), so
+    # neither of the worker's branches runs at all. Before the fix the `ValueError`
+    # tore through that loop and the worker's generic `except Exception` wrote
+    # "analysis failed: embedded null byte" -- the symptom #474 was reported as.
     assert str(job["message"]).startswith("Analysis failed: 1 chunk(s) failed, 1/2 complete")
 
     chunks = store.source_chunks(job_id)

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -18,6 +18,7 @@ from verinote.pipeline.extract import (
     create_chunked_extraction_job,
     process_extraction_job,
 )
+from verinote.pipeline.query import _short_reason
 from verinote.prompts import save_prompt_override
 from verinote.store import Store
 
@@ -454,14 +455,20 @@ def test_claude_cli_unsendable_text_says_what_to_do_about_it(tmp_path, monkeypat
 
 @pytest.mark.parametrize("invoke", _INVOCATIONS)
 def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkeypatch, invoke):
-    """`text=True` decodes the CLI's stdout AND its stderr as strict UTF-8, so a
-    mangled byte on *either* stream surfaces as a `ValueError` (`UnicodeDecodeError`
-    is one). Same exception family as the argument clause, opposite direction, and
-    the advice cannot be the argument clause's: this says nothing about which stream
-    carried the bytes, so "go edit your document" would be a claim the code never
-    made. It cannot even promise the answer was lost -- a valid JSON reply on stdout
-    is thrown away just the same when one byte of the log beside it will not decode
-    -- so the message names the operation that failed and stops there.
+    """`text=True` decodes BOTH of the CLI's streams in the interpreter's locale
+    encoding -- UTF-8 wherever this runs today -- so a mangled byte on *either* one
+    surfaces as a `ValueError` (`UnicodeDecodeError` is one). Same exception family
+    as the argument clause, opposite direction, and the advice cannot be the
+    argument clause's: this says nothing about which stream carried the bytes, so
+    "go edit your document" would be a claim the code never made. It cannot even
+    promise the answer was lost -- a valid JSON reply on stdout is thrown away just
+    the same when one byte of the log beside it will not decode.
+
+    What is left to say is the little this clause does know. The literal pinned
+    below names the failed operation, states that the argv was accepted so the text
+    got as far as the CLI, and points at the CLI's version. It stops short of "your
+    text was sent": the CLI may have failed to relay it onward and be reporting that
+    in the very bytes that will not decode.
 
     This clause also may not quote its cause, which is why the absence assertions
     below are as load-bearing as the presence one. `UnicodeDecodeError`'s text is
@@ -490,9 +497,17 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     # the wording turns this red and makes someone read it again.
     assert message == (
         "claude CLI request failed: the CLI's output was not valid UTF-8 and could "
-        "not be read. Reading the CLI's output is what failed, not sending your "
-        "text. If it fails the same way again, check the claude CLI's version."
+        "not be read. The text reached the CLI; it is the CLI's output that could "
+        "not be read. Check the claude CLI's version if it recurs."
     )
+
+    # The reason that reaches a job row goes through `_short_reason`'s 240-char
+    # cap with an `llm error: ` prefix already on it. `_UNSENDABLE_ARGUMENT` is
+    # over that cap today and loses its last sentence there; this pins that this
+    # constant does not. (`verinote/pipeline/ask.py` keeps a second copy of
+    # `_short_reason` with the same cap.)
+    prefixed = f"llm error: {message}"
+    assert _short_reason(prefixed) == prefixed
 
 
 @pytest.mark.parametrize("invoke", _INVOCATIONS)
@@ -644,6 +659,8 @@ def test_claude_cli_cause_table_mirrors_every_except_clause_in_source():
     `except OSError` -- because it is the clause list this has to line up with.
     """
     source = textwrap.dedent(inspect.getsource(ClaudeCliAdapter._invoke))
+    # `ast.walk` descends into any nested function too, so a helper defined inside
+    # `_invoke` would contribute its clauses here. There is none today.
     handlers = sorted(
         (node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.ExceptHandler)),
         key=lambda node: node.lineno,

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -507,10 +507,13 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     # constant does not. (`verinote/pipeline/ask.py` keeps a second copy of
     # `_short_reason` with the same cap.)
     #
-    # Only for THIS prefix, though: `query.py:387` composes a much longer one and
-    # does truncate this message -- mid-word, even when the reason it prepends is
-    # empty. That site is over budget on its own and closing it is a separate
-    # change; what is pinned here is that this constant is not what put it there.
+    # Only for THIS prefix, though. `query.py:387` puts a variable reason and a
+    # much longer fixed clause in front of the message before the same cap
+    # applies, so the message's share of the room there is far smaller than it is
+    # here -- too small for this constant even when that reason is empty, and the
+    # tail goes mid-word. The reason and the message share that room between them;
+    # which of the two gives is a separate change. What the assertion below pins
+    # is only that this message arrives whole on the `llm error: ` path.
     prefixed = f"llm error: {message}"
     assert _short_reason(prefixed) == prefixed
 

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -8,7 +8,12 @@ from verinote.config import Config
 from verinote.llm.base import LLMError
 from verinote.llm.claude_cli_adapter import ClaudeCliAdapter
 from verinote.llm.factory import get_client
+from verinote.pipeline.extract import (
+    create_chunked_extraction_job,
+    process_extraction_job,
+)
 from verinote.prompts import save_prompt_override
+from verinote.store import Store
 
 
 def _cfg(tmp_path, *, model: str = "", llm_timeout_seconds: float = 600.0) -> Config:
@@ -510,3 +515,68 @@ def test_claude_cli_does_not_swallow_a_programming_error(tmp_path, monkeypatch, 
 
     with pytest.raises(TypeError):
         invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds="not-a-number")), "Ada")
+
+
+# --- one unsendable chunk must not discard the rest of the job (#474) --------
+
+
+def test_one_unsendable_chunk_fails_alone_and_the_job_keeps_going(tmp_path, monkeypatch):
+    """The whole point of normalising to `LLMError`, exercised end to end.
+
+    `process_extraction_job` catches `LLMError` per chunk, marks that chunk failed
+    and moves on; anything else escapes the loop and takes the job with it. So the
+    NUL goes in chunk *zero* deliberately -- ORDER IS WHAT MAKES THIS TEST MEAN
+    ANYTHING. With it in the last chunk, the earlier chunks would already have been
+    committed before the crash and every assertion below would pass against the
+    unfixed adapter. In chunk zero, the unfixed adapter kills the loop on the first
+    iteration: chunk one is never claimed, no candidate is ever written, and
+    `process_extraction_job` raises instead of returning.
+
+    A real `claude` on PATH, not a stub, for the same reason as the tests above:
+    the `ValueError` has to come from CPython refusing to build the argv.
+    """
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    source_id = store.add_source("doc.txt")
+    # Two paragraphs, each under the chunk size, over it together -> two chunks.
+    # No overlap, or chunk zero's NUL would be copied into chunk one's prefix and
+    # both chunks would fail. Nothing here matches `_ROLE_CUE_RE`: a match would
+    # make the pipeline issue a second, focused extraction call per chunk.
+    text = (
+        "Ada Lovelace was a mathematician.\x00 She wrote notes on the engine.\n\n"
+        "Grace Hopper was a computer scientist. She built early compilers."
+    )
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        source_text=text,
+        provider="claudecli",
+        model="",
+        chunk_chars=120,
+        chunk_overlap_chars=0,
+    )
+    assert [c["chunk_index"] for c in store.source_chunks(job_id)] == [0, 1]
+    assert "\x00" in store.source_chunks(job_id)[0]["text"]
+    assert "\x00" not in store.source_chunks(job_id)[1]["text"]
+
+    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+
+    # Returns; before the fix the ValueError escaped this call entirely.
+    process_extraction_job(store, ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), job_id=job_id)
+
+    job = store.get_extraction_job(job_id)
+    assert job["status"] == "failed"
+    # The web worker's `except LLMError` branch is what produces this wording; the
+    # generic `except Exception` branch says "analysis failed: <python error>"
+    # instead, which is the symptom #474 was reported as.
+    assert str(job["message"]).startswith("Analysis failed: 1 chunk(s) failed, 1/2 complete")
+
+    chunks = store.source_chunks(job_id)
+    assert chunks[0]["status"] == "failed"
+    assert "cannot travel in a command-line argument" in str(chunks[0]["error"])
+    assert chunks[1]["status"] == "done"  # `pending` before the fix: never reached
+    # The job's candidate tally can only have come from chunk one -- chunk zero
+    # never reached the LLM.
+    assert int(job["candidate_count"]) > 0
+    assert len(store.facts()) >= 1  # zero before the fix
+    store.close()

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -23,6 +23,46 @@ def _cfg(tmp_path, *, model: str = "", llm_timeout_seconds: float = 600.0) -> Co
     )
 
 
+# The two command shapes, as the *caller* reaches them: `extract_facts` goes
+# through `_run` (--json-schema), `answer_question` through `_run_text`. Both take
+# the text under test as the `-p` argument, which is where an unsendable character
+# stops the call. Parametrizing on these is what makes a fix applied to only one
+# shape visible -- the shape of #474 itself, whose `except` clauses were copy-pasted
+# and drifted.
+_INVOCATIONS = [
+    pytest.param(lambda a, text: a.extract_facts(source_text=text), id="extract_facts"),
+    pytest.param(lambda a, text: a.answer_question(question=text, context="c"), id="answer_question"),
+]
+
+_FACT_JSON = (
+    '{"facts":[{"subject":"Ada","relation":"is_a",'
+    '"object":"mathematician","confidence":0.9}]}'
+)
+
+
+def _no_claude_on_path(tmp_path, monkeypatch) -> None:
+    """PATH with no `claude` on it, so a real `subprocess.run` cannot reach one.
+
+    Used by the argument-encoding tests, which must NOT stub `subprocess.run`: a
+    stub that raises `ValueError` on demand only proves the `except` clause catches
+    what the stub throws. The point is that CPython raises it for real, before any
+    process is spawned -- which is also why an absent binary does not matter here.
+    """
+    empty = tmp_path / "empty-bin"
+    empty.mkdir(exist_ok=True)
+    monkeypatch.setenv("PATH", str(empty))
+
+
+def _fake_claude(tmp_path, monkeypatch, body: str) -> None:
+    """Put a `claude` on PATH that runs `body` -- a real process, real pipes."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    script = bindir / "claude"
+    script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    script.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bindir))
+
+
 def test_factory_selects_claude_cli_adapter(tmp_path):
     assert isinstance(get_client(_cfg(tmp_path)), ClaudeCliAdapter)
 
@@ -95,14 +135,15 @@ def test_claude_cli_normalizes_display_model_names(tmp_path, monkeypatch):
     assert commands[0][0:3] == ["claude", "--model", "opus"]
 
 
-def test_claude_cli_missing_binary_is_llm_error(tmp_path, monkeypatch):
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_missing_binary_is_llm_error(tmp_path, monkeypatch, invoke):
     def fake_run(cmd, **kwargs):
         raise FileNotFoundError
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     with pytest.raises(LLMError, match="claude CLI not found"):
-        ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="x")
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "x")
 
 
 def test_claude_cli_nonzero_is_llm_error(tmp_path, monkeypatch):
@@ -278,3 +319,194 @@ def test_claude_cli_routes_every_command_shape_through_one_call_site(tmp_path, m
     assert len(seen) == 2
     assert "--json-schema" in seen[0]
     assert "--json-schema" not in seen[1]
+
+
+# --- text that cannot travel in an exec argument (#474) ---
+#
+# A chunk carrying a NUL made `subprocess.run` raise `ValueError: embedded null
+# byte` *before spawning anything*, and neither call site caught it. The job died
+# on the web worker's generic `except Exception` branch as "analysis failed:
+# embedded null byte" -- a Python internal, on the wrong branch, for a failure
+# that is squarely an LLM-call failure.
+#
+# None of these stub `subprocess.run`. CPython raising the error for real is the
+# whole claim; a stub that raises on demand would only test the stub.
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_nul_in_the_text_is_llm_error(tmp_path, monkeypatch, invoke):
+    _no_claude_on_path(tmp_path, monkeypatch)
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada\x00Lovelace")
+
+    message = str(excinfo.value)
+    assert "cannot travel in a command-line argument" in message
+    # The argument list is encoded before PATH is even consulted, so an absent
+    # binary must NOT be what gets reported. Blaming the install for a bad
+    # character sends the user to fix something that is not broken.
+    assert "claude CLI not found" not in message
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_unpaired_surrogate_in_the_text_is_llm_error(tmp_path, monkeypatch, invoke):
+    """NUL is not the only unsendable character: `os.fsencode` refuses a surrogate
+    it cannot round-trip, raising `UnicodeEncodeError` -- a *different* exception
+    from the same call, which the same clause has to cover.
+
+    U+D800 specifically, because it is outside the U+DC80..U+DCFF band that
+    surrogateescape round-trips to bytes. `\\udcff` and friends encode fine and
+    would make this test pass against a NUL-only fix (see the test below, which
+    pins that they keep working).
+    """
+    _no_claude_on_path(tmp_path, monkeypatch)
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada\ud800Lovelace")
+
+    message = str(excinfo.value)
+    assert "cannot travel in a command-line argument" in message
+    assert "claude CLI not found" not in message
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_still_sends_a_surrogate_that_round_trips(tmp_path, monkeypatch, invoke):
+    """U+DC80..U+DCFF is how surrogateescape carries an undecodable *byte*, and
+    `os.fsencode` turns it straight back into that byte. Such text reaches the CLI
+    today and must keep reaching it: rejecting it up front -- the tempting
+    "validate the string before calling" fix -- would refuse work that succeeds.
+    """
+    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+
+    result = invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada\udcffLovelace")
+
+    assert result  # the CLI really ran and its reply came back
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_unsendable_text_says_what_to_do_about_it(tmp_path, monkeypatch, invoke):
+    """`embedded null byte` names a C-level fact about argv. The user needs the
+    thing they can act on: which text is at fault and what to do with it.
+
+    Asserted as literals rather than against the module constant on purpose --
+    importing the constant would compare the message to itself and pass for any
+    wording at all, including none.
+    """
+    _no_claude_on_path(tmp_path, monkeypatch)
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada\x00Lovelace")
+
+    message = str(excinfo.value)
+    assert "cannot travel in a command-line argument" in message  # what is wrong
+    assert "re-ingest that source" in message  # what to do next
+    assert "embedded null byte" in message  # the original cause, still legible
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkeypatch, invoke):
+    """`text=True` decodes the CLI's stdout as strict UTF-8, so a mangled *reply*
+    also surfaces as a `ValueError` (`UnicodeDecodeError` is one). Same exception
+    family, opposite direction, opposite advice: nothing is wrong with the source
+    text here, and telling the user to go edit their document would send them
+    hunting for a character that is not there.
+    """
+    _fake_claude(tmp_path, monkeypatch, r"printf '\xff\xfe'")
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada Lovelace")
+
+    message = str(excinfo.value)
+    assert "was not valid UTF-8" in message
+    assert "re-ingest" not in message
+    assert "Remove it from the source" not in message
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_timeout_is_llm_error(tmp_path, monkeypatch, invoke):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 5.0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(LLMError, match="timed out"):
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "x")
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_os_error_is_llm_error(tmp_path, monkeypatch, invoke):
+    def fake_run(cmd, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(LLMError, match="request failed"):
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "x")
+
+
+def _raise(exc):
+    def fake_run(cmd, **kwargs):
+        raise exc
+
+    return fake_run
+
+
+def _stub(exc):
+    def setup(tmp_path, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", _raise(exc))
+
+    return setup
+
+
+# One entry per `except` clause in `_invoke`, each with text that reaches it: the
+# argument clause needs a NUL, the rest must NOT have one or they would trip that
+# clause first.
+_CAUSES = [
+    pytest.param(_stub(FileNotFoundError()), "Ada", FileNotFoundError, id="missing-binary"),
+    pytest.param(
+        _stub(subprocess.TimeoutExpired(["claude"], 5.0)),
+        "Ada",
+        subprocess.TimeoutExpired,
+        id="timeout",
+    ),
+    pytest.param(_stub(PermissionError(13, "Permission denied")), "Ada", OSError, id="os-error"),
+    pytest.param(
+        lambda tmp_path, monkeypatch: _fake_claude(tmp_path, monkeypatch, r"printf '\xff\xfe'"),
+        "Ada",
+        UnicodeDecodeError,
+        id="undecodable-reply",
+    ),
+    pytest.param(_no_claude_on_path, "Ada\x00Lovelace", ValueError, id="unsendable-argument"),
+]
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+@pytest.mark.parametrize(("setup", "text", "expected_cause"), _CAUSES)
+def test_claude_cli_keeps_the_original_exception_as_the_cause(
+    tmp_path, monkeypatch, invoke, setup, text, expected_cause
+):
+    """Every clause chains with `from exc`. The `LLMError` text is written for a
+    human, which means it drops detail; a traceback with no `__cause__` leaves
+    nowhere to recover that detail when the human message turns out to be wrong
+    about what happened.
+    """
+    setup(tmp_path, monkeypatch)
+
+    with pytest.raises(LLMError) as excinfo:
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), text)
+
+    assert isinstance(excinfo.value.__cause__, expected_cause)
+
+
+@pytest.mark.parametrize("invoke", _INVOCATIONS)
+def test_claude_cli_does_not_swallow_a_programming_error(tmp_path, monkeypatch, invoke):
+    """A misconfigured timeout makes `subprocess.run` raise `TypeError` from inside
+    the guarded call. Catching `ValueError` there is only defensible because it
+    stays that narrow: widened to `Exception`, this bug would be reported to the
+    user as "your text contains a bad character" and the real defect -- a
+    non-numeric setting -- would never be seen.
+    """
+    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+
+    with pytest.raises(TypeError):
+        invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds="not-a-number")), "Ada")

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
+import os
+import shlex
 import subprocess
 import tempfile
 from types import SimpleNamespace
@@ -59,14 +61,42 @@ def _no_claude_on_path(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("PATH", str(empty))
 
 
-def _fake_claude(tmp_path, monkeypatch, body: str) -> None:
-    """Put a `claude` on PATH that runs `body` -- a real process, real pipes."""
+def _fake_claude(tmp_path, monkeypatch, reply: bytes) -> None:
+    """Put a `claude` on PATH that writes exactly `reply` -- a real process, real pipes.
+
+    PYTHON WRITES THE BYTES; THE SCRIPT ONLY `cat`s THEM. Nothing the fake emits
+    passes through a shell's escape handling, because that handling is not
+    portable: `printf '\\xff\\xfe'` produces those two bytes under bash and the
+    eight ASCII characters `\\xff\\xfe` under dash. Written that way, the
+    undecodable-reply tests passed on a macOS `/bin/sh` (bash) and, on a CI runner
+    where `/bin/sh` is dash, handed the adapter *valid ASCII* -- so the decode
+    clause was never reached and four tests failed for a reason that had nothing to
+    do with the code under test. `cat` is POSIX-mandated and interprets nothing.
+
+    PATH is PREPENDED, not replaced: the script needs `cat`, and coming first is
+    already enough to shadow a real `claude` on the developer's machine.
+
+    Then the fake is run once and its output checked. A fixture that does not
+    produce `reply` must fail saying *that*, in its own words -- the alternative is
+    what happened above, a broken fixture arriving as a claim about the adapter.
+    """
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
+    payload = tmp_path / "claude-reply.bin"
+    payload.write_bytes(reply)
     script = bindir / "claude"
-    script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    script.write_text(f"#!/bin/sh\ncat {shlex.quote(str(payload))}\n", encoding="utf-8")
     script.chmod(0o755)
-    monkeypatch.setenv("PATH", str(bindir))
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+
+    # Resolved through PATH, under the environment the adapter will see, so this
+    # also proves the shadowing works and not merely that the file was written.
+    proof = subprocess.run(["claude"], capture_output=True, check=False)
+    assert (proof.returncode, proof.stdout) == (0, reply), (
+        f"the FIXTURE is broken, not the adapter: the fake `claude` exited "
+        f"{proof.returncode} emitting {proof.stdout!r}, not the {reply!r} this test "
+        f"is about ({proof.stderr!r})"
+    )
 
 
 def test_factory_selects_claude_cli_adapter(tmp_path):
@@ -382,7 +412,7 @@ def test_claude_cli_still_sends_a_surrogate_that_round_trips(tmp_path, monkeypat
     today and must keep reaching it: rejecting it up front -- the tempting
     "validate the string before calling" fix -- would refuse work that succeeds.
     """
-    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+    _fake_claude(tmp_path, monkeypatch, _FACT_JSON.encode())
 
     result = invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada\udcffLovelace")
 
@@ -426,7 +456,7 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     interpolates *its* cause (pinned by the test above) precisely because the
     character it names cannot be document content; here it can be.
     """
-    _fake_claude(tmp_path, monkeypatch, r"printf '\xff\xfe'")
+    _fake_claude(tmp_path, monkeypatch, b"\xff\xfe")
 
     with pytest.raises(LLMError) as excinfo:
         invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada Lovelace")
@@ -500,7 +530,7 @@ def test_claude_cli_failing_temp_directory_cleanup_is_llm_error(tmp_path, monkey
         def __exit__(self, *exc_info):
             raise OSError(39, "Directory not empty")
 
-    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+    _fake_claude(tmp_path, monkeypatch, _FACT_JSON.encode())
     monkeypatch.setattr(tempfile, "TemporaryDirectory", lambda **kwargs: _CleanupFails())
 
     with pytest.raises(LLMError) as excinfo:
@@ -562,7 +592,7 @@ _CAUSES = [
     ),
     pytest.param(_stub(PermissionError(13, "Permission denied")), "Ada", OSError, id="os-error"),
     pytest.param(
-        lambda tmp_path, monkeypatch: _fake_claude(tmp_path, monkeypatch, r"printf '\xff\xfe'"),
+        lambda tmp_path, monkeypatch: _fake_claude(tmp_path, monkeypatch, b"\xff\xfe"),
         "Ada",
         UnicodeDecodeError,
         id="undecodable-reply",
@@ -597,7 +627,7 @@ def test_claude_cli_does_not_swallow_a_programming_error(tmp_path, monkeypatch, 
     user as "your text contains a bad character" and the real defect -- a
     non-numeric setting -- would never be seen.
     """
-    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+    _fake_claude(tmp_path, monkeypatch, _FACT_JSON.encode())
 
     with pytest.raises(TypeError):
         invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds="not-a-number")), "Ada")
@@ -645,7 +675,7 @@ def test_one_unsendable_chunk_fails_alone_and_the_job_keeps_going(tmp_path, monk
     assert "\x00" in store.source_chunks(job_id)[0]["text"]
     assert "\x00" not in store.source_chunks(job_id)[1]["text"]
 
-    _fake_claude(tmp_path, monkeypatch, f"printf '%s' '{_FACT_JSON}'")
+    _fake_claude(tmp_path, monkeypatch, _FACT_JSON.encode())
 
     # Returns; before the fix the ValueError escaped this call entirely.
     process_extraction_job(store, ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), job_id=job_id)

--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
+import ast
+import inspect
 import os
 import shlex
 import subprocess
 import tempfile
+import textwrap
 from types import SimpleNamespace
 
 import pytest
@@ -97,6 +100,13 @@ def _fake_claude(tmp_path, monkeypatch, reply: bytes) -> None:
         f"{proof.returncode} emitting {proof.stdout!r}, not the {reply!r} this test "
         f"is about ({proof.stderr!r})"
     )
+
+
+def _unusable_temp_directory(tmp_path, monkeypatch) -> None:
+    def boom(**kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(tempfile, "TemporaryDirectory", boom)
 
 
 def test_factory_selects_claude_cli_adapter(tmp_path):
@@ -515,10 +525,7 @@ def test_claude_cli_unusable_temp_directory_is_llm_error(tmp_path, monkeypatch, 
     worker's generic branch as "analysis failed: [Errno 28] ...", the same shape
     #474 was reported as.
     """
-    def boom(**kwargs):
-        raise OSError(28, "No space left on device")
-
-    monkeypatch.setattr(tempfile, "TemporaryDirectory", boom)
+    _unusable_temp_directory(tmp_path, monkeypatch)
 
     with pytest.raises(LLMError) as excinfo:
         invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada")
@@ -591,10 +598,13 @@ def _stub(exc):
     return setup
 
 
-# One entry per `except` clause in `_invoke`, each with text that reaches it: the
-# argument clause needs a NUL, the rest must NOT have one or they would trip that
-# clause first.
+# One entry per `except` clause in `_invoke`, in the order the clauses appear, each
+# with text that reaches it: the argument clause needs a NUL, the rest must NOT have
+# one or they would trip that clause first. Neither the count nor the order is
+# maintained by hand -- the test below reads both off `_invoke`'s source and fails
+# when this list stops matching it.
 _CAUSES = [
+    pytest.param(_unusable_temp_directory, "Ada", OSError, id="temp-directory-creation"),
     pytest.param(_stub(FileNotFoundError()), "Ada", FileNotFoundError, id="missing-binary"),
     pytest.param(
         _stub(subprocess.TimeoutExpired(["claude"], 5.0)),
@@ -602,7 +612,6 @@ _CAUSES = [
         subprocess.TimeoutExpired,
         id="timeout",
     ),
-    pytest.param(_stub(PermissionError(13, "Permission denied")), "Ada", OSError, id="os-error"),
     pytest.param(
         lambda tmp_path, monkeypatch: _fake_claude(tmp_path, monkeypatch, b"\xff\xfe"),
         "Ada",
@@ -610,7 +619,40 @@ _CAUSES = [
         id="undecodable-reply",
     ),
     pytest.param(_no_claude_on_path, "Ada\x00Lovelace", ValueError, id="unsendable-argument"),
+    pytest.param(_stub(PermissionError(13, "Permission denied")), "Ada", OSError, id="os-error"),
 ]
+
+
+def test_claude_cli_cause_table_mirrors_every_except_clause_in_source():
+    """`_CAUSES` claims one entry per `except` clause in `_invoke`. That claim was
+    hand-counted once and went stale two commits later, when the temp directory's
+    creation clause was added and the table was not. So it is read off the function
+    instead of retyped.
+
+    MIRRORS, not covers. This holds the table to the source's clause list and
+    nothing more. A clause that no input can reach -- say a `ValueError` subclass
+    placed below the `ValueError` clause -- passes here with an entry that never
+    fires, and the two `OSError` entries could swap places unnoticed because the
+    comparison is by name. Reachability is what the parametrised tests below and
+    mutation runs are for.
+
+    `expected_cause` names the clause's *declared* type, not necessarily the type
+    its setup raises -- the `os-error` entry raises `PermissionError` into
+    `except OSError` -- because it is the clause list this has to line up with.
+    """
+    source = textwrap.dedent(inspect.getsource(ClaudeCliAdapter._invoke))
+    handlers = sorted(
+        (node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.ExceptHandler)),
+        key=lambda node: node.lineno,
+    )
+    # Not vacuous if `_invoke` is ever refactored so the clauses live elsewhere.
+    assert handlers
+    # A bare `except:` would be a defect of its own, and would silently drop out
+    # of the comparison below rather than failing it.
+    assert all(handler.type is not None for handler in handlers)
+    clauses = [ast.unparse(handler.type).rsplit(".", 1)[-1] for handler in handlers]
+
+    assert clauses == [param.values[2].__name__ for param in _CAUSES]
 
 
 @pytest.mark.parametrize("invoke", _INVOCATIONS)

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -143,42 +143,64 @@ class ClaudeCliAdapter:
         """Run `cmd` and return its stdout, or raise `LLMError`.
 
         One body, because the two call sites' copy-pasted `except` clauses missing
-        the same case IS this bug (#474). The `with` is OUTSIDE the `try` so the
-        `try` guards exactly one statement: in this repo `ValueError` is also a
-        domain type (`CorroborationPolicyError` subclasses it), and the only reason
-        a broader `except ValueError` is safe here is that nothing else runs inside.
-        Structure, not a comment.
+        the same case IS this bug (#474). The `with` is OUTSIDE the clause block
+        below so that `try` guards exactly one statement: in this repo `ValueError`
+        is also a domain type (`CorroborationPolicyError` subclasses it), and the
+        only reason a broader `except ValueError` is safe here is that nothing else
+        runs inside. Structure, not a comment.
+
+        Which is why the temp directory is not simply left outside the contract.
+        Creating it (ENOSPC, an unwritable TMPDIR) and cleaning it up can each
+        fail, and §10.1 says every failure of an LLM call reaches the caller as
+        `LLMError` -- landing on the web worker's generic `except Exception` as
+        "analysis failed: [Errno 28] ..." is the exact shape #474 was reported as.
+        So creation gets its own clause and one `except OSError` out here covers the
+        rest. That one may be broad where the `ValueError` above may not, for the
+        reason above: `OSError` is not a domain type in this repo.
         """
-        with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
-            try:
-                proc = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    check=False,
-                    cwd=tmpdir,
-                    stdin=subprocess.DEVNULL,
-                    text=True,
-                    timeout=self.cfg.llm_timeout_seconds,
-                )
-            except FileNotFoundError as exc:
-                raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
-            except subprocess.TimeoutExpired as exc:
-                raise LLMError("claude CLI request timed out") from exc
-            except OSError as exc:
-                raise LLMError(f"claude CLI request failed: {exc}") from exc
-            except UnicodeDecodeError as exc:
-                # The CLI's OUTPUT could not be decoded. Do not tell the user to fix
-                # their source. Constant message: this exception's text carries byte
-                # values and offsets from the model's output, which derives from the
-                # user's document.
-                raise LLMError(_UNDECODABLE_OUTPUT) from exc
-            except ValueError as exc:
-                # The ARGUMENT could not be encoded. MUST stay below
-                # UnicodeDecodeError, which is a ValueError subclass.
-                # `ValueError("embedded null byte")` and `UnicodeEncodeError` are
-                # fixed-shape strings carrying no document content, so qualifying
-                # with them preserves the cause without opening an oracle.
-                raise LLMError(f"{_UNSENDABLE_ARGUMENT} ({type(exc).__name__}: {exc})") from exc
+        try:
+            tmp = tempfile.TemporaryDirectory(prefix="verinote-claudecli-")
+        except OSError as exc:
+            raise LLMError(f"claude CLI request failed: {exc}") from exc
+        try:
+            with tmp as tmpdir:
+                try:
+                    proc = subprocess.run(
+                        cmd,
+                        capture_output=True,
+                        check=False,
+                        cwd=tmpdir,
+                        stdin=subprocess.DEVNULL,
+                        text=True,
+                        timeout=self.cfg.llm_timeout_seconds,
+                    )
+                except FileNotFoundError as exc:
+                    raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
+                except subprocess.TimeoutExpired as exc:
+                    raise LLMError("claude CLI request timed out") from exc
+                except UnicodeDecodeError as exc:
+                    # The CLI's OUTPUT could not be decoded. Do not tell the user to
+                    # fix their source. Constant message: this exception's text
+                    # carries byte values and offsets from the model's output, which
+                    # derives from the user's document.
+                    raise LLMError(_UNDECODABLE_OUTPUT) from exc
+                except ValueError as exc:
+                    # The ARGUMENT could not be encoded. MUST stay below
+                    # UnicodeDecodeError, which is a ValueError subclass. The
+                    # character this names is by definition an unsendable surrogate
+                    # or a NUL, so it is not document content; only a position
+                    # offset leaks, and an offset alone is not an oracle. That is
+                    # what makes qualifying the message with the cause safe here and
+                    # not in the clause above.
+                    raise LLMError(f"{_UNSENDABLE_ARGUMENT} ({type(exc).__name__}: {exc})") from exc
+        except OSError as exc:
+            # Every OSError from the whole region: the spawn's own (a permission
+            # error, a broken pipe -- `FileNotFoundError` is claimed above and does
+            # not reach here) and the directory's cleanup. ONE clause, out here,
+            # because base caught both with one clause and duplicating it inside
+            # buys nothing -- an inner copy is unreachable-by-equivalence, which is
+            # how a handler rots without a single test noticing.
+            raise LLMError(f"claude CLI request failed: {exc}") from exc
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "").strip()
             raise LLMError(f"claude CLI exited with {proc.returncode}: {detail}")

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -50,12 +50,18 @@ _UNSENDABLE_ARGUMENT = (
     "source file and re-ingest that source."
 )
 
-# `text=True` makes subprocess decode the CLI's stdout/stderr as strict UTF-8.
-# This is the CLI's OUTPUT failing, not the source text.
+# `text=True` makes subprocess decode the CLI's stdout AND stderr as strict
+# UTF-8, so either stream can land here. What this clause learns is that those
+# bytes did not decode -- not where they came from, and not that the answer
+# itself was lost: a valid JSON reply on stdout is discarded all the same when
+# one byte of the log beside it will not decode. The source text is one place
+# those bytes can come from -- the U+DC80..U+DCFF band above reaches the CLI as
+# raw 0x80-0xFF and can echo back -- so the message names the operation that
+# failed and claims nothing about the source either way.
 _UNDECODABLE_OUTPUT = (
-    "claude CLI request failed: the CLI's reply was not valid UTF-8 and could "
-    "not be read. Nothing is wrong with the source text -- re-run the analysis, "
-    "and if it keeps happening check the claude CLI's own version."
+    "claude CLI request failed: the CLI's output was not valid UTF-8 and could "
+    "not be read. Reading the CLI's output is what failed, not sending your "
+    "text. If it fails the same way again, check the claude CLI's version."
 )
 
 

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -39,6 +39,25 @@ CLI_MODEL_ALIASES = tuple(_MODEL_ALIASES)
 # names ("Opus 4.8", "Claude Opus") are collapsed to an alias.
 _CANONICAL_MODEL_ID = re.compile(r"^claude-[a-z0-9]+(?:-[a-z0-9]+)+$")
 
+# The CLI takes the prompt as an exec ARGUMENT, and an argument cannot carry
+# every str Python can hold. Two kinds fail, both before the process is spawned:
+# a NUL byte, and a surrogate outside the U+DC80..U+DCFF range that `os.fsencode`
+# round-trips (D800..DC7F, DD00..DFFF -- what `json.loads('"\\ud800"')` yields).
+_UNSENDABLE_ARGUMENT = (
+    "claude CLI request failed: the text could not be sent. It contains a "
+    "character that cannot travel in a command-line argument -- a NUL byte, or "
+    "an unpaired surrogate left behind by a bad decode. Remove it from the "
+    "source file and re-ingest that source."
+)
+
+# `text=True` makes subprocess decode the CLI's stdout/stderr as strict UTF-8.
+# This is the CLI's OUTPUT failing, not the source text.
+_UNDECODABLE_OUTPUT = (
+    "claude CLI request failed: the CLI's reply was not valid UTF-8 and could "
+    "not be read. Nothing is wrong with the source text -- re-run the analysis, "
+    "and if it keeps happening check the claude CLI's own version."
+)
+
 
 class ClaudeCliAdapter:
     name = "ClaudeCLI"
@@ -147,6 +166,19 @@ class ClaudeCliAdapter:
                 raise LLMError("claude CLI request timed out") from exc
             except OSError as exc:
                 raise LLMError(f"claude CLI request failed: {exc}") from exc
+            except UnicodeDecodeError as exc:
+                # The CLI's OUTPUT could not be decoded. Do not tell the user to fix
+                # their source. Constant message: this exception's text carries byte
+                # values and offsets from the model's output, which derives from the
+                # user's document.
+                raise LLMError(_UNDECODABLE_OUTPUT) from exc
+            except ValueError as exc:
+                # The ARGUMENT could not be encoded. MUST stay below
+                # UnicodeDecodeError, which is a ValueError subclass.
+                # `ValueError("embedded null byte")` and `UnicodeEncodeError` are
+                # fixed-shape strings carrying no document content, so qualifying
+                # with them preserves the cause without opening an oracle.
+                raise LLMError(f"{_UNSENDABLE_ARGUMENT} ({type(exc).__name__}: {exc})") from exc
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "").strip()
             raise LLMError(f"claude CLI exited with {proc.returncode}: {detail}")

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -103,27 +103,7 @@ class ClaudeCliAdapter:
         model = _cli_model(self.cfg.model)
         if model:
             cmd = ["claude", "--model", model, *cmd[1:]]
-        try:
-            with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
-                proc = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    check=False,
-                    cwd=tmpdir,
-                    stdin=subprocess.DEVNULL,
-                    text=True,
-                    timeout=self.cfg.llm_timeout_seconds,
-                )
-        except FileNotFoundError as exc:
-            raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise LLMError("claude CLI request timed out") from exc
-        except OSError as exc:
-            raise LLMError(f"claude CLI request failed: {exc}") from exc
-        if proc.returncode != 0:
-            detail = (proc.stderr or proc.stdout or "").strip()
-            raise LLMError(f"claude CLI exited with {proc.returncode}: {detail}")
-        return proc.stdout.strip()
+        return self._invoke(cmd)
 
     def _run_text(self, prompt: "_Prompt") -> str:
         cmd = [
@@ -138,8 +118,20 @@ class ClaudeCliAdapter:
         model = _cli_model(self.cfg.model)
         if model:
             cmd = ["claude", "--model", model, *cmd[1:]]
-        try:
-            with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
+        return self._invoke(cmd)
+
+    def _invoke(self, cmd: list[str]) -> str:
+        """Run `cmd` and return its stdout, or raise `LLMError`.
+
+        One body, because the two call sites' copy-pasted `except` clauses missing
+        the same case IS this bug (#474). The `with` is OUTSIDE the `try` so the
+        `try` guards exactly one statement: in this repo `ValueError` is also a
+        domain type (`CorroborationPolicyError` subclasses it), and the only reason
+        a broader `except ValueError` is safe here is that nothing else runs inside.
+        Structure, not a comment.
+        """
+        with tempfile.TemporaryDirectory(prefix="verinote-claudecli-") as tmpdir:
+            try:
                 proc = subprocess.run(
                     cmd,
                     capture_output=True,
@@ -149,12 +141,12 @@ class ClaudeCliAdapter:
                     text=True,
                     timeout=self.cfg.llm_timeout_seconds,
                 )
-        except FileNotFoundError as exc:
-            raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise LLMError("claude CLI request timed out") from exc
-        except OSError as exc:
-            raise LLMError(f"claude CLI request failed: {exc}") from exc
+            except FileNotFoundError as exc:
+                raise LLMError("claude CLI not found; install Claude Code and ensure `claude` is on PATH") from exc
+            except subprocess.TimeoutExpired as exc:
+                raise LLMError("claude CLI request timed out") from exc
+            except OSError as exc:
+                raise LLMError(f"claude CLI request failed: {exc}") from exc
         if proc.returncode != 0:
             detail = (proc.stderr or proc.stdout or "").strip()
             raise LLMError(f"claude CLI exited with {proc.returncode}: {detail}")

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -50,18 +50,26 @@ _UNSENDABLE_ARGUMENT = (
     "source file and re-ingest that source."
 )
 
-# `text=True` makes subprocess decode the CLI's stdout AND stderr as strict
-# UTF-8, so either stream can land here. What this clause learns is that those
-# bytes did not decode -- not where they came from, and not that the answer
-# itself was lost: a valid JSON reply on stdout is discarded all the same when
-# one byte of the log beside it will not decode. The source text is one place
-# those bytes can come from -- the U+DC80..U+DCFF band above reaches the CLI as
-# raw 0x80-0xFF and can echo back -- so the message names the operation that
-# failed and claims nothing about the source either way.
+# `text=True` makes subprocess decode BOTH of the CLI's streams in the
+# interpreter's locale encoding -- UTF-8 wherever this runs today, so a bad byte
+# on stdout or on stderr can land here. (Under a latin-1 locale nothing fails to
+# decode at all and this clause goes unreachable; pinning `encoding=` so that
+# stops being true is left to the follow-up that owns it.) What this clause
+# learns is that those bytes did not decode -- not which stream carried them,
+# and not that the answer itself was lost: a valid JSON reply on stdout is
+# discarded all the same when one byte of the log beside it will not decode. The
+# source text is one place those bytes can come from -- the U+DC80..U+DCFF band
+# above reaches the CLI as raw 0x80-0xFF and can echo back.
+#
+# So the message names the operation that failed, then states the one thing this
+# code did establish -- the argv was accepted, i.e. the text got as far as the
+# CLI -- and points at the version. It deliberately does NOT say the send
+# succeeded: the CLI may have failed to relay the text onward and be reporting
+# exactly that in the bytes that will not decode.
 _UNDECODABLE_OUTPUT = (
     "claude CLI request failed: the CLI's output was not valid UTF-8 and could "
-    "not be read. Reading the CLI's output is what failed, not sending your "
-    "text. If it fails the same way again, check the claude CLI's version."
+    "not be read. The text reached the CLI; it is the CLI's output that could "
+    "not be read. Check the claude CLI's version if it recurs."
 )
 
 


### PR DESCRIPTION
`Closes #474`

## 무엇을 고치나

`ClaudeCliAdapter` 는 프롬프트를 exec **인자**로 넘기는데, `except` 절이 `FileNotFoundError` / `TimeoutExpired` / `OSError` 뿐이었다. 인자에 NUL 이 있으면 `subprocess.run` 이 `ValueError` 를 던지고, `ValueError` 는 `OSError` 하위가 아니라 안 잡힌다 — 기능 명세 §10.1("모든 실패는 `LLMError` 로 정규화된다")이 깨지는 지점이다.

## 정의역은 NUL 하나가 아니었다

이슈 본문은 NUL 만 보고했지만 실제 구멍은 **`ValueError` 전체**다:

| 입력 | 예외 |
|---|---|
| argv 어느 원소든(argv[0] 포함) 또는 `cwd` 에 NUL | `ValueError("embedded null byte")` |
| `\ud800`, `\udfff`, `\udc7f` 등 | `UnicodeEncodeError` (`ValueError` 하위) |
| **`\udc80`–`\udcff`** | **예외 없음** — `os.fsencode` 의 `surrogateescape` 가 원래 바이트로 되돌린다 |

마지막 줄이 중요하다. 파일을 `surrogateescape` 로 읽어 남은 잔재는 **전부** 그 구간이라 이 경로로는 안 깨진다. 현실적 유입구는 JSON(`json.loads('"\\ud800"')`)이다. 왕복하는 서로게이트가 **정상 통과**하는 것을 회귀 테스트가 지킨다.

## 절을 나눈 이유 — 출력 실패를 입력 탓으로 돌리지 않는다

`text=True` 라서 `subprocess.run` 내부의 stdout/stderr 디코딩이 strict UTF-8 이다. CLI 가 비-UTF-8 을 뱉으면 `UnicodeDecodeError`(역시 `ValueError` 하위)가 **같은 절에 걸린다.** 이건 입력이 아니라 출력의 문제인데, 청크 에러 문자열은 Sources 에 그대로 렌더되므로 한 절로 합치면 사용자를 존재하지 않는 원인으로 보낸다.

절 순서는 정확성의 일부다 — `UnicodeDecodeError` 가 `ValueError` **위**에 있어야 한다. 뒤집으면 디코드 절이 죽은 코드가 되고, 그걸 전용 뮤턴트가 지킨다.

### `errors="replace"` 를 기각한 이유

출력 디코딩을 관대하게 만드는 안은 검토했고 **기각했다.** 깨진 바이트가 JSON 문자열 **값 안에** 있으면 치환문자가 붙은 채 JSON 이 유효해지고 `parse_facts` 를 그대로 통과한다 — 원래 신뢰도 그대로, 경고 한 줄 없이 오염된 후보 사실이 KB 에 들어간다. `schema.py` 가 명시적으로 막으려는 밀반입(#168)을 **파서가 볼 수 있는 층보다 아래에서** 우회하는 셈이다. 시끄러운 실패를 조용한 오염으로 바꾸는 거래라 채택할 수 없다.

## 리댁션은 절별로 다르다

- **디코드 절**: 상수 메시지. `UnicodeDecodeError` 텍스트는 바이트값과 오프셋을 담고 그 바이트는 CLI 가 사용자 문서를 처리한 출력에서 나온다 — 콘텐츠 오라클이다.
- **인자 절**: `({type}: {exc})` 보간. 여기서 드러나는 문자는 정의상 전송 불가능한 서로게이트/NUL 이라 문서 콘텐츠가 아니고, 새는 것은 위치 오프셋뿐이라 오라클이 되지 않는다.

`from exc` 는 다섯 절 모두 유지한다. 추출 경로에 로거가 없어 체인이 렌더되지 않으므로, 인자 절의 보간이 원인을 남기는 유일한 수단이다.

## 하류에서 실제로 달라지는 것

수정 전에는 `ValueError` 가 청크 루프를 뚫고 나가 **잡 전체가 죽었다** — 뒤 청크는 처리조차 되지 않았다. 수정 후에는 청크별 `except LLMError` 가 잡아 그 청크만 실패로 적고 루프가 완주한다.

**잡은 여전히 `failed` 로 끝난다.** 바뀌는 것은 메시지 생성지(`app.py` → `_refresh_extraction_job`)와, **성공한 청크들의 candidate 가 KB 에 남는다는 것**이다. 통합 테스트가 그것을 단언한다 — NUL 을 첫 번째 청크에 넣어야 비공허하다(뒤 청크에 넣으면 앞 청크가 수정 전에도 커밋돼 테스트가 무의미해진다).

## `refactor:` 라벨에 대한 정정

`d903c53` 은 `refactor:` 를 달고 있지만 **무동작변경이 아니었다.** `with tempfile.TemporaryDirectory()` 를 `try` 밖으로 뺀 결과 그 생성이 던지는 `OSError`(ENOSPC 등)가 어떤 절에도 안 걸리게 됐고, 하필 이 PR 이 고치려는 계약의 후퇴였다:

```
e957d5a : LLMError: claude CLI request failed: [Errno 28] No space left on device
b98941c : RAW OSError            ← 회귀
c61e464 : base 와 문자 단위로 동일한 LLMError   ← 복구
```

`c61e464` 가 창설 절을 따로 두고 정리 실패까지 덮는 region-wide 절로 복원한다. 히스토리를 다시 쓰지 않고 후속 커밋이 명시적으로 정정하는 쪽을 택했다 — 계획이 옳다고 믿었고 프로브가 반증했다는 기록이 남는 편이 낫다.

## 범위

이 PR 은 `claude_cli_adapter.py` 로 한정한다. **같은 계약 위반이 다른 어댑터에도 있다** — anthropic/openai/openrouter 의 `client = self._client()` 와 ollama 의 `urllib.request.Request(...)` 가 전부 `try` 밖이라, 사용자가 설정한 잘못된 `base_url` 이 `LLMError` 로 정규화되지 않는다. 별도 이슈로 분리했다.

## 검증

- 커밋 4개, 각각 단독 green. 워크트리 기준선 `2876 passed, 14 skipped` → `2911 passed, 14 skipped`.
- `ruff check` 통과. 만진 파일은 어댑터와 그 전용 테스트 둘뿐.
- 뮤테이션 25종 전부 사살, 생존 0. 비대칭 확인: 한쪽 메서드만 인라인하면 반대쪽은 green(두 호출 형태를 구분한다), `except ValueError` 삭제해도 디코드 테스트는 green(두 절이 실제로 분리돼 있다), 상수를 `""` 로 바꾸면 문구 테스트가 red(테스트가 상수를 import 하지 않는다).
