### PR TITLE
fix(llm): try 경계 밖에 있던 클라이언트·요청 생성 실패를 LLMError 로 정규화한다

### DIFF
--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -605,21 +605,23 @@ def test_each_adapter_names_only_its_own_vendor_base_url_variable(adapter, own, 
     `ANTHROPIC_BASE_URL='::::'` raises `httpx.InvalidURL` for anthropic and
     nothing for openai, and `OPENAI_BASE_URL='::::'` the other way round.
 
-    Scoped by role, not by spelling: only the paragraph opening "Deliberately
-    does NOT name" is read, because that is the one that enumerates causes, and
-    the vendor variable named there has to be the file's own. An earlier version
-    anchored on the `VAR='::::'` spelling every cause happens to use, which got
-    the trade the wrong way round -- it let "A malformed `OPENAI_BASE_URL` does
-    the same, so check that too" into the anthropic cause paragraph, and failed
-    a harmless reflow of that paragraph's own clause.
+    Scoped by role, not by spelling: only the paragraph carrying the marker
+    "Deliberately does NOT name" is read -- matched anywhere in it, though today
+    it is that paragraph's opening phrase -- because that is the paragraph
+    enumerating causes, and the vendor variable named there has to be the file's
+    own. An earlier version anchored on the `VAR='::::'` spelling every cause
+    happens to use, which got the trade the wrong way round: it let "A malformed
+    `OPENAI_BASE_URL` does the same, so check that too" into the anthropic cause
+    paragraph, and failed a harmless reflow of that paragraph's own clause.
 
     Mentions in the other paragraphs stay legal, and the anthropic docstring
     makes one deliberately: that `OPENAI_BASE_URL` does nothing in that
     constructor is a measured fact worth stating, and it is not a misdirection
     because it is not offered as a cause. `len(causes) == 1` is what stops that
-    permissiveness from swallowing the guard -- reword the marker away, or grow
-    a second paragraph carrying it, and this fails rather than quietly checking
-    nothing or checking the wrong half of a split.
+    permissiveness from swallowing the guard: reword the marker away and
+    `causes` is empty, duplicate it into a second paragraph and `causes` has
+    two, and either way this fails instead of quietly checking nothing or
+    checking only one of them.
     """
     paragraphs = [" ".join(p.split()) for p in _client_failed_docstring(adapter).split("\n\n")]
     causes = [p for p in paragraphs if "Deliberately does NOT name" in p]

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -410,5 +410,186 @@ def test_no_key_refuses_instead_of_falling_back_to_the_vendor_env_var(
     adapter_cls = _KEYED_ADAPTERS[provider]
     _raising_sdk(monkeypatch, provider, RuntimeError("unreachable"))
 
-    with pytest.raises(LLMError, match="requires an API key"):
+    # Anchored, and interpolating the provider, because `match` is `re.search`:
+    # an unanchored "requires an API key" also matches
+    # "openai client could not be created: openai requires an API key", which is
+    # exactly what re-inlining `_require_key()` as a constructor argument would
+    # produce. Without the `^` this test passes against that regression.
+    with pytest.raises(LLMError, match=rf"^{provider} requires an API key"):
         adapter_cls(_keyed_cfg(tmp_path, provider, None)).extract_facts(source_text="x")
+
+
+# --- the client could not be built, so nothing was ever dialled (#493) ---
+
+# Long enough for `redact_secret` to act on, unlike the `"key"` most fixtures in
+# this file use. Its role is the opposite of `_LONG_KEY`'s: a key that is present
+# and unremarkable, so the failure under test is the construction and never the
+# key check standing in front of it.
+_CONFIGURED_KEY = "sk-test-CONFIGURED-0001"
+
+# The value #493 was filed for. Measured against the installed SDKs: both
+# `anthropic.Anthropic(base_url="::::")` and `openai.OpenAI(base_url="::::")`
+# raise `httpx.InvalidURL: Relative URLs cannot have a path starting with ':'`.
+_UNUSABLE_BASE_URL = "::::"
+
+
+def _unusable_url_cfg(tmp_path, provider: str) -> Config:
+    """A keyed Config whose Base URL the SDK constructor cannot accept.
+
+    Spelled out rather than left at `base_url=None`, which matters for
+    `openrouter`: its `_base_url()` substitutes a perfectly good default, so a
+    `None` here would hand the SDK a working endpoint and assert nothing.
+    """
+    return Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider=provider,
+        model="model",
+        api_key=_CONFIGURED_KEY,
+        base_url=_UNUSABLE_BASE_URL,
+    )
+
+
+def _sdk_failing_to_construct(monkeypatch, provider: str, exc: Exception) -> None:
+    """Stub the vendor SDK so the CONSTRUCTOR raises, before any client exists.
+
+    `_raising_sdk` cannot express this. It stubs the constructor as
+    `lambda **k: client` — a function that always succeeds — and puts the failure
+    on `.create`, so every failure it can produce happens after a client was
+    built. That is precisely the case `_client_failed` is *not* about, which is
+    why this is a second fake rather than a parameter on the first.
+    """
+
+    def _boom(**kwargs):
+        raise exc
+
+    if provider in ("openai", "openrouter"):
+        monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=_boom))
+    else:
+        monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(Anthropic=_boom))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_client_that_cannot_be_built_is_a_normalised_failure(
+    tmp_path, monkeypatch, method, provider
+):
+    """A `base_url` typo is settings-UI input, so this is reachable by typing.
+    Left unnormalised the SDK's `httpx.InvalidURL` escapes the adapter, lands in
+    the web worker's generic handler as "analysis failed" and in the CLI as a
+    traceback — the §10.1 violation #474 fixed from the other direction.
+
+    Anchored at the start of the message. Unanchored it would also pass with
+    `_client()` moved inside each method's own `try`, which double-wraps into
+    "openai request failed: openai client could not be created: ..." — a message
+    claiming a request was made when none was.
+    """
+    _sdk_failing_to_construct(
+        monkeypatch, provider, RuntimeError("Relative URLs cannot have a path starting with ':'")
+    )
+    adapter = _KEYED_ADAPTERS[provider](_unusable_url_cfg(tmp_path, provider))
+
+    with pytest.raises(LLMError, match=rf"^{provider} client could not be created"):
+        _INVOCATIONS[method](adapter)
+
+
+def test_a_client_that_cannot_be_built_keeps_the_sdk_error_as_the_cause(tmp_path, monkeypatch):
+    """`from exc`, so the SDK's own words survive for a log even though the
+    user-facing message is the adapter's."""
+    boom = RuntimeError("Relative URLs cannot have a path starting with ':'")
+    _sdk_failing_to_construct(monkeypatch, "openai", boom)
+
+    with pytest.raises(LLMError) as exc:
+        OpenAIAdapter(_unusable_url_cfg(tmp_path, "openai")).extract_facts(source_text="x")
+
+    assert exc.value.__cause__ is boom
+
+
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_client_construction_error_never_carries_the_key(tmp_path, monkeypatch, provider):
+    """The second construction site has to redact too, and only a fake can show
+    it: the real `httpx.InvalidURL` this path exists for carries the URL and not
+    the key, so the real-SDK anchors below would stay green with `redact_secret`
+    deleted from `_client_failed`. That asymmetry is why this is written against
+    a stub — a construction error that *does* echo the key (a gateway rejecting
+    it during setup) is possible, and this message reaches `source_chunks.error`
+    like any other.
+    """
+    _sdk_failing_to_construct(monkeypatch, provider, RuntimeError(f"401 {_LONG_KEY}"))
+
+    with pytest.raises(LLMError) as exc:
+        _KEYED_ADAPTERS[provider](_keyed_cfg(tmp_path, provider, _LONG_KEY)).extract_facts(
+            source_text="x"
+        )
+
+    assert _LONG_KEY not in str(exc.value)
+    assert "***" in str(exc.value)
+
+
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_client_failure_does_not_send_a_user_to_a_field_they_left_blank(
+    tmp_path, monkeypatch, provider
+):
+    """`base_url` unset, and the SDK still fails to construct: measured against
+    both installed SDKs, `SSL_CERT_FILE` naming a missing file does exactly this,
+    and `HTTPS_PROXY='::::'` raises `httpx.InvalidURL` with no `base_url` in
+    sight. Naming the Base URL setting in the message would send those users to
+    edit an empty field — the misdirection #474 was reported as. The urllib
+    adapters DO name it, and correctly; see `base_url_unusable`.
+    """
+    _sdk_failing_to_construct(
+        monkeypatch, provider, FileNotFoundError(2, "No such file or directory")
+    )
+
+    with pytest.raises(LLMError) as exc:
+        _KEYED_ADAPTERS[provider](_keyed_cfg(tmp_path, provider, _CONFIGURED_KEY)).extract_facts(
+            source_text="x"
+        )
+
+    assert "Base URL" not in str(exc.value)
+    assert "base_url" not in str(exc.value)
+
+
+@pytest.mark.parametrize(("provider", "module"), [("anthropic", "anthropic"), ("openai", "openai")])
+def test_a_missing_sdk_still_says_the_sdk_is_missing(tmp_path, monkeypatch, provider, module):
+    """The `ImportError` clause has to stay in front of the construction guard.
+    Folded into it, "install the optional dependency" — an instruction the user
+    can act on — becomes "client could not be created", which is true and useless.
+    """
+    monkeypatch.setitem(sys.modules, module, None)
+
+    with pytest.raises(LLMError, match=rf"^{provider} SDK not installed"):
+        _KEYED_ADAPTERS[provider](_keyed_cfg(tmp_path, provider, _CONFIGURED_KEY)).extract_facts(
+            source_text="x"
+        )
+
+
+def test_the_installed_anthropic_sdk_really_does_reject_an_unusable_base_url(tmp_path):
+    """The stubs above show the adapter normalises whatever the constructor
+    raises; this shows the constructor raises at all for the value #493 was filed
+    with. Without it every test in this section could be green against an SDK
+    that quietly accepted `::::`.
+
+    Skipped where the optional dependency is absent, which includes CI — it
+    installs `.[test,wirelog]` and neither vendor SDK. Local green therefore does
+    not speak for CI on this one axis, which is why the stubs carry the contract.
+    """
+    pytest.importorskip("anthropic")
+
+    with pytest.raises(LLMError, match="^anthropic client could not be created"):
+        AnthropicAdapter(_unusable_url_cfg(tmp_path, "anthropic")).extract_facts(source_text="x")
+
+
+def test_the_installed_openai_sdk_really_does_reject_an_unusable_base_url(tmp_path):
+    """The openai half of the anchor above. #493 could only reason about this SDK
+    by structural analogy because it was not installed when the issue was filed;
+    measured on openai 2.53.0 it raises the same `httpx.InvalidURL` anthropic
+    0.116.0 does.
+
+    No openrouter twin: `OpenRouterAdapter` inherits `_client` unchanged, so a
+    third anchor would dial the same constructor and add only a skip.
+    """
+    pytest.importorskip("openai")
+
+    with pytest.raises(LLMError, match="^openai client could not be created"):
+        OpenAIAdapter(_unusable_url_cfg(tmp_path, "openai")).extract_facts(source_text="x")

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
+import ast
+import inspect
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -548,6 +551,60 @@ def test_a_client_failure_does_not_send_a_user_to_a_field_they_left_blank(
 
     assert "Base URL" not in str(exc.value)
     assert "base_url" not in str(exc.value)
+
+
+def _client_failed_docstring(adapter) -> str:
+    """`_client_failed`'s docstring as the source spells it.
+
+    Read out of the AST, not off `__doc__`: under `python -OO` the interpreter
+    strips docstrings, so `adapter._client_failed.__doc__` is `None` and every
+    assertion below would collapse into a claim about the empty case. Parsing
+    the file is indifferent to that, and it is what the other source-shape
+    guards in this suite already do.
+    """
+    tree = ast.parse(Path(inspect.getfile(adapter)).read_text(encoding="utf-8"))
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == adapter.__name__
+    )
+    method = next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_client_failed"
+    )
+    doc = ast.get_docstring(method)
+    assert doc is not None, f"{adapter.__name__}._client_failed has no docstring to check"
+    return doc
+
+
+@pytest.mark.parametrize(
+    ("adapter", "own", "foreign"),
+    [
+        (AnthropicAdapter, "ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"),
+        (OpenAIAdapter, "OPENAI_BASE_URL", "ANTHROPIC_BASE_URL"),
+    ],
+    ids=["anthropic", "openai"],
+)
+def test_each_adapter_names_only_its_own_vendor_base_url_variable(adapter, own, foreign):
+    """These two docstrings are near-identical prose about two different SDKs,
+    and the anthropic one shipped naming `OPENAI_BASE_URL` — a variable measured
+    to do nothing in `anthropic.Anthropic(...)`. That is the misdirection the
+    docstring itself argues against, one indirection out: a user handed a name
+    their SDK never reads goes looking for a setting that cannot be their cause.
+
+    Measured with each variable set alone in an `env -i` environment, against
+    anthropic 0.116.0 / openai 2.44.0 / httpx 0.28.1, with `base_url=None`:
+    `ANTHROPIC_BASE_URL='::::'` raises `httpx.InvalidURL` for anthropic and
+    nothing for openai, and `OPENAI_BASE_URL='::::'` the other way round.
+
+    Absence is the half that fails today; presence is here so that satisfying
+    it by deleting the sentence is not a way out.
+    """
+    doc = _client_failed_docstring(adapter)
+
+    assert own in doc
+    assert foreign not in doc
 
 
 @pytest.mark.parametrize(("provider", "module"), [("anthropic", "anthropic"), ("openai", "openai")])

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -557,10 +557,14 @@ def _client_failed_docstring(adapter) -> str:
     """`_client_failed`'s docstring as the source spells it.
 
     Read out of the AST, not off `__doc__`: under `python -OO` the interpreter
-    strips docstrings, so `adapter._client_failed.__doc__` is `None`. Measured,
-    a `__doc__` version does not go quietly vacuous under that flag -- it raises
-    `TypeError` and both parameterisations fail loudly -- but a guard that
-    cannot run under a supported interpreter flag is still not a guard. And what
+    strips docstrings, so `adapter._client_failed.__doc__` is `None`. A
+    `__doc__` version does not go quietly vacuous under that flag: measured
+    against the body below, it dies on `None.split` with an `AttributeError` and
+    both parameterisations fail loudly. (That exception type is a fact about the
+    body, not about `-OO` -- it has already gone stale once here when the body
+    changed. Re-measure it rather than reasoning about it.) Failing loudly is
+    still failing, and a guard that cannot run under a supported interpreter
+    flag is not a guard. And what
     is being asserted is a property of the source text that ships, so reading
     the source is the direct route as well as the flag-independent one; the
     source-shape guards elsewhere in `tests/` take it for the same reason.

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -583,7 +583,7 @@ def test_the_installed_anthropic_sdk_really_does_reject_an_unusable_base_url(tmp
 def test_the_installed_openai_sdk_really_does_reject_an_unusable_base_url(tmp_path):
     """The openai half of the anchor above. #493 could only reason about this SDK
     by structural analogy because it was not installed when the issue was filed;
