### PR TITLE
refactor(store): 청크 클레임을 한 문장으로 발행한다 (RETURNING *)

### DIFF
--- a/tests/test_chunk_claim_atomicity.py
+++ b/tests/test_chunk_claim_atomicity.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: MPL-2.0
+"""The chunk claim is one statement: the CAS and its row arrive together (#489).
+
+`Store.mark_chunk_running` used to be an `UPDATE` and then a separate
+`get_source_chunk`. The connection is autocommit, so the claim was on disk before
+the second statement ran, and anything that happened in between happened to a
+chunk that was already `running` under a caller holding nothing. These tests pin
+the collapsed form from both sides of that gap: a read-back that cannot run at
+all, and a peer that arrives while the caller is between statements.
+
+THE SQLITE FLOOR IS ALREADY PAID FOR. `RETURNING` arrived in SQLite 3.35.0, and
+nothing added here gates on a version. It does not have to: this suite already
+runs `ALTER TABLE ... DROP COLUMN` (`test_ingest_unreadable_chars.py`,
+`test_cli.py`), which arrived in that same release, and there is no
+`sqlite_version` check anywhere under `verinote/` or `tests/` that could skip
+past either one. An interpreter these tests pass on has `RETURNING`.
+
+WHY THE GUARDS ARE SHAPED LIKE THIS. There is no injection point left inside the
+fixed method — that is the point of the fix — so the tests aimed at the old second
+statement either arrange the condition that *would* have hit it and assert the
+outcome is unaffected, or pin the statement count directly. Not every test here
+is aimed at that mutant, though, and which one each answers to is worth stating
+rather than blurring:
+
+* T1, T2 and T3 go red when the two statements are put back. T2b and T3a stay
+  green against that mutant, by design — neither is about the read-back.
+* T2b goes red against a mutant that keeps `RETURNING` but restores the
+  `rowcount != 1` guard in front of the fetch.
+* T3a goes red against a mutation that stops the matcher matching: a typo in
+  `READ_BACK_PREFIX`, or dropping the `.upper()` that normalises the SQL against
+  it — both measured, both with the same signature. Those disarm T3 while leaving
+  it, and everything else here, green, which is what T3a is for.
+
+The ordering notes below are what keeps each of them from passing for the wrong
+reason.
+"""
+
+import sqlite3
+
+import pytest
+
+from verinote.store.db import Store
+
+# The read-back the two-statement claim used to issue, as the interceptors below
+# match it: `get_source_chunk` is `SELECT * FROM source_chunks WHERE id = ?`
+# (`store/db.py`). Shared by the injectors and by their self-checks on purpose —
+# a typo here must not be able to disarm one while leaving the other looking
+# armed.
+READ_BACK_PREFIX = "SELECT * FROM SOURCE_CHUNKS"
+
+
+class SelectsFail:
+    """A connection whose every SELECT raises; writes go through untouched.
+
+    STATELESS ON PURPOSE — it fires again and again rather than once. Measured
+    against a mutant that restores the two statements, a one-shot injector plus a
+    positive control placed before the claim leaves T1 green; the injector's shape
+    and the control's placement are each enough on their own to keep it red, and
+    both are kept.
+    """
+
+    def __init__(self, conn):
+        self._conn = conn
+        self.fired = 0
+
+    def execute(self, sql, params=()):
+        if sql.lstrip().upper().startswith("SELECT"):
+            self.fired += 1
+            raise sqlite3.OperationalError("disk I/O error")
+        return self._conn.execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+class OnReadBack:
+    """Run `side_effect` once, the first time the read-back SELECT is issued."""
+
+    def __init__(self, conn, side_effect):
+        self._conn = conn
+        self._side_effect = side_effect
+        self.fired = False
+
+    def execute(self, sql, params=()):
+        if not self.fired and sql.lstrip().upper().startswith(READ_BACK_PREFIX):
+            self.fired = True
+            self._side_effect()
+        return self._conn.execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def _kb(path):
+    store = Store(path / "kb.sqlite")
+    store.init_schema()
+    source_id = store.add_source("sources/a.txt")
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id, source_id=source_id, chunks=["alpha"]
+    )[0]
+    return store, job_id, chunk_id
+
+
+def test_the_claim_survives_a_connection_that_cannot_read_the_chunk_back(tmp_path):
+    """T1. No SELECT can succeed, and the claim still comes back with its row."""
+    store, _job_id, chunk_id = _kb(tmp_path)
+    real = store._conn
+    store._conn = SelectsFail(real)
+    try:
+        claimed = store.mark_chunk_running(chunk_id)
+
+        # POSITIVE CONTROL, AND ITS PLACEMENT IS LOAD-BEARING. It proves the
+        # injector was armed for the whole of the call above rather than
+        # asserting anything about the claim. Run it *before* the claim and a
+        # one-shot injector would already be spent, so the two-statement mutant
+        # would sail through this test as well — the control has to come after.
+        with pytest.raises(sqlite3.OperationalError):
+            store.get_source_chunk(chunk_id)
+    finally:
+        store._conn = real
+
+    assert claimed is not None
+    assert claimed["id"] == chunk_id
+    assert claimed["status"] == "running"
+    assert claimed["attempts"] == 1
+    # and the caller's handle agrees with the disk, read on a healthy connection
+    assert dict(store.get_source_chunk(chunk_id)) == dict(claimed)
+
+
+def test_the_claim_is_a_single_statement_carrying_the_whole_post_image(tmp_path):
+    """T2. One statement touches `source_chunks`, and it returns the new row."""
+    store, _job_id, chunk_id = _kb(tmp_path)
+    before = store.get_source_chunk(chunk_id)
+
+    seen = []
+    store._conn.set_trace_callback(seen.append)
+    try:
+        claimed = store.mark_chunk_running(chunk_id)
+    finally:
+        store._conn.set_trace_callback(None)
+
+    touching = [sql for sql in seen if "source_chunks" in sql]
+    assert len(touching) == 1, touching
+    # the one statement is the CAS, and it is the one carrying the row back
+    assert touching[0].lstrip().upper().startswith("UPDATE")
+    assert "RETURNING" in touching[0].upper()
+    # `RETURNING *` has to be the same shape the callers used to get from
+    # `get_source_chunk`, post-image values and all.
+    assert list(claimed.keys()) == list(before.keys())
+    assert claimed["status"] == "running"
+    assert claimed["attempts"] == before["attempts"] + 1
+    assert claimed["error"] == ""
+    assert claimed["text"] == "alpha"
+
+
+def test_a_claim_that_matches_nothing_returns_none_and_writes_nothing(tmp_path):
+    """T2b. The missing row is the whole verdict — no `rowcount` reading it."""
+    store, _job_id, chunk_id = _kb(tmp_path)
+    assert store.mark_chunk_running(chunk_id) is not None
+
+    assert store.mark_chunk_running(chunk_id) is None  # already held
+    assert store.mark_chunk_running(999999) is None  # no such chunk
+
+    held = store.get_source_chunk(chunk_id)
+    assert held["status"] == "running"
+    assert held["attempts"] == 1  # the declined claim did not spend an attempt
+
+
+def test_the_matcher_the_peer_test_relies_on_really_fires_on_a_read_back(tmp_path):
+    """T3a. Self-check for T3's injector: a typo in it would disarm T3 silently.
+
+    T3 below detects the peer by intercepting the read-back SELECT. If
+    `READ_BACK_PREFIX` stops matching what `get_source_chunk` issues, that
+    interceptor fires for nobody and T3 goes green on both the fixed code and the
+    two-statement mutant — a dead guard with no red anywhere. This asserts the
+    matcher against a call that exists in either version, so the typo has
+    somewhere to show up.
+    """
+    store, _job_id, chunk_id = _kb(tmp_path)
+    real = store._conn
+    interceptor = OnReadBack(real, lambda: None)
+    store._conn = interceptor
+    try:
+        store.get_source_chunk(chunk_id)
+    finally:
+        store._conn = real
+
+    assert interceptor.fired is True
+
+
+def test_the_claim_hands_back_its_own_attempt_count_not_a_peers(tmp_path):
+    """T3. A peer that reclaims the chunk cannot be mistaken for the caller.
+
+    `requeue_chunk_claim` releases a claim only while the row still carries the
+    attempt count the caller's own claim put there (`store/db.py`). With the
+    read-back as a separate statement, a peer rewinding and re-taking the chunk
+    in between made that read-back return the PEER's count, and the caller then
+    released a claim that was not its own. Collapsed into one statement, the
+    count the caller holds is the one its own CAS wrote.
+
+    Note what is deliberately NOT asserted: that the interceptor fired during the
+    claim. On the fixed code it never can, because there is no read-back to fire
+    on — so `fired` is the wrong thing to pin here, and T3a pins the matcher
+    instead. What is asserted is the outcome the caller sees either way.
+    """
+    store, job_id, chunk_id = _kb(tmp_path)
+    peer = Store(tmp_path / "kb.sqlite")
+
+    def peer_reclaims():
+        # what a second process's resume loop amounts to: rewind the stray
+        # `running` chunk with the job, then take it afresh
+        peer.rollback_extraction_job(job_id, "rewound by the resume loop")
+        peer.mark_chunk_running(chunk_id)
+
+    real = store._conn
+    interceptor = OnReadBack(real, peer_reclaims)
+    store._conn = interceptor
+    try:
+        claimed = store.mark_chunk_running(chunk_id)
+    finally:
+        store._conn = real
+    if not interceptor.fired:
+        # No read-back existed to land inside, so the peer lands immediately
+        # after instead — the same peer at the same logical moment, which is what
+        # makes this comparable across both versions of the claim.
+        peer_reclaims()
+
+    assert claimed["attempts"] == 1  # ours, not the peer's second attempt
+    assert store.requeue_chunk_claim(chunk_id, attempts=int(claimed["attempts"])) is False
+
+    still_the_peers = store.get_source_chunk(chunk_id)
+    assert still_the_peers["status"] == "running"
+    assert still_the_peers["attempts"] == 2
+    peer.close()

