### PR TITLE
fix(extract): 클레임을 try 안에서 쥐고, 어떤 예외로 빠져나가든 해제한다

### DIFF
--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -382,16 +382,22 @@ def test_a_halted_kb_still_rewinds_the_whole_job_without_failing_the_chunk(
     Releasing it as `failed` here would both double-write and label a healthy
     chunk as broken.
 
-    THE EVENT LOG IS THE LOAD-BEARING ASSERTION, and it has to be, because the
-    end states cannot tell the difference. Delete the `except PolicyMissingError:
-    raise` clause and the broad handler below it fails the chunk — but
-    `rollback_extraction_job` then rewinds `failed` chunks to `pending` along with
-    the `running` one, so the final statuses, the job row and the run summary all
-    come out identical. What does not get rewound is history: the spurious
-    `chunk_failed` event stays in `fact_events`, recording a failure that never
-    happened against a chunk that was fine.
+    TWO INDEPENDENT OUTCOMES CATCH THIS, and both assertions below are real.
+    Delete the `except PolicyMissingError: raise` clause and the broad handler
+    releases the chunk as `failed`; then
 
-    An `assert` on a monkeypatched `_release_claimed_chunk` would also catch it,
+    * `fact_events` gains a `chunk_failed` row, and
+    * the chunk is still `failed` at the end. `rollback_extraction_job` rewinds
+      ONLY the in-flight `running` chunk (`store/db.py`: "`failed` chunks keep
+      their error. Only the in-flight `running` chunk is returned to the queue" —
+      its UPDATE is scoped `WHERE job_id = ? AND status = 'running'`), so a chunk
+      the release already failed is not swept back to `pending`.
+
+    The event assertion is written first because it names the thing that must not
+    happen — a release fired — instead of inferring it from a state, not because
+    the status assertion is too weak. Both are load-bearing; keep both.
+
+    An `assert` on a monkeypatched `_release_claimed_chunk` would catch it too,
     but that watches for a named private call rather than for an outcome, and a
     later refactor that renames or inlines the helper would silently defang it.
     The spy is kept only as a redundant, non-load-bearing check.
@@ -481,6 +487,16 @@ def test_cli_sync_leaves_the_job_running_but_never_the_chunk(tmp_path, monkeypat
     inside `process_extraction_job`, below every caller, so it holds even where
     the job row does not get written.
 
+    THE TWO ASSERTIONS BELOW HAVE DIFFERENT STATUSES. (b), the chunk, is a
+    GUARANTEE — it is what #475 fixed and it must not regress. (a), the job left
+    `running`, is a CHARACTERISATION of a defect that is still open as #488: the
+    blanket handler exists only in the web worker, so `verinote sync` strands the
+    job row. Fixing #488 MUST turn (a) red, and the correct response then is to
+    update (a) to whatever terminal status the new handler writes — never to
+    restore the stranded job in order to keep this line green. #488 carries the
+    same instruction from its side, so the test and the issue each point at the
+    other.
+
     THIS ALSO CHANGES BEHAVIOUR, DELIBERATELY. Before the fix the chunk stayed
     `running` with no failed chunk on the job, so `plan_source_extraction` never
     saw a retry budget to spend and `verinote sync --recover` would rewind and
@@ -513,9 +529,11 @@ def test_cli_sync_leaves_the_job_running_but_never_the_chunk(tmp_path, monkeypat
     jobs = list(store._conn.execute("SELECT id, status FROM extraction_jobs"))
     assert len(jobs) == 1
     job_id = int(jobs[0]["id"])
-    # (a) the job row is untouched — no CLI code path writes it on this failure
+    # (a) CHARACTERISATION of open defect #488, not a guarantee: no CLI code path
+    # writes the job row on this failure, so it is stranded `running`. Fixing #488
+    # must turn this line red; update it then, do not restore the defect.
     assert jobs[0]["status"] == "running"
-    # (b) the chunk is released anyway, which is what the fix guarantees
+    # (b) GUARANTEE (#475): the chunk is released regardless of the caller
     chunks = store.source_chunks(job_id)
     assert len(chunks) > 1, "the note must split, or 'first chunk' means nothing"
     assert chunks[0]["status"] == "failed"

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -3,8 +3,9 @@
 
 THE INVARIANT THESE TESTS PIN:
 
-    Whether `process_extraction_job` returns or escapes by exception, immediately
-    after the call none of that job's chunks are `running`.
+    Whether `process_extraction_job` returns or escapes by exception, no chunk
+    THAT CALL CLAIMED is left `running`. Every claim it took has reached a resting
+    place by the time the call is over.
 
 Stated over the *chunks*, deliberately, and not as "once the job reaches a
 terminal status...". `process_extraction_job` does not write the job row when a
@@ -13,6 +14,30 @@ non-`LLMError` escapes — the worker thread's `except Exception` in
 all. Phrasing the invariant over the job would make it a statement about a
 caller, so the tests below that need a job in its post-failure resting state call
 `_worker_marks_job_failed` and say so.
+
+Scoped to THIS CALL'S CLAIMS, equally deliberately, because a broader reading is
+false and `extract.py` says so in two places:
+
+* A CALL THAT NEVER TOOK THE JOB promises nothing about that job's chunks. Lose
+  the ownership CAS and `process_extraction_job` raises `ExtractionJobBusyError`
+  having touched nothing — the comment on that raise (`extract.py`) is explicit
+  that the owner "may have a chunk in flight, so we must NOT reset its chunks"
+  (#240). A `running` chunk therefore survives such a call, and must. This needs
+  no concurrency to see: one call against a KB carrying a zombie `running` job
+  does it, and `test_a_busy_job_is_left_entirely_to_its_owner` is that call.
+* `BaseException` IS NOT COVERED, by the same design. `extract.py` states that
+  Ctrl-C and `SystemExit` are "deliberately not caught", because the job does not
+  reach a terminal status on that path either and the startup resume
+  (`_resume_source_extraction_jobs` -> `rollback_extraction_job`) is what reclaims
+  the chunk. `test_a_keyboard_interrupt_leaves_the_claim_to_the_resume_path` pins
+  both halves: the claim survives the interrupt, and the resume path clears it.
+
+THREE RESTING PLACES, not two. A claim ends as `done`, or as `failed` carrying its
+cause, or — when the release is for a condition the chunk did not cause, i.e. the
+fact-term sidecar being held by another process — back at `pending` with its
+attempt refunded and the job rolled back around it. That third one has its own
+module, `test_chunk_claim_sidecar_lock.py`, because what matters there is what the
+release COSTS rather than that it happened.
 
 `canceled` is out of scope: it exists in the `schema.sql` CHECK constraint but no
 production code sets it.
@@ -33,6 +58,7 @@ import pytest
 from verinote.llm.base import ExtractedFact, LLMError
 import verinote.pipeline.extract as extract_mod
 from verinote.pipeline.extract import (
+    ExtractionJobBusyError,
     ExtractionJobPlan,
     MAX_CHUNK_ATTEMPTS,
     create_chunked_extraction_job,
@@ -471,6 +497,75 @@ def test_an_llm_error_still_fails_only_its_own_chunk_and_the_pass_continues(tmp_
     # row and the rendered page instead of on this string.
     assert "provider down" in job["message"]
     assert "1 chunk(s) failed" in job["message"]
+    s.close()
+
+
+# --- The two escapes the invariant cannot cover --------------------------------
+
+
+def test_a_busy_job_is_left_entirely_to_its_owner(tmp_path):
+    """A call that loses the ownership CAS promises nothing about that job's chunks.
+
+    This is the exclusion the module docstring names first, and it is why the
+    invariant is scoped to the claims a call TOOK. The setup is a KB in the state
+    a live owner (or a crashed one) leaves behind: job `running`, chunk 0 claimed.
+    A second pass must back off having written nothing — resetting that chunk is
+    precisely the #240 bug, the same chunk sent to the LLM twice.
+
+    No second thread is needed to reach it: the state is a property of the rows,
+    not of the timing, so one call against those rows reproduces it exactly.
+
+    The `client.calls` assertion is the one that says "nothing happened" rather
+    than "nothing changed": a pass that claimed a chunk and then rewound it would
+    leave the same statuses behind but would already have spent an LLM call.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+    assert s.claim_pending_extraction_job(job_id) is True  # the owner takes it
+    chunk_id = int(s.next_pending_chunk(job_id)["id"])
+    assert s.mark_chunk_running(chunk_id) is not None  # ...and puts one in flight
+    before = [(c["status"], c["attempts"]) for c in s.source_chunks(job_id)]
+    client = _ChunkClient()
+
+    with pytest.raises(ExtractionJobBusyError):
+        process_extraction_job(s, client, job_id=job_id)
+
+    assert _statuses(s, job_id) == ["running", "pending", "pending"]
+    assert _running(s, job_id) == [chunk_id]  # the owner's claim, untouched
+    assert [(c["status"], c["attempts"]) for c in s.source_chunks(job_id)] == before
+    assert client.calls == []
+    s.close()
+
+
+def test_a_keyboard_interrupt_leaves_the_claim_to_the_resume_path(tmp_path):
+    """Ctrl-C is not caught, on purpose — and something else is responsible for it.
+
+    The second exclusion. `extract.py` says `BaseException` is "deliberately not
+    caught" because the job does not reach a terminal status on that path either;
+    the claim outlives the process and the startup resume is what reclaims it.
+    Prose alone would leave that as an intention, so both halves are pinned here:
+    the interrupt really does strand the claim, AND the named recovery really does
+    clear it.
+
+    The second half calls `rollback_extraction_job` directly — the same call
+    `_resume_source_extraction_jobs` (`web/app.py`) makes on a job left `running`.
+    It is a stand-in for that loop, not the code under test.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+
+    with pytest.raises(KeyboardInterrupt):
+        process_extraction_job(
+            s, _ChunkClient(fail_on=2, exc=KeyboardInterrupt()), job_id=job_id
+        )
+
+    # chunk 0 finished, chunk 1's claim is still held: nothing released it
+    assert _statuses(s, job_id) == ["done", "running", "pending"]
+
+    s.rollback_extraction_job(job_id, "rewound at startup after an interrupted run")
+
+    assert _statuses(s, job_id) == ["done", "pending", "pending"]
+    assert _running(s, job_id) == []
     s.close()
 
 

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -340,9 +340,16 @@ def test_a_released_job_is_retried_rather_than_rebuilt_from_scratch(tmp_path):
 
     Compared as a whole `ExtractionJobPlan` on purpose: `retry_job_id` alone would
     also be satisfied if `resume_job_id`/`exhausted_job_id`/`busy_job_id` came
-    along with it. Release the chunk any other way — rewind it to `pending`, or
-    mark it `done` — and the job's `failed_chunks` drops to zero, planning falls
-    through to "rebuild fresh", and chunk 0's completed work is paid for twice.
+    along with it. Release the chunk any other way while leaving the job to be
+    written `failed` — rewind the chunk to `pending`, or mark it `done` — and the
+    job's `failed_chunks` drops to zero, planning falls through to "rebuild
+    fresh", and chunk 0's completed work is paid for twice.
+
+    The qualifier is load-bearing, because one release DOES rewind the chunk to
+    `pending`: a locked fact-term sidecar (`test_chunk_claim_sidecar_lock.py`).
+    That path is safe from this trap precisely because it does not stop at the
+    chunk — it rolls the JOB back to `pending` too, and a `pending` job with
+    unfinished chunks is a resume, which needs no failed chunk to be planned.
     """
     s = _store(tmp_path)
     source_id, job_id = _three_chunk_job(s)

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: MPL-2.0
+"""A claimed source chunk is released however the job pass ends (#475).
+
+THE INVARIANT THESE TESTS PIN:
+
+    Whether `process_extraction_job` returns or escapes by exception, immediately
+    after the call none of that job's chunks are `running`.
+
+Stated over the *chunks*, deliberately, and not as "once the job reaches a
+terminal status...". `process_extraction_job` does not write the job row when a
+non-`LLMError` escapes — the web worker's `except Exception` does
+(`web/app.py:1753-1755`), and the CLI does not do it at all. Phrasing the
+invariant over the job would make it a statement about a caller, so the tests
+below that need a job in its post-failure resting state call
+`_worker_marks_job_failed` and say so.
+
+`canceled` is out of scope: it exists in the `schema.sql` CHECK constraint but no
+production code sets it.
+
+The failure this guards is real and observed: a chunk claimed (`status='running'`,
+one attempt burned, `error=''`) and then abandoned when an exception that was not
+an `LLMError` walked out of the loop. Nothing resets such a chunk, so the source
+could neither finish nor be re-synced.
+
+The exceptions injected here are plain builtins raised from the LLM stub. That is
+on purpose — the guard must not depend on any particular adapter normalising its
+errors into `LLMError` (#474), or it goes vacuous the moment that adapter is
+fixed.
+"""
+
+import pytest
+
+from verinote.llm.base import ExtractedFact, LLMError
+import verinote.pipeline.extract as extract_mod
+from verinote.pipeline.extract import (
+    ExtractionJobPlan,
+    MAX_CHUNK_ATTEMPTS,
+    create_chunked_extraction_job,
+    plan_source_extraction,
+    process_extraction_job,
+)
+from verinote.pipeline.policy_state import PolicyMissingError
+from verinote.store import Store
+
+SOURCE_TEXT = "alpha\n\nbeta\n\ngamma"
+CHUNK_CHARS = 8
+CHUNK_OVERLAP_CHARS = 0
+PROVIDER = "fake"
+MODEL = "m"
+
+
+class _ChunkClient:
+    """One fact per chunk, with an exception injected at a chosen call.
+
+    `fail_on` counts `extract_facts` calls from 1. The chunk texts carry no role
+    cue, so `_extract_chunk_facts` makes exactly one call per chunk and the count
+    is the chunk ordinal.
+    """
+
+    name = "stub"
+
+    def __init__(self, *, fail_on: int | None = None, exc=None):
+        self.calls: list[str] = []
+        self._fail_on = fail_on
+        self._exc = exc
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        self.calls.append(source_text)
+        if self._fail_on is not None and len(self.calls) == self._fail_on:
+            raise self._exc
+        return [ExtractedFact(source_text.strip(), "seen_in", "source", 0.9)]
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _three_chunk_job(store: Store) -> tuple[int, int]:
+    """A real job over three chunks — `alpha`, `beta`, `gamma`.
+
+    Built through `create_chunked_extraction_job` with explicit chunk settings so
+    that `_plan` can hand `plan_source_extraction` the very same artifact,
+    provider, model and chunk config and clear its staleness gates.
+    """
+    source_id = store.add_source("sources/a.txt")
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        artifact_id=None,
+        source_text=SOURCE_TEXT,
+        provider=PROVIDER,
+        model=MODEL,
+        chunk_chars=CHUNK_CHARS,
+        chunk_overlap_chars=CHUNK_OVERLAP_CHARS,
+    )
+    assert [c["text"] for c in store.source_chunks(job_id)] == ["alpha", "beta", "gamma"]
+    return source_id, job_id
+
+
+def _plan(store: Store, source_id: int) -> ExtractionJobPlan:
+    return plan_source_extraction(
+        store,
+        source_id=source_id,
+        artifact_id=None,
+        source_text=SOURCE_TEXT,
+        provider=PROVIDER,
+        model=MODEL,
+        chunk_chars=CHUNK_CHARS,
+        chunk_overlap_chars=CHUNK_OVERLAP_CHARS,
+    )
+
+
+def _worker_marks_job_failed(store: Store, job_id: int, message: str) -> None:
+    """Stand-in for the web worker. NOT the code under test.
+
+    `process_extraction_job` leaves the job row alone when a non-`LLMError`
+    escapes; `web/app.py:1753-1755` is what writes `failed`. A test that wants the
+    job in its post-failure resting state has to perform that write itself, so it
+    is spelled out here rather than hidden behind a fixture — nothing in
+    `verinote/pipeline` will do it.
+    """
+    store.fail_extraction_job(job_id, message)
+
+
+def _statuses(store: Store, job_id: int) -> list[str]:
+    return [c["status"] for c in store.source_chunks(job_id)]
+
+
+def _running(store: Store, job_id: int) -> list[int]:
+    return [int(c["id"]) for c in store.source_chunks(job_id) if c["status"] == "running"]
+
+
+# --- T1: the invariant, with the failure originating in `_extract_chunk` --------
+
+
+@pytest.mark.parametrize("exc_type", [ValueError, RuntimeError, KeyError])
+def test_no_chunk_stays_claimed_when_a_chunk_raises_a_non_llm_error(tmp_path, exc_type):
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+    client = _ChunkClient(fail_on=2, exc=exc_type("boom"))
+
+    # The exception must still reach the caller: releasing the claim is not the
+    # same as swallowing an unmodelled failure. Without this the loop could
+    # `continue` past anything at all and the job would report success.
+    with pytest.raises(exc_type):
+        process_extraction_job(s, client, job_id=job_id)
+
+    assert _running(s, job_id) == []
+    assert _statuses(s, job_id) == ["done", "failed", "pending"]
+    # chunk 0's work survives — the release must not touch a completed chunk
+    assert [f["subject"] for f in s.facts()] == ["alpha"]
+    s.close()
+
+
+def test_terminal_job_has_no_running_chunk_after_a_non_llm_error(tmp_path):
+    """T1's invariant restated the way an operator sees it, once the job is `failed`.
+
+    The `fail_extraction_job` call below is the web worker's write, performed here
+    by the harness because `process_extraction_job` does not do it. It is a
+    stand-in, not production code under test.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+
+    with pytest.raises(ValueError):
+        process_extraction_job(s, _ChunkClient(fail_on=2, exc=ValueError("boom")), job_id=job_id)
+    _worker_marks_job_failed(s, job_id, "analysis failed: boom")
+
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "failed"
+    assert _running(s, job_id) == []
+    # the symptom in #475 was `failed=0` on a `failed` job — the claim never landed
+    assert job["failed_chunks"] == 1
+    s.close()
+
+
+# --- T2: the invariant, with the failure originating in `mark_chunk_done` -------
+
+
+def test_no_chunk_stays_claimed_when_mark_chunk_done_raises(tmp_path, monkeypatch):
+    """`mark_chunk_done` is inside the claim, so it must be inside the `try`.
+
+    A `try` that wraps only the LLM call leaves this write unguarded, and a chunk
+    whose completion write failed is exactly as stranded as one whose LLM call
+    did.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+
+    def _boom(chunk_id, *, candidates=0):
+        raise RuntimeError("completion write failed")
+
+    monkeypatch.setattr(s, "mark_chunk_done", _boom)
+
+    with pytest.raises(RuntimeError):
+        process_extraction_job(s, _ChunkClient(), job_id=job_id)
+
+    assert _running(s, job_id) == []
+    assert _statuses(s, job_id) == ["failed", "pending", "pending"]
+    s.close()
+
+
+def test_a_chunk_already_written_done_is_not_flipped_to_failed(tmp_path, monkeypatch):
+    """The release asks whether the claim is still held — it does not re-decide.
+
+    `mark_chunk_done` writes in several steps and can raise *after* the chunk row
+    already says `done` (the job's `candidate_count` update, or
+    `_refresh_extraction_job`). Overwriting that with `failed` would destroy real
+    work. Counters are deliberately not asserted here: the stand-in aborts
+    part-way through `mark_chunk_done`, so they are mid-write by construction.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+
+    def _done_then_boom(chunk_id, *, candidates=0):
+        s._conn.execute(
+            "UPDATE source_chunks SET status = 'done' WHERE id = ?", (chunk_id,)
+        )
+        raise RuntimeError("counter update failed")
+
+    monkeypatch.setattr(s, "mark_chunk_done", _done_then_boom)
+
+    with pytest.raises(RuntimeError):
+        process_extraction_job(s, _ChunkClient(), job_id=job_id)
+
+    assert _running(s, job_id) == []
+    assert _statuses(s, job_id) == ["done", "pending", "pending"]
+    s.close()
+
+
+# --- T3: the released chunk says why ------------------------------------------
+
+
+def test_a_released_chunk_records_a_cause_even_for_an_empty_message(tmp_path):
+    """`str(ValueError())` is `''`, and an empty `error` renders as a bare "failed".
+
+    `sources.html` falls back to the literal word "failed" when `error` is empty,
+    so a release that copied the message verbatim would reproduce the very
+    `error=''` chunk #475 reports. The exception type is therefore part of the
+    recorded cause.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+
+    with pytest.raises(ValueError):
+        process_extraction_job(s, _ChunkClient(fail_on=2, exc=ValueError()), job_id=job_id)
+
+    error = s.source_chunks(job_id)[1]["error"]
+    assert error != ""
+    assert "ValueError" in error
+    s.close()
+
+
+def test_the_recorded_cause_reaches_the_sources_page(tmp_path):
+    """The other half of T3: the cause has to be visible, not merely stored.
+
+    Rendered through `create_app` + `TestClient` so the assertion runs against the
+    real `_source_inspector_rows` -> `sources.html` path rather than a hand-built
+    context dict.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from verinote.config import Config
+    from verinote.web import create_app
+
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider=PROVIDER,
+        model=MODEL,
+        api_key=None,
+        base_url=None,
+    )
+    app = create_app(cfg)
+    store = app.state.store
+    _source_id, job_id = _three_chunk_job(store)
+    with pytest.raises(ValueError):
+        process_extraction_job(
+            store, _ChunkClient(fail_on=2, exc=ValueError()), job_id=job_id
+        )
+    _worker_marks_job_failed(store, job_id, "analysis failed: ")  # worker stand-in
+
+    html = TestClient(app).get("/sources").text
+
+    assert "chunk 1</span> ValueError" in html
+
+
+# --- T4/T5: what the released chunk costs, and what it preserves ---------------
+
+
+def test_a_released_chunk_burns_exactly_one_attempt(tmp_path):
+    """The release must not spend the retry budget faster than a modelled failure.
+
+    Three passes take a chunk from one attempt to exhausted, which is the same
+    budget `MAX_CHUNK_ATTEMPTS` gives an `LLMError`. Each pass ends with the
+    worker stand-in writing `failed`, because the retry claim only accepts a
+    `pending`/`failed` job.
+    """
+    s = _store(tmp_path)
+    source_id, job_id = _three_chunk_job(s)
+
+    with pytest.raises(ValueError):
+        process_extraction_job(s, _ChunkClient(fail_on=1, exc=ValueError("boom")), job_id=job_id)
+    _worker_marks_job_failed(s, job_id, "analysis failed: boom")
+
+    assert s.source_chunks(job_id)[0]["attempts"] == 1
+    assert _plan(s, source_id) == ExtractionJobPlan(retry_job_id=job_id)
+
+    for expected_attempts, expected_plan in (
+        (2, ExtractionJobPlan(retry_job_id=job_id)),
+        (3, ExtractionJobPlan(exhausted_job_id=job_id)),
+    ):
+        with pytest.raises(ValueError):
+            process_extraction_job(
+                s,
+                _ChunkClient(fail_on=1, exc=ValueError("boom")),
+                job_id=job_id,
+                retry=True,
+                retry_max_attempts=MAX_CHUNK_ATTEMPTS,
+            )
+        _worker_marks_job_failed(s, job_id, "analysis failed: boom")
+        assert s.source_chunks(job_id)[0]["attempts"] == expected_attempts
+        assert _running(s, job_id) == []
+        assert _plan(s, source_id) == expected_plan
+
+    s.close()
+
+
+def test_a_released_job_is_retried_rather_than_rebuilt_from_scratch(tmp_path):
+    """Releasing as `failed` is what keeps the finished chunk's work.
+
+    Compared as a whole `ExtractionJobPlan` on purpose: `retry_job_id` alone would
+    also be satisfied if `resume_job_id`/`exhausted_job_id`/`busy_job_id` came
+    along with it. Release the chunk any other way — rewind it to `pending`, or
+    mark it `done` — and the job's `failed_chunks` drops to zero, planning falls
+    through to "rebuild fresh", and chunk 0's completed work is paid for twice.
+    """
+    s = _store(tmp_path)
+    source_id, job_id = _three_chunk_job(s)
+
+    with pytest.raises(RuntimeError):
+        process_extraction_job(
+            s, _ChunkClient(fail_on=2, exc=RuntimeError("boom")), job_id=job_id
+        )
+    _worker_marks_job_failed(s, job_id, "analysis failed: boom")
+
+    assert _plan(s, source_id) == ExtractionJobPlan(retry_job_id=job_id)
+
+    # Corroborating, not load-bearing: the retry pass re-reads chunks 1 and 2 only.
+    retry_client = _ChunkClient()
+    process_extraction_job(
+        s,
+        retry_client,
+        job_id=job_id,
+        retry=True,
+        retry_max_attempts=MAX_CHUNK_ATTEMPTS,
+    )
+    assert retry_client.calls == ["beta", "gamma"]
+    assert _statuses(s, job_id) == ["done", "done", "done"]
+    s.close()
+
+
+# --- T6/T7: the two paths that already worked, unchanged -----------------------
+
+
+def test_a_halted_kb_still_rewinds_the_whole_job_without_failing_the_chunk(
+    tmp_path, monkeypatch
+):
+    """`PolicyMissingError` is not this chunk's failure and must skip the release.
+
+    The outer handler rewinds the entire job (`_halt_extraction_job` ->
+    `rollback_extraction_job`, which returns the in-flight chunk to the queue).
+    Releasing it as `failed` here would both double-write and label a healthy
+    chunk as broken.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+    released: list[int] = []
+    real_release = extract_mod._release_claimed_chunk
+
+    def _spy(store, chunk_id, exc):
+        released.append(chunk_id)
+        return real_release(store, chunk_id, exc)
+
+    monkeypatch.setattr(extract_mod, "_release_claimed_chunk", _spy)
+
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(
+            s,
+            _ChunkClient(fail_on=2, exc=PolicyMissingError("policy file is missing")),
+            job_id=job_id,
+        )
+
+    assert released == []
+    assert _statuses(s, job_id) == ["done", "pending", "pending"]
+    assert _running(s, job_id) == []
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "pending"
+    assert "policy reset --force" in job["message"]
+    summaries = [row["summary"] for row in s._conn.execute("SELECT summary FROM runs")]
+    assert any("halted because this KB's policy file went missing" in x for x in summaries)
+    s.close()
+
+
+def test_an_llm_error_still_fails_only_its_own_chunk_and_the_pass_continues(tmp_path):
+    """The modelled failure keeps its old behaviour: `failed`, verbatim message, next chunk."""
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+
+    result = process_extraction_job(
+        s, _ChunkClient(fail_on=2, exc=LLMError("provider down")), job_id=job_id
+    )
+
+    assert _statuses(s, job_id) == ["done", "failed", "done"]
+    assert _running(s, job_id) == []
+    assert s.source_chunks(job_id)[1]["error"] == "provider down"
+    assert (result.completed_chunks, result.failed_chunks) == (2, 1)
+    assert s.get_extraction_job(job_id)["status"] == "failed"
+    s.close()

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -8,10 +8,10 @@ THE INVARIANT THESE TESTS PIN:
 
 Stated over the *chunks*, deliberately, and not as "once the job reaches a
 terminal status...". `process_extraction_job` does not write the job row when a
-non-`LLMError` escapes — the web worker's `except Exception` does
-(`web/app.py:1753-1755`), and the CLI does not do it at all. Phrasing the
-invariant over the job would make it a statement about a caller, so the tests
-below that need a job in its post-failure resting state call
+non-`LLMError` escapes — the worker thread's `except Exception` in
+`_start_source_extraction` (`web/app.py`) does, and the CLI does not do it at
+all. Phrasing the invariant over the job would make it a statement about a
+caller, so the tests below that need a job in its post-failure resting state call
 `_worker_marks_job_failed` and say so.
 
 `canceled` is out of scope: it exists in the `schema.sql` CHECK constraint but no
@@ -116,10 +116,11 @@ def _worker_marks_job_failed(store: Store, job_id: int, message: str) -> None:
     """Stand-in for the web worker. NOT the code under test.
 
     `process_extraction_job` leaves the job row alone when a non-`LLMError`
-    escapes; `web/app.py:1753-1755` is what writes `failed`. A test that wants the
-    job in its post-failure resting state has to perform that write itself, so it
-    is spelled out here rather than hidden behind a fixture — nothing in
-    `verinote/pipeline` will do it.
+    escapes; the worker thread's `except Exception` in `_start_source_extraction`
+    (`web/app.py`) is what writes `failed`. A test that wants the job in its
+    post-failure resting state has to perform that write itself, so it is spelled
+    out here rather than hidden behind a fixture — nothing in `verinote/pipeline`
+    will do it.
     """
     store.fail_extraction_job(job_id, message)
 
@@ -199,6 +200,11 @@ def test_no_chunk_stays_claimed_when_mark_chunk_done_raises(tmp_path, monkeypatc
 
     assert _running(s, job_id) == []
     assert _statuses(s, job_id) == ["failed", "pending", "pending"]
+    # Both halves of the cause, so that writing a constant ("failed") or dropping
+    # either half still leaves a chunk whose recorded reason is worth reading.
+    error = s.source_chunks(job_id)[0]["error"]
+    assert "RuntimeError" in error
+    assert "completion write failed" in error
     s.close()
 
 
@@ -375,6 +381,20 @@ def test_a_halted_kb_still_rewinds_the_whole_job_without_failing_the_chunk(
     `rollback_extraction_job`, which returns the in-flight chunk to the queue).
     Releasing it as `failed` here would both double-write and label a healthy
     chunk as broken.
+
+    THE EVENT LOG IS THE LOAD-BEARING ASSERTION, and it has to be, because the
+    end states cannot tell the difference. Delete the `except PolicyMissingError:
+    raise` clause and the broad handler below it fails the chunk — but
+    `rollback_extraction_job` then rewinds `failed` chunks to `pending` along with
+    the `running` one, so the final statuses, the job row and the run summary all
+    come out identical. What does not get rewound is history: the spurious
+    `chunk_failed` event stays in `fact_events`, recording a failure that never
+    happened against a chunk that was fine.
+
+    An `assert` on a monkeypatched `_release_claimed_chunk` would also catch it,
+    but that watches for a named private call rather than for an outcome, and a
+    later refactor that renames or inlines the helper would silently defang it.
+    The spy is kept only as a redundant, non-load-bearing check.
     """
     s = _store(tmp_path)
     _source_id, job_id = _three_chunk_job(s)
@@ -394,7 +414,15 @@ def test_a_halted_kb_still_rewinds_the_whole_job_without_failing_the_chunk(
             job_id=job_id,
         )
 
-    assert released == []
+    event_types = [
+        row["event_type"]
+        for row in s._conn.execute(
+            "SELECT event_type FROM fact_events WHERE job_id = ? ORDER BY id", (job_id,)
+        )
+    ]
+    assert "chunk_failed" not in event_types
+    assert "extraction_job_rolled_back" in event_types
+
     assert _statuses(s, job_id) == ["done", "pending", "pending"]
     assert _running(s, job_id) == []
     job = s.get_extraction_job(job_id)
@@ -402,6 +430,7 @@ def test_a_halted_kb_still_rewinds_the_whole_job_without_failing_the_chunk(
     assert "policy reset --force" in job["message"]
     summaries = [row["summary"] for row in s._conn.execute("SELECT summary FROM runs")]
     assert any("halted because this KB's policy file went missing" in x for x in summaries)
+    assert released == []  # redundant with the event assertion above, not load-bearing
     s.close()
 
 
@@ -418,5 +447,78 @@ def test_an_llm_error_still_fails_only_its_own_chunk_and_the_pass_continues(tmp_
     assert _running(s, job_id) == []
     assert s.source_chunks(job_id)[1]["error"] == "provider down"
     assert (result.completed_chunks, result.failed_chunks) == (2, 1)
-    assert s.get_extraction_job(job_id)["status"] == "failed"
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "failed"
+    # The job message carries the cause on THIS path and only this one. Running to
+    # completion with a failed chunk is what reaches `finish_extraction_job(final=
+    # True)` -> `_refresh_extraction_job`'s `status == 'failed'` branch, whose
+    # `AND error != ''` lookup copies the first failed chunk's error into the job
+    # message. A non-`LLMError` escape never gets here (nothing calls
+    # `finish_extraction_job`), which is why the sibling tests assert on the chunk
+    # row and the rendered page instead of on this string.
+    assert "provider down" in job["message"]
+    assert "1 chunk(s) failed" in job["message"]
     s.close()
+
+
+# --- The other caller: the CLI ------------------------------------------------
+
+
+def test_cli_sync_leaves_the_job_running_but_never_the_chunk(tmp_path, monkeypatch):
+    """`verinote sync` is why the invariant is stated over chunks, not over jobs.
+
+    DOMAIN NOTE — READ BEFORE REUSING THIS SHAPE. The derived phrasing "once the
+    job reaches a terminal status, no chunk is `running`" does NOT cover this
+    caller, and this test is the proof. `cmd_sync` wraps
+    `process_extraction_job` in a `try` that catches only
+    `ExtractionJobBusyError`, and `cli.main` catches only `KBLocationError` and
+    `DuckDBFactTermStoreLockedError`, so an unmodelled exception unwinds the whole
+    command with the job row untouched: it stays `running` forever. Nothing in the
+    CLI plays the part the web worker's `except Exception` plays. Asserting a
+    terminal job status here would be asserting something no production code does.
+
+    The chunk is a different matter, and that is the point: the release happens
+    inside `process_extraction_job`, below every caller, so it holds even where
+    the job row does not get written.
+
+    THIS ALSO CHANGES BEHAVIOUR, DELIBERATELY. Before the fix the chunk stayed
+    `running` with no failed chunk on the job, so `plan_source_extraction` never
+    saw a retry budget to spend and `verinote sync --recover` would rewind and
+    re-run the same source every single time. Now the chunk is `failed`, the
+    attempt counts up, and after `MAX_CHUNK_ATTEMPTS` the job is surfaced as
+    exhausted and skipped. A repeating sync becoming a terminating one is the
+    intended consequence.
+    """
+    from verinote import cli
+
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_CHARS", "40")
+    monkeypatch.setenv("VERINOTE_EXTRACTION_CHUNK_OVERLAP_CHARS", "0")
+    src = tmp_path / "note.txt"
+    src.write_text(
+        "alpha beta gamma delta epsilon\n\nzeta eta theta iota kappa",
+        encoding="utf-8",
+    )
+    assert cli.main(["ingest", str(src)]) == 0
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: _ChunkClient(fail_on=1, exc=ValueError("boom")),
+    )
+
+    with pytest.raises(ValueError):
+        cli.main(["sync"])
+
+    store = Store(tmp_path / "kb.sqlite")
+    jobs = list(store._conn.execute("SELECT id, status FROM extraction_jobs"))
+    assert len(jobs) == 1
+    job_id = int(jobs[0]["id"])
+    # (a) the job row is untouched — no CLI code path writes it on this failure
+    assert jobs[0]["status"] == "running"
+    # (b) the chunk is released anyway, which is what the fix guarantees
+    chunks = store.source_chunks(job_id)
+    assert len(chunks) > 1, "the note must split, or 'first chunk' means nothing"
+    assert chunks[0]["status"] == "failed"
+    assert chunks[0]["attempts"] == 1
+    assert [c for c in chunks if c["status"] == "running"] == []
+    store.close()

--- a/tests/test_chunk_claim_sidecar_lock.py
+++ b/tests/test_chunk_claim_sidecar_lock.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: MPL-2.0
+"""A claim released because the sidecar was locked costs the chunk nothing (#475).
+
+THE DISTINCTION THESE TESTS PIN. `test_chunk_claim_release.py` establishes that a
+claimed chunk is never left `running`. It does not say what the release should
+cost, and for one class of failure the answer is "nothing": another process
+holding the DuckDB fact-term sidecar is a condition of the host, not of the
+chunk's content, and the error text itself instructs the reader to wait and retry.
+Charging it as a chunk failure spends a retry attempt per occurrence, and
+`MAX_CHUNK_ATTEMPTS` of them make `plan_source_extraction` give up on the source
+for good — over a condition that clears by itself.
+
+So this release has its own shape, and all of it is load-bearing:
+
+* the CHUNK goes back to `pending` with its attempt refunded — the row exactly as
+  `next_pending_chunk` handed it out;
+* the JOB is rolled back to `pending` too, without which a `failed` job with zero
+  failed chunks reads to planning as "rebuild fresh" and every finished chunk is
+  re-sent to the LLM;
+* the exception still propagates, so no caller mistakes this for a completed pass.
+
+THREE OUTCOMES MUST STAY APART, and the tests below separate them on purpose:
+`failed` (no dedicated clause at all), `pending` with the attempt kept (a clause
+that rewinds but does not refund), and `pending` with the attempt refunded (what
+is wanted). Only the middle one is subtle, and it is exactly the arrangement that
+still gives up on a source: three locks and one real failure reach
+`attempts = 4 >= MAX_CHUNK_ATTEMPTS`.
+
+WHY A REAL PEER PROCESS, and not only the injected stub. DuckDB's single-writer
+lock only bites across an OS process boundary — two connections inside one process
+share its instance cache and never conflict — so an in-process stub can only
+assert that the pipeline handles the exception it was handed. The peer test is
+what keeps the stub honest about the exception being reachable at all: it holds
+the real sidecar with a real second process and lets the real write path find it.
+"""
+
+import select
+import subprocess
+import sys
+import time
+
+import pytest
+
+from verinote.llm.base import ExtractedFact
+from verinote.pipeline.extract import (
+    ExtractionJobPlan,
+    MAX_CHUNK_ATTEMPTS,
+    create_chunked_extraction_job,
+    plan_source_extraction,
+    process_extraction_job,
+)
+from verinote.store import Store
+from verinote.store import duckdb_fact_terms
+from verinote.store.duckdb_fact_terms import (
+    FACT_TERMS_FILENAME,
+    DuckDBFactTermStoreLockedError,
+)
+
+SOURCE_TEXT = "alpha\n\nbeta\n\ngamma"
+CHUNK_CHARS = 8
+CHUNK_OVERLAP_CHARS = 0
+PROVIDER = "fake"
+MODEL = "m"
+
+# Same shape as `test_duckdb_fact_terms_concurrency.py`: reading a child's stdout
+# through `select` is POSIX-only, and so is the file-locking behaviour being
+# exercised. The injected-stub tests carry no such dependency and run everywhere.
+_posix_only = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="cross-process file-lock contention needs POSIX select/lock semantics",
+)
+
+# A raw DuckDB connection held open by another process — a `verinote ui` serving
+# the same KB, or a second `verinote sync`. Post-#169 the store holds no
+# connection between operations, so only a genuine outside process can hold this
+# lock while our pipeline runs.
+_HOLDER = """
+import sys, time, duckdb
+path, max_hold = sys.argv[1], float(sys.argv[2])
+con = duckdb.connect(path)
+con.execute(
+    "CREATE TABLE IF NOT EXISTS fact_terms ("
+    "fact_id BIGINT PRIMARY KEY, subject VARCHAR NOT NULL, "
+    "rel VARCHAR NOT NULL, object VARCHAR NOT NULL, term_token VARCHAR)"
+)
+sys.stdout.write("READY\\n")
+sys.stdout.flush()
+time.sleep(max_hold)
+con.close()
+"""
+
+
+def _spawn(tmp_path, source, *args):
+    script = tmp_path / "sidecar_holder.py"
+    script.write_text(source)
+    return subprocess.Popen(
+        [sys.executable, str(script), *[str(a) for a in args]],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=str(tmp_path),
+    )
+
+
+def _readline_until(proc, token, timeout):
+    end = time.monotonic() + timeout
+    while True:
+        remaining = end - time.monotonic()
+        if remaining <= 0:
+            return None
+        ready, _, _ = select.select([proc.stdout], [], [], remaining)
+        if not ready:
+            return None
+        line = proc.stdout.readline()
+        if line == "":
+            return None
+        if token in line:
+            return line
+
+
+def _terminate(proc):
+    if proc.poll() is None:
+        proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+class _ChunkClient:
+    """One fact per chunk; optionally raises a chosen exception at call `fail_on`.
+
+    Call `n` is chunk `n`: the chunk texts carry no role cue, so
+    `_extract_chunk_facts` makes exactly one call per chunk.
+    """
+
+    name = "stub"
+
+    def __init__(self, *, fail_on: int | None = None, exc=None):
+        self.calls: list[str] = []
+        self._fail_on = fail_on
+        self._exc = exc
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        self.calls.append(source_text)
+        if self._fail_on is not None and len(self.calls) == self._fail_on:
+            raise self._exc
+        return [ExtractedFact(source_text.strip(), "seen_in", "source", 0.9)]
+
+
+class _HoldsTheSidecarFromCall:
+    """Starts a real peer process holding the sidecar, mid-job.
+
+    The hold has to begin AFTER a chunk has completed, or there is no finished
+    work to prove the release preserves. Timing it from inside the LLM stub is the
+    only place with that control: by the time call `hold_from` returns, the peer
+    owns the file and the write that follows is the one that finds it locked.
+    """
+
+    name = "stub"
+
+    def __init__(self, tmp_path, sidecar, *, hold_from: int):
+        self.calls: list[str] = []
+        self.holder = None
+        self._tmp_path = tmp_path
+        self._sidecar = sidecar
+        self._hold_from = hold_from
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        self.calls.append(source_text)
+        if len(self.calls) == self._hold_from and self.holder is None:
+            assert self._sidecar.is_file(), "no sidecar yet — nothing for a peer to hold"
+            self.holder = _spawn(self._tmp_path, _HOLDER, self._sidecar, 60)
+            assert _readline_until(self.holder, "READY", 20) is not None, (
+                "the peer process never took the sidecar lock"
+            )
+        return [ExtractedFact(source_text.strip(), "seen_in", "source", 0.9)]
+
+
+class _LocksOnPut:
+    """The real sidecar store, except that put number `lock_on` reports it locked.
+
+    A wrapper rather than a hand-written double: every other call goes to the real
+    `DuckDBFactTermStore`, so the surrounding writes behave as they really do and
+    only the one failure is injected.
+    """
+
+    def __init__(self, inner, *, lock_on: int):
+        self._inner = inner
+        self._lock_on = lock_on
+        self.puts = 0
+
+    def put_fact_terms(self, *args, **kwargs):
+        self.puts += 1
+        if self.puts == self._lock_on:
+            raise DuckDBFactTermStoreLockedError(
+                "the DuckDB fact-term store is locked by another process."
+            )
+        return self._inner.put_fact_terms(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def _store(tmp_path) -> Store:
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    return s
+
+
+def _lock_the_sidecar_on_put(store: Store, *, lock_on: int) -> _LocksOnPut:
+    """Route this store's sidecar writes through `_LocksOnPut`.
+
+    `Store.fact_terms` builds the real store on first use and caches it in
+    `_fact_terms`; replacing that attribute is what the property itself checks, so
+    the wrapper is used from here on without disturbing anything else.
+    """
+    wrapper = _LocksOnPut(store.fact_terms, lock_on=lock_on)
+    store._fact_terms = wrapper
+    return wrapper
+
+
+def _three_chunk_job(store: Store) -> tuple[int, int]:
+    source_id = store.add_source("sources/a.txt")
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        artifact_id=None,
+        source_text=SOURCE_TEXT,
+        provider=PROVIDER,
+        model=MODEL,
+        chunk_chars=CHUNK_CHARS,
+        chunk_overlap_chars=CHUNK_OVERLAP_CHARS,
+    )
+    assert [c["text"] for c in store.source_chunks(job_id)] == ["alpha", "beta", "gamma"]
+    return source_id, job_id
+
+
+def _plan(store: Store, source_id: int) -> ExtractionJobPlan:
+    return plan_source_extraction(
+        store,
+        source_id=source_id,
+        artifact_id=None,
+        source_text=SOURCE_TEXT,
+        provider=PROVIDER,
+        model=MODEL,
+        chunk_chars=CHUNK_CHARS,
+        chunk_overlap_chars=CHUNK_OVERLAP_CHARS,
+    )
+
+
+def _chunk_states(store: Store, job_id: int) -> list[tuple[str, int]]:
+    return [(c["status"], int(c["attempts"])) for c in store.source_chunks(job_id)]
+
+
+def _worker_marks_job_failed(store: Store, job_id: int, message: str) -> None:
+    """Stand-in for the web worker's `except Exception`. NOT code under test.
+
+    `process_extraction_job` does not write the job row when a non-`LLMError`
+    escapes; `_start_source_extraction` (`web/app.py`) does. A test that needs a
+    job in its post-failure resting state performs that write itself.
+    """
+    store.fail_extraction_job(job_id, message)
+
+
+# --- the release, and everything it must leave alone --------------------------
+
+
+def test_a_locked_sidecar_requeues_the_chunk_and_rewinds_the_job(tmp_path):
+    """All four outcomes of the release, in the one place they have to agree.
+
+    The `resume_job_id` assertion is the one that catches a half-fix. Rewind the
+    chunk without rewinding the job and every state below still looks reasonable
+    in isolation — until the worker writes `failed` over a job with no failed
+    chunk, planning calls that an edge state, and the finished chunk is extracted
+    a second time.
+    """
+    s = _store(tmp_path)
+    source_id, job_id = _three_chunk_job(s)
+    _lock_the_sidecar_on_put(s, lock_on=2)  # chunk 0 lands; chunk 1 finds it locked
+
+    with pytest.raises(DuckDBFactTermStoreLockedError):
+        process_extraction_job(s, _ChunkClient(), job_id=job_id)
+
+    # chunk 0 keeps its work and its spent attempt; chunk 1 is back exactly as it
+    # was handed out — `pending`, no error, nothing charged
+    assert _chunk_states(s, job_id) == [("done", 1), ("pending", 0), ("pending", 0)]
+    assert s.source_chunks(job_id)[1]["error"] == ""
+    assert s.get_extraction_job(job_id)["status"] == "pending"
+    assert _plan(s, source_id) == ExtractionJobPlan(resume_job_id=job_id)
+    assert [f["subject"] for f in s.facts()] == ["alpha"]
+    s.close()
+
+
+def test_a_locked_sidecar_records_no_chunk_event(tmp_path):
+    """The requeue is not a chunk transition a reader has to be told about.
+
+    `mark_chunk_failed` and the retry claim each leave a row someone may later
+    query and need explained; this leaves none. What IS recorded is the job
+    rollback, so the pause is not silent.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+    _lock_the_sidecar_on_put(s, lock_on=1)
+
+    with pytest.raises(DuckDBFactTermStoreLockedError):
+        process_extraction_job(s, _ChunkClient(), job_id=job_id)
+
+    event_types = [
+        row["event_type"]
+        for row in s._conn.execute(
+            "SELECT event_type FROM fact_events WHERE job_id = ? ORDER BY id", (job_id,)
+        )
+    ]
+    assert "chunk_failed" not in event_types
+    assert "chunk_retried" not in event_types
+    assert "extraction_job_rolled_back" in event_types
+    job = s.get_extraction_job(job_id)
+    assert "another process is holding this KB's fact-term store" in job["message"]
+    s.close()
+
+
+def test_a_locked_sidecar_leaves_the_whole_retry_budget_for_a_real_failure(tmp_path):
+    """The refund, isolated: locks must not bring a real failure closer to giving up.
+
+    Three locked passes first — the number of times the error message invites the
+    operator to retry before `MAX_CHUNK_ATTEMPTS` would be gone — and then the
+    chunk starts failing for real. It must still get its full three attempts.
+
+    THIS IS THE TEST THAT SEPARATES the refund from a bare rewind. Requeue without
+    `attempts - 1` and the three locks leave the chunk at three attempts, so the
+    FIRST genuine failure reaches `attempts = 4 >= MAX_CHUNK_ATTEMPTS` and the
+    source is abandoned on its first real error.
+    """
+    s = _store(tmp_path)
+    source_id, job_id = _three_chunk_job(s)
+
+    for _ in range(3):
+        _lock_the_sidecar_on_put(s, lock_on=1)
+        with pytest.raises(DuckDBFactTermStoreLockedError):
+            process_extraction_job(s, _ChunkClient(), job_id=job_id)
+        assert _chunk_states(s, job_id)[0] == ("pending", 0)
+        assert _plan(s, source_id) == ExtractionJobPlan(resume_job_id=job_id)
+
+    # the peer let go; the chunk now fails on its own content, and the budget is
+    # spent one attempt per pass exactly as if the locks had never happened
+    s._fact_terms = None
+    for expected_attempts, expected_plan in (
+        (1, ExtractionJobPlan(retry_job_id=job_id)),
+        (2, ExtractionJobPlan(retry_job_id=job_id)),
+        (3, ExtractionJobPlan(exhausted_job_id=job_id)),
+    ):
+        with pytest.raises(ValueError):
+            process_extraction_job(
+                s,
+                _ChunkClient(fail_on=1, exc=ValueError("boom")),
+                job_id=job_id,
+                retry=expected_attempts > 1,
+                retry_max_attempts=MAX_CHUNK_ATTEMPTS if expected_attempts > 1 else None,
+            )
+        _worker_marks_job_failed(s, job_id, "analysis failed: boom")
+        assert _chunk_states(s, job_id)[0] == ("failed", expected_attempts)
+        assert _plan(s, source_id) == expected_plan
+
+    s.close()
+
+
+def test_a_reclaimed_chunk_is_not_requeued_by_the_call_that_lost_it(tmp_path):
+    """The CAS on `attempts`: a release applies to its own claim or to nothing.
+
+    `status = 'running'` alone cannot tell "my claim" from "somebody's claim" —
+    the row has no owner column. Here the startup recovery path rewinds the job
+    and the chunk is claimed afresh (#242), so the first claimant's release must
+    find nothing to release rather than rewinding and refunding the new owner's.
+    """
+    s = _store(tmp_path)
+    _source_id, job_id = _three_chunk_job(s)
+    chunk_id = int(s.next_pending_chunk(job_id)["id"])
+    stale_attempts = int(s.mark_chunk_running(chunk_id)["attempts"])
+
+    s.rollback_extraction_job(job_id, "rewound by the resume loop")
+    reissued = s.mark_chunk_running(chunk_id)
+    assert int(reissued["attempts"]) == stale_attempts + 1
+
+    assert s.requeue_chunk_claim(chunk_id, attempts=stale_attempts) is False
+
+    row = s.get_source_chunk(chunk_id)
+    assert (row["status"], int(row["attempts"])) == ("running", stale_attempts + 1)
+    s.close()
+
+
+# --- the same thing, against a real second process ----------------------------
+
+
+@_posix_only
+def test_a_real_peer_process_holding_the_sidecar_requeues_the_chunk(tmp_path, monkeypatch):
+    """The injected stub, replaced by an actual process holding the actual file.
+
+    Nothing here is simulated: the peer opens the sidecar with DuckDB, the
+    pipeline's own write path (`reconcile_fact` -> `put_fact_terms` ->
+    `_open_with_retry`) hits the conflict, and the error class is whatever that
+    path really raises. This is what keeps the stub tests above from going vacuous
+    if the sidecar ever stops raising `DuckDBFactTermStoreLockedError` from a
+    chunk write — the stub would keep passing; this would not.
+
+    The retry budget is set to zero so the pass fails at the lock instead of
+    waiting the peer out, which is the same condition a peer that holds the file
+    for longer than the budget produces.
+    """
+    pytest.importorskip("duckdb")
+    monkeypatch.setattr(duckdb_fact_terms, "_LOCK_TIMEOUT_SECONDS", 0.0)
+    s = _store(tmp_path)
+    source_id, job_id = _three_chunk_job(s)
+    client = _HoldsTheSidecarFromCall(
+        tmp_path, tmp_path / FACT_TERMS_FILENAME, hold_from=2
+    )
+
+    try:
+        with pytest.raises(DuckDBFactTermStoreLockedError):
+            process_extraction_job(s, client, job_id=job_id)
+
+        assert client.holder is not None, "the peer never started; nothing was locked"
+        assert _chunk_states(s, job_id) == [("done", 1), ("pending", 0), ("pending", 0)]
+        assert s.get_extraction_job(job_id)["status"] == "pending"
+        assert _plan(s, source_id) == ExtractionJobPlan(resume_job_id=job_id)
+        assert [f["subject"] for f in s.facts()] == ["alpha"]
+    finally:
+        if client.holder is not None:
+            _terminate(client.holder)
+        s.close()

--- a/tests/test_chunk_partial_insert_accounting.py
+++ b/tests/test_chunk_partial_insert_accounting.py
@@ -16,12 +16,13 @@ provenance pages, while the job reports `candidate_count = 0`.
 The chunk itself is released as `failed` (#475), which is the part that is fixed.
 The counter drift is not.
 
-FOLLOW-UP ISSUE: #TBD
+FOLLOW-UP ISSUE: #482
 
-That number is written exactly once, on the line above, and nothing else in this
-file refers to it — so filing the issue is a one-token edit. When it is fixed the
-assertions below GO RED, and the right response is to update them to the new,
-correct behaviour rather than to restore the drift.
+That issue owns the drift; this file only records it. #482 says in its own text
+that fixing it must turn the assertions below RED, and this docstring says the
+same thing from the other side, so neither can be read without finding the other.
+When they do go red, the correct response is to update them to the new, counted
+behaviour — never to restore the drift in order to keep them green.
 """
 
 import pytest

--- a/tests/test_chunk_partial_insert_accounting.py
+++ b/tests/test_chunk_partial_insert_accounting.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Characterisation: what the job counters say when a chunk dies mid-insert.
+
+CHARACTERISATION, NOT A GUARANTEE. This file records current behaviour so that a
+later change to it is visible, and it describes a known defect. It makes no claim
+that the behaviour below is correct and must not be read as a no-regression
+guard.
+
+`_extract_chunk` writes its candidate facts one at a time and only returns the
+count once every one of them has landed; `mark_chunk_done` — which adds that
+count to the job's `candidate_count` — runs after it. So a chunk that raises
+part-way through its insert loop leaves facts in the KB that no counter accounts
+for: the facts are real, carry this run's `run_id`, and are visible on the
+provenance pages, while the job reports `candidate_count = 0`.
+
+The chunk itself is released as `failed` (#475), which is the part that is fixed.
+The counter drift is not, and is left for a follow-up issue. WHEN THAT ISSUE IS
+FIXED THIS TEST GOES RED, and the right response is to update the expectations
+here — not to restore the drift.
+"""
+
+import pytest
+
+from verinote.llm.base import ExtractedFact
+from verinote.pipeline.extract import process_extraction_job
+from verinote.store import Store
+
+
+class _TwoFactClient:
+    """Two facts for the one chunk, so the insert loop has a middle to die in."""
+
+    name = "stub"
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        return [
+            ExtractedFact("alpha", "seen_in", "source", 0.9),
+            ExtractedFact("beta", "seen_in", "source", 0.9),
+        ]
+
+
+def test_facts_written_before_a_mid_chunk_failure_are_not_counted(tmp_path):
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    source_id = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=1
+    )
+    s.add_source_chunks(job_id=job_id, source_id=source_id, chunks=["alpha beta"])
+
+    real_reconcile = s.reconcile_fact
+    calls = {"n": 0}
+
+    def _second_insert_raises(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("write failed mid-chunk")
+        return real_reconcile(*args, **kwargs)
+
+    s.reconcile_fact = _second_insert_raises
+
+    with pytest.raises(RuntimeError):
+        process_extraction_job(s, _TwoFactClient(), job_id=job_id)
+
+    # The first fact is in the KB, with evidence, attributed to this run.
+    assert [f["subject"] for f in s.facts()] == ["alpha"]
+    # ...and no counter knows about it. This is the defect being characterised.
+    job = s.get_extraction_job(job_id)
+    assert job["candidate_count"] == 0
+    assert job["completed_chunks"] == 0
+    # The claim, by contrast, is released — that part is #475's fix.
+    chunk = s.source_chunks(job_id)[0]
+    assert chunk["status"] == "failed"
+    assert "RuntimeError" in chunk["error"]
+    s.close()

--- a/tests/test_chunk_partial_insert_accounting.py
+++ b/tests/test_chunk_partial_insert_accounting.py
@@ -14,9 +14,14 @@ for: the facts are real, carry this run's `run_id`, and are visible on the
 provenance pages, while the job reports `candidate_count = 0`.
 
 The chunk itself is released as `failed` (#475), which is the part that is fixed.
-The counter drift is not, and is left for a follow-up issue. WHEN THAT ISSUE IS
-FIXED THIS TEST GOES RED, and the right response is to update the expectations
-here — not to restore the drift.
+The counter drift is not.
+
+FOLLOW-UP ISSUE: #TBD
+
+That number is written exactly once, on the line above, and nothing else in this
+file refers to it — so filing the issue is a one-token edit. When it is fixed the
+assertions below GO RED, and the right response is to update them to the new,
+correct behaviour rather than to restore the drift.
 """
 
 import pytest

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -1706,10 +1706,16 @@ def test_a_halt_under_a_held_claim_returns_the_chunk_to_the_queue(tmp_path):
     rewind — marking it `failed` first would record a failure against a chunk
     that did nothing wrong.
 
-    THE EVENT ASSERTION IS THE LOAD-BEARING ONE. `rollback_extraction_job` rewinds
-    `failed` chunks to `pending` too, so if the release did fire, every end state
-    checked below would still look right; only the spurious `chunk_failed` row in
-    `fact_events` survives the rollback to give it away.
+    THE EVENT LOG AND THE CHUNK STATUS BOTH CATCH IT, independently. If the
+    release did fire, `fact_events` gains a `chunk_failed` row AND the chunk ends
+    `failed` rather than `pending` — `rollback_extraction_job` returns only the
+    in-flight `running` chunk to the queue ("`failed` chunks keep their error",
+    `store/db.py`; the UPDATE is scoped `WHERE job_id = ? AND status =
+    'running'`), so it does not sweep away a chunk the release already failed.
+
+    The event assertion comes first because it says directly that no release
+    happened, rather than inferring it from a resulting state. That is an ordering
+    preference, not a claim that the status assertion is redundant — keep both.
     """
     from verinote.pipeline.extract import process_extraction_job
 

--- a/tests/test_policy_state.py
+++ b/tests/test_policy_state.py
@@ -1672,6 +1672,76 @@ def test_resumed_job_summary_counts_only_this_run(tmp_path):
     assert "2/3 chunk(s), 1 candidate(s) written by this run" not in summaries[1]
 
 
+class _PolicyVanishingAfterClaimStore(Store):
+    """A Store whose policy disappears once the *second* chunk is already claimed.
+
+    Sibling of `_PolicyVanishingStore` above, aimed one step later in the loop.
+    That one deletes the policy at dequeue, so the pre-claim gate stops the pass
+    before any chunk is claimed. This one deletes it inside `mark_chunk_running`,
+    which puts the halt where the claim is HELD: the LLM call goes out, and the
+    write boundary inside `_extract_chunk` raises `PolicyMissingError` with the
+    chunk sitting at `running`. That is the only arrangement that reaches the
+    chunk-release handling in `process_extraction_job` by way of a halt.
+    """
+
+    def __init__(self, db_path, policy_path):
+        super().__init__(db_path)
+        self.policy_path = policy_path
+        self.claims = []
+
+    def mark_chunk_running(self, chunk_id: int):
+        row = super().mark_chunk_running(chunk_id)
+        self.claims.append(chunk_id)
+        if len(self.claims) == 2:
+            self.policy_path.unlink()
+        return row
+
+
+def test_a_halt_under_a_held_claim_returns_the_chunk_to_the_queue(tmp_path):
+    """The broad chunk-release handler (#475) must not intercept a halt.
+
+    `process_extraction_job` grew an `except Exception` that fails the claimed
+    chunk. A halt has to keep skipping it: `_halt_extraction_job` rewinds the
+    WHOLE job, and returning the in-flight chunk to the queue is part of that
+    rewind — marking it `failed` first would record a failure against a chunk
+    that did nothing wrong.
+
+    THE EVENT ASSERTION IS THE LOAD-BEARING ONE. `rollback_extraction_job` rewinds
+    `failed` chunks to `pending` too, so if the release did fire, every end state
+    checked below would still look right; only the spurious `chunk_failed` row in
+    `fact_events` survives the rollback to give it away.
+    """
+    from verinote.pipeline.extract import process_extraction_job
+
+    path, job_id = _halted_mid_job_kb(tmp_path)
+    store = _PolicyVanishingAfterClaimStore(tmp_path / "kb.sqlite", path)
+    store.init_schema()
+    client = _ChunkClient()
+
+    with pytest.raises(PolicyMissingError):
+        process_extraction_job(store, client, job_id=job_id)
+
+    event_types = [
+        row["event_type"]
+        for row in store._conn.execute(
+            "SELECT event_type FROM fact_events WHERE job_id = ? ORDER BY id", (job_id,)
+        )
+    ]
+    assert "chunk_failed" not in event_types
+    assert "extraction_job_rolled_back" in event_types
+
+    chunks = store.source_chunks(job_id)
+    # chunk 2 was claimed and its LLM call was made before the halt hit the write
+    # boundary — so this really did run with the claim held, unlike the pre-claim
+    # gate case in `test_chunk_is_not_claimed_on_a_kb_that_went_halted`
+    assert store.claims == [int(chunks[0]["id"]), int(chunks[1]["id"])]
+    assert client.calls == 2
+    assert [c["status"] for c in chunks] == ["done", "pending"]
+    assert chunks[1]["error"] == ""
+    assert store.get_extraction_job(job_id)["status"] == "pending"
+    store.close()
+
+
 class _AlwaysEligibleEngine:
     """A recommendation engine that reads no policy and accepts everything.
 

--- a/tests/test_sources_running_chunk_display.py
+++ b/tests/test_sources_running_chunk_display.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The Sources page counts a claimed chunk as running, not pending (#475).
+
+DOMAIN NOTE — this is deliberately tested on a LIVE job, and that is a different
+domain from the rest of #475's tests. Those pin that a chunk is never left
+`running` once a job pass ends; with that fixed, a job in a terminal status can
+no longer have a `running` chunk to display, so the display can only be exercised
+while a job is genuinely in flight. The reported symptom (a `failed` job showing
+"49 pending" for 48 untouched chunks plus one claimed) is the same miscount seen
+in a state that no longer occurs.
+
+What is asserted is the rendered page, through `create_app` + `TestClient`, so
+the `_source_inspector_rows` -> `sources.html` path is the thing under test
+rather than a hand-built context dict.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from verinote.config import Config  # noqa: E402
+from verinote.web import create_app  # noqa: E402
+
+
+def test_an_in_flight_job_shows_its_claimed_chunk_apart_from_the_waiting_ones(tmp_path):
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    app = create_app(cfg)
+    store = app.state.store
+    source_id = store.add_source("sources/a.txt")
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="anthropic", model="m", total_chunks=4
+    )
+    chunk_ids = store.add_source_chunks(
+        job_id=job_id, source_id=source_id, chunks=["a", "b", "c", "d"]
+    )
+    # A job mid-pass: one chunk finished, one claimed and out at the LLM, two still
+    # in the queue.
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_done(chunk_ids[0], candidates=1)
+    assert store.mark_chunk_running(chunk_ids[1]) is not None
+
+    html = TestClient(app).get("/sources").text
+
+    assert "1 running" in html
+    assert "2 pending" in html
+    # the miscount: 2 waiting + 1 claimed reported as three chunks nobody has touched
+    assert "3 pending" not in html

--- a/tests/test_sources_running_chunk_display.py
+++ b/tests/test_sources_running_chunk_display.py
@@ -2,12 +2,25 @@
 """The Sources page counts a claimed chunk as running, not pending (#475).
 
 DOMAIN NOTE — this is deliberately tested on a LIVE job, and that is a different
-domain from the rest of #475's tests. Those pin that a chunk is never left
-`running` once a job pass ends; with that fixed, a job in a terminal status can
-no longer have a `running` chunk to display, so the display can only be exercised
-while a job is genuinely in flight. The reported symptom (a `failed` job showing
-"49 pending" for 48 untouched chunks plus one claimed) is the same miscount seen
-in a state that no longer occurs.
+domain from the rest of #475's tests. Those pin that a claim this pipeline took is
+never left `running` once the pass ends, which makes an in-flight job the
+straightforward way to get a `running` chunk onto the page: the state arrives by
+ordinary progress instead of by arranging a failure to produce it.
+
+WHAT THAT CHOICE MUST NOT BE READ AS. A job in a terminal status can still have a
+`running` chunk, by at least two routes, and this same change documents both:
+
+* the read-back window at the claim, described in `verinote/pipeline/extract.py`
+  and owned by #489 — `mark_chunk_running` commits the claim and then reads the
+  row back in a separate statement, so a failure in that read strands a chunk
+  whose id the caller never received, after which the web worker's blanket
+  handler writes the job `failed`;
+* chunks already stranded by the bug this change fixes. Existing KBs carry them,
+  and they render here beside whatever status their job came to rest in.
+
+The reported symptom (a `failed` job showing "49 pending" for 48 untouched chunks
+plus one claimed) is therefore a state that still occurs. A live job is simply the
+cheapest way to render the same miscount.
 
 What is asserted is the rendered page, through `create_app` + `TestClient`, so
 the `_source_inspector_rows` -> `sources.html` path is the thing under test

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -49,7 +49,10 @@ from verinote.pipeline.query import query_path  # noqa: E402
 from verinote.pipeline.query_intent import parse_query_intent  # noqa: E402
 from verinote.store import Store  # noqa: E402
 from verinote.store import db as store_db  # noqa: E402
-from verinote.store.duckdb_fact_terms import fact_terms_path  # noqa: E402
+from verinote.store.duckdb_fact_terms import (  # noqa: E402
+    DuckDBFactTermStoreLockedError,
+    fact_terms_path,
+)
 from verinote.store.fact_input import structural_term  # noqa: E402
 from verinote.web import create_app  # noqa: E402
 
@@ -4622,6 +4625,45 @@ def test_worker_config_corrupt_does_not_mark_the_job_failed(tmp_path, monkeypatc
     time.sleep(0.2)  # let a (wrong) fail_extraction_job land, if the order regressed
     job = _job_row(cfg, job_id)
     assert job["status"] == "pending", "a corrupt-config race buried the job in `failed`"
+    assert "analysis failed" not in (job["message"] or "")
+    assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
+
+
+def test_worker_sidecar_lock_does_not_overwrite_the_rollback(tmp_path, monkeypatch, fake_client):
+    """`except DuckDBFactTermStoreLockedError` must stay ABOVE `except Exception`.
+
+    It is a `ValueError` subclass, so without a clause of its own the generic
+    handler takes it and calls `fail_extraction_job`. That is worse here than in
+    the sibling cases: `process_extraction_job` has ALREADY rolled the job back to
+    `pending` so the next pass resumes it, and the `failed` write lands on top of
+    that rollback. The result is a `failed` job with no failed chunk, which
+    `plan_source_extraction` treats as an edge state and rebuilds from scratch —
+    every chunk the pass finished is sent to the LLM again.
+
+    The stand-in raises after rewinding the job, which is the state the real
+    pipeline hands the worker (`_back_off_from_locked_sidecar`).
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    called = threading.Event()
+
+    def locked(store, *args, **kwargs):
+        store.rollback_extraction_job(job_id, "Paused: another process is holding it.")
+        called.set()
+        raise DuckDBFactTermStoreLockedError("the fact-term store is locked")
+
+    monkeypatch.setattr(webapp, "process_extraction_job", locked)
+
+    create_app(cfg)
+
+    assert called.wait(timeout=2.0)
+    time.sleep(0.2)  # let a (wrong) fail_extraction_job land, if the order regressed
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "pending", "the rollback was overwritten by a `failed` write"
     assert "analysis failed" not in (job["message"] or "")
     assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -24,6 +24,7 @@ from verinote.pipeline.normalize import normalize_for_extraction
 from verinote.pipeline.policy_state import PolicyMissingError, assert_writable
 from verinote.prompts import PromptError, render_prompt
 from verinote.store import Store
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreLockedError
 from verinote.store.fact_input import nfc_term, structural_term
 from verinote.text import nfc
 
@@ -201,10 +202,15 @@ def is_live_extraction_job(job, latest_job_ids: dict[int, int]) -> bool:
 
 
 # The total attempt budget for a single chunk before its job gives up. `attempts`
-# counts every `mark_chunk_running` — the initial pass plus each auto-retry — so a
-# chunk with `attempts >= MAX_CHUNK_ATTEMPTS` has spent the whole budget and its
-# job is surfaced as exhausted rather than retried forever (#323). The web retry
-# button is a human override and ignores this cap (`max_attempts=None`).
+# counts the attempts a chunk has SPENT ON ITS OWN CONTENT — the initial pass plus
+# each auto-retry — so a chunk with `attempts >= MAX_CHUNK_ATTEMPTS` has spent the
+# whole budget and its job is surfaced as exhausted rather than retried forever
+# (#323). Not the same as "every `mark_chunk_running`": a claim released because
+# the fact-term sidecar was locked is refunded (`Store.requeue_chunk_claim`), so a
+# chunk claimed six times can still sit at one attempt if five of those stopped on
+# a peer process rather than on this chunk. That is the point of the refund — an
+# availability condition must not spend a content budget. The web retry button is
+# a human override and ignores this cap (`max_attempts=None`).
 MAX_CHUNK_ATTEMPTS = 3
 
 
@@ -468,14 +474,23 @@ def process_extraction_job(
             # in this frame can cover a write that completed inside a callee before
             # the callee returned. Closing it means making the claim atomic with its
             # own result, i.e. folding the CAS and the read-back into one statement
-            # (`UPDATE ... RETURNING *`), which is a `Store` API change and belongs
-            # to whoever owns that layer. That work is #489 — it owns this window
+            # (`UPDATE ... RETURNING *`). That is a change to how the claim itself
+            # is issued, and it is deferred on its own merits, not because this
+            # change refuses to touch the `Store`: it does — `requeue_chunk_claim`
+            # is new here. Rewriting `mark_chunk_running`'s contract, though, would
+            # put every existing caller of the claim under review in a change about
+            # releasing one, and the window it closes is unreachable from this
+            # frame either way. That work is #489 — it owns this window
             # and records the same reasoning from its side, so neither this comment
             # nor the issue can be read without finding the other. Do not "fix" it
             # here by re-reading the chunk after the fact: that reintroduces the
             # same two-step race.
             try:
                 chunk_id = int(running["id"])
+                # Read back from our own claim, for `requeue_chunk_claim`'s CAS:
+                # it releases this claim only while the row still carries the
+                # attempt count this claim put on it.
+                claimed_attempts = int(running["attempts"])
                 inserted = _extract_chunk(
                     store,
                     client,
@@ -499,14 +514,39 @@ def process_extraction_job(
                 # the queue). Releasing it as `failed` here would both double-write
                 # and mislabel a healthy chunk.
                 raise
+            except DuckDBFactTermStoreLockedError:
+                # Not this chunk's failure either: another process holds the
+                # fact-term sidecar. The error text itself says so and tells the
+                # reader to wait and retry — so recording it as this chunk's
+                # failure would charge a retry attempt for a peer's timing, and
+                # `MAX_CHUNK_ATTEMPTS` of them would give up on the source for
+                # good over a condition that clears by itself. `web/app.py` made
+                # the same call one layer up for a corrupt config (#269): a
+                # host/environment condition is not content-attributable and must
+                # not consume the content's budget.
+                #
+                # So the claim is REWOUND rather than released as failed —
+                # `pending` with the attempt refunded, which is exactly the row
+                # `next_pending_chunk` handed out — and the outer handler then
+                # rewinds the job around it, the same two-level shape the halt
+                # path uses. Must sit ABOVE the broad clause:
+                # `DuckDBFactTermStoreLockedError` is a `ValueError` subclass.
+                store.requeue_chunk_claim(chunk_id, attempts=claimed_attempts)
+                raise
             except Exception as exc:
-                # The single release point for a held claim. Broad on purpose —
-                # but NOT because `LLMError` is the only failure this pipeline
-                # models. Name the modelled set and it is plainly larger:
-                # `PolicyMissingError` (the clause directly above) and
-                # `ExtractionJobBusyError` at the ownership claim, plus, inside
-                # `_extract_chunk` and the helpers it calls, `LLMError`,
-                # `PromptError`, `CorroborationPolicyError` and `TermParseError`.
+                # The release point for a claim whose failure IS this chunk's own.
+                # No longer the only release: the sidecar clause above rewinds a
+                # claim instead, for a cause the chunk did not commit. This is the
+                # last one, though — nothing below it releases anything, so every
+                # exception that is not named above leaves through here.
+                #
+                # Broad on purpose, but NOT because `LLMError` is the only failure
+                # this pipeline models. Name the modelled set and it is plainly
+                # larger: `PolicyMissingError` and `DuckDBFactTermStoreLockedError`
+                # (the two clauses above) and `ExtractionJobBusyError` at the
+                # ownership claim, plus, inside `_extract_chunk` and the helpers it
+                # calls, `LLMError`, `PromptError`, `CorroborationPolicyError` and
+                # `TermParseError`.
                 #
                 # What justifies the breadth is that the set is OPEN. It has grown
                 # with every subsystem extraction learned to talk to, and each new
@@ -523,6 +563,24 @@ def process_extraction_job(
         # gate above) or between its LLM call and its first insert (the boundary in
         # `_extract_chunk`). Rewind so the KB is recoverable, then let the error out.
         _halt_extraction_job(
+            store,
+            job_id=job_id,
+            run_id=run_id,
+            source_path=str(source["path"]),
+            run_candidates=candidates,
+            run_chunks=run_chunks,
+        )
+        raise
+    except DuckDBFactTermStoreLockedError:
+        # The sidecar was held by another process while this chunk was writing.
+        # The chunk clause above already rewound its own claim; this rewinds the
+        # JOB around it, and the pairing is not optional. Leave the job `running`
+        # and the web worker's blanket handler writes `failed` over it, at which
+        # point the job has a `failed` status with zero failed chunks — an edge
+        # state `plan_source_extraction` reads as "rebuild fresh", throwing away
+        # the chunks this pass already finished and re-sending them to the LLM.
+        # Rolling back to `pending` is what makes the next pass a resume.
+        _back_off_from_locked_sidecar(
             store,
             job_id=job_id,
             run_id=run_id,
@@ -614,6 +672,62 @@ def _halt_extraction_job(
         f"{source_path}: halted because this KB's policy file went missing; "
         f"job rolled back to pending at job progress {completed}/{total} chunk(s); "
         f"this run wrote {run_candidates} candidate(s) from {run_chunks} chunk(s)",
+    )
+
+
+def _back_off_from_locked_sidecar(
+    store: Store,
+    *,
+    job_id: int,
+    run_id: int,
+    source_path: str,
+    run_candidates: int,
+    run_chunks: int,
+) -> None:
+    """Rewind a job that stopped because another process holds the fact-term sidecar.
+
+    The availability sibling of `_halt_extraction_job`, and deliberately the same
+    shape: rewind to `pending` through `rollback_extraction_job`, then record what
+    this run really did. The reasons carry over unchanged — a job left `running`
+    that nothing is running is a KB lying about its own state, and `failed` would
+    mislabel chunks that never ran — and `pending` is again the one status from
+    which the documented remedy ("stop the other process, then retry") actually
+    works.
+
+    `rollback_extraction_job` also returns any `running` chunk to the queue, but by
+    the time we get here the chunk clause has already rewound the one claim this
+    pass held, so that part is a no-op. It is reused rather than sidestepped
+    because the rest is exactly what is wanted: `done` chunks kept, counters left
+    true, a `canceled` job left alone entirely, and the rollback recorded as an
+    event.
+
+    THE ONE ASYMMETRY WITH THE HALT PATH is the attempt refund, and it belongs to
+    the chunk clause rather than here (see `Store.requeue_chunk_claim`): a halted
+    KB is closed to writes, so nobody is waiting on a chunk's retry budget, while
+    a locked sidecar clears on its own and the next pass must find that budget
+    intact.
+
+    The counts are read back from the KB for the same reason `_halt_extraction_job`
+    reads them back, and the two scopes stay apart in the sentence: `completed`/
+    `total` are the job's progress across every pass, `run_chunks`/`run_candidates`
+    are this run's.
+    """
+    job = store.get_extraction_job(job_id)
+    completed = int(job["completed_chunks"]) if job is not None else 0
+    total = int(job["total_chunks"]) if job is not None else 0
+    store.rollback_extraction_job(
+        job_id,
+        f"Paused: another process is holding this KB's fact-term store. Rolled "
+        f"back to pending at {completed}/{total} chunk(s). Stop that process (most "
+        f"likely another `verinote ui` or `verinote sync` on this KB), or wait for "
+        f"it to finish, then re-run the analysis.",
+    )
+    store.set_run_summary(
+        run_id,
+        f"{source_path}: paused because another process holds this KB's fact-term "
+        f"store; job rolled back to pending at job progress {completed}/{total} "
+        f"chunk(s); this run wrote {run_candidates} candidate(s) from "
+        f"{run_chunks} chunk(s)",
     )
 
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -469,8 +469,11 @@ def process_extraction_job(
             # the callee returned. Closing it means making the claim atomic with its
             # own result, i.e. folding the CAS and the read-back into one statement
             # (`UPDATE ... RETURNING *`), which is a `Store` API change and belongs
-            # to whoever owns that layer. Do not "fix" it here by re-reading the
-            # chunk after the fact: that reintroduces the same two-step race.
+            # to whoever owns that layer. That work is #489 — it owns this window
+            # and records the same reasoning from its side, so neither this comment
+            # nor the issue can be read without finding the other. Do not "fix" it
+            # here by re-reading the chunk after the fact: that reintroduces the
+            # same two-step race.
             try:
                 chunk_id = int(running["id"])
                 inserted = _extract_chunk(

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -442,6 +442,16 @@ def process_extraction_job(
             running = store.mark_chunk_running(int(chunk["id"]))
             if running is None:
                 continue
+            chunk_id = int(running["id"])
+            # From here to the end of this block the claim is HELD. Every statement
+            # inside — including `mark_chunk_done` — is a write that can fail, and a
+            # failure that escapes without releasing leaves the chunk `running`
+            # under a job nobody will resume (#475). The `try` therefore starts at
+            # the claim, not at the LLM call.
+            #
+            # `BaseException` (Ctrl-C, `SystemExit`) is deliberately not caught: the
+            # job does not reach a terminal status either, and the existing recovery
+            # path (`_resume_source_extraction_jobs`) is what reclaims it.
             try:
                 inserted = _extract_chunk(
                     store,
@@ -453,15 +463,28 @@ def process_extraction_job(
                     artifact_id=(
                         int(job["artifact_id"]) if job["artifact_id"] is not None else None
                     ),
-                    chunk_id=int(running["id"]),
+                    chunk_id=chunk_id,
                     schema_hint=schema_hint,
                 )
-            except LLMError as exc:
-                store.mark_chunk_failed(int(running["id"]), str(exc))
+                store.mark_chunk_done(chunk_id, candidates=inserted)
+                candidates += inserted
+                run_chunks += 1
+            except PolicyMissingError:
+                # Not this chunk's failure: the KB went halted. The outer handler
+                # rewinds the WHOLE job (`_halt_extraction_job` ->
+                # `rollback_extraction_job`, which returns this `running` chunk to
+                # the queue). Releasing it as `failed` here would both double-write
+                # and mislabel a healthy chunk.
+                raise
+            except Exception as exc:
+                # The single release point for a held claim. Broad on purpose:
+                # `LLMError` is the only failure this pipeline models, so anything
+                # else is by definition unmodelled and must not be allowed to
+                # strand the claim.
+                _release_claimed_chunk(store, chunk_id, exc)
+                if not isinstance(exc, LLMError):
+                    raise
                 continue
-            candidates += inserted
-            store.mark_chunk_done(int(running["id"]), candidates=inserted)
-            run_chunks += 1
     except PolicyMissingError:
         # The policy vanished mid-job — either before this chunk was claimed (the
         # gate above) or between its LLM call and its first insert (the boundary in
@@ -492,6 +515,29 @@ def process_extraction_job(
         run_candidates=candidates,
         run_chunks=run_chunks,
     )
+
+
+def _release_claimed_chunk(store: Store, chunk_id: int, exc: BaseException) -> None:
+    """Release a chunk claim that is escaping via an exception — iff still held.
+
+    ONE judgement point for "a claimed chunk that will not complete becomes
+    `failed`". The status re-read is not a second decision: it asks whether the
+    claim is still held at all. `mark_chunk_done` writes in several steps and can
+    raise after the chunk is already `done` (its `candidate_count` update or
+    `_refresh_extraction_job` failing), and flipping a completed chunk to `failed`
+    would destroy real work and desync the job counters.
+
+    The message is type-qualified for unmodelled exceptions because `str()` of a
+    bare `ValueError()` is the empty string, and a chunk whose `error` is empty
+    renders as a bare "failed" with no cause (sources.html) — reproducing the
+    `error=''` symptom this fix exists to remove. `LLMError` keeps its own text
+    verbatim: it is already a domain message and existing tests pin the wording.
+    """
+    chunk = store.get_source_chunk(chunk_id)
+    if chunk is None or chunk["status"] != "running":
+        return
+    message = str(exc) if isinstance(exc, LLMError) else f"{type(exc).__name__}: {exc}"
+    store.mark_chunk_failed(chunk_id, message)
 
 
 def _halt_extraction_job(

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -500,10 +500,20 @@ def process_extraction_job(
                 # and mislabel a healthy chunk.
                 raise
             except Exception as exc:
-                # The single release point for a held claim. Broad on purpose:
-                # `LLMError` is the only failure this pipeline models, so anything
-                # else is by definition unmodelled and must not be allowed to
-                # strand the claim.
+                # The single release point for a held claim. Broad on purpose —
+                # but NOT because `LLMError` is the only failure this pipeline
+                # models. Name the modelled set and it is plainly larger:
+                # `PolicyMissingError` (the clause directly above) and
+                # `ExtractionJobBusyError` at the ownership claim, plus, inside
+                # `_extract_chunk` and the helpers it calls, `LLMError`,
+                # `PromptError`, `CorroborationPolicyError` and `TermParseError`.
+                #
+                # What justifies the breadth is that the set is OPEN. It has grown
+                # with every subsystem extraction learned to talk to, and each new
+                # member arrives as an exception type that reaches this loop before
+                # anyone writes it a clause of its own. The broad clause is the
+                # floor under that list — it keeps the NEXT unmodelled type from
+                # stranding a claim — not an assertion that the list is empty.
                 _release_claimed_chunk(store, chunk_id, exc)
                 if not isinstance(exc, LLMError):
                     raise

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -703,12 +703,16 @@ def _back_off_from_locked_sidecar(
     been reclaimed and re-issued to someone else, and this UPDATE is unconditional
     (`WHERE job_id = ? AND status = 'running'`), so it resets that other holder's
     in-flight chunk — undoing, one line later, the thing the CAS declined to do.
-    That is not a gap this function can close and not one it introduces: it is
-    exactly the #242 scope boundary `_resume_source_extraction_jobs` states in
-    `web/app.py` — DB state alone cannot distinguish a crashed zombie from a live
-    owner — and `_halt_extraction_job` reaches the same UPDATE by the same route
-    with the same consequence. Closing it needs a liveness lease, which is that
-    follow-up's business, not this clause's.
+    That overlap follows from reusing `rollback_extraction_job` whole, not from
+    anything this clause is unable to do: a job-only variant that skipped the chunk
+    UPDATE would not have it, the chunk clause having already settled this pass's
+    own claim either way. The paragraph below is why the shared one is taken
+    anyway. What remains is not a regression either — `_halt_extraction_job`
+    reaches the same UPDATE by the same route with the same consequence, and both
+    sit inside the #242 scope boundary `_resume_source_extraction_jobs` states in
+    `web/app.py`: DB state alone cannot distinguish a crashed zombie from a live
+    owner. Closing that belongs to the #242 follow-up, which `web/app.py`
+    describes, not to this clause.
 
     Reused rather than sidestepped because the rest is exactly what is wanted:
     `done` chunks kept, counters left true, a `canceled` job left alone entirely,

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -544,9 +544,11 @@ def process_extraction_job(
                 # this pipeline models. Name the modelled set and it is plainly
                 # larger: `PolicyMissingError` and `DuckDBFactTermStoreLockedError`
                 # (the two clauses above) and `ExtractionJobBusyError` at the
-                # ownership claim, plus, inside `_extract_chunk` and the helpers it
-                # calls, `LLMError`, `PromptError`, `CorroborationPolicyError` and
-                # `TermParseError`.
+                # ownership claim, plus `LLMError` from `_extract_chunk` — which is
+                # also how `PromptError`, `CorroborationPolicyError` and
+                # `TermParseError` arrive, each normalised to `LLMError` before it
+                # leaves the helper, so none of those three reaches this clause
+                # under its own name.
                 #
                 # What justifies the breadth is that the set is OPEN. It has grown
                 # with every subsystem extraction learned to talk to, and each new
@@ -694,12 +696,23 @@ def _back_off_from_locked_sidecar(
     which the documented remedy ("stop the other process, then retry") actually
     works.
 
-    `rollback_extraction_job` also returns any `running` chunk to the queue, but by
-    the time we get here the chunk clause has already rewound the one claim this
-    pass held, so that part is a no-op. It is reused rather than sidestepped
-    because the rest is exactly what is wanted: `done` chunks kept, counters left
-    true, a `canceled` job left alone entirely, and the rollback recorded as an
-    event.
+    `rollback_extraction_job` also returns any `running` chunk to the queue. WHEN
+    THE CHUNK CLAUSE'S CAS SUCCEEDED — the ordinary case, and the only one this
+    pass can bring about by itself — that part is a no-op: the claim this pass
+    held is already `pending`. WHEN IT FAILED, it did so because the chunk had
+    been reclaimed and re-issued to someone else, and this UPDATE is unconditional
+    (`WHERE job_id = ? AND status = 'running'`), so it resets that other holder's
+    in-flight chunk — undoing, one line later, the thing the CAS declined to do.
+    That is not a gap this function can close and not one it introduces: it is
+    exactly the #242 scope boundary `_resume_source_extraction_jobs` states in
+    `web/app.py` — DB state alone cannot distinguish a crashed zombie from a live
+    owner — and `_halt_extraction_job` reaches the same UPDATE by the same route
+    with the same consequence. Closing it needs a liveness lease, which is that
+    follow-up's business, not this clause's.
+
+    Reused rather than sidestepped because the rest is exactly what is wanted:
+    `done` chunks kept, counters left true, a `canceled` job left alone entirely,
+    and the rollback recorded as an event.
 
     THE ONE ASYMMETRY WITH THE HALT PATH is the attempt refund, and it belongs to
     the chunk clause rather than here (see `Store.requeue_chunk_claim`): a halted

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -442,17 +442,37 @@ def process_extraction_job(
             running = store.mark_chunk_running(int(chunk["id"]))
             if running is None:
                 continue
-            chunk_id = int(running["id"])
             # From here to the end of this block the claim is HELD. Every statement
             # inside — including `mark_chunk_done` — is a write that can fail, and a
             # failure that escapes without releasing leaves the chunk `running`
             # under a job nobody will resume (#475). The `try` therefore starts at
-            # the claim, not at the LLM call.
+            # the claim, not at the LLM call, and nothing sits between the two.
             #
             # `BaseException` (Ctrl-C, `SystemExit`) is deliberately not caught: the
             # job does not reach a terminal status either, and the existing recovery
             # path (`_resume_source_extraction_jobs`) is what reclaims it.
+            #
+            # ONE RESIDUAL WINDOW REMAINS, AND IT CANNOT BE CLOSED HERE. The line
+            # above is two round trips, not one: `mark_chunk_running` commits the
+            # `pending`->`running` UPDATE (autocommit) and then does a *separate*
+            # `get_source_chunk` read-back to return the row (`store/db.py`
+            # `mark_chunk_running`). If that SELECT raises, the claim is already
+            # committed while the caller never binds `running` at all — so there is
+            # no chunk id to release and the chunk is stranded exactly as #475
+            # describes.
+            #
+            # This is a DIFFERENT KIND of gap from the one the `try` below fixes,
+            # and the distinction is why it is left open rather than patched. That
+            # one was reachable code this function could guard with a handler; this
+            # one is unreachable from here in principle — no arrangement of `try`
+            # in this frame can cover a write that completed inside a callee before
+            # the callee returned. Closing it means making the claim atomic with its
+            # own result, i.e. folding the CAS and the read-back into one statement
+            # (`UPDATE ... RETURNING *`), which is a `Store` API change and belongs
+            # to whoever owns that layer. Do not "fix" it here by re-reading the
+            # chunk after the fact: that reintroduces the same two-step race.
             try:
+                chunk_id = int(running["id"])
                 inserted = _extract_chunk(
                     store,
                     client,

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1278,6 +1278,67 @@ class Store:
                 return None
             return self.get_source_chunk(chunk_id)
 
+    def requeue_chunk_claim(self, chunk_id: int, *, attempts: int) -> bool:
+        """Undo one `mark_chunk_running`: back to `pending`, attempt refunded.
+
+        The exact inverse of the claim — `pending`->`running` with `attempts + 1`
+        becomes `running`->`pending` with `attempts - 1` — for a caller that took
+        a chunk and then hit a condition that is neither the chunk's failure nor
+        attributable to its content (the fact-term sidecar held by another
+        process). `mark_chunk_failed` is the wrong release for that class: it
+        spends a retry attempt on a peer's timing, and `MAX_CHUNK_ATTEMPTS` of
+        those give up on the source permanently.
+
+        `attempts` is the value the caller read back from its own claim, and it is
+        in the WHERE clause as a compare-and-set. `status = 'running'` alone would
+        establish only that SOMEBODY holds the chunk — there is no owner column on
+        the row — so a caller whose claim had meanwhile been reclaimed and
+        re-issued to someone else (`claim_pending_extraction_job` rewinds stray
+        `running` chunks as it takes a job, and the new owner then claims them
+        afresh) would rewind and refund a claim that is no longer its own. Pinning
+        the attempt count makes this apply to the caller's own claim or to nothing
+        at all: a stale caller gets `False` and writes nothing.
+
+        THE REFUND IS THE DIFFERENCE from `rollback_extraction_job`, which also
+        returns a `running` chunk to the queue but leaves `attempts` alone. Both
+        are right for their own case. A halt freezes the whole KB against writes,
+        so nothing is queued up behind that counter — restoring the policy file is
+        the only way forward, and the count is not what stands in the way. A
+        locked sidecar clears the moment the other process lets go, and the very
+        next pass should find the budget it started with.
+
+        WHO READS `attempts`. Planning reads it in exactly two places,
+        `failed_chunk_attempt_status` and `claim_extraction_job_for_retry`, and
+        both are scoped `WHERE status = 'failed'` — so a refunded `pending` chunk
+        is invisible to them, and the refund reaches planning only later, if this
+        chunk goes on to fail for real. There is a third reader, and it is not
+        scoped: `_chunk_event_payload` carries `attempts` into every
+        `chunk_failed`/`chunk_retried` payload in `fact_events`, so a refund does
+        change the number a subsequent chunk event records. That is the intended
+        reading rather than a cost — the history should say a chunk has spent one
+        attempt when it has spent one, not two because a peer process happened to
+        be holding a file at the time.
+
+        NO EVENT OF ITS OWN, and the asymmetry with the transitions that do record
+        one is the reason. `mark_chunk_failed` and the retry claim each leave the
+        row somewhere a reader can later find it and ask why — failed carrying an
+        error, or requeued after having failed — so the event is what accounts for
+        the residue. This leaves the row bit-for-bit as `next_pending_chunk` first
+        handed it out, so there is nothing left behind for an event to explain:
+        the same ground `claim_pending_extraction_job` stands on when it rewinds
+        stray chunks with a raw update and no event. Nor is the occurrence lost —
+        the caller re-raises, its job is rolled back with a message naming the
+        cause, and the web worker logs it.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE source_chunks SET status = 'pending', error = '', "
+                "attempts = attempts - 1, updated_at = datetime('now') "
+                "WHERE id = ? AND status = 'running' AND attempts = ?",
+                (chunk_id, attempts),
+            )
+            return cur.rowcount == 1
+
     def mark_chunk_done(self, chunk_id: int, *, candidates: int = 0) -> None:
         with self._lock:
             chunk = self.get_source_chunk(chunk_id)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1297,7 +1297,16 @@ class Store:
         `running` chunks as it takes a job, and the new owner then claims them
         afresh) would rewind and refund a claim that is no longer its own. Pinning
         the attempt count makes this apply to the caller's own claim or to nothing
-        at all: a stale caller gets `False` and writes nothing.
+        at all: a stale caller gets `False`, and THIS METHOD writes nothing.
+
+        That promise is one statement wide, and it is worth saying where it stops.
+        What the caller does after a `False` is the caller's business, and the
+        pipeline's caller goes on to roll the whole job back — an unconditional
+        requeue of every `running` chunk, which resets the very claim the CAS here
+        declined to touch. `pipeline/extract.py::_back_off_from_locked_sidecar`
+        owns that overlap and records the #242 scope boundary it belongs to; the
+        guarantee to read out of THIS method is narrower: it never rewinds or
+        refunds a claim it cannot prove is the caller's.
 
         THE REFUND IS THE DIFFERENCE from `rollback_extraction_job`, which also
         returns a `running` chunk to the queue but leaves `attempts` alone. Both
@@ -1323,10 +1332,15 @@ class Store:
         one is the reason. `mark_chunk_failed` and the retry claim each leave the
         row somewhere a reader can later find it and ask why — failed carrying an
         error, or requeued after having failed — so the event is what accounts for
-        the residue. This leaves the row bit-for-bit as `next_pending_chunk` first
-        handed it out, so there is nothing left behind for an event to explain:
-        the same ground `claim_pending_extraction_job` stands on when it rewinds
-        stray chunks with a raw update and no event. Nor is the occurrence lost —
+        the residue. This restores `status`, `error` and `attempts` to what
+        `next_pending_chunk` first handed out (`updated_at` moves, as it does on
+        every write here), so there is nothing left behind for an event to
+        explain. `claim_pending_extraction_job` reasons the same way about its
+        stray-chunk rewind, though only up to a point: that UPDATE is by its own
+        account "a defensive no-op" that fires in no real path, whereas this one
+        is a transition that really happens. The shared part is the ground — a
+        row put back exactly as it was needs no history — not the frequency. Nor
+        is the occurrence lost —
         the caller re-raises, its job is rolled back with a message naming the
         cause, and the web worker logs it.
         """

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1425,13 +1425,22 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             row["artifacts"] = [dict(artifact) for artifact in store.source_artifacts(source_id)]
             row["failed_chunk_details"] = []
             row["pending_chunks"] = 0
+            row["running_chunks"] = 0
             if source["job_id"]:
                 chunks = store.source_chunks(int(source["job_id"]))
                 row["failed_chunk_details"] = [
                     dict(chunk) for chunk in chunks if chunk["status"] == "failed"
                 ]
+                # `pending` and `running` are counted apart. Summed, the page read
+                # "49 pending" for a job holding 48 untouched chunks and one it had
+                # already claimed and sent to the LLM (#475) — which says none of
+                # this has been started. They are different states to anyone who
+                # has to act on them, so they are different numbers here.
                 row["pending_chunks"] = sum(
-                    1 for chunk in chunks if chunk["status"] in {"pending", "running"}
+                    1 for chunk in chunks if chunk["status"] == "pending"
+                )
+                row["running_chunks"] = sum(
+                    1 for chunk in chunks if chunk["status"] == "running"
                 )
             rows.append(row)
         return rows

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -127,7 +127,10 @@ from verinote.store import (
     is_engine_input,
     review_statuses,
 )
-from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreError
+from verinote.store.duckdb_fact_terms import (
+    DuckDBFactTermStoreError,
+    DuckDBFactTermStoreLockedError,
+)
 from verinote.store.fact_input import nfc_term, structural_term, term_input_kind
 from verinote.text import nfc
 
@@ -1752,6 +1755,28 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # unrelated to the source content (#269).
                 logger.warning(
                     "extraction job %s halted (%s): %s", job_id, type(exc).__name__, exc
+                )
+            except DuckDBFactTermStoreLockedError as exc:
+                # ORDER IS LOAD-BEARING — above `except Exception`
+                # (`DuckDBFactTermStoreLockedError` is a `ValueError` subclass, so
+                # only the generic clause would otherwise take it). Another process
+                # holds this KB's fact-term sidecar: a host/environment condition
+                # that clears when that process lets go, exactly the category the
+                # ConfigCorrupt clause above refuses to charge to the content.
+                #
+                # This handler writes NOTHING, and here that is not merely
+                # conservative — `process_extraction_job` has already rolled the job
+                # back to `pending` so the next pass RESUMES it, and
+                # `fail_extraction_job` would overwrite that with `failed`. A
+                # `failed` job whose chunks are all `pending`/`done` has no failed
+                # chunk for planning to retry, so `plan_source_extraction` reads it
+                # as an edge state and rebuilds from scratch, paying the LLM again
+                # for every chunk this pass finished. Log and leave it.
+                logger.warning(
+                    "extraction job %s paused (fact-term store locked by another "
+                    "process): %s",
+                    job_id,
+                    exc,
                 )
             except LLMError as e:
                 with Store(cfg.db_path) as worker_store:

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -92,6 +92,12 @@
           {% if s["pending_chunks"] %}
             <span class="warn-inline">{{ s["pending_chunks"] }} pending</span>
           {% endif %}
+          {# A claimed chunk is in flight, not waiting, and saying "pending" about it
+             hid the difference between a job that has not started and one that is
+             mid-call (#475). Its own count, so the two are never summed again. #}
+          {% if s["running_chunks"] %}
+            <span class="warn-inline">{{ s["running_chunks"] }} running</span>
+          {% endif %}
           {# Chunk progress as a bar (#228). `completed_chunks` and `failed_chunks` are
              disjoint counts of the job's chunk rows (db.py `_refresh_extraction_job`
              counts `done` and `failed` separately), so the two segments tile the track


### PR DESCRIPTION
`Closes #475`

## 무엇을 고치나

청크를 `mark_chunk_running` 으로 클레임한 뒤의 `except` 절이 `LLMError` 하나뿐이라, 다른 예외는 루프를 통째로 빠져나가고 **클레임이 해제되지 않았다.** 잡은 `failed` 인데 청크는 `running` 으로 남는다.

## 이슈에 적힌 것보다 비용이 컸다

`plan_source_extraction` 은 `failed` + `failed_chunks == 0` 을 재시도 대상으로 보지 않고 **fresh 재빌드**로 보낸다(코드 주석이 그렇게 말한다). 즉 청크 30개를 끝낸 뒤 터지면 그 30번의 LLM 호출이 버려지고 다시 과금된다. 관측된 케이스는 첫 청크에서 죽어 `done=0` 이라 손실이 안 보였을 뿐이다.

이게 해제 상태를 `pending` 롤백이 아니라 **`failed`** 로 고른 이유다. `failed` 는 재시도 예산·exhausted 표면화·실패 청크 상세 UI·`chunk_failed` 이벤트까지 소비자가 전부 있다.

## `try` 경계가 클레임 직후에서 시작한다

원래 `try:` 는 `_extract_chunk` 만 감쌌고 `mark_chunk_done` 은 **밖**이었다. 즉 `mark_chunk_done` 이 던지면 이슈가 보고한 상태가 그대로 재현된다. 초안 수정은 그 경로를 막지 못했고, 리뷰에서 잡혀 `try` 를 클레임 직후로 올렸다. 클레임과 `try:` 사이에 실행문이 하나도 없다.

해제는 `_release_claimed_chunk` 한 곳에서만 일어나고, **아직 클레임을 쥐고 있을 때만** 한다 — `mark_chunk_done` 은 여러 쓰기로 이루어져 청크가 이미 `done` 이 된 뒤에도 던질 수 있고, 완료된 청크를 `failed` 로 뒤집으면 실제 작업이 파괴된다.

`except PolicyMissingError: raise` 가 broad handler **앞**에 있다. `PolicyMissingError` 와 `LLMError` 는 둘 다 `RuntimeError` 직계 형제라, 순서가 없으면 halt 경로를 삼킨다. halt 는 "청크 해제"가 아니라 "잡 전체 rewind"라는 다른 결정이다.

## 불변식

> **`process_extraction_job` 이 반환하든 예외로 빠져나오든, 호출 직후 그 잡의 청크 중 `running` 인 것은 0이다.**

조건절이 없다. "잡이 종료 상태이면…" 으로 쓰면 `process_extraction_job` 이 잡 상태를 안 쓰기 때문에 전제가 거짓이 되어 **테스트가 공허하게 통과한다.** 잡 상태가 필요한 테스트는 웹 워커를 흉내내는 하네스를 명시적으로 부르고, 그것이 프로덕션 코드가 아님을 주석에 못박았다.

`canceled` 는 정의역에서 뺐다 — CHECK 제약과 self-guard 에만 있고 프로덕션 세터가 없다. **CLI 는 이 파생 표현("잡이 종료 상태면…")의 정의역 밖이다** — 블랭킷 핸들러가 웹 워커에만 있어 잡이 애초에 종료 상태가 되지 않는다(별도 이슈).

## 남는 창 하나 — 여기서는 못 고친다

`mark_chunk_running` 은 UPDATE(autocommit 으로 이미 커밋) 뒤 별도 read-back SELECT 를 한다. 그 SELECT 가 던지면 클레임은 커밋됐는데 호출 프레임이 핸들을 못 받는다. **이건 위 `try` 경계 문제와 성격이 다르다** — 그건 여기서 한 줄로 막을 수 있었는데 안 막혀 있던 것이고, 이건 이 계층에서 원리적으로 불가능하다(커넥션이 죽은 게 원인이면 어떤 해제 코드도 같은 실패를 만난다). `RETURNING *` 로 CAS 와 반환을 한 문장으로 접어야 닫히고, 그건 Store API 변경이다. 코드 주석이 그 이슈를 지목한다.

## 기존 좀비 청크에 대해

이 변경 이전에 생긴 좀비 청크는 **해당 소스를 다시 sync 하기 전까지 남는다.** `sync --recover` 는 치우지 않는다. 재싱크하면 fresh 잡이 생기며 자연 소멸한다.

주의: 진행 표시 수정 때문에 그런 소스는 `failed` 뱃지 옆에 `1 running` 으로 보이게 된다 — 새 불변식이 화면에서 위반된 것처럼 보이지만, **새 코드가 만든 상태가 아니라 이 수정 이전에 생긴 것**이다. 시작 시 회수는 `canceled` 특례가 필요하고 근본적으로 liveness lease 미결(#242)에 걸려서 범위 밖으로 뒀다.

## 알려진 결함 하나를 특성화로 고정했다

청크의 insert 루프 중간에 예외가 나면 **팩트는 KB 에 남는데 `candidate_count` 는 0** 이고, 재시도하면 dedupe 때문에 그 차이가 영구화된다. 이 비대칭은 `LLMError` 경로에는 없다(발생점 셋이 전부 insert 루프 이전이고, `rollback_extraction_job` 독스트링이 그 성질에 의존한다).

무회귀 가드가 **아니다.** 현재 동작의 기술이고, 후속 이슈를 고치면 red 가 되어야 하며 그때 새 동작에 맞게 갱신하는 것이 정상 경로다. 파일과 이슈가 서로를 가리킨다.

## 검증

- 커밋 8개. 첫 커밋(테스트만)이 그 시점에 `10 failed, 2 passed` 로 red 임을 확인했다.
- 워크트리 기준선 `2876 passed, 14 skipped` → `2892 passed, 14 skipped`.
- `ruff check` 통과. `store/db.py` 무수정.
- 뮤테이션 14종 전부 사살. 단독 가드로 죽는 것들: `try` 경계 원위치→`mark_chunk_done` 테스트, 해제상태를 `pending` 롤백으로→`plan_source_extraction` 동등 비교, 해제 가드 삭제→"완료된 청크를 뒤집지 않는다", halt 절 삭제→`chunk_failed` 이벤트 단언.
- halt 경로 가드는 처음에 monkeypatch 스파이에 걸려 있었다(= 처방의 흔적을 감시). 리뷰에서 잡혀 `fact_events` 기반 결과 단언으로 옮겼고, 스파이를 지운 상태에서도 뮤턴트가 죽는 것을 확인했다.