-    measured on openai 2.53.0 it raises the same `httpx.InvalidURL` anthropic
+    measured on openai 2.54.0 it raises the same `httpx.InvalidURL` anthropic
     0.116.0 does.
 
     No openrouter twin: `OpenRouterAdapter` inherits `_client` unchanged, so a

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -598,13 +598,23 @@ def test_each_adapter_names_only_its_own_vendor_base_url_variable(adapter, own, 
     `ANTHROPIC_BASE_URL='::::'` raises `httpx.InvalidURL` for anthropic and
     nothing for openai, and `OPENAI_BASE_URL='::::'` the other way round.
 
-    Absence is the half that fails today; presence is here so that satisfying
-    it by deleting the sentence is not a way out.
-    """
-    doc = _client_failed_docstring(adapter)
+    Anchored on the `VAR='::::'` spelling that every cause in those paragraphs
+    uses, which is what scopes this to the defect: the variable named as a
+    *cause* has to be the file's own. A bare mention of the other vendor's
+    stays legal, and the anthropic docstring makes one deliberately -- that
+    `OPENAI_BASE_URL` does nothing in that constructor is a measured fact worth
+    stating, and it is not a misdirection because it is not offered as a cause.
 
-    assert own in doc
-    assert foreign not in doc
+    Both halves earn their keep under that anchor: deleting the cause clause
+    fails the first assertion, and naming the wrong vendor in it fails the
+    second. An unanchored `own in doc` would not -- the OpenRouter paragraph
+    further down `openai_adapter` mentions `OPENAI_BASE_URL` again, so the
+    presence half would survive gutting the paragraph this is about.
+    """
+    flat = " ".join(_client_failed_docstring(adapter).split())
+
+    assert f"{own}='::::'" in flat
+    assert f"{foreign}='::::'" not in flat
 
 
 @pytest.mark.parametrize(("provider", "module"), [("anthropic", "anthropic"), ("openai", "openai")])

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -601,23 +601,28 @@ def test_each_adapter_names_only_its_own_vendor_base_url_variable(adapter, own, 
     `ANTHROPIC_BASE_URL='::::'` raises `httpx.InvalidURL` for anthropic and
     nothing for openai, and `OPENAI_BASE_URL='::::'` the other way round.
 
-    Anchored on the `VAR='::::'` spelling that every cause in those paragraphs
-    uses, which is what scopes this to the defect: the variable named as a
-    *cause* has to be the file's own. A bare mention of the other vendor's
-    stays legal, and the anthropic docstring makes one deliberately -- that
-    `OPENAI_BASE_URL` does nothing in that constructor is a measured fact worth
-    stating, and it is not a misdirection because it is not offered as a cause.
+    Scoped by role, not by spelling: only the paragraph opening "Deliberately
+    does NOT name" is read, because that is the one that enumerates causes, and
+    the vendor variable named there has to be the file's own. An earlier version
+    anchored on the `VAR='::::'` spelling every cause happens to use, which got
+    the trade the wrong way round -- it let "A malformed `OPENAI_BASE_URL` does
+    the same, so check that too" into the anthropic cause paragraph, and failed
+    a harmless reflow of that paragraph's own clause.
 
-    Both halves earn their keep under that anchor: deleting the cause clause
-    fails the first assertion, and naming the wrong vendor in it fails the
-    second. An unanchored `own in doc` would not -- the OpenRouter paragraph
-    further down `openai_adapter` mentions `OPENAI_BASE_URL` again, so the
-    presence half would survive gutting the paragraph this is about.
+    Mentions in the other paragraphs stay legal, and the anthropic docstring
+    makes one deliberately: that `OPENAI_BASE_URL` does nothing in that
+    constructor is a measured fact worth stating, and it is not a misdirection
+    because it is not offered as a cause. `len(causes) == 1` is what stops that
+    permissiveness from swallowing the guard -- reword the marker away, or grow
+    a second paragraph carrying it, and this fails rather than quietly checking
+    nothing or checking the wrong half of a split.
     """
-    flat = " ".join(_client_failed_docstring(adapter).split())
+    paragraphs = [" ".join(p.split()) for p in _client_failed_docstring(adapter).split("\n\n")]
+    causes = [p for p in paragraphs if "Deliberately does NOT name" in p]
+    assert len(causes) == 1, paragraphs
 
-    assert f"{own}='::::'" in flat
-    assert f"{foreign}='::::'" not in flat
+    assert own in causes[0]
+    assert foreign not in causes[0]
 
 
 @pytest.mark.parametrize(("provider", "module"), [("anthropic", "anthropic"), ("openai", "openai")])

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -557,10 +557,13 @@ def _client_failed_docstring(adapter) -> str:
     """`_client_failed`'s docstring as the source spells it.
 
     Read out of the AST, not off `__doc__`: under `python -OO` the interpreter
-    strips docstrings, so `adapter._client_failed.__doc__` is `None` and every
-    assertion below would collapse into a claim about the empty case. Parsing
-    the file is indifferent to that, and it is what the other source-shape
-    guards in this suite already do.
+    strips docstrings, so `adapter._client_failed.__doc__` is `None`. Measured,
+    a `__doc__` version does not go quietly vacuous under that flag -- it raises
+    `TypeError` and both parameterisations fail loudly -- but a guard that
+    cannot run under a supported interpreter flag is still not a guard. And what
+    is being asserted is a property of the source text that ships, so reading
+    the source is the direct route as well as the flag-independent one; the
+    source-shape guards elsewhere in `tests/` take it for the same reason.
     """
     tree = ast.parse(Path(inspect.getfile(adapter)).read_text(encoding="utf-8"))
     cls = next(

--- a/tests/test_llm_base.py
+++ b/tests/test_llm_base.py
@@ -15,11 +15,16 @@ from verinote.llm.base import LLMError, base_url_unusable
 
 # Every URL the three call sites can be made to refuse, as a user could type it.
 # `Invalid IPv6 URL` is the one that earns the `url` parameter: alone among these
-# it comes back from `Request` with no trace of what was handed in.
+# it comes back from `Request` with no trace of what was handed in. The tab is
+# the one that earns comparing on `repr`: `unknown url type` quotes the URL with
+# `!r`, so a URL containing anything `repr` escapes is present in the exception
+# in escaped form and absent in raw form. Every URL here is ASCII except that
+# one, and an all-ASCII fixture cannot see the difference.
 _REFUSED_URLS = [
     "::::/api/tags",  # the settings-UI typo #493 was reported for
     "http://[/api/tags",  # an unclosed IPv6 literal
     "/api/tags",  # a path pasted where a URL was wanted
+    "lo\tcal/api/chat",  # whitespace `repr` escapes, as a paste can carry
 ]
 
 
@@ -84,10 +89,27 @@ def test_the_refused_url_is_in_the_message_however_the_exception_words_itself(ur
     """The message names the Base URL setting, so it has to quote what is in it.
     Held for every refusable URL and not just the reported one, because which of
     these a user types is not something this code gets to choose.
+
+    Asserted on `repr(url)`, which is how the URL reaches the message from either
+    branch: `unknown url type: {url!r}` is the exception's own wording, and the
+    appended clause matches it deliberately. A raw-substring assertion would be
+    false for a URL containing a tab even when the message displays it perfectly.
     """
     err, _ = _refused(url)
 
-    assert url in str(err)
+    assert f"{url!r}" in str(err)
+
+
+@pytest.mark.parametrize("url", _REFUSED_URLS)
+def test_the_refused_url_is_printed_once_and_not_twice(url):
+    """Which branch the helper takes is a presentation choice; that the URL is
+    named exactly once is the contract. Parametrised over every refusable URL
+    rather than asserted for the reported one alone, because the branch is chosen
+    by testing the exception's text and each of these words itself differently.
+    """
+    err, _ = _refused(url)
+
+    assert str(err).count(f"{url!r}") == 1
 
 
 def test_an_exception_that_omits_the_url_is_why_the_url_is_a_parameter():
@@ -113,4 +135,19 @@ def test_a_url_the_exception_already_quotes_is_not_repeated():
     err, _ = _refused(url)
 
     assert str(err).count(url) == 1
+    assert "tried" not in str(err)
+
+
+def test_a_url_the_exception_quotes_in_escaped_form_is_not_repeated_either():
+    """The gap a raw-substring test leaves open. `repr` escapes the tab, so the
+    exception carries `'lo\\tcal/api/chat'` while the URL itself contains a real
+    tab — a containment test on the raw string finds nothing, decides the
+    exception never mentioned it, and appends a second copy. Pasted URLs pick up
+    invisible characters (ZWSP, BOM) all the time, and `base_url` is settings-UI
+    input, so this is reachable by pasting.
+    """
+    url = "lo\tcal/api/chat"
+    err, _ = _refused(url)
+
+    assert str(err).count(f"{url!r}") == 1
     assert "tried" not in str(err)

--- a/tests/test_llm_base.py
+++ b/tests/test_llm_base.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Unit tests for the provider-agnostic helpers in `verinote.llm.base`.
+
+The adapters' own suites cover these through a request; what is pinned here is
+the part that has to hold identically for every caller, including the two
+module-level `list_models` functions that hold no `Config` and no adapter.
+"""
+
+import urllib.request
+
+import pytest
+
+from verinote.llm.base import LLMError, base_url_unusable
+
+
+def test_base_url_unusable_is_an_llm_error_naming_the_provider_and_the_setting():
+    """Both halves are load-bearing. `LLMError` is what every caller catches
+    (functional spec §10.1); the provider name is what the settings banner and a
+    persisted chunk error use to say which of several configured endpoints broke.
+    """
+    err = base_url_unusable("ollama", ValueError("unknown url type: '::::'"))
+
+    assert isinstance(err, LLMError)
+    assert str(err) == (
+        "ollama base URL is unusable: unknown url type: '::::' (check the Base URL setting)"
+    )
+
+
+def test_base_url_unusable_does_not_claim_the_request_failed():
+    """"request failed" means a remote was dialled and did not cooperate. Nothing
+    was dialled here, and a user reading that would go looking at a server that
+    never heard from them."""
+    assert "request failed" not in str(base_url_unusable("openrouter", ValueError("boom")))
+
+
+def test_base_url_unusable_returns_rather_than_raises():
+    """So the call site writes `raise base_url_unusable(...) from exc` and the
+    original exception survives in `__cause__`. A helper that raised on its own
+    would drop the chain unless every site remembered to rebuild it."""
+    assert isinstance(base_url_unusable("ollama", ValueError("boom")), LLMError)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "::::/api/tags",  # the settings-UI typo #493 was reported for
+        "http://[/api/tags",  # an unclosed IPv6 literal
+        "/api/tags",  # a path pasted where a URL was wanted
+    ],
+)
+def test_the_urls_this_exists_for_really_do_raise_valueerror(url):
+    """The narrow `except ValueError` at each call site is only correct if that
+    is what `Request` actually raises. Measured here rather than assumed, so a
+    Python release that changed the type would fail this instead of silently
+    turning the new clauses into dead code."""
+    with pytest.raises(ValueError):
+        urllib.request.Request(url)

--- a/tests/test_llm_base.py
+++ b/tests/test_llm_base.py
@@ -13,16 +13,43 @@ import pytest
 from verinote.llm.base import LLMError, base_url_unusable
 
 
+# Every URL the three call sites can be made to refuse, as a user could type it.
+# `Invalid IPv6 URL` is the one that earns the `url` parameter: alone among these
+# it comes back from `Request` with no trace of what was handed in.
+_REFUSED_URLS = [
+    "::::/api/tags",  # the settings-UI typo #493 was reported for
+    "http://[/api/tags",  # an unclosed IPv6 literal
+    "/api/tags",  # a path pasted where a URL was wanted
+]
+
+
+def _refused(url: str, provider: str = "ollama") -> tuple[LLMError, ValueError]:
+    """Build the error from the ValueError `Request` really raises for `url`.
+
+    Not from a hand-written `ValueError("...")`: every claim below is about how
+    much of the URL survives into the message, and a stand-in exception would let
+    this file decide that instead of CPython. `pytest.fail` rather than a skip if
+    the URL is accepted — a URL that stopped raising would make the assertions
+    that follow vacuous rather than inapplicable.
+    """
+    try:
+        urllib.request.Request(url)
+    except ValueError as exc:
+        return base_url_unusable(provider, url, exc), exc
+    pytest.fail(f"{url!r} no longer raises; the call sites' clauses would be dead code")
+
+
 def test_base_url_unusable_is_an_llm_error_naming_the_provider_and_the_setting():
     """Both halves are load-bearing. `LLMError` is what every caller catches
     (functional spec §10.1); the provider name is what the settings banner and a
     persisted chunk error use to say which of several configured endpoints broke.
     """
-    err = base_url_unusable("ollama", ValueError("unknown url type: '::::'"))
+    err, _ = _refused("::::/api/tags")
 
     assert isinstance(err, LLMError)
     assert str(err) == (
-        "ollama base URL is unusable: unknown url type: '::::' (check the Base URL setting)"
+        "ollama base URL is unusable: unknown url type: '::::/api/tags' "
+        "(check the Base URL setting)"
     )
 
 
@@ -30,24 +57,19 @@ def test_base_url_unusable_does_not_claim_the_request_failed():
     """"request failed" means a remote was dialled and did not cooperate. Nothing
     was dialled here, and a user reading that would go looking at a server that
     never heard from them."""