--- a/tests/test_sources_running_chunk_display.py
+++ b/tests/test_sources_running_chunk_display.py
@@ -8,15 +8,23 @@ straightforward way to get a `running` chunk onto the page: the state arrives by
 ordinary progress instead of by arranging a failure to produce it.
 
 WHAT THAT CHOICE MUST NOT BE READ AS. A job in a terminal status can still have a
-`running` chunk, by at least two routes, and this same change documents both:
+`running` chunk, by at least two routes:
 
-* the read-back window at the claim, described in `verinote/pipeline/extract.py`
-  and owned by #489 — `mark_chunk_running` commits the claim and then reads the
-  row back in a separate statement, so a failure in that read strands a chunk
-  whose id the caller never received, after which the web worker's blanket
-  handler writes the job `failed`;
+* the release write itself failing. The broad clause in
+  `verinote/pipeline/extract.py::process_extraction_job` releases a claim through
+  `_release_claimed_chunk`, which calls `mark_chunk_failed`; if THAT write is the
+  one that raises, the exception leaves `process_extraction_job` with the chunk
+  still `running`. The web worker's blanket handler then writes the job `failed`
+  (`verinote/web/app.py`), and `fail_extraction_job` writes no `source_chunks`
+  row — nothing puts the chunk back;
 * chunks already stranded by the bug this change fixes. Existing KBs carry them,
   and they render here beside whatever status their job came to rest in.
