### PR TITLE
test(#459): 트립와이어가 주장하는 중첩 철자를 실제로 붙든다

### DIFF
--- a/tests/test_query_measure_unit.py
+++ b/tests/test_query_measure_unit.py
@@ -288,9 +288,10 @@ def test_the_counter_table_is_the_size_the_comment_names():
     The overlap pinned above is an intersection, so it does not move for a
     counter that names no unit: adding `마리` leaves it at 13 and reaches
     nothing else in this file. The comment beside the table in `query_intent.py`
-    quotes both figures and points here for both, so this counts the table
-    itself -- otherwise a widening that touches no unit lands unremarked, and
-    the figure in that comment is one no assertion holds.
+    quotes both figures, points at this file for both, and names this test for
+    the 29, so this counts the table itself -- otherwise a widening that touches
+    no unit lands unremarked, and the figure in that comment is one no assertion
+    holds.
 
     Its own test rather than a line beside the overlap: the 13 is what that
     sweep is built from, while this is a documentation guard, and an author who

--- a/tests/test_query_measure_unit.py
+++ b/tests/test_query_measure_unit.py
@@ -246,7 +246,6 @@ def test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat(monkeypatc
     import re
 
     import verinote.pipeline.query_measure_unit as qmu
-    from verinote.pipeline.query_intent import _KOREAN_MEASURE_COUNTER
     from verinote.pipeline.query_measure_unit import (
         _VALUE_MEASUREMENT,
         korean_measure_unit_mismatch,
@@ -254,11 +253,6 @@ def test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat(monkeypatc
 
     counters = _unit_bearing_counters()
     assert len(counters) == 13
-    # The 13 is an intersection, so it stays 13 when a counter that names no
-    # unit is added to the table -- `마리` widens the table and reaches nothing
-    # here. query_intent.py's comment points at this test for the size of the
-    # table too, so the table is counted here as well or that figure is unheld.
-    assert len(_KOREAN_MEASURE_COUNTER.split("|")) == 29
     questions = [f"샘플대상의 지표는 몇 {counter}인가?" for counter in counters]
     pairs = [(question, value) for question in questions for value in _PROSE_VALUES]
     assert len(pairs) == len(counters) * len(_PROSE_VALUES)
@@ -286,6 +280,26 @@ def test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat(monkeypatc
         if korean_measure_unit_mismatch(question, value) is not None
     )
     assert fires == 68
+
+
+def test_the_counter_table_is_the_size_the_comment_names():
+    """29 alternatives in `_KOREAN_MEASURE_COUNTER`, and nothing else counts them.
+
+    The overlap pinned above is an intersection, so it does not move for a
+    counter that names no unit: adding `마리` leaves it at 13 and reaches
+    nothing else in this file. The comment beside the table in `query_intent.py`
+    quotes both figures and points here for both, so this counts the table
+    itself -- otherwise a widening that touches no unit lands unremarked, and
+    the figure in that comment is one no assertion holds.
+
+    Its own test rather than a line beside the overlap: the 13 is what that
+    sweep is built from, while this is a documentation guard, and an author who
+    widens the table should be told that by name and not by a failure in a
+    test about the digit requirement.
+    """
+    from verinote.pipeline.query_intent import _KOREAN_MEASURE_COUNTER
+
+    assert len(_KOREAN_MEASURE_COUNTER.split("|")) == 29
 
 
 def test_a_cross_family_unit_is_not_a_unit_mismatch():
@@ -3665,7 +3679,9 @@ def test_query_intent_never_imports_the_measure_unit_module():
 
     Parsed rather than imported, so a re-export inside `if TYPE_CHECKING` or
     behind a function is caught too -- those never execute and so could never
-    fail an import probe.
+    fail an import probe. Both of those are swept below rather than only
+    claimed here: this file spells neither, so nothing the live arm reads can
+    tell a scan that walks the tree from one that reads its top level.
     """
     import pathlib
 
@@ -3702,15 +3718,23 @@ def test_query_intent_never_imports_the_measure_unit_module():
         "from . import query_measure_unit",
         "from verinote.pipeline import query_measure_unit as qmu",
         "from verinote.pipeline import query_intent, query_measure_unit",
+        "def _rexport():\n"
+        "    from verinote.pipeline import query_measure_unit\n"
+        "\n"
+        "    return query_measure_unit\n",
+        "if TYPE_CHECKING:\n"
+        "    from .query_measure_unit import korean_measure_unit_mismatch\n"
+        "\n"
+        "_ELSEWHERE = 1\n",
     ],
 )
 def test_every_spelling_of_the_forbidden_import_is_caught(statement):
     """The tripwire above reads one file, which today spells nothing this way.
 
-    So the spellings it would catch are measured here instead. The last four
-    name the module as a bound name rather than as the module imported from,
-    and `node.module` is `verinote.pipeline` or `None` for all of them -- the
-    check on it never sees the word. They are caught by the check on
+    So the spellings it would catch are measured here instead. Four of the flat
+    ones name the module as a bound name rather than as the module imported
+    from, and `node.module` is `verinote.pipeline` or `None` for all of them --
+    the check on it never sees the word. They are caught by the check on
     `node.names`, and before that check existed a re-export written
     `from verinote.pipeline import query_measure_unit` -- the form this
     codebase already writes three times under `verinote/`, once for a sibling
@@ -3722,6 +3746,14 @@ def test_every_spelling_of_the_forbidden_import_is_caught(statement):
     import query_measure_unit` puts it in `node.names`, so each falls to a
     check that was going to run anyway. A gate on `node.level` would only
     re-decide what these two already decide.
+
+    The last two are indented -- one inside a function, one under `if
+    TYPE_CHECKING` -- and they are what holds the tripwire's claim to catch
+    both of those. Nothing else here does: every other case is a single
+    top-level statement, and so is the line the live arm appends, so a scan
+    narrowed to `ast.parse(source).body` passed all of them. Each also has a
+    line after the import, which a scan narrowed to the last line it was
+    handed does not survive.
     """
     assert _measure_unit_imports(statement) != []
 

--- a/tests/test_query_measure_unit.py
+++ b/tests/test_query_measure_unit.py
@@ -3619,8 +3619,12 @@ def _measure_unit_imports(source: str) -> list[tuple[int, str]]:
     module, and matching the bound names loosely would read
     `query_measure_unit_helpers` as it.
 
-    Reported as `(line number, spelling as written)` so a failure says where to
-    look; relative spellings keep their leading dots.
+    Reported as `(line number, the module's dotted name as the statement
+    addresses it)` so a failure says where to look. That is the text as
+    written for the two positions that spell the module out, and a join of the
+    two halves for the third: `from verinote.pipeline import
+    query_measure_unit` reports `verinote.pipeline.query_measure_unit`, which
+    no line of the file contains. Relative spellings keep their leading dots.
     """
     import ast
 
@@ -3695,13 +3699,14 @@ def test_query_intent_never_imports_the_measure_unit_module():
         f"the other way. Found: {offenders}"
     )
 
-    # The assertion above is green on a file that imports nothing at all, which
-    # is every file it will ever be handed -- so on its own it cannot tell this
-    # scan from one that returns [] whatever it is given. The sweeps below are
-    # short synthetic snippets and would not notice either: a scan that bailed
-    # on anything file-sized would pass all of them. So re-run it over this same
-    # text with one forbidden line appended -- real source, real length, real
-    # line numbers -- and pin what comes back, not just that something did.
+    # The assertion above is green on a file that imports nothing forbidden,
+    # which is every file it will ever be handed -- so on its own it cannot
+    # tell this scan from one that returns [] whatever it is given. The sweeps
+    # below are short synthetic snippets and would not notice either: a scan
+    # that bailed on anything file-sized would pass all of them. So re-run it
+    # over this same text with one forbidden line appended -- real source, real
+    # length, real line numbers -- and pin what comes back, not just that
+    # something did.
     probe = source + "\nfrom verinote.pipeline import query_measure_unit\n"
     assert _measure_unit_imports(probe) == [
         (len(probe.splitlines()), "verinote.pipeline.query_measure_unit")
@@ -3782,7 +3787,12 @@ def test_a_module_merely_spelled_like_it_is_not_the_forbidden_import(statement):
     check to `startswith` and its suffixed one does. Measured one loosening at
     a time, all six of them: each reddens its own case and no other.
 
-    `query_intent` is the seventh case because the file under test really does
-    import it, and a scan that fired on any sibling would be no guard at all.
+    `query_intent` is the seventh case because a sibling import is one this
+    pair of modules really does make -- in another spelling: every one of the
+    eight imports of `query_intent` under `verinote/` names it in the module
+    position, `query_measure_unit.py:8` among them, and none in the bound-name
+    position swept here. A scan that fired on a sibling would be no guard at
+    all in either spelling, so it is the spelling not otherwise covered that is
+    worth a case.
     """
     assert _measure_unit_imports(statement) == []

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -606,12 +606,13 @@ _KOREAN_ATTRIBUTE_LABEL_TAIL = re.compile(
 )
 _KOREAN_ATTRIBUTE_LABEL_JOSA = re.compile(r"(?:은|는|이|가)\s*$")
 
-# tests/test_query_measure_unit.py, now a module away, pins this string twice in
-# test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat: its overlap
-# with _MEASUREMENT_UNIT_SPELLINGS at 13, and its own alternatives at 29. The
-# overlap is an intersection, so it does not move for a counter that names no
-# unit -- `마리`, say; the count of 29 is what notices that one. Either way the
-# red lands in that file, not in this one's.
+# tests/test_query_measure_unit.py, now a module away, pins this string twice.
+# test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat pins its
+# overlap with _MEASUREMENT_UNIT_SPELLINGS at 13, and
+# test_the_counter_table_is_the_size_the_comment_names pins its own alternatives
+# at 29. The overlap is an intersection, so it does not move for a counter that
+# names no unit -- `마리`, say; the count of 29 is what notices that one. Either
+# way the red lands in that file, not in this one's.
 _KOREAN_MEASURE_COUNTER = (
     r"살|명|개|건|년|개월|달|주|일|시간|분|초|번|회|차|가지|종류|종|"
     r"퍼센트|프로|원|점|위|권|장|쪽|편|배|층"


### PR DESCRIPTION
Closes #459

## 무엇인가

#503 리뷰의 마지막 라운드에서 나온 커밋 둘이 머지에 포함되지 않았다. #503 은 07:03:16Z 에 머지됐고 이 커밋들은 07:22 에 push 됐다. 새 main(f3483e3) 위에 cherry-pick 한 것이고 내용은 동일하다.

## 왜 지금 중요한가 — main 에 미보증 주장이 하나 있다

현재 main 의 `tests/test_query_measure_unit.py:3667` 트립와이어 docstring:

> Parsed rather than imported, so a re-export inside `if TYPE_CHECKING` or behind a function is **caught too** -- those never execute and so could never fail an import probe.

**이 문장을 지키는 것이 없다.** `ast.walk(ast.parse(source))` 를 `ast.parse(source).body` 로(톱레벨만 스캔) 바꾸면:

```
242 passed
+ 함수 안 순환 주입      → 242 passed
+ TYPE_CHECKING 순환 주입 → 242 passed   ← 트립와이어 사망, 여전히 green
```

양성 스윕이 전부 톱레벨 단문이고 라이브 arm 의 probe 도 EOF 에 톱레벨로 붙기 때문이다.

## 커밋 1 — `test: hold the nested spellings the tripwire docstring claims`

양성 스윕에 중첩 두 건을 추가한다. **각 케이스에 import 뒤 한 줄이 더 붙는 것이 load-bearing 이다** — import 가 스니펫의 마지막 줄이면 "마지막 줄만 본다" 우회가 안 막힌다 (측정: 뒤따르는 줄 없는 판본 + `last-line-only` → 245 passed, 완전 침묵).

이 브랜치에서 재측정:

```
clean                                → 245 passed
.body 뮤턴트 (톱레벨만 스캔)          → 2 failed, 243 passed
                                        죽는 것이 정확히 새 두 파라미터
```

같은 커밋에서 `assert len(_KOREAN_MEASURE_COUNTER.split("|")) == 29` 가드를 독립 테스트 `test_the_counter_table_is_the_size_the_comment_names` 로 분리한다. 그 단언은 `test_the_digit_requirement_...` 가 쓰지 않는 순수 문서 가드였고, 거기 있으면 계수사를 추가한 사람이 "the digit requirement keeps ordinary prose out of the caveat" 실패를 받아 원인을 못 찾는다. 분리 후에는 실패 헤더가 원인을 직접 가리킨다.

## 커밋 2 — `docs: correct three claims the sweeps do not support`

- 헬퍼 docstring 의 "spelling as written" — bound-name 경로는 두 조각을 합친 점표기 모듈 경로를 보고하므로 그 문자열은 파일 어느 줄에도 없다.
- 음성 스윕 docstring — 실제 존재하는 형제 import 철자는 **module 위치**다 (`verinote/` 아래 `query_intent` import 8곳 전부 module, bound-name 0곳).
- 라이브 arm 주석의 "imports nothing at all" → "imports nothing **forbidden**" (검사 대상 파일에는 import 가 많다).

## 범위

`tests/test_query_measure_unit.py` 와 `verinote/pipeline/query_intent.py` 주석. 프로덕션 로직 변경 0.

## 검증

- `pytest tests/test_query_measure_unit.py -q` → `245 passed`
- `.body` 뮤턴트 → `2 failed, 243 passed` (새 두 파라미터만), 복원 후 clean
- `ruff check .` → clean