-    assert "request failed" not in str(base_url_unusable("openrouter", ValueError("boom")))
+    err, _ = _refused("::::/models", provider="openrouter")
+
+    assert "request failed" not in str(err)
 
 
 def test_base_url_unusable_returns_rather_than_raises():
     """So the call site writes `raise base_url_unusable(...) from exc` and the
     original exception survives in `__cause__`. A helper that raised on its own
     would drop the chain unless every site remembered to rebuild it."""
-    assert isinstance(base_url_unusable("ollama", ValueError("boom")), LLMError)
+    assert isinstance(base_url_unusable("ollama", "::::", ValueError("boom")), LLMError)
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "::::/api/tags",  # the settings-UI typo #493 was reported for
-        "http://[/api/tags",  # an unclosed IPv6 literal
-        "/api/tags",  # a path pasted where a URL was wanted
-    ],
-)
+@pytest.mark.parametrize("url", _REFUSED_URLS)
 def test_the_urls_this_exists_for_really_do_raise_valueerror(url):
     """The narrow `except ValueError` at each call site is only correct if that
     is what `Request` actually raises. Measured here rather than assumed, so a
@@ -55,3 +77,40 @@ def test_the_urls_this_exists_for_really_do_raise_valueerror(url):
     turning the new clauses into dead code."""
     with pytest.raises(ValueError):
         urllib.request.Request(url)
+
+
+@pytest.mark.parametrize("url", _REFUSED_URLS)
+def test_the_refused_url_is_in_the_message_however_the_exception_words_itself(url):
+    """The message names the Base URL setting, so it has to quote what is in it.
+    Held for every refusable URL and not just the reported one, because which of
+    these a user types is not something this code gets to choose.
+    """
+    err, _ = _refused(url)
+
+    assert url in str(err)
+
+
+def test_an_exception_that_omits_the_url_is_why_the_url_is_a_parameter():
+    """The case a two-argument helper loses outright. `Request('http://[...')`
+    raises a bare `Invalid IPv6 URL` — no URL, no quoting, nothing the user can
+    match against the field they are being sent to check. Passing the URL in is
+    the only way the message can carry it, and this is the test that says so.
+    """
+    url = "http://[/api/tags"
+    err, exc = _refused(url)
+
+    assert url not in str(exc)  # the exception alone cannot carry it
+    assert url in str(err)
+    assert "tried 'http://[/api/tags'" in str(err)
+
+
+def test_a_url_the_exception_already_quotes_is_not_repeated():
+    """The other branch, and the reason there are two: `unknown url type` quotes
+    the URL itself, so appending it again would print the same string twice in
+    one sentence for the case #493 was actually reported with.
+    """
+    url = "::::/api/tags"
+    err, _ = _refused(url)
+
+    assert str(err).count(url) == 1
+    assert "tried" not in str(err)

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -462,6 +462,105 @@ def test_a_schema_failure_is_not_reported_as_a_request_failure(tmp_path, monkeyp
     assert "did not match schema" in str(exc.value)
 
 
+# --- a base URL no request can be built from ---
+
+# The settings-UI typo #493 was reported for. `urllib.request.Request` rejects
+# it with `ValueError: unknown url type` before any socket is opened.
+_UNUSABLE_BASE_URL = "::::"
+
+
+def _unusable_cfg(tmp_path) -> Config:
+    """A Config whose Base URL cannot be turned into a request at all.
+
+    Built here rather than by widening `_cfg`, so no existing test in this file
+    changes shape for a case only these ones care about.
+    """
+    return Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="ollama",
+        model="qwen3:8b",
+        api_key=None,
+        base_url=_UNUSABLE_BASE_URL,
+    )
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_an_unusable_base_url_is_normalised_before_anything_is_dialled(
+    tmp_path, monkeypatch, method
+):
+    """A `base_url` typo is a settings-UI input, so this is reachable by typing.
+    Unnormalised it escapes as a bare `ValueError`, which the web worker's
+    generic handler turns into "analysis failed" and the CLI into a traceback.
+
+    `urlopen` is stubbed to fail the test outright: "nothing was dialled" is half
+    of what makes the message honest, and an assertion on the message alone would
+    hold even if the adapter had opened a socket first.
+    """
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: pytest.fail("an unbuildable request must not reach the network"),
+    )
+
+    with pytest.raises(LLMError, match="^ollama base URL is unusable"):
+        _INVOCATIONS[method](OllamaAdapter(_unusable_cfg(tmp_path)))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_an_unusable_base_url_keeps_the_original_error_as_the_cause(
+    tmp_path, monkeypatch, method
+):
+    """`from exc`, so `unknown url type: '::::/api/chat'` — the part that says
+    which URL and why — survives for a log even though the user-facing message
+    is the shorter one."""
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError) as exc:
+        _INVOCATIONS[method](OllamaAdapter(_unusable_cfg(tmp_path)))
+
+    assert isinstance(exc.value.__cause__, ValueError)
+
+
+def test_a_payload_that_cannot_be_serialised_is_not_blamed_on_the_base_url(
+    tmp_path, monkeypatch
+):
+    """`json.dumps(payload).encode(...)` used to be an ARGUMENT to `Request`,
+    which means it would be evaluated inside the guarded region if left there.
+    A `ValueError` raised while serialising is a bug in this file, and reporting
+    it as "base URL is unusable" would send the user to edit a field that is
+    perfectly fine — the same misattribution #474 was reported as.
+    """
+    monkeypatch.setattr(
+        "json.dumps", lambda *a, **k: (_ for _ in ()).throw(ValueError("payload not serialisable"))
+    )
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(ValueError) as exc:
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+    assert "base URL" not in str(exc.value)
+
+
+def test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url(
+    tmp_path, monkeypatch
+):
+    """The clause catches `ValueError` and nothing wider. `Request` cannot raise
+    a `TypeError` for any value reachable through settings — it stringifies
+    whatever it is handed — so this stubs one in: the point is that widening the
+    clause to `except Exception` would relabel a genuine programming error as a
+    user configuration mistake, and no reachable input can demonstrate that.
+    """
+
+    def boom(*args, **kwargs):
+        raise TypeError("Request() got an unexpected keyword argument")
+
+    monkeypatch.setattr("urllib.request.Request", boom)
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(TypeError):
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+
 # --- list_models: the settings picker's source of truth ---
 
 
@@ -584,4 +683,31 @@ def test_list_models_raises_on_schema_mismatch(monkeypatch, payload):
     _tags(monkeypatch, payload)
 
     with pytest.raises(LLMError, match="did not match schema"):
+        list_models(None, 5.0)
+
+
+def test_list_models_normalises_a_base_url_no_request_can_be_built_from(monkeypatch):
+    """The worst of the three sites: `GET /settings/model-field?base_url=::::`
+    reaches this with a URL that was never saved, so a user only has to type into
+    the Base URL box to get a 500 out of the settings page. `LLMError` is what
+    that endpoint already knows how to render as a banner.
+    """
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError, match="^ollama base URL is unusable"):
+        list_models(_UNUSABLE_BASE_URL, 5.0)
+
+
+def test_list_models_does_not_blame_the_base_url_for_a_non_valueerror(monkeypatch):
+    """The lister's clause is as narrow as the adapter's, for the same reason:
+    `except Exception` here would report every future bug in this statement as
+    the user's typo."""
+
+    def boom(*args, **kwargs):
+        raise TypeError("Request() got an unexpected keyword argument")
+
+    monkeypatch.setattr("urllib.request.Request", boom)
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(TypeError):
         list_models(None, 5.0)

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -328,6 +328,27 @@ _INVOCATIONS = {
     "answer_question": lambda a: a.answer_question(question="Who?", context="c"),
 }
 
+_DATALOG = 'answer_q1(V) :- relation(V, "is_a", "x").'
+_INTENT = {
+    "kind": "unknown_or_unsupported",
+    "subject": None,
+    "relation": None,
+    "object": None,
+    "relation_candidates": None,
+    "operator": None,
+    "value_type": None,
+    "value": None,
+    "reason": "unsupported",
+}
+
+# What each method's parse accepts, so a stub can answer any of the four.
+_VALID_CONTENT = {
+    "extract_facts": json.dumps({"facts": []}),
+    "translate_query": json.dumps({"datalog": _DATALOG}),
+    "extract_query_intent": json.dumps(_INTENT),
+    "answer_question": "ok",
+}
+
 # The three methods that parse the response *after* the request region closes.
 # `answer_question` stringifies whatever came back and has no parse step, so it
 # has no failure of that kind to mislabel — it is left out rather than given a
@@ -360,6 +381,33 @@ class _RawResponse:
 
 def _raw_body(monkeypatch, raw: bytes) -> None:
     monkeypatch.setattr("urllib.request.urlopen", lambda req, *, timeout: _RawResponse(raw))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_every_method_posts_through_the_one_request_site(tmp_path, monkeypatch, method):
+    """All four methods go through `_post_chat`, so the guarded region below is
+    written once and every case pinned here applies to all four.
+
+    A method that grew its own inline `urlopen` again would still talk to a real
+    server and satisfy every other test in this file; this is the one that would
+    notice. `urlopen` is stubbed to fail so such a bypass is caught here instead
+    of quietly passing against an Ollama actually running on the machine.
+    """
+    payloads = []
+
+    def spy(self, payload):
+        payloads.append(payload)
+        return {"message": {"content": _VALID_CONTENT[method]}}
+
+    monkeypatch.setattr(OllamaAdapter, "_post_chat", spy)
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: pytest.fail(f"{method} dialled without going through _post_chat"),
+    )
+
+    _INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
+
+    assert [payload["model"] for payload in payloads] == ["qwen3:8b"]
 
 
 @pytest.mark.parametrize("method", sorted(_INVOCATIONS))

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -521,6 +521,36 @@ def test_an_unusable_base_url_keeps_the_original_error_as_the_cause(
     assert isinstance(exc.value.__cause__, ValueError)
 
 
+# A Base URL whose rejection message says nothing about it: `Request` answers an
+# unclosed IPv6 literal with a bare `Invalid IPv6 URL`. Distinct from `::::`,
+# whose `unknown url type: '::::/api/chat'` quotes the URL for free — against
+# that value alone, a call site that passed the wrong URL, or no URL at all,
+# would look identical.
+_SILENTLY_REFUSED_BASE_URL = "http://["
+
+
+def test_the_url_reaches_the_message_even_when_the_exception_omits_it(tmp_path, monkeypatch):
+    """What the user has to be given back is the string that was refused. The
+    exception cannot supply it here, so `_post_chat` passes it — including the
+    `/api/chat` this call appended, which is the URL `Request` actually saw.
+    """
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+    cfg = Config(
+        root=tmp_path,
+        db_path=tmp_path / "kb.sqlite",
+        provider="ollama",
+        model="qwen3:8b",
+        api_key=None,
+        base_url=_SILENTLY_REFUSED_BASE_URL,
+    )
+
+    with pytest.raises(LLMError) as exc:
+        OllamaAdapter(cfg).extract_facts(source_text="Ada")
+
+    assert "Invalid IPv6 URL" in str(exc.value)
+    assert "http://[/api/chat" in str(exc.value)
+
+
 def test_a_payload_that_cannot_be_serialised_is_not_blamed_on_the_base_url(
     tmp_path, monkeypatch
 ):
@@ -696,6 +726,19 @@ def test_list_models_normalises_a_base_url_no_request_can_be_built_from(monkeypa
 
     with pytest.raises(LLMError, match="^ollama base URL is unusable"):
         list_models(_UNUSABLE_BASE_URL, 5.0)
+
+
+def test_list_models_puts_the_refused_url_in_the_message(monkeypatch):
+    """The lister's own call site, not the adapter's: it appends `/api/tags` and
+    has to hand that same string over. `Invalid IPv6 URL` carries nothing, so a
+    lister that forgot would leave the settings banner naming a field without
+    ever saying what is in it."""
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError) as exc:
+        list_models(_SILENTLY_REFUSED_BASE_URL, 5.0)
+
+    assert "http://[/api/tags" in str(exc.value)
 
 
 def test_list_models_does_not_blame_the_base_url_for_a_non_valueerror(monkeypatch):

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -317,6 +317,103 @@ def test_padded_base_url_env_does_not_break_the_request_url(tmp_path, monkeypatc
     assert urls == ["https://llm.internal/v1/api/chat"]
 
 
+# --- what the request region normalises, and what it must not claim ---
+
+# One invocation per LLM method. Each method builds and dials its own request,
+# so a single-method test would leave three sites unguarded.
+_INVOCATIONS = {
+    "extract_facts": lambda a: a.extract_facts(source_text="Ada"),
+    "translate_query": lambda a: a.translate_query(question="Who?", qid=1),
+    "extract_query_intent": lambda a: a.extract_query_intent(question="What?"),
+    "answer_question": lambda a: a.answer_question(question="Who?", context="c"),
+}
+
+# The three methods that parse the response *after* the request region closes.
+# `answer_question` stringifies whatever came back and has no parse step, so it
+# has no failure of that kind to mislabel — it is left out rather than given a
+# case that could only ever pass.
+_PARSING_INVOCATIONS = {
+    name: call for name, call in _INVOCATIONS.items() if name != "answer_question"
+}
+
+
+class _RawResponse:
+    """Answer with bytes the adapter has to decode and parse itself.
+
+    `_Response` above always hands back a well-formed envelope built by
+    `json.dumps`, so it can never exercise the decode and parse steps that sit
+    inside the request region. This one can.
+    """
+
+    def __init__(self, raw: bytes):
+        self.raw = raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return None
+
+    def read(self):
+        return self.raw
+
+
+def _raw_body(monkeypatch, raw: bytes) -> None:
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, *, timeout: _RawResponse(raw))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_a_response_body_that_is_not_json_is_a_normalised_request_failure(
+    tmp_path, monkeypatch, method
+):
+    """A proxy or a captive portal answering HTML is a transport failure the
+    caller already handles, not a `JSONDecodeError` escaping the adapter.
+
+    `json.loads` is inside the guarded region today. Pinning that here means a
+    later edit that folds the four request sites into one helper cannot quietly
+    leave the parse outside it, which would turn this into an unnormalised raise.
+    """
+    _raw_body(monkeypatch, b"not json")
+
+    with pytest.raises(LLMError, match="^ollama request failed"):
+        _INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_a_response_body_that_is_not_utf8_is_a_normalised_request_failure(
+    tmp_path, monkeypatch, method
+):
+    """`.decode("utf-8")` is the other statement in the region that can raise on
+    an otherwise well-formed HTTP response — a server that ignored the content
+    type and sent UTF-16 gets here. Separate from the non-JSON case because the
+    two are different statements, and an edit can move one without the other.
+    """
+    _raw_body(monkeypatch, b"\xff\xfe")
+
+    with pytest.raises(LLMError, match="^ollama request failed"):
+        _INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
+
+
+@pytest.mark.parametrize("method", sorted(_PARSING_INVOCATIONS))
+def test_a_schema_failure_is_not_reported_as_a_request_failure(tmp_path, monkeypatch, method):
+    """The transport succeeded and the server answered valid JSON; the *model's*
+    output did not match the schema. Calling that "request failed" sends the user
+    to check an endpoint that answered fine — the misdirection #474 was reported
+    as, arriving from the other direction.
+
+    This is the boundary the region must NOT swallow, so it is the counterweight
+    to the two cases above: widening the guard until it covers `parse_facts`
+    would make both of those pass and this one fail.
+    """
+    _raw_body(monkeypatch, json.dumps({"message": {"content": "{}"}}).encode("utf-8"))
+
+    with pytest.raises(LLMError) as exc:
+        _PARSING_INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
+
+    assert "request failed" not in str(exc.value)
+    assert "did not match schema" in str(exc.value)
+
+
 # --- list_models: the settings picker's source of truth ---
 
 

--- a/tests/test_openrouter_adapter.py
+++ b/tests/test_openrouter_adapter.py
@@ -404,6 +404,19 @@ def test_list_models_names_openrouter_not_ollama_for_an_unusable_base_url(monkey
     assert "ollama" not in str(exc.value)
 
 
+def test_list_models_puts_the_refused_url_in_the_message(monkeypatch):
+    """`Request` answers an unclosed IPv6 literal with a bare `Invalid IPv6 URL`
+    — no URL in it anywhere — so unlike `::::` this value cannot be green against
+    a call site that forgot to pass the URL on. The `/models` suffix is part of
+    it: that is the string `Request` was handed."""
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError) as exc:
+        list_models("http://[", 5.0)
+
+    assert "http://[/models" in str(exc.value)
+
+
 def test_list_models_does_not_blame_the_base_url_for_a_non_valueerror(monkeypatch):
     """The clause catches `ValueError` and nothing wider, so a genuine bug in
     this statement is not relabelled as the user's configuration mistake."""

--- a/tests/test_openrouter_adapter.py
+++ b/tests/test_openrouter_adapter.py
@@ -372,3 +372,47 @@ def test_list_models_raises_on_schema_mismatch(monkeypatch, payload):
 
     with pytest.raises(LLMError, match="did not match schema"):
         list_models(None, 5.0)
+
+
+# The settings-UI typo #493 was reported for. Passed explicitly and never as
+# `None`: an unset base_url resolves to OPENROUTER_DEFAULT_BASE_URL, which is a
+# perfectly good URL, so a `None` here would assert nothing at all.
+_UNUSABLE_BASE_URL = "::::"
+
+
+def test_list_models_normalises_a_base_url_no_request_can_be_built_from(monkeypatch):
+    """`GET /settings/model-field?provider=openrouter&base_url=::::` reaches this
+    with a URL the user has only typed, not saved. Unnormalised the `ValueError`
+    escapes as a 500 from the settings page; `LLMError` is what that endpoint
+    already renders as a banner.
+    """
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError, match="^openrouter base URL is unusable"):
+        list_models(_UNUSABLE_BASE_URL, 5.0)
+
+
+def test_list_models_names_openrouter_not_ollama_for_an_unusable_base_url(monkeypatch):
+    """Two listers now share one helper, and the provider name is the only thing
+    distinguishing their messages. It is what the banner shows, so a copy-paste
+    that left "ollama" here would point at a provider the user is not using."""
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError) as exc:
+        list_models(_UNUSABLE_BASE_URL, 5.0)
+
+    assert "ollama" not in str(exc.value)
+
+
+def test_list_models_does_not_blame_the_base_url_for_a_non_valueerror(monkeypatch):
+    """The clause catches `ValueError` and nothing wider, so a genuine bug in
+    this statement is not relabelled as the user's configuration mistake."""
+
+    def boom(*args, **kwargs):
+        raise TypeError("Request() got an unexpected keyword argument")
+
+    monkeypatch.setattr("urllib.request.Request", boom)
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(TypeError):
+        list_models(None, 5.0)

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -97,8 +97,10 @@ class AnthropicAdapter:
         *base-URL* variable: measured, `OPENAI_BASE_URL` carrying that same
         `::::` leaves this constructor raising nothing at all. It is named here
         as a non-cause, which is what the guard in `tests/test_cloud_adapters.py`