+
+The read-back window at the claim used to head that list, and #489 took it off:
+the claim is one `UPDATE ... RETURNING *` now, and the interruption named for the
+step still left inside it is a `BaseException` — which, by `pipeline/extract.py`'s
+own account at the claim, leaves the job short of a terminal status too. So that
+route no longer produces the pairing this note is about.
 
 The reported symptom (a `failed` job showing "49 pending" for 48 untouched chunks
 plus one claimed) is therefore a state that still occurs. A live job is simply the

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -458,38 +458,46 @@ def process_extraction_job(
             # job does not reach a terminal status either, and the existing recovery
             # path (`_resume_source_extraction_jobs`) is what reclaims it.
             #
-            # ONE RESIDUAL WINDOW REMAINS, AND IT CANNOT BE CLOSED HERE. The line
-            # above is two round trips, not one: `mark_chunk_running` commits the
-            # `pending`->`running` UPDATE (autocommit) and then does a *separate*
-            # `get_source_chunk` read-back to return the row (`store/db.py`
-            # `mark_chunk_running`). If that SELECT raises, the claim is already
-            # committed while the caller never binds `running` at all — so there is
-            # no chunk id to release and the chunk is stranded exactly as #475
-            # describes.
+            # THE READ-BACK WINDOW AT THE CLAIM IS NOW ONE STEP, NOT TWO
+            # STATEMENTS (#489). The line above used to be an `UPDATE` that
+            # committed on an autocommit connection followed by a *separate*
+            # `get_source_chunk`; a failure in that second statement left the chunk
+            # `running` while this frame never bound `running` at all, so there was
+            # no chunk id to release. `mark_chunk_running` is a single
+            # `UPDATE ... RETURNING *` now, and the CAS travels with the row it
+            # wrote.
             #
-            # This is a DIFFERENT KIND of gap from the one the `try` below fixes,
-            # and the distinction is why it is left open rather than patched. That
-            # one was reachable code this function could guard with a handler; this
-            # one is unreachable from here in principle — no arrangement of `try`
-            # in this frame can cover a write that completed inside a callee before
-            # the callee returned. Closing it means making the claim atomic with its
-            # own result, i.e. folding the CAS and the read-back into one statement
-            # (`UPDATE ... RETURNING *`). That is a change to how the claim itself
-            # is issued, and it is deferred on its own merits, not because this
-            # change refuses to touch the `Store`: it does — `requeue_chunk_claim`
-            # is new here. Rewriting `mark_chunk_running`'s contract, though, would
-            # put every existing caller of the claim under review in a change about
-            # releasing one, and the window it closes is unreachable from this
-            # frame either way. That work is #489 — it owns this window
-            # and records the same reasoning from its side, so neither this comment
-            # nor the issue can be read without finding the other. Do not "fix" it
-            # here by re-reading the chunk after the fact: that reintroduces the
-            # same two-step race.
+            # WHAT IS LEFT IS THE CARVE-OUT DIRECTLY ABOVE, not a second kind of
+            # gap. The statement still steps twice — the commit happens in the
+            # `fetchone()`, not the `execute()` (`store/db.py`
+            # `mark_chunk_running`) — so an interruption arriving between them
+            # commits a claim this frame never receives. The interruption named
+            # for that is a `BaseException`, and the `BaseException` paragraph
+            # above already says what happens then and who recovers it. Two
+            # statements became one step, and the remainder is the same class of
+            # thing this loop was already living with.
+            #
+            # It stayed open here as long as it did because it was never fixable
+            # from this frame: no arrangement of `try` can cover a write that
+            # completed inside a callee before the callee returned, which is what
+            # made it a different kind of gap from the one the `try` below closes.
+            # Do not "fix" what remains here by re-reading the chunk after the
+            # fact: that puts the two-step race back.
             try:
                 chunk_id = int(running["id"])
-                # Read back from our own claim, for `requeue_chunk_claim`'s CAS:
-                # it releases this claim only while the row still carries the
-                # attempt count this claim put on it.
+                # The attempt count for `requeue_chunk_claim`'s CAS, which releases
+                # this claim only while the row still carries the count this claim
+                # put on it. It comes out of the claim's own post-image now, not
+                # out of a later read of the row (#489) — and that shuts a second
+                # window incidentally rather than by aim. While the claim was two
+                # statements, a peer's resume loop could rewind and re-take this
+                # chunk in between, and the read-back then handed this frame the
+                # PEER's count, which the CAS in the sidecar clause below would
+                # spend rewinding a claim that was no longer ours. It needed that
+                # landing and then the sidecar-locked path to matter, so it was
+                # unlikely twice over. What makes it possible at all is that a
+                # chunk carries no owner and a job carries no liveness lease
+                # (#242); one statement here shuts in a symptom, not the cause.
                 claimed_attempts = int(running["attempts"])
                 inserted = _extract_chunk(
                     store,

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1356,8 +1356,11 @@ class Store:
         spends a retry attempt on a peer's timing, and `MAX_CHUNK_ATTEMPTS` of
         those give up on the source permanently.
 
-        `attempts` is the value the caller read back from its own claim, and it is
-        in the WHERE clause as a compare-and-set. `status = 'running'` alone would
+        `attempts` is the value the claim itself returned — `mark_chunk_running`
+        is one `UPDATE ... RETURNING *`, so the number a caller holds is the one
+        its own claim wrote rather than whatever a later read of the row found
+        (#489) — and it is in the WHERE clause as a compare-and-set.
+        `status = 'running'` alone would
         establish only that SOMEBODY holds the chunk — there is no owner column on
         the row — so a caller whose claim had meanwhile been reclaimed and
         re-issued to someone else (`claim_pending_extraction_job` rewinds stray

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1293,16 +1293,57 @@ class Store:
             return True
 
     def mark_chunk_running(self, chunk_id: int) -> sqlite3.Row | None:
+        """Claim a `pending` chunk and hand back the row that claim produced.
+
+        ONE PREPARED STATEMENT, WHERE THERE WERE TWO. The compare-and-set
+        (`WHERE status = 'pending'`) and the post-image the caller needs are the
+        same statement, so the caller's row is the row this claim wrote rather
+        than whatever a later read happens to find. The form this replaces was an
+        `UPDATE` followed by a separate `get_source_chunk`: on an autocommit
+        connection the claim was committed by the time the second statement ran,
+        so a failure there left the chunk `running` while the caller never bound
+        anything to release it by (#489; `pipeline/extract.py` describes the same
+        window from the claim site).
+
+        `None` MEANS THE CAS MATCHED NOTHING — no such chunk, or one that is no
+        longer `pending`: somebody else holds it, or it has already gone `done` or
+        `failed`. The absent row is the whole verdict; there is no `rowcount`
+        check any more, and putting one back would be a bug rather than a
+        redundancy. `rowcount` on a `RETURNING` cursor reads `0` until the
+        rows are consumed and only then becomes `1`, so a `rowcount != 1` guard
+        placed in front of the fetch returns `None` while the write lands anyway
+        as the cursor is discarded on the way out — which is exactly the stranded
+        chunk this method exists to stop producing.
+
+        THE CURSOR MUST BE CONSUMED BEFORE THIS RETURNS, and the `fetchone()` is
+        what consumes it. `UPDATE ... RETURNING` holds the write lock until the
+        statement finishes stepping, and the commit happens inside `fetchone()`,
+        not inside `execute()`. Measured on this connection's own settings
+        (autocommit; in WAL, which is what `store/schema.sql` sets for a real KB,
+        and again on the rollback journal, with the same result both ways): with
+        the cursor left alive and unfetched, another PROCESS reads the row as
+        `pending` and its write fails `database is locked`; after the `fetchone()`
+        it reads `running` and writes fine. `in_transaction` reports `False` the
+        whole time and will not warn anyone who gets this wrong. So no early
+        return, no branch, and nothing that can raise belongs between `execute`
+        and the fetch.
+
+        WHAT REMAINS IS ONE STEP, NOT ZERO. An interruption arriving after
+        `execute()` returns and before `fetchone()`'s result is bound still leaves
+        a committed claim nobody received — a cursor dropped without being fetched
+        commits, measured the same way as above. The interruption this code can
+        name for that is a `BaseException` (`KeyboardInterrupt`, `SystemExit`),
+        which is the carve-out `pipeline/extract.py` already declares at the claim
+        for the same reason. The window narrowed from two statements to one step.
+        It is not gone.
+        """
         with self._lock:
-            cur = self._conn.execute(
+            return self._conn.execute(
                 "UPDATE source_chunks SET status = 'running', attempts = attempts + 1, "
                 "error = '', updated_at = datetime('now') "
-                "WHERE id = ? AND status = 'pending'",
+                "WHERE id = ? AND status = 'pending' RETURNING *",
                 (chunk_id,),
-            )
-            if cur.rowcount != 1:
-                return None
-            return self.get_source_chunk(chunk_id)
+            ).fetchone()
 
     def requeue_chunk_claim(self, chunk_id: int, *, attempts: int) -> bool:
         """Undo one `mark_chunk_running`: back to `pending`, attempt refunded.


### PR DESCRIPTION
Closes #489

## 무엇을 고치는가

`Store.mark_chunk_running` 이 두 문장이고 커넥션은 autocommit(`db.py:345 isolation_level=None`)입니다. UPDATE 는 즉시 커밋되는데 이어지는 read-back `get_source_chunk` 가 던지면 **클레임은 커밋됐고 호출자는 해제할 핸들을 못 받습니다.** 단일 `UPDATE ... RETURNING *` 로 바꿉니다.

`with self._lock:` 안에서 `.fetchone()`, 결과를 그대로 반환. `rowcount` 검사는 제거하고 판정은 `row is None` — `RETURNING` 과 함께 쓰면 `rowcount` 는 첫 fetch 전까지 0 이라, 그 줄을 남기면 **`None` 을 돌려주면서 쓰기는 커서가 버려지며 그대로 랜딩합니다**(= 이 이슈가 고치려는 좌초 상태를 100% 재생산). 측정으로 확인했고 docstring 에 그렇게 적었습니다.

## 무엇을 주장하지 않는가

**"창이 닫혔다" 고 쓰지 않았습니다.** 두 문장에서 한 step 으로 **좁아진** 것이고, 커밋을 수행하는 그 step 이 완료되기 전에 `BaseException` 이 도착하면 클레임은 커밋되고 핸들은 전달되지 않습니다. 커서를 fetch 없이 버려도 쓰기가 커밋된다는 것을 측정해 근거로 넣었습니다. 남는 잔여는 `extract.py` 가 이미 문서화한 `BaseException` 카브아웃과 같은 클래스입니다.

`mark_chunk_done`/`mark_chunk_failed` 는 손대지 않았습니다 — 그 둘은 쓰기 **전에** 읽으므로(`job_id`·이벤트 payload 때문) "커밋된 클레임인데 핸들이 없다" 는 창 자체가 없습니다. 모양이 반대라 이 원자성이 이전되지 않습니다.

## 커서 소진 불변식 (새로 문서화)

`UPDATE ... RETURNING` 은 커서를 소진할 때까지 **커밋하지 않고 쓰기 락을 잡습니다.** 커밋은 두 번째 step — `fetchone()` 이 하는 그 step — 에서 일어납니다. 그리고 **`in_transaction` 은 그 동안 `False` 라고 보고합니다.**

스토어의 실제 설정(`isolation_level=None`, `journal_mode=WAL` — `verinote/store/schema.sql:7` 이 설정)으로 **별도 프로세스**를 띄워 측정. 리뷰에서 WAL 과 rollback journal 양쪽으로 재현했고 **결과 동일**:

```
커서 살려두고 미fetch        child: read [1,'pending',0]   write: OperationalError: database is locked
execute(...).fetchone()      child: read [2,'running',1]   write: OK
in_transaction               두 경우 모두 False
```

제안 코드는 안전하지만 그게 우연이 아니라 `fetchone()` 이 커밋 step 을 수행하기 때문입니다. docstring 에 그 불변식과 "early return·분기·raise 가능한 것 금지" 를 적었습니다.

## 부수적으로 닫히는 두 번째 창

read-back 갭에 다른 프로세스의 rewind+reclaim 이 들어오면 호출자가 읽는 `attempts` 가 **남의 값**이라 #492 의 `requeue_chunk_claim` CAS 가 뚫립니다:

```
BEFORE  피어가 갭에 착지: True   handle.attempts=2(남의 값)  낡은 release → True, 새 소유자 클레임을 되감음
AFTER   피어가 갭에 착지: False  handle.attempts=1(우리 것)  낡은 release → False, CAS 유지
```

**주된 동기로 승격시키지 않았습니다** — 실제 피해는 (a) 두 문장 사이 창에 두 번째 프로세스의 resume 루프가 착지 + (b) 그 뒤 sidecar-locked 경로, 두 희소 사건의 곱입니다. 근본 원인은 #242 이고 이 변경은 증상 하나를 가둡니다.

## `RETURNING` 실현 가능성

로컬 SQLite 버전은 근거로 쓰지 않았습니다 (CI 이미지의 증거가 아니므로). 직접 증거:

```
tests/test_ingest_unreadable_chars.py  conn.execute("ALTER TABLE source_artifacts DROP COLUMN ...")
tests/test_cli.py                      conn.execute("ALTER TABLE facts DROP COLUMN job_id")
grep -rn "sqlite_version" verinote/ tests/   → 0건 (버전 게이트 없음)
```

`ALTER TABLE ... DROP COLUMN` 과 `RETURNING`(INSERT/UPDATE/DELETE 3종 동시)은 **SQLite 3.35.0 한 릴리스**에서 도입됐고 부분 도입이 없습니다. 위 두 문장은 조건 없이 실제로 실행되므로 CI 가 green 인 한 CI 의 SQLite ≥ 3.35.0 입니다.

(프로덕션의 기존 `RETURNING` 11곳은 전부 `INSERT ... RETURNING id` 이고 `UPDATE ... RETURNING` 은 한 곳도 없습니다 — 근거로 쓰지 않았습니다.)

## 테스트 — `tests/test_chunk_claim_atomicity.py` (신규)

**T1** 연결이 SELECT 를 못 해도 클레임이 핸들을 반환. **주입기는 stateless, 양성 대조는 클레임 뒤** — 이 배치가 load-bearing 입니다. vacuity 가 두 조건의 곱임을 측정했습니다:

```
stateless + control-after   RED     stateless + control-before  RED
one-shot  + control-after   RED     one-shot  + control-before  GREEN → VACUOUS
```

**T2** 클레임 중 `source_chunks` 를 건드리는 문장이 1개이고 `UPDATE` 로 시작하며 `RETURNING` 을 포함. SQL 리터럴 비교는 쓰지 않았습니다 — trace callback 이 파라미터를 전개해 공백 하나에도 부서지는 가드가 됩니다.

**T2b** 두 번째 클레임·없는 id 가 `None` 이고 attempts 를 쓰지 않음. rowcount 함정 뮤턴트에 red 인 유일한 테스트입니다.

**T3** 피어 재클레임이 갭에 착지 못 함. **T3a** 가 매처 자기검증 — 같은 `READ_BACK_PREFIX` 를 공유하는 무해한 인터셉터로 `get_source_chunk` 를 부르고 `fired is True`. 오타 하나로 T3 가 통째로 죽는 사각지대를 덮습니다.

### 비-vacuity 측정

| 뮤턴트 | 결과 |
|---|---|
| 두 문장 판본 복귀 | **3 failed** — T1·T2·T3 전부 |
| `READ_BACK_PREFIX` 오타 | **1 failed** — T3a 만 (T3 는 green) |
| `RETURNING` + `rowcount != 1` 가드 복귀 | 신규 파일 **4 failed** / 청크 클레임 6파일 **26 failed** |

## 검증

- 기준선 `2976 passed, 14 skipped` → HEAD **`2981 passed, 14 skipped`** (+5)
- 커밋 4개 각각 `ruff check .` 통과 + 청크 클레임 관련 6파일 32 passed



---

**정정 (팀리드)**: 이 본문의 이전 판은 스토어 설정을 `journal_mode=delete` 라고 적었습니다. 거짓입니다 — `verinote/store/schema.sql:7` 이 `PRAGMA journal_mode = WAL;` 을 설정하고 `init_schema()` 가 이를 실행합니다. 제가 잘못 브리핑한 것이고 개발자가 그대로 받아 쓴 것입니다. **측정 결론은 바뀌지 않습니다** — 락/커밋 프로브를 WAL 과 rollback journal 양쪽에서 돌린 결과가 동일함을 리뷰에서 확인했습니다.
