### PR TITLE
docs(#473): 미측정 아티팩트 행을 실제로 없애는 것이 무엇인지 범위를 좁힌다

### DIFF
--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -94,7 +94,14 @@
                  `store.source_artifacts` returns -- the note survives, beside
                  the new count. That is the "if this note stays" branch, and
                  `store.delete_source`, with the file sweep beside it in the
-                 delete route, is the only thing that ends it.
+                 delete route, is the only thing THIS PAGE offers that ends it.
+                 One other code path reaches the row:
+                 `Store._apply_source_identity_group` DELETEs a retired
+                 source's artifact when the retained source already holds the
+                 same (kind, checksum), so repairing a duplicate citation can
+                 take an unmeasured row with it. That is a CLI repair, over
+                 citations that resolve to one file -- not an action offered
+                 here, and not one to name in a badge.
 
                  Re-analyze is not a third option, and the predicate deciding
                  that is MAX(id) -- LATEST, not only. `reanalyze_source` feeds


### PR DESCRIPTION
Refs #473 — 자동으로 닫지 않는다. #490 과 같은 이유로 범위 한계(#494, #495, #496)가 남아 있다.

## 무엇인가

#490 리뷰의 마지막 라운드에서 승인된 커밋 하나가 머지에 포함되지 않았다. #490 은 07:01:41Z 에 머지됐고 이 커밋은 07:12 에 push 됐다. 새 main(f3483e3) 위에 cherry-pick 한 것이고 내용은 동일하다.

## 무엇을 고치는가

`verinote/web/templates/sources.html` 의 주석이 배타성 단정을 하는데 측정하면 거짓이다:

> `store.delete_source`, with the file sweep beside it in the delete route, **is the only thing that ends it**.

두 번째 경로가 있다. `Store._apply_source_identity_group`(`verinote/store/db.py`)이 중복 인용 병합에서 유지 소스가 같은 `(kind, checksum)` 을 가지면 퇴출 소스의 아티팩트 행을 `DELETE FROM source_artifacts WHERE id = ?` 로 지운다. 미측정 행이 퇴출 쪽이면 `delete_source` 없이도 그 행과 노트가 사라진다.

## 새 문장이 주장하는 것과 그 근거

범위를 UI 행위로 좁히고, 빠진 경로를 전제조건까지 붙여 명명한다. 세 주장을 코드에서 재도출했다:

| 주장 | 확인 |
|---|---|
| `apply_source_identity_repairs` 호출자가 CLI 뿐 | `verinote/cli.py:1045` 하나, `verinote/web/` 에 0건 |
| DELETE 조건 | `db.py:821-843` — 유지 쪽에 같은 `(kind, checksum)` 이 있을 때만. 없으면 `UPDATE source_id` 후 `continue` |
| "citations that resolve to one file" | `_source_identity_samefile_status` 가 쌍마다 `samefile()` 을 걸고, `apply_source_identity_repairs` 와 `_source_identity_group` 이 각각 `!= "ready"` 면 `continue` — 두 번 강제 |

리뷰에서 추가로 확인된 것: 프로덕션 전체에서 `DELETE FROM source_artifacts` 는 `db.py:843` **한 곳**이고, `UPDATE source_artifacts`(`:830`)는 삭제가 아니라 `source_id` 이관이며, 나머지는 `DELETE FROM sources` 의 FK CASCADE = 이미 이름이 나온 `delete_source`. 즉 문단이 명명한 두 경로가 완전집합이다.

## 범위

주석 한 문단. 실행 경로 변경 0 — Jinja 문·마크업 라인 diff 0, 배지 문자열 byte-identical.

## 검증

- `pytest tests/test_ingest_unreadable_chars.py -q` → `23 passed`
- `ruff check .` → clean