-        allows: that guard rejects the other vendor's variable from the cause
-        list above and permits a mention like this one. The other two
+        allows: it reads the paragraph above -- the one enumerating causes,
+        located by its opening words -- and rejects the other vendor's variable
+        from *that paragraph*, leaving a mention like this one in a later
+        paragraph legal. The other two
         entries above are not vendor-scoped -- both SDKs read `SSL_CERT_FILE`
         and `HTTPS_PROXY` -- which is why they are listed unqualified. The
         otherwise identical paragraph in `openai_adapter` therefore has to name

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -23,13 +23,35 @@ class AnthropicAdapter:
         self.cfg = cfg
 
     def _request_failed(self, exc: Exception) -> LLMError:
-        """One construction site for provider failures, so a raise site somebody
-        forgot cannot let the configured key survive into an error message.
+        """Provider failures from a *request*, redacted.
 
-        It can only redact the key it knows about, which is why `_require_key`
-        refuses to let the SDK authenticate with one this process never saw.
+        One of two construction sites in this class -- `_client_failed` is the
+        other, for failures that happen before any request is made. Both redact,
+        which is the property that matters: a raise site somebody forgot must not
+        let the configured key survive into an error message. Splitting them is
+        what keeps each message able to say something true about *when* it failed.
+
+        Redaction covers only the key this process knows about, which is why
+        `_require_key` refuses to let the SDK authenticate with one it never saw.
         """
         return LLMError(redact_secret(f"{self.name} request failed: {exc}", self.cfg.api_key))
+
+    def _client_failed(self, exc: Exception) -> LLMError:
+        """The client could not be built, so nothing was ever dialled.
+
+        Deliberately does NOT name the Base URL setting. A malformed `base_url`
+        is the reachable cause this exists for (#493), but measured against the
+        installed SDKs it is not the only one: with `base_url` unset entirely,
+        `SSL_CERT_FILE` pointing at a missing file raises `FileNotFoundError`,
+        and `HTTPS_PROXY='::::'` or `OPENAI_BASE_URL='::::'` raise
+        `httpx.InvalidURL`. Telling those users to check a field they left blank
+        sends them to fix something that is not broken -- the misdirection #474
+        was reported as. The urllib adapters can be specific, and are, because
+        `Request(url)` has no second cause; see `base_url_unusable`.
+        """
+        return LLMError(
+            redact_secret(f"{self.name} client could not be created: {exc}", self.cfg.api_key)
+        )
 
     def _require_key(self) -> str:
         """The configured key, or a clear failure instead of a silent fallback.
@@ -63,11 +85,19 @@ class AnthropicAdapter:
             import anthropic
         except ImportError as exc:  # pragma: no cover - optional dep
             raise LLMError("anthropic SDK not installed; `pip install verinote[anthropic]`") from exc
-        return anthropic.Anthropic(
-            api_key=self._require_key(),
-            base_url=self.cfg.base_url,
-            timeout=self.cfg.llm_timeout_seconds,
-        )
+        # Hoisted out of the constructor call, not merely out of the `try`: as an
+        # ARGUMENT it would be evaluated inside the guarded region, and the
+        # `LLMError` it raises for a missing key would come back out relabelled
+        # "client could not be created" -- a config error reported as an SDK
+        # failure. The region below must contain no statement that raises
+        # `LLMError`, and this line is how that stays true.
+        key = self._require_key()
+        try:
+            return anthropic.Anthropic(
+                api_key=key, base_url=self.cfg.base_url, timeout=self.cfg.llm_timeout_seconds
+            )
+        except Exception as exc:  # noqa: BLE001 - normalise SDK construction errors
+            raise self._client_failed(exc) from exc
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -41,13 +41,20 @@ class AnthropicAdapter:
 
         Deliberately does NOT name the Base URL setting. A malformed `base_url`
         is the reachable cause this exists for (#493), but measured against the
-        installed SDKs it is not the only one: with `base_url` unset entirely,
-        `SSL_CERT_FILE` pointing at a missing file raises `FileNotFoundError`,
-        and `HTTPS_PROXY='::::'` or `OPENAI_BASE_URL='::::'` raise
-        `httpx.InvalidURL`. Telling those users to check a field they left blank
-        sends them to fix something that is not broken -- the misdirection #474
-        was reported as. The urllib adapters can be specific, and are, because
-        `Request(url)` has no second cause; see `base_url_unusable`.
+        installed `anthropic` SDK it is not the only one: with `base_url` unset
+        entirely, `SSL_CERT_FILE` pointing at a missing file raises
+        `FileNotFoundError`, and `HTTPS_PROXY='::::'` or
+        `ANTHROPIC_BASE_URL='::::'` raise `httpx.InvalidURL`. Telling those users
+        to check a field they left blank sends them to fix something that is not
+        broken -- the misdirection #474 was reported as. The urllib adapters can
+        be specific, and are, because `Request(url)` has no second cause; see
+        `base_url_unusable`.
+
+        Singular SDK, and its own variable, because each SDK reads only its own:
+        measured, the same `::::` in the *other* vendor's base-URL variable
+        leaves this constructor raising nothing at all. The otherwise identical
+        paragraph in `openai_adapter` therefore has to name a different variable
+        -- two paragraphs documenting two SDKs, not one copied twice.
         """
         return LLMError(
             redact_secret(f"{self.name} client could not be created: {exc}", self.cfg.api_key)

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -36,21 +36,22 @@ class AnthropicAdapter:
         than one. Module-level `_render_prompt` builds `LLMError(str(exc))` and
         does NOT redact; nothing leaks through it today, because it catches only
         `PromptError` and those messages are fixed strings plus a prompt id,
-        placeholder name, or title. The schema helpers each generation method
-        calls just past its guarded region -- `parse_facts`, `parse_query`,
-        `parse_query_intent` -- do not redact either, and none of the three is
-        harmless. What they parse is the provider's response payload, which in
-        this adapter is the already-decoded `tool_use` input rather than a
-        string (`parse_facts(block.input)`), and `_require_key` below already
-        establishes the mechanism that puts a credential in it: `base_url` is
-        caller-supplied, so the endpoint dialled is one a user can point
-        anywhere, and what it echoes is persisted. `_require_key` applies that
-        to a key verinote never resolved, which `redact_secret` could not match
-        anyway; the *configured* key arrives the same way and could be matched,
-        but nothing on this path tries. Measured, an echoing response reaches
-        `llm/schema.py`'s "malformed fact object {item!r}" verbatim, with no
-        `***`. What `_request_failed` redacts is that echo arriving as an
-        *error*; arriving as a parsable response it goes around the guard
+        placeholder name, or title. The schema helpers three of the four
+        generation methods call just past their guarded region -- `parse_facts`,
+        `parse_query`, `parse_query_intent`; `answer_question` calls none, it
+        joins the stripped text blocks -- do not redact either, and none of the
+        three is harmless. What they parse is the provider's response payload,
+        which in this adapter is the already-decoded `tool_use` input rather
+        than a string (`parse_facts(block.input)`), and `_require_key` below
+        already establishes the mechanism that puts a credential in it:
+        `base_url` is caller-supplied, so the endpoint dialled is one a user can
+        point anywhere, and what it echoes is persisted. `_require_key` applies
+        that to a key verinote never resolved, which `redact_secret` could not
+        match anyway; the *configured* key arrives the same way and could be
+        matched, but nothing on this path tries. Measured, an echoing response
+        reaches `llm/schema.py`'s "malformed fact object {item!r}" verbatim,
+        with no `***`. What `_request_failed` redacts is that echo arriving as
+        an *error*; arriving as a parsable response it goes around the guard
         entirely. That predates this change and is tracked as #514, not
         something prose can fix. Neither of the two carrier lists in this
         paragraph is offered as exhaustive. The point is that "every site

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -59,7 +59,14 @@ class AnthropicAdapter:
         `get_prompt` reads an override with `read_text`, so a hand-edited
         non-UTF-8 file raises `UnicodeDecodeError`, which `_render_prompt`'s
         `except PromptError` does not catch and no caller's `except LLMError`
-        catches either. Today the guarded region absorbs it.
+        catches either. Today the guarded region absorbs it. Nor would that
+        escape be loud: `pipeline/extract.py` guards its chunk loop with
+        `except LLMError` alone, so the chunk is left `running`, and the web
+        worker's job-level `except Exception` files the whole job as "analysis
+        failed" and spends the retry budget -- content blamed for a config
+        error. That is not a guess about the backstop: a sibling handler in that
+        worker exists in order not to fall through to it, and its comment names
+        those same two costs.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -72,19 +72,21 @@ class AnthropicAdapter:
         as "anthropic request failed" with nothing dialled (measured). Read this
         message as "the SDK call yielded no result", not "the provider
         answered"; `_client_failed` is the one entitled to speak about when.
-        That imprecision predates this change and is left to #500 rather than
-        fixed by hoisting the render out, because hoisting it opens a gap:
-        `get_prompt` reads an override with `read_text`, so a hand-edited
-        non-UTF-8 file raises `UnicodeDecodeError`, which `_render_prompt`'s
-        `except PromptError` does not catch and no caller's `except LLMError`
-        catches either. Today the guarded region absorbs it. Nor would that
-        escape be loud: `pipeline/extract.py` guards its chunk loop with
-        `except LLMError` alone, so the chunk is left `running`, and the web
-        worker's job-level `except Exception` files the whole job as "analysis
-        failed" and spends the retry budget -- content blamed for a config
-        error. That is not a guess about the backstop: a sibling handler in that
-        worker exists in order not to fall through to it, and its comment names
-        those same two costs.
+        That imprecision predates this change and is #500's. Its stated fix is
+        to hoist the render out of the `try` and leave only the SDK call inside
+        -- the shape `key = self._require_key()` already has in `_client`. Done
+        bare, that satisfies what #500 asks for: measured, the same broken
+        override then reports "Datalog translation prompt must include required
+        placeholder {qid}", with no "request failed" in front of it. Something
+        it also does is not in the issue, and is measured here. `get_prompt`
+        reads an override with `read_text`, so a hand-edited non-UTF-8 file
+        raises `UnicodeDecodeError`, which `_render_prompt`'s
+        `except PromptError` does not convert. Inside the guarded region that is
+        normalised like every other failure; hoisted out, it leaves this adapter
+        as itself -- an LLM failure that is not an `LLMError`, which is the
+        §10.1 violation this change closes at the client-construction site,
+        reopened at the render. So the hoist wants the render's other failures
+        normalised along with it.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -51,12 +51,12 @@ class AnthropicAdapter:
         `llm/schema.py`'s "malformed fact object {item!r}" verbatim, with no
         `***`. What `_request_failed` redacts is that echo arriving as an
         *error*; arriving as a parsable response it goes around the guard
-        entirely. That predates this change and is a follow-up, not something
-        prose can fix. Neither of the two carrier lists in this paragraph is
-        offered as exhaustive. The
-        point is that "every site carrying a caught exception redacts" stops
-        being true the moment you leave this class, and asserting it unqualified
-        is the almost-true claim this docstring was rewritten to stop making.
+        entirely. That predates this change and is tracked as #514, not
+        something prose can fix. Neither of the two carrier lists in this
+        paragraph is offered as exhaustive. The point is that "every site
+        carrying a caught exception redacts" stops being true the moment you
+        leave this class, and asserting it unqualified is the almost-true claim
+        this docstring was rewritten to stop making.
 
         The remaining raises use fixed strings and carry nothing caught:
         `_require_key`, the `ImportError` clause in `_client`, and the three "no

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -39,11 +39,16 @@ class AnthropicAdapter:
         placeholder name, or title. The schema helpers three of the four
         generation methods call just past their guarded region -- `parse_facts`,
         `parse_query`, `parse_query_intent`; `answer_question` calls none, it
-        joins the stripped text blocks -- do not redact either, and none of the
-        three is harmless. What they parse is the provider's response payload,
-        which in this adapter is the already-decoded `tool_use` input rather
-        than a string (`parse_facts(block.input)`), and `_require_key` below
-        already establishes the mechanism that puts a credential in it:
+        joins the stripped text blocks -- do not redact either, and two of the
+        three are not harmless. Measured, `parse_facts` and `parse_query_intent`
+        put what they were handed into the message they raise; `parse_query`
+        cannot, and sits in the bounded column with `_render_prompt` above --
+        its two raise sites carry a missing key name, a builtin `TypeError`
+        phrase, or a JSON position, and nothing of the payload. What those two
+        parse is the provider's response payload, which in this adapter is the
+        already-decoded `tool_use` input rather than a string
+        (`parse_facts(block.input)`), and `_require_key` below already
+        establishes the mechanism that puts a credential in it:
         `base_url` is caller-supplied, so the endpoint dialled is one a user can
         point anywhere, and what it echoes is persisted. `_require_key` applies
         that to a key verinote never resolved, which `redact_secret` could not

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -38,13 +38,23 @@ class AnthropicAdapter:
         `PromptError` and those messages are fixed strings plus a prompt id,
         placeholder name, or title. The schema helpers each generation method
         calls just past its guarded region -- `parse_facts`, `parse_query`,
-        `parse_query_intent` -- do not redact either, and are harmless for a
-        different reason: what they carry is a parse failure over a provider
-        *response*, never over configuration. Neither list is offered as
-        exhaustive. The point is that "every site carrying a caught exception
-        redacts" stops being true the moment you leave this class, and asserting
-        it unqualified is the almost-true claim this docstring was rewritten to
-        stop making.
+        `parse_query_intent` -- do not redact either, and that one is NOT
+        harmless. What they parse is provider response text, and `_require_key`
+        below already establishes the mechanism that puts a credential there:
+        `base_url` is caller-supplied, so the endpoint dialled is one a user can
+        point anywhere, and what it echoes is persisted. `_require_key` applies
+        that to a key verinote never resolved, which `redact_secret` could not
+        match anyway; the *configured* key arrives the same way and could be
+        matched, but nothing on this path tries. Measured, an echoing 200 body
+        reaches `llm/schema.py`'s
+        "malformed fact object {item!r}" verbatim, with no `***`. What
+        `_request_failed` redacts is that echo arriving as an *error*; arriving
+        as a parsable response it goes around the guard entirely. That predates
+        this change and is a follow-up, not something prose can fix. Neither of
+        the two carrier lists in this paragraph is offered as exhaustive. The
+        point is that "every site carrying a caught exception redacts" stops
+        being true the moment you leave this class, and asserting it unqualified
+        is the almost-true claim this docstring was rewritten to stop making.
 
         The remaining raises use fixed strings and carry nothing caught:
         `_require_key`, the `ImportError` clause in `_client`, and the three "no

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -80,11 +80,15 @@ class AnthropicAdapter:
         be specific, and are, because `Request(url)` has no second cause; see
         `base_url_unusable`.
 
-        Singular SDK, and its own variable, because each SDK reads only its own:
-        measured, the same `::::` in the *other* vendor's base-URL variable
-        leaves this constructor raising nothing at all. The otherwise identical
-        paragraph in `openai_adapter` therefore has to name a different variable
-        -- two paragraphs documenting two SDKs, not one copied twice.
+        Singular SDK, and its own variable, because each SDK reads only its own
+        *base-URL* variable: measured, `OPENAI_BASE_URL` carrying that same
+        `::::` leaves this constructor raising nothing at all. It is named here
+        as a non-cause, which is the one thing it may be named as. The other two
+        entries above are not vendor-scoped -- both SDKs read `SSL_CERT_FILE`
+        and `HTTPS_PROXY` -- which is why they are listed unqualified. The
+        otherwise identical paragraph in `openai_adapter` therefore has to name
+        a different variable: two paragraphs documenting two SDKs, not one
+        copied twice.
         """
         return LLMError(
             redact_secret(f"{self.name} client could not be created: {exc}", self.cfg.api_key)

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -23,13 +23,43 @@ class AnthropicAdapter:
         self.cfg = cfg
 
     def _request_failed(self, exc: Exception) -> LLMError:
-        """Provider failures from a *request*, redacted.
+        """Failures from a `client.messages.create` call, redacted.
 
-        One of two construction sites in this class -- `_client_failed` is the
-        other, for failures that happen before any request is made. Both redact,
-        which is the property that matters: a raise site somebody forgot must not
-        let the configured key survive into an error message. Splitting them is
-        what keeps each message able to say something true about *when* it failed.
+        Redaction is the property that matters, not the split. Two sites in this
+        class put a *caught* exception into an `LLMError` -- this one and
+        `_client_failed` -- and both redact, so a raise site somebody forgot
+        cannot let the configured key survive into a message that is persisted
+        to `source_chunks.error`. Those two are the whole of the safety
+        argument; the class's other `LLMError`s are a different kind.
+
+        A third carrier lives outside the class: module-level `_render_prompt`
+        builds `LLMError(str(exc))` and does NOT redact. Nothing leaks through
+        it today, because it catches only `PromptError` and those messages are
+        fixed strings plus a prompt id, placeholder name, or title. But "every
+        site carrying a caught exception redacts" is false of this *file*, and
+        asserting it unqualified is the sort of almost-true claim this docstring
+        was rewritten to stop making.
+
+        The remaining raises use fixed strings and carry nothing caught:
+        `_require_key`, the `ImportError` clause in `_client`, and the three "no
+        tool_use block" raises in the generation methods. `_require_key` is the
+        instructive one -- it fails before anything is dialled and is
+        deliberately NOT `_client_failed`, which is what the hoist comment in
+        `_client` is protecting. "Before the request" is therefore not what
+        separates these messages.
+
+        Timing is not what this name promises, either. Prompt rendering is an
+        ARGUMENT to `client.messages.create`, so it is evaluated inside the
+        guarded region: an override missing a required placeholder is reported
+        as "anthropic request failed" with nothing dialled (measured). Read this
+        message as "the SDK call yielded no result", not "the provider
+        answered"; `_client_failed` is the one entitled to speak about when.
+        That imprecision predates this change and is left to a follow-up rather
+        than fixed by hoisting the render out, because hoisting it opens a gap:
+        `get_prompt` reads an override with `read_text`, so a hand-edited
+        non-UTF-8 file raises `UnicodeDecodeError`, which `_render_prompt`'s
+        `except PromptError` does not catch and no caller's `except LLMError`
+        catches either. Today the guarded region absorbs it.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -38,20 +38,22 @@ class AnthropicAdapter:
         `PromptError` and those messages are fixed strings plus a prompt id,
         placeholder name, or title. The schema helpers each generation method
         calls just past its guarded region -- `parse_facts`, `parse_query`,
-        `parse_query_intent` -- do not redact either, and that one is NOT
-        harmless. What they parse is provider response text, and `_require_key`
-        below already establishes the mechanism that puts a credential there:
-        `base_url` is caller-supplied, so the endpoint dialled is one a user can
-        point anywhere, and what it echoes is persisted. `_require_key` applies
-        that to a key verinote never resolved, which `redact_secret` could not
-        match anyway; the *configured* key arrives the same way and could be
-        matched, but nothing on this path tries. Measured, an echoing 200 body
-        reaches `llm/schema.py`'s
-        "malformed fact object {item!r}" verbatim, with no `***`. What
-        `_request_failed` redacts is that echo arriving as an *error*; arriving
-        as a parsable response it goes around the guard entirely. That predates
-        this change and is a follow-up, not something prose can fix. Neither of
-        the two carrier lists in this paragraph is offered as exhaustive. The
+        `parse_query_intent` -- do not redact either, and none of the three is
+        harmless. What they parse is the provider's response payload, which in
+        this adapter is the already-decoded `tool_use` input rather than a
+        string (`parse_facts(block.input)`), and `_require_key` below already
+        establishes the mechanism that puts a credential in it: `base_url` is
+        caller-supplied, so the endpoint dialled is one a user can point
+        anywhere, and what it echoes is persisted. `_require_key` applies that
+        to a key verinote never resolved, which `redact_secret` could not match
+        anyway; the *configured* key arrives the same way and could be matched,
+        but nothing on this path tries. Measured, an echoing response reaches
+        `llm/schema.py`'s "malformed fact object {item!r}" verbatim, with no
+        `***`. What `_request_failed` redacts is that echo arriving as an
+        *error*; arriving as a parsable response it goes around the guard
+        entirely. That predates this change and is a follow-up, not something
+        prose can fix. Neither of the two carrier lists in this paragraph is
+        offered as exhaustive. The
         point is that "every site carrying a caught exception redacts" stops
         being true the moment you leave this class, and asserting it unqualified
         is the almost-true claim this docstring was rewritten to stop making.
@@ -108,11 +110,11 @@ class AnthropicAdapter:
         `::::` leaves this constructor raising nothing at all. It is named here
         as a non-cause, which is what the guard in `tests/test_cloud_adapters.py`
         allows: it reads the paragraph above -- the one enumerating causes,
-        located by its opening words -- and rejects the other vendor's variable
-        from *that paragraph*, leaving a mention like this one in a later
-        paragraph legal. The other two
-        entries above are not vendor-scoped -- both SDKs read `SSL_CERT_FILE`
-        and `HTTPS_PROXY` -- which is why they are listed unqualified. The
+        found by a marker phrase that paragraph contains -- and rejects the
+        other vendor's variable from *that paragraph*, leaving a mention like
+        this one in a later paragraph legal. The other two entries above are not
+        vendor-scoped -- both SDKs read `SSL_CERT_FILE` and `HTTPS_PROXY` --
+        which is why they are listed unqualified. The
         otherwise identical paragraph in `openai_adapter` therefore has to name
         a different variable: two paragraphs documenting two SDKs, not one
         copied twice.

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -32,13 +32,19 @@ class AnthropicAdapter:
         to `source_chunks.error`. Those two are the whole of the safety
         argument; the class's other `LLMError`s are a different kind.
 
-        A third carrier lives outside the class: module-level `_render_prompt`
-        builds `LLMError(str(exc))` and does NOT redact. Nothing leaks through
-        it today, because it catches only `PromptError` and those messages are
-        fixed strings plus a prompt id, placeholder name, or title. But "every
-        site carrying a caught exception redacts" is false of this *file*, and
-        asserting it unqualified is the sort of almost-true claim this docstring
-        was rewritten to stop making.
+        Carriers outside the class are not covered by that, and there is more
+        than one. Module-level `_render_prompt` builds `LLMError(str(exc))` and
+        does NOT redact; nothing leaks through it today, because it catches only
+        `PromptError` and those messages are fixed strings plus a prompt id,
+        placeholder name, or title. The schema helpers each generation method
+        calls just past its guarded region -- `parse_facts`, `parse_query`,
+        `parse_query_intent` -- do not redact either, and are harmless for a
+        different reason: what they carry is a parse failure over a provider
+        *response*, never over configuration. Neither list is offered as
+        exhaustive. The point is that "every site carrying a caught exception
+        redacts" stops being true the moment you leave this class, and asserting
+        it unqualified is the almost-true claim this docstring was rewritten to
+        stop making.
 
         The remaining raises use fixed strings and carry nothing caught:
         `_require_key`, the `ImportError` clause in `_client`, and the three "no
@@ -90,7 +96,9 @@ class AnthropicAdapter:
         Singular SDK, and its own variable, because each SDK reads only its own
         *base-URL* variable: measured, `OPENAI_BASE_URL` carrying that same
         `::::` leaves this constructor raising nothing at all. It is named here
-        as a non-cause, which is the one thing it may be named as. The other two
+        as a non-cause, which is what the guard in `tests/test_cloud_adapters.py`
+        allows: that guard rejects the other vendor's variable from the cause
+        list above and permits a mention like this one. The other two
         entries above are not vendor-scoped -- both SDKs read `SSL_CERT_FILE`
         and `HTTPS_PROXY` -- which is why they are listed unqualified. The
         otherwise identical paragraph in `openai_adapter` therefore has to name

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -72,8 +72,8 @@ class AnthropicAdapter:
         as "anthropic request failed" with nothing dialled (measured). Read this
         message as "the SDK call yielded no result", not "the provider
         answered"; `_client_failed` is the one entitled to speak about when.
-        That imprecision predates this change and is left to a follow-up rather
-        than fixed by hoisting the render out, because hoisting it opens a gap:
+        That imprecision predates this change and is left to #500 rather than
+        fixed by hoisting the render out, because hoisting it opens a gap:
         `get_prompt` reads an override with `read_text`, so a hand-edited
         non-UTF-8 file raises `UnicodeDecodeError`, which `_render_prompt`'s
         `except PromptError` does not catch and no caller's `except LLMError`

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -75,13 +75,17 @@ def base_url_unusable(provider: str, url: str, exc: Exception) -> LLMError:
 
     The URL is appended only where the exception has not already quoted it, so
     the ordinary case stays one sentence instead of saying the same string
-    twice.
+    twice. The test is on `repr(url)`, not on `url`: `unknown url type` quotes
+    with `!r`, so a URL holding anything `repr` escapes — a tab, a newline, a
+    zero-width space or BOM carried along by a paste — is in that message in
+    escaped form and not in raw form. Comparing raw would read "not mentioned"
+    and append a second copy of a URL already on the line.
 
     Returns rather than raises, so the call site keeps `raise ... from exc` and
     the original stays in the chain — the shape `_request_failed` already uses.
     """
     hint = "check the Base URL setting"
-    if url not in str(exc):
+    if f"{url!r}" not in str(exc):
         hint = f"tried {url!r}; {hint}"
     return LLMError(f"{provider} base URL is unusable: {exc} ({hint})")
 

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -48,7 +48,7 @@ def redact_secret(text: str, secret: str | None) -> str:
     return text.replace(secret, "***")
 
 
-def base_url_unusable(provider: str, exc: Exception) -> LLMError:
+def base_url_unusable(provider: str, url: str, exc: Exception) -> LLMError:
     """The configured endpoint is not something a request can even be built for.
 
     Nothing was dialled, so "request failed" would name the wrong suspect: the
@@ -60,10 +60,30 @@ def base_url_unusable(provider: str, exc: Exception) -> LLMError:
     proxy and certificate environment too and a blank field is a live suspect
     there; see `_client_failed`.
 
+    `url` is the string `Request` was actually handed — the configured base URL
+    with this call's path already on it — and it is a parameter rather than
+    something read back out of `exc` because the exception carries it only
+    sometimes. Measured against `urllib.request.Request`:
+
+        '::::/api/tags'     -> ValueError: unknown url type: '::::/api/tags'
+        'http://[/api/tags' -> ValueError: Invalid IPv6 URL
+        ''                  -> ValueError: unknown url type: ''
+
+    The middle one is the whole argument for this parameter: told only "Invalid
+    IPv6 URL", a user cannot see which of their settings produced it, and the
+    message names a field without ever quoting what is in it.
+
+    The URL is appended only where the exception has not already quoted it, so
+    the ordinary case stays one sentence instead of saying the same string
+    twice.
+
     Returns rather than raises, so the call site keeps `raise ... from exc` and
     the original stays in the chain — the shape `_request_failed` already uses.
     """
-    return LLMError(f"{provider} base URL is unusable: {exc} (check the Base URL setting)")
+    hint = "check the Base URL setting"
+    if url not in str(exc):
+        hint = f"tried {url!r}; {hint}"
+    return LLMError(f"{provider} base URL is unusable: {exc} ({hint})")
 
 
 @dataclass(frozen=True)

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -48,6 +48,24 @@ def redact_secret(text: str, secret: str | None) -> str:
     return text.replace(secret, "***")
 
 
+def base_url_unusable(provider: str, exc: Exception) -> LLMError:
+    """The configured endpoint is not something a request can even be built for.
+
+    Nothing was dialled, so "request failed" would name the wrong suspect: the
+    remote never heard from us and may be perfectly healthy. Naming the Base URL
+    setting IS right here, and only here — `urllib.request.Request(url)` takes
+    one caller-supplied string and rejects it for being that string, so there is
+    no second cause to misdirect anyone towards. The cloud adapters' equivalent
+    deliberately does not name the setting, because their SDK constructors read
+    proxy and certificate environment too and a blank field is a live suspect
+    there; see `_client_failed`.
+
+    Returns rather than raises, so the call site keeps `raise ... from exc` and
+    the original stays in the chain — the shape `_request_failed` already uses.
+    """
+    return LLMError(f"{provider} base URL is unusable: {exc} (check the Base URL setting)")
+
+
 @dataclass(frozen=True)
 class ExtractedFact:
     """One candidate fact the extractor proposes from a source.

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -11,7 +11,7 @@ import json
 import urllib.request
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError, ModelListing
+from verinote.llm.base import ExtractedFact, LLMError, ModelListing, base_url_unusable
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -55,7 +55,14 @@ def list_models(base_url: str | None, timeout: float) -> ModelListing:
     showing an empty picker).
     """
     root = (base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/")
-    req = urllib.request.Request(f"{root}/api/tags")
+    # The settings picker calls this with whatever is typed in the Base URL box,
+    # unsaved, so a half-typed URL reaches `Request` on every keystroke that
+    # triggers a refresh. Left to escape, that is a 500 from the model-field
+    # endpoint instead of the banner the page already knows how to render.
+    try:
+        req = urllib.request.Request(f"{root}/api/tags")
+    except ValueError as exc:
+        raise base_url_unusable("ollama", exc) from exc
     try:
         with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
             req, timeout=timeout
@@ -91,15 +98,25 @@ class OllamaAdapter:
         caller's own failure -- is written once instead of four times in
         parallel.
 
-        `Request(...)` sits deliberately OUTSIDE the `try`, exactly where each
-        method had it before the fold. Moving it in would change behaviour, and
-        this extraction changes none; that move is its own commit.
+        `Request(...)` gets its own narrow clause rather than joining the one
+        below: a URL that cannot be built is not a request that failed, and
+        telling a user their server did not answer when nothing was ever dialled
+        sends them to the wrong place (#493).
         """
-        req = urllib.request.Request(
-            f"{self.base_url}/api/chat",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-        )
+        # Hoisted out of the `Request(...)` call, not merely out of the `try`:
+        # as an ARGUMENT it would be evaluated inside the guarded region, so a
+        # `ValueError` from serialising the payload would come back out labelled
+        # "base URL is unusable" — a bug in this file blamed on the user's
+        # setting. The region below must contain nothing but the URL parse.
+        data = json.dumps(payload).encode("utf-8")
+        try:
+            req = urllib.request.Request(
+                f"{self.base_url}/api/chat",
+                data=data,
+                headers={"Content-Type": "application/json"},
+            )
+        except ValueError as exc:
+            raise base_url_unusable(self.name, exc) from exc
         try:
             with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
                 req, timeout=self.cfg.llm_timeout_seconds

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -83,6 +83,31 @@ class OllamaAdapter:
         self.cfg = cfg
         self.base_url = (cfg.base_url or OLLAMA_DEFAULT_BASE_URL).rstrip("/")
 
+    def _post_chat(self, payload: dict) -> dict:
+        """POST one chat payload to `/api/chat` and return the decoded body.
+
+        The single request site for all four methods, so which statements count
+        as "the request" -- and which are the caller's own parse, reported as the
+        caller's own failure -- is written once instead of four times in
+        parallel.
+
+        `Request(...)` sits deliberately OUTSIDE the `try`, exactly where each
+        method had it before the fold. Moving it in would change behaviour, and
+        this extraction changes none; that move is its own commit.
+        """
+        req = urllib.request.Request(
+            f"{self.base_url}/api/chat",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
+                req, timeout=self.cfg.llm_timeout_seconds
+            ) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
+            raise LLMError(f"ollama request failed: {exc}") from exc
+
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         system = _with_schema_hint(
             _render_prompt(
@@ -106,18 +131,7 @@ class OllamaAdapter:
                 {"role": "user", "content": source_text},
             ],
         }
-        req = urllib.request.Request(
-            f"{self.base_url}/api/chat",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-        )
-        try:
-            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
-                req, timeout=self.cfg.llm_timeout_seconds
-            ) as resp:
-                body = json.loads(resp.read().decode("utf-8"))
-        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
-            raise LLMError(f"ollama request failed: {exc}") from exc
+        body = self._post_chat(payload)
 
         return parse_facts(body.get("message", {}).get("content", ""))
 
@@ -136,18 +150,7 @@ class OllamaAdapter:
                 {"role": "user", "content": question},
             ],
         }
-        req = urllib.request.Request(
-            f"{self.base_url}/api/chat",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-        )
-        try:
-            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
-                req, timeout=self.cfg.llm_timeout_seconds
-            ) as resp:
-                body = json.loads(resp.read().decode("utf-8"))
-        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
-            raise LLMError(f"ollama request failed: {exc}") from exc
+        body = self._post_chat(payload)
 
         return parse_query(body.get("message", {}).get("content", ""))
 
@@ -166,18 +169,7 @@ class OllamaAdapter:
                 {"role": "user", "content": question},
             ],
         }
-        req = urllib.request.Request(
-            f"{self.base_url}/api/chat",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-        )
-        try:
-            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
-                req, timeout=self.cfg.llm_timeout_seconds
-            ) as resp:
-                body = json.loads(resp.read().decode("utf-8"))
-        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
-            raise LLMError(f"ollama request failed: {exc}") from exc
+        body = self._post_chat(payload)
 
         return parse_query_intent(body.get("message", {}).get("content", ""))
 
@@ -195,18 +187,7 @@ class OllamaAdapter:
                 },
             ],
         }
-        req = urllib.request.Request(
-            f"{self.base_url}/api/chat",
-            data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-        )
-        try:
-            with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
-                req, timeout=self.cfg.llm_timeout_seconds
-            ) as resp:
-                body = json.loads(resp.read().decode("utf-8"))
-        except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
-            raise LLMError(f"ollama request failed: {exc}") from exc
+        body = self._post_chat(payload)
         return str(body.get("message", {}).get("content", "")).strip()
 
 

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -59,10 +59,11 @@ def list_models(base_url: str | None, timeout: float) -> ModelListing:
     # unsaved, so a half-typed URL reaches `Request` on every keystroke that
     # triggers a refresh. Left to escape, that is a 500 from the model-field
     # endpoint instead of the banner the page already knows how to render.
+    url = f"{root}/api/tags"
     try:
-        req = urllib.request.Request(f"{root}/api/tags")
+        req = urllib.request.Request(url)
     except ValueError as exc:
-        raise base_url_unusable("ollama", exc) from exc
+        raise base_url_unusable("ollama", url, exc) from exc
     try:
         with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
             req, timeout=timeout
@@ -109,14 +110,15 @@ class OllamaAdapter:
         # "base URL is unusable" — a bug in this file blamed on the user's
         # setting. The region below must contain nothing but the URL parse.
         data = json.dumps(payload).encode("utf-8")
+        url = f"{self.base_url}/api/chat"
         try:
             req = urllib.request.Request(
-                f"{self.base_url}/api/chat",
+                url,
                 data=data,
                 headers={"Content-Type": "application/json"},
             )
         except ValueError as exc:
-            raise base_url_unusable(self.name, exc) from exc
+            raise base_url_unusable(self.name, url, exc) from exc
         try:
             with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
                 req, timeout=self.cfg.llm_timeout_seconds

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -45,10 +45,18 @@ class OpenAIAdapter:
         reason: it is a module-level function precisely so that no key is in
         scope for it to leak, which its own docstring argues at length. The
         schema helpers called just past each guarded region -- `parse_facts`,
-        `parse_query`, `parse_query_intent` -- are a third kind again: also
-        unredacted, harmless because a parse failure over a provider *response*
-        is not a place configuration appears. That enumeration is not offered as
-        complete. What it is for is the shape of the claim: "both carriers
+        `parse_query`, `parse_query_intent` -- are worse than a third kind: also
+        unredacted, and not harmless. Their input is provider response text, and
+        the threat model is the one `_require_key` sets out below, transposed:
+        there an attacker-influenced endpoint -- `base_url` is caller-supplied --
+        echoes back a credential verinote never resolved, so `redact_secret` has
+        nothing to match. Here the same endpoint echoes the key verinote *did*
+        resolve, which `redact_secret` would match, down a path that never calls
+        it. Measured, it survives into `llm/schema.py`'s
+        "malformed fact object {item!r}" with no `***`. `_request_failed` covers
+        that echo when it arrives as an *error*; as a parsable response it never
+        meets a redactor. Pre-existing, and a follow-up rather than a
+        docstring's business. That enumeration is not offered as complete. What it is for is the shape of the claim: "both carriers
         redact" is true of this class and not of the call graph around it, and
         stating only the first half is how the sentence this paragraph replaces
         went wrong.

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -23,13 +23,41 @@ class OpenAIAdapter:
         self.cfg = cfg
 
     def _request_failed(self, exc: Exception) -> LLMError:
-        """Provider failures from a *request*, redacted.
+        """Failures from a `client.chat.completions.create` call, redacted.
 
-        One of two construction sites in this class -- `_client_failed` is the
-        other, for failures that happen before any request is made. Both redact,
-        which is the property that matters: a raise site somebody forgot must not
-        let the configured key survive into an error message. Splitting them is
-        what keeps each message able to say something true about *when* it failed.
+        What has to hold is redaction, not the two-way split. Exactly two sites
+        in this class hand a *caught* exception to `LLMError`: this one and
+        `_client_failed`. Both redact, which is what keeps a forgotten raise
+        site from persisting the configured key into `source_chunks.error`.
+        `OpenRouterAdapter` adds no third and overrides neither, so it inherits
+        the guarantee whole; what it does change is `name`, which only alters
+        which provider the message blames.
+
+        Redaction is not universal in this file, though. Module-level
+        `_render_prompt` builds `LLMError(str(exc))` with no redaction, a third
+        carrier of caught text. It is harmless as written, because the only
+        thing it catches is `PromptError` and those messages are fixed strings
+        plus a prompt id, placeholder name, or title. Claiming the two sites
+        above are all of them would be true of the class and false of the file.
+
+        Everything else raising `LLMError` here uses a fixed string and carries
+        nothing caught: `_require_key` and the `ImportError` clause in
+        `_client`. Both fail before anything is dialled and neither is
+        `_client_failed` -- which is the point of the hoist comment in
+        `_client`, and the reason "before the request" cannot be the line
+        between these two messages.
+
+        Nor does this name promise timing. The prompt render is an ARGUMENT to
+        the SDK call and so is evaluated inside the guarded region: an override
+        missing a required placeholder surfaces as "openai request failed"
+        without a request (measured). The honest reading is "the SDK call
+        yielded no result"; `_client_failed` is the message that can speak about
+        when. The imprecision predates this change and belongs to a follow-up,
+        not to a hoist: pulling the render out would let a hand-edited non-UTF-8
+        override -- read by `get_prompt` as `read_text`, so a
+        `UnicodeDecodeError` rather than the `PromptError` that `_render_prompt`
+        guards for -- leave the adapter raw, past every caller's
+        `except LLMError`. The guarded region is what absorbs it today.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -41,13 +41,21 @@ class OpenAIAdapter:
 
         Deliberately does NOT name the Base URL setting. A malformed `base_url`
         is the reachable cause this exists for (#493), but measured against the
-        installed SDKs it is not the only one: with `base_url` unset entirely,
-        `SSL_CERT_FILE` pointing at a missing file raises `FileNotFoundError`,
-        and `HTTPS_PROXY='::::'` or `OPENAI_BASE_URL='::::'` raise
-        `httpx.InvalidURL`. Telling those users to check a field they left blank
-        sends them to fix something that is not broken -- the misdirection #474
-        was reported as. The urllib adapters can be specific, and are, because
-        `Request(url)` has no second cause; see `base_url_unusable`.
+        installed `openai` SDK it is not the only one: with `base_url` unset
+        entirely, `SSL_CERT_FILE` pointing at a missing file raises
+        `FileNotFoundError`, and `HTTPS_PROXY='::::'` or `OPENAI_BASE_URL='::::'`
+        raise `httpx.InvalidURL`. Telling those users to check a field they left
+        blank sends them to fix something that is not broken -- the misdirection
+        #474 was reported as. The urllib adapters can be specific, and are,
+        because `Request(url)` has no second cause; see `base_url_unusable`.
+
+        `OpenRouterAdapter` inherits this, and one clause above cannot reach it:
+        its `_base_url()` substitutes `OPENROUTER_DEFAULT_BASE_URL` for a blank
+        field, so `base_url` is never unset there and the SDK's
+        `OPENAI_BASE_URL` fallback is never consulted -- measured, the `::::`
+        that raises with `base_url=None` raises nothing once that default is
+        supplied. `SSL_CERT_FILE` and `HTTPS_PROXY` still do reach it, so the
+        conclusion -- do not name the Base URL setting -- holds there too.
         """
         return LLMError(
             redact_secret(f"{self.name} client could not be created: {exc}", self.cfg.api_key)

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -23,13 +23,35 @@ class OpenAIAdapter:
         self.cfg = cfg
 
     def _request_failed(self, exc: Exception) -> LLMError:
-        """One construction site for provider failures, so a raise site somebody
-        forgot cannot let the configured key survive into an error message.
+        """Provider failures from a *request*, redacted.
 
-        It can only redact the key it knows about, which is why `_require_key`
-        refuses to let the SDK authenticate with one this process never saw.
+        One of two construction sites in this class -- `_client_failed` is the
+        other, for failures that happen before any request is made. Both redact,
+        which is the property that matters: a raise site somebody forgot must not
+        let the configured key survive into an error message. Splitting them is
+        what keeps each message able to say something true about *when* it failed.
+
+        Redaction covers only the key this process knows about, which is why
+        `_require_key` refuses to let the SDK authenticate with one it never saw.
         """
         return LLMError(redact_secret(f"{self.name} request failed: {exc}", self.cfg.api_key))
+
+    def _client_failed(self, exc: Exception) -> LLMError:
+        """The client could not be built, so nothing was ever dialled.
+
+        Deliberately does NOT name the Base URL setting. A malformed `base_url`
+        is the reachable cause this exists for (#493), but measured against the
+        installed SDKs it is not the only one: with `base_url` unset entirely,
+        `SSL_CERT_FILE` pointing at a missing file raises `FileNotFoundError`,
+        and `HTTPS_PROXY='::::'` or `OPENAI_BASE_URL='::::'` raise
+        `httpx.InvalidURL`. Telling those users to check a field they left blank
+        sends them to fix something that is not broken -- the misdirection #474
+        was reported as. The urllib adapters can be specific, and are, because
+        `Request(url)` has no second cause; see `base_url_unusable`.
+        """
+        return LLMError(
+            redact_secret(f"{self.name} client could not be created: {exc}", self.cfg.api_key)
+        )
 
     def _require_key(self) -> str:
         """The configured key, or a clear failure instead of a silent fallback.
@@ -64,11 +86,23 @@ class OpenAIAdapter:
             from openai import OpenAI
         except ImportError as exc:  # pragma: no cover - optional dep
             raise LLMError("openai SDK not installed; `pip install verinote[openai]`") from exc
-        return OpenAI(
-            api_key=self._require_key(),
-            base_url=self._base_url(),
-            timeout=self.cfg.llm_timeout_seconds,
-        )
+        # Hoisted out of the constructor call, not merely out of the `try`: as an
+        # ARGUMENT it would be evaluated inside the guarded region, and the
+        # `LLMError` it raises for a missing key would come back out relabelled
+        # "client could not be created" -- a config error reported as an SDK
+        # failure. The region below must contain no statement that raises
+        # `LLMError`, and this line is how that stays true.
+        key = self._require_key()
+        # Hoisted for uniformity rather than for a fix: `_base_url` cannot raise
+        # today, so no mutant can prove this line necessary. It keeps the region
+        # below to the constructor call alone, which makes the rule above
+        # "nothing else lives here" instead of a per-line judgement about which
+        # helper happens to be safe this month.
+        base = self._base_url()
+        try:
+            return OpenAI(api_key=key, base_url=base, timeout=self.cfg.llm_timeout_seconds)
+        except Exception as exc:  # noqa: BLE001 - normalise SDK construction errors
+            raise self._client_failed(exc) from exc
 
     def _base_url(self) -> str | None:
         """The endpoint to dial. `None` lets the SDK use its own default.

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -44,22 +44,28 @@ class OpenAIAdapter:
         imports no `redact_secret` at all -- and is harmless for a different
         reason: it is a module-level function precisely so that no key is in
         scope for it to leak, which its own docstring argues at length. The
-        schema helpers called just past each guarded region -- `parse_facts`,
-        `parse_query`, `parse_query_intent` -- are worse than a third kind: also
-        unredacted, and not harmless. Their input is provider response text, and
-        the threat model is the one `_require_key` sets out below, transposed:
-        there an attacker-influenced endpoint -- `base_url` is caller-supplied --
-        echoes back a credential verinote never resolved, so `redact_secret` has
-        nothing to match. Here the same endpoint echoes the key verinote *did*
-        resolve, which `redact_secret` would match, down a path that never calls
-        it. Measured, it survives into `llm/schema.py`'s "malformed fact object
-        {item!r}" with no `***`. `_request_failed` covers that echo when it
-        arrives as an *error*; as a parsable response it never meets a redactor.
-        Pre-existing, and #514 rather than a docstring's business. That
-        enumeration is not offered as complete. What it is for is the shape of
-        the claim: "both carriers redact" is true of this class and not of the
-        call graph around it, and stating only the first half is how the
-        sentence this paragraph replaces went wrong.
+        schema helpers three of the four generation methods call just past their
+        guarded region -- `parse_facts`, `parse_query`, `parse_query_intent`;
+        `answer_question` calls none, it strips the message text and returns --
+        are unredacted too, and two of them are worse than a third kind.
+        Measured, `parse_facts` and `parse_query_intent` copy what they were
+        handed into the message they raise. `parse_query` does not: its two
+        raise sites can carry a missing key name, a builtin `TypeError` phrase,
+        or a JSON position, which puts it beside `_render_prompt` above --
+        unredacted but bounded. For the other two the input is provider response
+        text, and the threat model is the one `_require_key` sets out below,
+        transposed: there an attacker-influenced endpoint -- `base_url` is
+        caller-supplied -- echoes back a credential verinote never resolved, so
+        `redact_secret` has nothing to match. Here the same endpoint echoes the
+        key verinote *did* resolve, which `redact_secret` would match, down a
+        path that never calls it. Measured, it survives into `llm/schema.py`'s
+        "malformed fact object {item!r}" with no `***`. `_request_failed` covers
+        that echo when it arrives as an *error*; as a parsable response it never
+        meets a redactor. Pre-existing, and #514 rather than a docstring's
+        business. That enumeration is not offered as complete. What it is for is
+        the shape of the claim: "both carriers redact" is true of this class and
+        not of the call graph around it, and stating only the first half is how
+        the sentence this paragraph replaces went wrong.
 
         Everything else raising `LLMError` here uses a fixed string and carries
         nothing caught: `_require_key` and the `ImportError` clause in

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -43,10 +43,15 @@ class OpenAIAdapter:
         `LLMError(f"openrouter request failed: {exc}")`, in a module that
         imports no `redact_secret` at all -- and is harmless for a different
         reason: it is a module-level function precisely so that no key is in
-        scope for it to leak, which its own docstring argues at length. So
-        "both carriers redact" is true of this class and false of everything a
-        user of it runs, and stating only the first half is how the sentence
-        this paragraph replaces went wrong.
+        scope for it to leak, which its own docstring argues at length. The
+        schema helpers called just past each guarded region -- `parse_facts`,
+        `parse_query`, `parse_query_intent` -- are a third kind again: also
+        unredacted, harmless because a parse failure over a provider *response*
+        is not a place configuration appears. That enumeration is not offered as
+        complete. What it is for is the shape of the claim: "both carriers
+        redact" is true of this class and not of the call graph around it, and
+        stating only the first half is how the sentence this paragraph replaces
+        went wrong.
 
         Everything else raising `LLMError` here uses a fixed string and carries
         nothing caught: `_require_key` and the `ImportError` clause in

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -73,8 +73,8 @@ class OpenAIAdapter:
         missing a required placeholder surfaces as "openai request failed"
         without a request (measured). The honest reading is "the SDK call
         yielded no result"; `_client_failed` is the message that can speak about
-        when. The imprecision predates this change and belongs to a follow-up,
-        not to a hoist: pulling the render out would let a hand-edited non-UTF-8
+        when. The imprecision predates this change and belongs to #500, not to a
+        hoist: pulling the render out would let a hand-edited non-UTF-8
         override -- read by `get_prompt` as `read_text`, so a
         `UnicodeDecodeError` rather than the `PromptError` that `_render_prompt`
         guards for -- leave the adapter raw, past every caller's

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -55,7 +55,7 @@ class OpenAIAdapter:
         it. Measured, it survives into `llm/schema.py`'s "malformed fact object
         {item!r}" with no `***`. `_request_failed` covers that echo when it
         arrives as an *error*; as a parsable response it never meets a redactor.
-        Pre-existing, and a follow-up rather than a docstring's business. That
+        Pre-existing, and #514 rather than a docstring's business. That
         enumeration is not offered as complete. What it is for is the shape of
         the claim: "both carriers redact" is true of this class and not of the
         call graph around it, and stating only the first half is how the

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -65,7 +65,15 @@ class OpenAIAdapter:
         override -- read by `get_prompt` as `read_text`, so a
         `UnicodeDecodeError` rather than the `PromptError` that `_render_prompt`
         guards for -- leave the adapter raw, past every caller's
-        `except LLMError`. The guarded region is what absorbs it today.
+        `except LLMError`. The guarded region is what absorbs it today. "Raw"
+        overstates how visible that would be, and the real outcome is the
+        stronger argument: the chunk loop in `pipeline/extract.py` catches only
+        `LLMError`, so the chunk stays `running` and the escape is swept up by
+        the web worker's job-level `except Exception`, which records "analysis
+        failed" against the source and consumes the retry budget for a cause
+        that has nothing to do with the source. The worker already treats that
+        as a bad outcome: another handler there is ordered above the backstop
+        specifically to avoid falling through to it.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -73,20 +73,20 @@ class OpenAIAdapter:
         missing a required placeholder surfaces as "openai request failed"
         without a request (measured). The honest reading is "the SDK call
         yielded no result"; `_client_failed` is the message that can speak about
-        when. The imprecision predates this change and belongs to #500, not to a
-        hoist: pulling the render out would let a hand-edited non-UTF-8
-        override -- read by `get_prompt` as `read_text`, so a
-        `UnicodeDecodeError` rather than the `PromptError` that `_render_prompt`
-        guards for -- leave the adapter raw, past every caller's
-        `except LLMError`. The guarded region is what absorbs it today. "Raw"
-        overstates how visible that would be, and the real outcome is the
-        stronger argument: the chunk loop in `pipeline/extract.py` catches only
-        `LLMError`, so the chunk stays `running` and the escape is swept up by
-        the web worker's job-level `except Exception`, which records "analysis
-        failed" against the source and consumes the retry budget for a cause
-        that has nothing to do with the source. The worker already treats that
-        as a bad outcome: another handler there is ordered above the backstop
-        specifically to avoid falling through to it.
+        when. The imprecision predates this change and is #500's, which
+        prescribes pulling the render out of the `try` so that only the SDK call
+        is left inside -- four methods here, plus `OpenRouterAdapter` by
+        inheritance. Two things follow from doing that, and only the first is in
+        the issue. A template error stops being announced as a request failure,
+        which is the outcome #500 is written to get. The second was measured
+        while writing this: a hand-edited non-UTF-8 override -- read by
+        `get_prompt` as `read_text`, so a `UnicodeDecodeError` and not the
+        `PromptError` that `_render_prompt` converts -- has nothing left to
+        catch it once the render sits outside, and leaves this adapter
+        unnormalised. §10.1 is that an LLM failure reaches its caller as an
+        `LLMError`; this change is closing that hole at the constructor, and a
+        bare hoist would open it again at the render. So the hoist belongs with
+        the rest of the render's failures normalised, not on its own.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -29,16 +29,24 @@ class OpenAIAdapter:
         in this class hand a *caught* exception to `LLMError`: this one and
         `_client_failed`. Both redact, which is what keeps a forgotten raise
         site from persisting the configured key into `source_chunks.error`.
-        `OpenRouterAdapter` adds no third and overrides neither, so it inherits
-        the guarantee whole; what it does change is `name`, which only alters
-        which provider the message blames.
+        `OpenRouterAdapter` overrides neither and adds no third, so both
+        carriers reach it unchanged. What it does override is `name` and
+        `_base_url` -- the latter being what the `_client_failed` note below
+        turns on, so this is not a subclass that merely renames things.
 
-        Redaction is not universal in this file, though. Module-level
-        `_render_prompt` builds `LLMError(str(exc))` with no redaction, a third
-        carrier of caught text. It is harmless as written, because the only
-        thing it catches is `PromptError` and those messages are fixed strings
-        plus a prompt id, placeholder name, or title. Claiming the two sites
-        above are all of them would be true of the class and false of the file.
+        Redaction is not universal outside that class boundary, though.
+        Module-level `_render_prompt` in this file builds `LLMError(str(exc))`
+        with no redaction, a third carrier of caught text; it is harmless as
+        written, because the only thing it catches is `PromptError` and those
+        messages are fixed strings plus a prompt id, placeholder name, or title.
+        `openrouter_adapter.list_models` is the same shape -- a bare
+        `LLMError(f"openrouter request failed: {exc}")`, in a module that
+        imports no `redact_secret` at all -- and is harmless for a different
+        reason: it is a module-level function precisely so that no key is in
+        scope for it to leak, which its own docstring argues at length. So
+        "both carriers redact" is true of this class and false of everything a
+        user of it runs, and stating only the first half is how the sentence
+        this paragraph replaces went wrong.
 
         Everything else raising `LLMError` here uses a fixed string and carries
         nothing caught: `_require_key` and the `ImportError` clause in

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -52,14 +52,14 @@ class OpenAIAdapter:
         echoes back a credential verinote never resolved, so `redact_secret` has
         nothing to match. Here the same endpoint echoes the key verinote *did*
         resolve, which `redact_secret` would match, down a path that never calls
-        it. Measured, it survives into `llm/schema.py`'s
-        "malformed fact object {item!r}" with no `***`. `_request_failed` covers
-        that echo when it arrives as an *error*; as a parsable response it never
-        meets a redactor. Pre-existing, and a follow-up rather than a
-        docstring's business. That enumeration is not offered as complete. What it is for is the shape of the claim: "both carriers
-        redact" is true of this class and not of the call graph around it, and
-        stating only the first half is how the sentence this paragraph replaces
-        went wrong.
+        it. Measured, it survives into `llm/schema.py`'s "malformed fact object
+        {item!r}" with no `***`. `_request_failed` covers that echo when it
+        arrives as an *error*; as a parsable response it never meets a redactor.
+        Pre-existing, and a follow-up rather than a docstring's business. That
+        enumeration is not offered as complete. What it is for is the shape of
+        the claim: "both carriers redact" is true of this class and not of the
+        call graph around it, and stating only the first half is how the
+        sentence this paragraph replaces went wrong.
 
         Everything else raising `LLMError` here uses a fixed string and carries
         nothing caught: `_require_key` and the `ImportError` clause in

--- a/verinote/llm/openrouter_adapter.py
+++ b/verinote/llm/openrouter_adapter.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import urllib.request
 
-from verinote.llm.base import LLMError, ModelListing
+from verinote.llm.base import LLMError, ModelListing, base_url_unusable
 from verinote.llm.openai_adapter import OpenAIAdapter
 
 # The endpoint an unset `base_url` resolves to. Named rather than inlined so the
@@ -72,7 +72,14 @@ def list_models(base_url: str | None, timeout: float) -> ModelListing:
     "does not advertise" would report a claim the catalogue never made.
     """
     root = (base_url or OPENROUTER_DEFAULT_BASE_URL).rstrip("/")
-    req = urllib.request.Request(f"{root}/models")
+    # Same reachable path as the Ollama lister: the settings picker dials the
+    # endpoint currently in the Base URL box, so a malformed one arrives here
+    # before it is ever saved. Escaping unnormalised makes that a 500 rather
+    # than the banner the settings page already renders for `LLMError`.
+    try:
+        req = urllib.request.Request(f"{root}/models")
+    except ValueError as exc:
+        raise base_url_unusable("openrouter", exc) from exc
     try:
         with urllib.request.urlopen(  # noqa: S310 - caller-named endpoint, dialled with no key
             req, timeout=timeout

--- a/verinote/llm/openrouter_adapter.py
+++ b/verinote/llm/openrouter_adapter.py
@@ -76,10 +76,11 @@ def list_models(base_url: str | None, timeout: float) -> ModelListing:
     # endpoint currently in the Base URL box, so a malformed one arrives here
     # before it is ever saved. Escaping unnormalised makes that a 500 rather
     # than the banner the settings page already renders for `LLMError`.
+    url = f"{root}/models"
     try:
-        req = urllib.request.Request(f"{root}/models")
+        req = urllib.request.Request(url)
     except ValueError as exc:
-        raise base_url_unusable("openrouter", exc) from exc
+        raise base_url_unusable("openrouter", url, exc) from exc
     try:
         with urllib.request.urlopen(  # noqa: S310 - caller-named endpoint, dialled with no key
             req, timeout=timeout


### PR DESCRIPTION
`Closes #493`

## 무엇을 고치나

#474 와 같은 계약(기능 명세 §10.1 "모든 LLM 실패는 `LLMError` 로 정규화")이 **다른 이유로** 깨진다. #474 는 좁은 except 튜플이었고, 이건 **`try` 경계가 잘못 그어진 것**이다.

`client = self._client()` 와 `urllib.request.Request(...)` 가 `try` **밖**이라, 사용자가 설정 UI 에 넣은 잘못된 `base_url` 이 `LLMError` 가 아닌 예외를 그대로 올린다.

## 이슈에 없던 구멍 둘이 더 있고 더 심하다

`ollama_adapter.list_models` 와 `openrouter_adapter.list_models` 도 같은 형태인데, **저장 없이 GET 한 방으로 500** 이 난다:

| | `e957d5a` | 이 PR |
|---|---|---|
| `GET /settings/model-field?provider=ollama&base_url=::::` | **500** | 200 + `ollama base URL is unusable: unknown url type: '::::/api/tags' (check the Base URL setting)` |
| `…provider=openrouter&base_url=::::` | **500** | 200 + `… '::::/models' …` |
| `…&base_url=http://[` | **500** | 200 + `Invalid IPv6 URL (tried 'http://[/api/tags'; check…)` |

**`web/app.py` 는 한 줄도 안 고쳤다** — 어댑터가 `LLMError` 를 내면 기존 핸들러가 배너로 렌더한다. 그게 설계의 요점이다.

범위 참고: ollama 쪽은 이슈 본문의 "`Request(...)` 가 **전부** try 밖"에 포함되므로 범위 안. **openrouter `list_models` 는 모듈 함수라 상속과 무관한 범위 확장**이다. 500 실측을 근거로 넣었다.

## 이슈의 미결을 해소했다

이슈는 openai/openrouter 판정을 "anthropic 과의 **구조 동형성 추론**"이라고 적고 실측 못 했다는 한계를 남겼다. 격리 venv 에서 직접 쟀다 — `openai 2.54.0`, `OpenAI(api_key='x', base_url='::::')` → `httpx.InvalidURL`. anthropic 과 문자 단위로 같다. **추론이 실측으로 승격됐다.** (공유 `.venv` 는 건드리지 않았다 — 설치하면 다른 레인의 skip 수가 바뀐다.)

## `_require_key()` 호이스트가 이 PR 의 본체다

`_client()` 안에서 생성자만 감싸면 안전하다고 처음엔 판단했다. **틀렸다.**

```python
return anthropic.Anthropic(
    api_key=self._require_key(),   # ← 생성자 호출의 인자
    ...
)
```

"생성자 한 표현식만 감싼다"는 곧 **인자 평가도 감싼다**는 뜻이다. 그대로 두면 `except Exception` 이 `_require_key()` 의 `LLMError` 를 삼켜, **API 키 미설정이 "client could not be created" 로 보고된다** — #474 가 고친 것과 같은 종류의 오귀속을, 그걸 고치는 PR 이 새로 만드는 셈이다.

**그리고 기존 테스트가 그 회귀를 못 잡았다.** `pytest.raises(LLMError, match="requires an API key")` 의 `match` 는 `re.search` 라 감싼 메시지 안에서도 통과한다. 그래서 `rf"^{provider} requires an API key"` 로 앵커링했다 — 앵커의 `^` 만 떼면 해당 뮤턴트가 **3 passed** 가 된다(실측). 앵커는 장식이 아니라 그 회귀를 죽이는 유일한 장치다.

`key = self._require_key()` 를 `try` **위 별도 문장**으로 호이스트했고, 그것을 되돌리는 뮤턴트(W7)가 정확히 그 3건만 죽인다.

## 문구가 절마다 다른 이유

**urllib 쪽은 원인을 단정한다** — `Request(url)` 은 caller 가 준 문자열 하나를 받아 그 문자열이라는 이유로 거부하므로, 오도할 제2의 원인이 없다. 그래서 `base_url_unusable` 은 "check the Base URL setting" 을 말한다.

**클라우드 쪽은 단정하지 않는다.** `base_url` 이 **비어 있어도** 생성자가 던지는 경우를 실측했다 — `SSL_CERT_FILE` 이 없는 파일을 가리키면 `FileNotFoundError`, `HTTPS_PROXY='::::'` 나 `OPENAI_BASE_URL='::::'` 면 `httpx.InvalidURL`. 비워둔 필드를 확인하라고 보내는 것은 **#474 가 신고된 바로 그 오도**다. 그래서 `_client_failed` 는 설정 이름을 대지 않는다. 두 독스트링이 서로를 참조하고, S6 뮤턴트(문구에 "check the Base URL setting" 복원)가 그 구분을 지킨다.

## 검토했다가 기각한 것

출력 디코딩을 `errors="replace"` 로 관대하게 만드는 안. 깨진 바이트가 **JSON 문자열 값 안**에 있으면 치환문자가 붙은 채 JSON 이 유효해지고, `parse_facts` 를 통과해 오염된 후보 사실이 **원래 신뢰도 그대로, 경고 한 줄 없이** KB 에 들어간다(실측). `schema.py` 가 막으려는 밀반입(#168)을 파서보다 아래에서 우회하는 셈이라 채택할 수 없었다.

## `except ValueError` 를 넓히지 않은 이유

`Request` 가 `AttributeError` 도 던진다는 관측이 있었으나, 그건 **`headers` 인자**에서 나온다. 세 호출지는 headers 를 안 넘기거나 딕셔너리 리터럴을 넘긴다. str url 20종 퍼즈에서 non-`ValueError` 는 0건. **도달 불가**이므로 넓히지 않았다 — 넓히면 "프로그래밍 오류를 삼키지 않는다"를 지키는 W4 뮤턴트가 오히려 죽지 않는다.

## repr 비교

중복 회피를 처음엔 `if url not in str(exc)` 로 썼다. 예외는 `{url!r}` 로 **repr** 을 쓰므로, url 에 repr 이 이스케이프하는 문자가 있으면 raw 비교가 실패해 **같은 URL 이 두 번** 찍힌다:
```
unknown url type: 'lo\tcal/api/chat' (tried 'lo\tcal/api/chat'; check the Base URL setting)
```
`f"{url!r}" not in str(exc)` 로 고쳤다. 픽스처가 전부 ASCII 라 기존 테스트가 이 축을 못 봤으므로 `"lo\tcal/api/chat"` 을 추가했다 — 픽스처만 넣고 수정 전에 돌려 **2 failed** 를 먼저 확인한 뒤 고쳤다.

정확히 하자면: 탭·개행·ZWSP·BOM 은 **넷 다 단독으로는 `Request` 를 거부시키지 못한다.** 스킴이 깨진 URL(`::::…`)에 얹혀서만 이 함수에 도달하고, 그때 예외가 `!r` 로 인용하므로 repr 비교가 맞다.

## 커밋 순서 — 그물을 먼저 친다

1. `0cf8d7c` **(d)(e)(f) 회귀 테스트만.** 프로덕션 무수정, 전부 green. *다음 커밋의 추출이 이 그물 위에서 일어나게 하려는 것 — 현재 스위트에는 본문이 JSON 이 아닌 케이스가 없어서, 추출이 `json.loads` 를 `try` 밖으로 내보내도 전부 green 이다.*
2. `23a670c` `_post_chat` 추출, 경계 보존, 무동작변경
3. `3001339` `base_url_unusable`
4. `75424da` urllib 3곳
5. `05cf6f8` 클라우드 2곳 + 호이스트 + 앵커링
6. `9a1c186` 3인자 — `Invalid IPv6 URL` 은 메시지에 URL 을 **안 담으므로** 2인자면 무엇을 넣어 실패했는지가 사라진다
7. `2ab52b4` repr 비교

## 검증

- 기준선 `2876 passed, 14 skipped` → **`2949 passed, 15 skipped`**. skip +1 은 openai 실물 앵커(로컬 미설치).
- `ruff check` 통과. 만진 파일은 `llm/` 5개 + 전용 테스트 4개. `claude_cli_adapter.py`·`web/app.py`·`pipeline/**` 무접촉.
- **뮤테이션 22종 전부 red, 생존 0.** 하네스는 대상 파일에서 아무것도 안 죽으면 자동으로 전체 스위트로 승격해 재확인한다(승격 발동 0건). 핵심: **W7**(호이스트 되돌리기) → 앵커링된 3건만 / **W8**(`json.loads` 를 try 밖으로) → 8건 / **D1 vs D2** → D1 은 anthropic 만, D2 는 openai+openrouter **동시** = `OpenRouterAdapter` 가 `_client` 를 상속한다는 증명 / **S4**(리댁션 제거) → `_LONG_KEY` 건만, 실물 앵커는 안 죽음(실제 `httpx.InvalidURL` 은 키를 안 담는다).

## 알려진 한계

**두 실물 SDK 앵커가 어느 CI 잡에서도 실행되지 않는다.** `ci.yml` 은 `.[test,wirelog]` 만 깔아 anthropic·openai 둘 다 없고, `provider-contract.yml` 은 pytest 스위트를 안 돌린다. 게이트가 검증하는 것은 페이크뿐이다. #502 로 분리했다.

`import httpx` 는 쓰지 않았다 — CI 에는 `httpx2` 만 있고, 로컬의 `httpx` 는 anthropic 이 끌고 온 전이 의존이다.
