### PR TITLE
fix(query): 후행 naming 술어를 관계명이 아니라 술어로 읽는다

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1655,10 +1655,16 @@ def test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer(tmp_path
     failure mode is a wrong answer under a top-level label, not a lost one, and
     that is why this is pinned at the answer and not at the parse.
 
-    Both spellings of the question are asserted, because the defect this
-    forbids is also an inconsistency: one KB, one question, two phrasings, and
-    an entity strip would make them return different subjects with the same
-    `VERIFIED — engine` on both.
+    Both spellings of the question are asserted, and what that catches depends
+    on how wide the strip is. A strip at the `of` site only -- the shape of the
+    commit this PR dropped -- is also an inconsistency: measured on this KB,
+    `of` comes back `Company, owner, Alice` and the possessive comes back
+    `Company named, owner, Bob`, both under `VERIFIED — engine`. A strip at
+    both entity sites is consistent and still wrong: measured the same way,
+    both spellings come back `Company, owner, Alice`. So agreement between the
+    two phrasings is not the test of a fix here, and each row is load-bearing
+    on its own -- a one-site mutant reddens that site's row, and a two-site
+    mutant reddens both.
 
     Refs #515, which records the two-entity KB as the case that separates a fix
     from a regression. The scope here is narrower than that issue's fixture.
@@ -1705,9 +1711,14 @@ def test_a_title_case_tail_in_the_label_is_left_alone(tmp_path):
 
     Adding `re.IGNORECASE` cuts it to `Also`, which the schema does not hold,
     and the question reaches the model instead -- measured on this tree, one
-    provider call where there were none. That is the direction
-    `_clean_english_attribute_label` names as the more expensive of the two:
-    giving up a correct deterministic answer rather than inventing one.
+    provider call where there were none. That is one of the two directions the
+    flag moves questions, not the dearer of them: measured the same way, it
+    also cuts `Date Labeled` to `Date`, so a KB holding `Date` answers
+    `Sample Dataset, Date, 2020-01-01` under `VERIFIED — engine` with no
+    provider call for a question that asked what the date is *labeled*; on
+    this tree that question reaches the model. This test pins the first row;
+    the flag comment on `_ENGLISH_ATTRIBUTE_TRAILING_PREDICATE` carries both,
+    and the gain the choice forgoes with them.
 
     PR #527 proposes a case-insensitive alternation for the label site: its
     diff carries `(?i:called|named)` on the possessive pattern. The argument

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1604,3 +1604,39 @@ def test_ask_keeps_the_provider_error_in_the_reason_when_it_skips(tmp_path):
 
     assert "llm error" in result.reason
     assert "synthetic outage" in result.reason
+
+
+def test_a_shortened_label_reaches_a_synonym_the_spelled_one_missed(tmp_path):
+    """The label strip can promote a question through the synonym set, not only
+    through what the schema literally spells.
+
+    `_clean_english_attribute_label`'s docstring counts four schema cases for
+    what shortening a label costs. Three turn on whether the schema holds the
+    cut name, the spelled name or both. This is the fourth, and it is the only
+    one where the schema holds *neither*: with `goal` as its one relation, the
+    KB below has no `purpose titled` and no `purpose`. The cut label re-enters
+    `PURPOSE_RELATION_CANDIDATES`, `goal` is in that set, and the question is
+    answered.
+
+    `test_a_shortened_label_re_enters_the_purpose_synonyms` pins the candidate
+    tuple growing from one to five. That is the parse, and a parse cannot show
+    that the verdict moved. Measured on `origin/main` at e032738 this question
+    reaches the model; here it does not, and `DeterministicOnlyClient` is what
+    says so -- it raises rather than answering, so any provider call is the red.
+
+    Refs #511
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact("Sample Dataset", "goal", "V0", status="confirmed", source_id=source_id)
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="What is Sample Dataset's purpose titled?",
+    )
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "V0" in result.answer

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1640,3 +1640,56 @@ def test_a_shortened_label_reaches_a_synonym_the_spelled_one_missed(tmp_path):
     assert result.route == "engine"
     assert result.label == "VERIFIED — engine"
     assert "V0" in result.answer
+
+
+def test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer(tmp_path):
+    """A name that really ends in a naming predicate still answers for itself.
+
+    This rule cleans the label. It deliberately does not clean the entity of
+    the `of` spelling, where the tail lands on the entity instead, because that
+    field is terminal: `Company named` is both a plausible entity whose name
+    ends in `named` and a plausible `Company` with a trailing predicate, and
+    nothing at parse time separates them. Cutting it answers a *different*
+    subject, and the KB below is where that shows -- both readings resolve, so
+    the cut plan is not empty and `_reinterpret_empty_plan` never runs. The
+    failure mode is a wrong answer under a top-level label, not a lost one, and
+    that is why this is pinned at the answer and not at the parse.
+
+    Both spellings of the question are asserted, because the defect this
+    forbids is also an inconsistency: one KB, one question, two phrasings, and
+    an entity strip would make them return different subjects with the same
+    `VERIFIED — engine` on both.
+
+    Refs #515, which records the two-entity KB as the case that separates a fix
+    from a regression. The scope here is narrower than that issue's fixture.
+    #515 spells the second entity `Company Named` in title case, and this
+    pattern carries no flags, so `Named` never matches the member `named` and
+    the title-case spelling is safe under every spelling of this rule -- pinning
+    it would pin nothing. The lower-case spelling below is the one where a strip
+    would actually fire, so it is the one that can observe the regression. This
+    test does not implement what #515 asks for, which is a store lookup or a
+    refusal of the shape; it holds today's safe behaviour still.
+
+    Refs #511
+    """
+    for shape, question in (
+        ("of", "What is the owner of Company named?"),
+        ("possessive", "What is Company named's owner?"),
+    ):
+        root = tmp_path / shape
+        root.mkdir()
+        store = _store(root)
+        source_id = store.add_source("sources/sample.txt")
+        store.add_fact("Company", "owner", "Alice", status="confirmed", source_id=source_id)
+        store.add_fact(
+            "Company named", "owner", "Bob", status="confirmed", source_id=source_id
+        )
+
+        result = ask_question(
+            store, DeterministicOnlyClient(), root=root, question=question
+        )
+
+        assert result.route == "engine", question
+        assert result.label == "VERIFIED — engine", question
+        assert "Bob" in result.answer, question
+        assert "Alice" not in result.answer, question

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1620,8 +1620,8 @@ def test_a_shortened_label_reaches_a_synonym_the_spelled_one_missed(tmp_path):
 
     `test_a_shortened_label_re_enters_the_purpose_synonyms` pins the candidate
     tuple growing from one to five. That is the parse, and a parse cannot show
-    that the verdict moved. Measured on `origin/main` at e032738 this question
-    reaches the model; here it does not, and `DeterministicOnlyClient` is what
+    that the verdict moved. Measured at e032738 this question reaches the
+    model; here it does not, and `DeterministicOnlyClient` is what
     says so -- it raises rather than answering, so any provider call is the red.
 
     Refs #511
@@ -1663,17 +1663,25 @@ def test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer(tmp_path
     both entity sites is consistent and still wrong: measured the same way,
     both spellings come back `Company, owner, Alice`. So agreement between the
     two phrasings is not the test of a fix here, and each row is load-bearing
-    on its own -- a one-site mutant reddens that site's row, and a two-site
-    mutant reddens both.
+    on its own -- a one-site mutant violates that site's row and leaves the
+    other passing, and a two-site mutant violates both, though pytest stops at
+    the first and reports one failure either way.
 
     Refs #515, which records the two-entity KB as the case that separates a fix
     from a regression. The scope here is narrower than that issue's fixture.
     #515 spells the second entity `Company Named` in title case, and this
-    pattern carries no flags, so `Named` never matches the member `named` and
-    the title-case spelling is safe under every spelling of this rule -- pinning
-    it would pin nothing. The lower-case spelling below is the one where a strip
-    would actually fire, so it is the one that can observe the regression. This
-    test does not implement what #515 asks for, which is a store lookup or a
+    pattern carries no flags, so `Named` never matches the member `named`
+    here. That is not safety under every spelling of this rule: an entity strip
+    under `re.IGNORECASE` does cut it, and measured on #515's own fixture both
+    phrasings then come back `Company, owner, Alice`, which is the regression
+    that issue records. Pinning the title-case spelling would still buy no
+    kill, because that same mutant makes the lower-case rows below come back
+    `Company, owner, Alice` too -- across both entity-strip spellings measured
+    here, with the flag and without, a title-case row is never red unless a
+    lower-case row is red with it. The lower-case spelling below is the one a
+    flagless strip fires on, so it is the one that can observe the regression
+    on its own. This test does not implement what #515 asks for, which is a
+    store lookup or a
     refusal of the shape; it holds today's safe behaviour still.
 
     Refs #511
@@ -1713,21 +1721,23 @@ def test_a_title_case_tail_in_the_label_is_left_alone(tmp_path):
     and the question reaches the model instead -- measured on this tree, one
     provider call where there were none. That is one of the two directions the
     flag moves questions, not the dearer of them: measured the same way, it
-    also cuts `Date Labeled` to `Date`, so a KB holding `Date` answers
-    `Sample Dataset, Date, 2020-01-01` under `VERIFIED — engine` with no
+    also cuts `Date Labeled` to `Date`, so a KB where `Sample Dataset` holds
+    `Date` answers `Sample Dataset, Date, 2020-01-01` under
+    `VERIFIED — engine` with no
     provider call for a question that asked what the date is *labeled*; on
     this tree that question reaches the model. This test pins the first row;
     the flag comment on `_ENGLISH_ATTRIBUTE_TRAILING_PREDICATE` carries both,
     and the gain the choice forgoes with them.
 
-    PR #527 proposes a case-insensitive alternation for the label site: its
-    diff carries `(?i:called|named)` on the possessive pattern. The argument
-    that case sensitivity is only load-bearing for the entity site this rule
-    does not touch is not in that PR -- its author makes it in the review of
-    this one. It is true of the entity site and false here, and the
-    measurement above is the counterexample. This test is the place that
-    argument now lives, so widening the flags reddens it rather than passing
-    silently.
+    The case-insensitive spelling has been written before. PR #527, closed on
+    2026-08-14, carries `_ENGLISH_ATTRIBUTE_QUESTION_TAIL =
+    r"(?:\\s+(?i:called|named))?"` appended to
+    `_ENGLISH_POSSESSIVE_ATTRIBUTE_QUESTION`. The reasoning that makes such a
+    spelling look free is that case sensitivity is load-bearing only for the
+    entity site, which this rule does not touch. That is true of the entity
+    site and false here: the measurement above is the counterexample, and this
+    test is where it lives, so widening the flags reddens it rather than
+    passing silently.
 
     Refs #511
     """

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1693,3 +1693,46 @@ def test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer(tmp_path
         assert result.label == "VERIFIED — engine", question
         assert "Bob" in result.answer, question
         assert "Alice" not in result.answer, question
+
+
+def test_a_title_case_tail_in_the_label_is_left_alone(tmp_path):
+    """The pattern carries no flags, and that costs something it also buys.
+
+    `Also Known As` is a real attribute name and a schema may spell it in title
+    case. Case sensitivity is what keeps this question deterministic: the tail
+    matches only the lower-case members, so the label survives whole and the
+    relation is found.
+
+    Adding `re.IGNORECASE` cuts it to `Also`, which the schema does not hold,
+    and the question reaches the model instead -- measured on this tree, one
+    provider call where there were none. That is the direction
+    `_clean_english_attribute_label` names as the more expensive of the two:
+    giving up a correct deterministic answer rather than inventing one.
+
+    PR #527 proposes a case-insensitive alternation for the label site: its
+    diff carries `(?i:called|named)` on the possessive pattern. The argument
+    that case sensitivity is only load-bearing for the entity site this rule
+    does not touch is not in that PR -- its author makes it in the review of
+    this one. It is true of the entity site and false here, and the
+    measurement above is the counterexample. This test is the place that
+    argument now lives, so widening the flags reddens it rather than passing
+    silently.
+
+    Refs #511
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/sample.txt")
+    store.add_fact(
+        "Sample Project", "Also Known As", "Ada", status="confirmed", source_id=source_id
+    )
+
+    result = ask_question(
+        store,
+        DeterministicOnlyClient(),
+        root=tmp_path,
+        question="What is Sample Project's Also Known As?",
+    )
+
+    assert result.route == "engine"
+    assert result.label == "VERIFIED — engine"
+    assert "Ada" in result.answer

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -993,3 +993,303 @@ def test_a_label_that_is_only_a_josa_is_not_claimed():
     boundary = deterministic_query_intent("샘플조직의 이는?")
     assert boundary.kind == QueryIntentKind.LOOKUP_OBJECT
     assert boundary.relation_candidates == ("이", "이는")
+
+
+_ENGLISH_TAIL_PREDICATE_FIXTURES = {
+    "called": "What is Sample Project's owner called?",
+    "named": "What is Sample Project's owner named?",
+    "titled": "What is Sample Project's owner titled?",
+    "labelled": "What is Sample Project's owner labelled?",
+    "labeled": "What is Sample Project's owner labeled?",
+    "spelled": "What is Sample Project's owner spelled?",
+    "spelt": "What is Sample Project's owner spelt?",
+    "known as": "What is Sample Project's owner known as?",
+    "listed as": "What is Sample Project's owner listed as?",
+    "set to": "What is Sample Project's owner set to?",
+}
+"""One question per member of `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS`.
+
+A literal dict plus a set-equality assertion, not a parametrize over the live
+tuple: parametrizing would delete the case along with the member and the test
+would pass vacuously. Reconstructing the questions from the tuple would be the
+same hole one step further away -- an unchecked re-implementation of the rule.
+Same shape as `_MONTH_WORD_FIXTURES` in tests/test_query_measure_unit.py, for
+the same reason.
+
+The possessive spelling, which is the one this commit reaches. The `of`
+spelling puts the same tail on the entity instead of on the label, where the
+label cleaner cannot see it; the commit that cleans the entity widens each
+value to both spellings.
+"""
+
+_ENGLISH_TAIL_ADVERB_FIXTURES = {
+    "also": "What is Sample Project's owner also known as?",
+    "otherwise": "What is Sample Project's owner otherwise called?",
+    "formerly": "What is Sample Project's owner formerly named?",
+    "previously": "What is Sample Project's owner previously titled?",
+    "originally": "What is Sample Project's owner originally labelled?",
+    "currently": "What is Sample Project's owner currently listed as?",
+    "commonly": "What is Sample Project's owner commonly spelled?",
+    "officially": "What is Sample Project's owner officially set to?",
+}
+"""One question per member of `_ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS`.
+
+Literal for the reason above. Each adverb sits in front of a different
+predicate so that a member surviving only in front of one predicate cannot hide
+behind a uniform pairing.
+"""
+
+
+def test_every_trailing_naming_predicate_is_read_as_a_predicate():
+    """A tail that says how the asking is phrased is not part of what is asked for.
+
+    Before this rule the parser stripped none of these -- #511 reads the tree as
+    already handling `called` and `named`, and it does not:
+    `_clean_english_attribute_label` normalised whitespace and dropped a leading
+    `the ` and nothing else. So `What is Sample Project's owner called?` asked
+    for a relation literally named `owner called`, which no schema holds, and
+    the question was planned empty.
+
+    The set-equality assertion is what stops a member being added to the tuple
+    without a question exercising it.
+    """
+    from verinote.pipeline.query_intent import (
+        _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS,
+    )
+
+    assert set(_ENGLISH_TAIL_PREDICATE_FIXTURES) == set(
+        _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS
+    )
+    for member, question in _ENGLISH_TAIL_PREDICATE_FIXTURES.items():
+        intent = deterministic_query_intent(question)
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, member
+        assert intent.subject == IntentTarget("entity", "Sample Project"), member
+        assert intent.relation_candidates == ("owner",), member
+
+
+def test_every_tail_adverb_is_read_with_the_predicate():
+    """`owner also known as` asks for `owner`, not for `owner also`.
+
+    The adverb slot only ever extends a cut the predicate alternation already
+    makes, so dropping a member here leaves its question stopping one word
+    short: `('owner also',)` instead of `('owner',)`. That is still a relation
+    no schema holds, so the failure is silent without this test.
+    """
+    from verinote.pipeline.query_intent import _ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS
+
+    assert set(_ENGLISH_TAIL_ADVERB_FIXTURES) == set(
+        _ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS
+    )
+    for adverb, question in _ENGLISH_TAIL_ADVERB_FIXTURES.items():
+        intent = deterministic_query_intent(question)
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, adverb
+        assert intent.subject == IntentTarget("entity", "Sample Project"), adverb
+        assert intent.relation_candidates == ("owner",), adverb
+
+
+def test_a_word_a_predicate_only_ends_is_left_alone():
+    """The tail binds with `\\s+`, so a member inside a longer word is not a tail.
+
+    These eight are chosen against the two known relaxations of that binding,
+    which are not the same one and are not caught by the same witness:
+
+    - `\\s*` has no boundary requirement at all and cuts every word below --
+      `recalled` to `re`, `nicknamed` to `nick`, `untitled` to `un`. A corpus of
+      `dataset`/`offset`/`blacklisted` would not notice: those end in `set` and
+      `listed`, which are the *first* words of `set to` and `listed as` and are
+      not members on their own, so the `\\s*` mutant leaves them whole and the
+      test passes vacuously against it.
+    - `\\s*\\b` spares all eight, because `_` and every letter are word
+      characters, and still cuts `re-called` to `re-`, because `-` is not.
+
+    So `re-called` is the witness that tells the second relaxation from the
+    first, and the eight are what make the first one red at all.
+    """
+    for label in (
+        "recalled",
+        "unnamed",
+        "renamed",
+        "entitled",
+        "misspelled",
+        "nicknamed",
+        "subtitled",
+        "untitled",
+        "so_called",
+        "re-called",
+    ):
+        intent = deterministic_query_intent(f"What is Sample Project's {label}?")
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, label
+        assert intent.relation_candidates == (label,), label
+
+
+def test_a_past_participle_relation_name_survives():
+    """A relation name whose last word is a past participle is not a tail.
+
+    Column headers are full of them, and none is a member. This is the test that
+    refuses the tempting generalisation -- `\\s+[A-Za-z]+(?:ed|en)(?:\\s+(?:as|to))?$`
+    instead of an enumerated list -- which cuts `date created` to `date`,
+    `last modified` to `last` and `amount owed` to `amount`. That mutant fails
+    in the other direction too: it misses `known as`, `set to` and `spelt`,
+    none of which is a participle ending in `ed`/`en` followed by a particle.
+    """
+    for label in (
+        "date created",
+        "last modified",
+        "last updated",
+        "tasks completed",
+        "issues closed",
+        "amount owed",
+        "budget approved",
+        "seats reserved",
+        "hours logged",
+        "items shipped",
+        "invoices paid",
+        "features shipped",
+        "date resolved",
+        "units sold",
+        "records seen",
+    ):
+        intent = deterministic_query_intent(f"What is Sample Project's {label}?")
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, label
+        assert intent.relation_candidates == (label,), label
+
+
+def test_a_multiword_predicate_is_not_cut_to_its_last_word():
+    """`known as`, `listed as` and `set to` are members only with their particle.
+
+    Matching the participle alone would be the cheaper pattern and it takes
+    ordinary relation names apart: `data set` becomes `data`, `well known`
+    becomes `well`, `publicly listed` becomes `publicly`. The same holds for
+    splitting the strip into two `sub` calls -- one for the particle, one for
+    the participle -- which is why the rule is a single alternation against a
+    single `$`.
+
+    The last row is the positive that stops this test from being satisfiable by
+    simply dropping the three multi-word members.
+    """
+    for label in (
+        "data set",
+        "target set",
+        "character set",
+        "test set",
+        "result set",
+        "publicly listed",
+        "well known",
+        "widely known",
+    ):
+        intent = deterministic_query_intent(f"What is Sample Project's {label}?")
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, label
+        assert intent.relation_candidates == (label,), label
+
+    cut = deterministic_query_intent("What is Sample Project's status set to?")
+    assert cut.relation_candidates == ("status",)
+
+
+def test_worth_and_like_stay_in_the_label():
+    """#511's two deliberate exclusions, pinned as exclusions.
+
+    `stock worth` is a plausible relation name whose last word belongs to the
+    measure, and `owner like` asks for a description rather than for the object
+    of `owner`, so stripping either would answer a different question.
+
+    Spelled as `What is ...`, not as the issue's `How much is Sample Product's
+    stock worth?`: that spelling is not one the possessive pattern claims at
+    all, so a test written on it would report `unknown_or_unsupported` whatever
+    the tuple holds, and would stay green with `worth` added as a member.
+    """
+    worth = deterministic_query_intent("What is Sample Product's stock worth?")
+    assert worth.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert worth.relation_candidates == ("stock worth",)
+
+    like = deterministic_query_intent("What is Sample Project's owner like?")
+    assert like.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert like.relation_candidates == ("owner like",)
+
+
+def test_the_strip_cannot_leave_the_field_empty():
+    """A question whose whole label is a predicate keeps a label.
+
+    The invariant is a property of the pattern, not of the tuple: both fields
+    are `.strip()`ed before the pattern is applied, so position 0 is never
+    whitespace, and the pattern must consume at least one leading `\\s`, so at
+    least one character always survives. "No member empties itself" would be the
+    same claim resting on today's list, and it would stop holding the day a
+    member is added that a caller can hand over whole.
+
+    Not empty is not the same as not rubbish, and the rows below are the
+    difference: `the the called` comes back as `the`, a relation name no schema
+    is expected to hold. The accepted-cost block at the end carries the rest of
+    that population, including the rows where the residue is *not* harmless.
+    """
+    for question, expected in (
+        ("What is Sample Project's called?", "called"),
+        ("What is Sample Project's known as?", "known as"),
+        ("What is Sample Project's set to?", "set to"),
+        ("What is Sample Project's the called?", "called"),
+        ("What is Sample Project's the listed as?", "listed as"),
+        ("What is Sample Project's the the called?", "the"),
+    ):
+        intent = deterministic_query_intent(question)
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, question
+        assert intent.subject == IntentTarget("entity", "Sample Project"), question
+        assert intent.relation_candidates == (expected,), question
+
+    # The rule's accepted cost, pinned so that it reads as measured rather than
+    # as overlooked. `also known as` is a real attribute name and the strip
+    # takes it to `also`; `so called` is the same shape. These are read *worse*
+    # than before the rule.
+    #
+    # The last three rows are the sharper half of that cost and they are not
+    # interchangeable with the first two. `also` and `so` are relation names no
+    # schema is expected to hold, so those questions still decline, just one
+    # word further along -- unless the schema holds the name the question
+    # actually spells, `also known as`, in which case the answer that used to
+    # be free is given up instead. `date`, `user` and `hand` are relation names
+    # a schema may really hold, and where it does the question stops declining:
+    # measured against a KB carrying a `date` relation, `date labeled` moves
+    # from `review_required` plus one provider call to `translated` with none,
+    # answering what the date is for a question asking what it is labeled.
+    # `date labeled` differs by one word from the `date created` that
+    # `test_a_past_participle_relation_name_survives` protects.
+    #
+    # So this block, not just the possessive-entity test, is where the change
+    # admits it can promote a question rather than only shorten a label.
+    # Anyone narrowing the rule to recover these should expect this red.
+    for question, expected in (
+        ("What is Sample Person's also known as?", "also"),
+        ("What is the also known as of Sample Person?", "also"),
+        ("What is Sample Project's so called?", "so"),
+        ("What is Sample Dataset's date labeled?", "date"),
+        ("What is Sample Record's user named?", "user"),
+        ("What is Sample Dataset's hand labeled?", "hand"),
+    ):
+        intent = deterministic_query_intent(question)
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, question
+        assert intent.relation_candidates == (expected,), question
+
+
+def test_a_shortened_label_re_enters_the_purpose_synonyms():
+    """The strip changes which questions reach the synonym table, not only labels.
+
+    `purpose titled` is not a key in `_attribute_relation_candidates`, so before
+    this rule the question asked for exactly one relation candidate. Cleaned to
+    `purpose`, it is a key, and the same question now asks for all five. So
+    "the rule only shortens a label, the result set is unchanged" is false, and
+    this is the measurement that says so.
+    """
+    for question in (
+        "What is Sample Project's purpose titled?",
+        "What is Sample Project's goal known as?",
+        "What is Sample Project's objective called?",
+    ):
+        intent = deterministic_query_intent(question)
+
+        assert intent.kind == QueryIntentKind.LOOKUP_OBJECT, question
+        assert intent.relation_candidates == PURPOSE_RELATION_CANDIDATES, question

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1260,9 +1260,12 @@ def test_the_strip_cannot_leave_the_field_empty():
     # `date labeled` differs by one word from the `date created` that
     # `test_a_past_participle_relation_name_survives` protects.
     #
-    # So this block, not just the possessive-entity test, is where the change
-    # admits it can promote a question rather than only shorten a label.
-    # Anyone narrowing the rule to recover these should expect this red.
+    # So this block is where the change admits it can promote a question
+    # rather than only shorten a label. The entity sites are not a second such
+    # place: this rule does not clean them, and
+    # `test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer`
+    # holds them where they are. Anyone narrowing the rule to recover these
+    # rows should expect this red.
     #
     # The six rows are witnesses, not the population. `self titled` -> `self`
     # and `correctly spelled` -> `correctly` are the same class as

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1093,20 +1093,21 @@ def test_every_tail_adverb_is_read_with_the_predicate():
 def test_a_word_a_predicate_only_ends_is_left_alone():
     """The tail binds with `\\s+`, so a member inside a longer word is not a tail.
 
-    These eight are chosen against the two known relaxations of that binding,
+    These ten are chosen against the two known relaxations of that binding,
     which are not the same one and are not caught by the same witness:
 
-    - `\\s*` has no boundary requirement at all and cuts every word below --
+    - `\\s*` has no boundary requirement at all and cuts all ten below --
       `recalled` to `re`, `nicknamed` to `nick`, `untitled` to `un`. A corpus of
       `dataset`/`offset`/`blacklisted` would not notice: those end in `set` and
       `listed`, which are the *first* words of `set to` and `listed as` and are
       not members on their own, so the `\\s*` mutant leaves them whole and the
       test passes vacuously against it.
-    - `\\s*\\b` spares all eight, because `_` and every letter are word
-      characters, and still cuts `re-called` to `re-`, because `-` is not.
+    - `\\s*\\b` spares nine of them, because `_` and every letter are word
+      characters -- `so_called` is the row that needs the `_` -- and still cuts
+      `re-called` to `re-`, because `-` is not.
 
     So `re-called` is the witness that tells the second relaxation from the
-    first, and the eight are what make the first one red at all.
+    first, and the other nine are what make the first one red at all.
     """
     for label in (
         "recalled",

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1047,8 +1047,8 @@ def test_every_trailing_naming_predicate_is_read_as_a_predicate():
     already handling `called` and `named`, and it does not:
     `_clean_english_attribute_label` normalised whitespace and dropped a leading
     `the ` and nothing else. So `What is Sample Project's owner called?` asked
-    for a relation literally named `owner called`, which no schema holds, and
-    the question was planned empty.
+    for a relation literally named `owner called`, which no schema is expected
+    to hold, and the question was planned empty.
 
     The set-equality assertion is what stops a member being added to the tuple
     without a question exercising it.
@@ -1074,7 +1074,7 @@ def test_every_tail_adverb_is_read_with_the_predicate():
     The adverb slot only ever extends a cut the predicate alternation already
     makes, so dropping a member here leaves its question stopping one word
     short: `('owner also',)` instead of `('owner',)`. That is still a relation
-    no schema holds, so the failure is silent without this test.
+    no schema is expected to hold, so the failure is silent without this test.
     """
     from verinote.pipeline.query_intent import _ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS
 

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1016,10 +1016,11 @@ same hole one step further away -- an unchecked re-implementation of the rule.
 Same shape as `_MONTH_WORD_FIXTURES` in tests/test_query_measure_unit.py, for
 the same reason.
 
-The possessive spelling, which is the one this commit reaches. The `of`
-spelling puts the same tail on the entity instead of on the label, where the
-label cleaner cannot see it; the commit that cleans the entity widens each
-value to both spellings.
+The possessive spelling, which is the one this rule reaches. The `of` spelling
+puts the same tail on the entity instead of on the label, where the label
+cleaner cannot see it, and this rule deliberately leaves it there. Refs #515,
+and `tests/test_ask.py::test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer`
+pins that at the answer.
 """
 
 _ENGLISH_TAIL_ADVERB_FIXTURES = {

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1107,7 +1107,9 @@ def test_a_word_a_predicate_only_ends_is_left_alone():
       `re-called` to `re-`, because `-` is not.
 
     So `re-called` is the witness that tells the second relaxation from the
-    first, and the other nine are what make the first one red at all.
+    first, and the other nine are what make the first one red without it. They
+    are not needed for that red: the first relaxation cuts all ten, `re-called`
+    included, so any one row would catch it.
     """
     for label in (
         "recalled",
@@ -1250,15 +1252,27 @@ def test_the_strip_cannot_leave_the_field_empty():
     # The last three rows are the sharper half of that cost and they are not
     # interchangeable with the first two. `also` and `so` are relation names no
     # schema is expected to hold, so those questions still decline, just one
-    # word further along -- unless the schema holds the name the question
-    # actually spells, `also known as`, in which case the answer that used to
-    # be free is given up instead. `date`, `user` and `hand` are relation names
-    # a schema may really hold, and where it does the question stops declining:
-    # measured against a KB carrying a `date` relation, `date labeled` moves
-    # from `review_required` plus one provider call to `translated` with none,
-    # answering what the date is for a question asking what it is labeled.
-    # `date labeled` differs by one word from the `date created` that
-    # `test_a_past_participle_relation_name_survives` protects.
+    # word further along -- unless the *queried subject* holds a fact under the
+    # name the question actually spells, `also known as`, in which case the
+    # answer that used to be free is given up instead: measured with
+    # `Sample Person` holding `also known as`, that question moves from
+    # `translated` with no provider call to `review_required` with one.
+    # `date`, `user` and `hand` are relation names a schema may really hold,
+    # and where the queried subject holds a fact under one of them the question
+    # stops declining: measured with `Sample Dataset` holding `date`,
+    # `date labeled` moves from `review_required` plus one provider call to
+    # `translated` with none, answering what the date is for a question asking
+    # what it is labeled. `date labeled` differs by one word from the
+    # `date created` that `test_a_past_participle_relation_name_survives`
+    # protects.
+    #
+    # The subject is what the branch turns on, not the schema, and both rows
+    # were measured the other way round too: with `Other Dataset` holding
+    # `date` and `Other Person` holding `also known as`, the questions are
+    # `review_required` with one provider call before this rule and after, so
+    # nothing is promoted and nothing is given up. That is the population
+    # `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS` records, and
+    # `_clean_english_attribute_label`'s four rows are keyed the same way.
     #
     # So this block is where the change admits it can promote a question
     # rather than only shorten a label. The entity sites are not a second such

--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -1261,6 +1261,12 @@ def test_the_strip_cannot_leave_the_field_empty():
     # So this block, not just the possessive-entity test, is where the change
     # admits it can promote a question rather than only shorten a label.
     # Anyone narrowing the rule to recover these should expect this red.
+    #
+    # The six rows are witnesses, not the population. `self titled` -> `self`
+    # and `correctly spelled` -> `correctly` are the same class as
+    # `also known as` -> `also` and `hand labeled` -> `hand`, and neither is
+    # listed here. The population is every label whose last word or two is a
+    # member, which is open by construction because the tuple is.
     for question, expected in (
         ("What is Sample Person's also known as?", "also"),
         ("What is the also known as of Sample Person?", "also"),

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -622,7 +622,8 @@ _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS = (
 
 `What is Sample Project's owner known as?` asks for `owner`; the tail says how
 the asking is phrased. Before this rule *no* member was stripped -- neither
-these nor `called`/`named`, which #511 reports as already handled and are not:
+these nor `called`/`named`, which #511's title reports as already handled and
+which `main` never stripped:
 `_clean_english_attribute_label` normalised whitespace and dropped a leading
 `the ` and nothing else. So every member here is new: `What is Sample
 Project's owner called?` asked for a relation literally named `owner called`,
@@ -633,14 +634,14 @@ name a schema is expected to hold.
 
 What stands in front of the member decides that, though, and not the member.
 With `also` in front of `known as` the question asked for `also known as`,
-which is a real attribute name: measured at e032738 against a KB holding it,
-`What is Sample Person's also known as?` is `VERIFIED — engine` with no
-provider call, and this rule takes that same question to
-`UNVERIFIED — source exploration` and to a recorded
-`['extract_query_intent', 'answer_question']`. So the shape above is claimed for
-the `owner ` witnesses, not for every label a member can follow; the
+which is a real attribute name: measured at e032738 against a KB where
+`Sample Person` holds it, `What is Sample Person's also known as?` is
+`VERIFIED — engine` with no provider call, and this rule takes that same
+question to `UNVERIFIED — source exploration` and to a recorded
+`['extract_query_intent', 'answer_question']`. So the shape above is claimed
+for the `owner ` witnesses, not for every label a member can follow; the
 accepted-cost rows at the end of `test_the_strip_cannot_leave_the_field_empty`
-are where the rest of that population is pinned.
+record the rest of that population, witnesses rather than the whole of it.
 
 Not exhaustive, and cannot be: `referred to as`, `recorded as`, `written as`
 and their kin belong to the same class and are absent. A tail whose predicate
@@ -748,14 +749,14 @@ _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
     # provider call here, `UNVERIFIED — source exploration` and a re-read
     # under the flag. It also cuts
     # `Date Labeled` to `Date` and `User Named` to `User`, which is the
-    # opposite move: against a KB holding `Date`, `What is Sample Dataset's
-    # Date Labeled?` reaches the model here and answers
+    # opposite move: against a KB where `Sample Dataset` holds `Date`,
+    # `What is Sample Dataset's Date Labeled?` reaches the model here and answers
     # `Sample Dataset, Date, 2020-01-01` under `VERIFIED — engine` with no
     # provider call under the flag, for a question that asked what the date is
     # *labeled*. So the choice does not rest on ranking those two against each
     # other. What it does give up is a gain: `owner Called` cuts to `owner`,
-    # and against a KB holding `owner` that question is answered
-    # deterministically under the flag and reaches the model here. A forgone
+    # and against a KB where `Sample Project` holds `owner` that question is
+    # answered deterministically under the flag and reaches the model here. A forgone
     # gain, not a wrong answer. The first row is pinned end to end in
     # tests/test_ask.py by
     # test_a_title_case_tail_in_the_label_is_left_alone. The leading `\s+` is
@@ -1009,14 +1010,16 @@ def _clean_english_attribute_label(value: str) -> str:
       could not, so what the schema literally spells is not the only thing
       deciding this -- the synonym set is the third.
 
-    Each row is measured with the queried subject holding the fact, which is
-    what the branch actually turns on. Where the schema holds the name for some
+    Each row is measured with the queried subject holding a fact under one of
+    the label's candidates -- the fourth row's KB holds only the synonym --
+    which is what the branch actually turns on. Where the name is held for some
     *other* subject the plan is empty either way and the model is reached both
     before this rule and after: with `Other Dataset/date/2020-01-01` beside
     `Sample Dataset/size/3`, `What is Sample Dataset's date labeled?` is
-    `UNVERIFIED — source exploration` recording
-    `['extract_query_intent', 'answer_question']` at e032738 and the same here.
-    That is the case `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS` records.
+    `review_required` with one provider call at e032738 and the same here.
+    That is the case `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS` records, and
+    `test_the_strip_cannot_leave_the_field_empty` carries the same pair of
+    measurements at its accepted-cost rows.
 
     These rows are not ranked against each other, and an earlier draft of this
     list ranked them: it called the second the more expensive direction. That

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -606,6 +606,94 @@ _KOREAN_ATTRIBUTE_LABEL_TAIL = re.compile(
 )
 _KOREAN_ATTRIBUTE_LABEL_JOSA = re.compile(r"(?:은|는|이|가)\s*$")
 
+_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS = (
+    "called",
+    "named",
+    "titled",
+    "labelled",
+    "labeled",
+    "spelled",
+    "spelt",
+    "known as",
+    "listed as",
+    "set to",
+)
+"""The predicates an English attribute question may trail after what it asks for.
+
+`What is Sample Project's owner known as?` asks for `owner`; the tail says how
+the asking is phrased. Before this rule *no* member was stripped -- neither
+these nor `called`/`named`, which #511 reports as already handled and are not:
+`_clean_english_attribute_label` normalised whitespace and dropped a leading
+`the ` and nothing else. So every member here is new, and each one carried a
+relation candidate no schema holds.
+
+Not exhaustive, and cannot be: `referred to as`, `recorded as`, `written as`
+and their kin belong to the same class and are absent. A tail outside this
+tuple is left in the field exactly as it was, which sends the question to the
+LLM rather than to a wrong answer -- the same cost the unstripped members paid
+before, not a new one.
+
+Two words that end questions of this shape are deliberately out, both from
+#511. `worth` is part of the measure, and `stock worth` is a plausible relation
+name on its own. `like` asks for a description rather than for the object of a
+relation, so stripping it would answer a different question.
+
+`known as`, `listed as` and `set to` carry their particle. Dropping it and
+matching the participle alone would cut `publicly listed`, `well known` and
+`data set` -- ordinary relation names whose last word is a member's first.
+"""
+
+_ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS = (
+    "also",
+    "otherwise",
+    "formerly",
+    "previously",
+    "originally",
+    "currently",
+    "commonly",
+    "officially",
+)
+"""The adverbs that may stand between the label and its trailing predicate.
+
+`owner also known as` is `owner known as` with one word inserted, and without
+this slot the strip stops at `owner also`. The slot only ever extends a cut the
+predicate alternation already makes: it is not an alternative of its own, so a
+label ending in a bare `formerly` keeps it.
+
+Also not exhaustive -- `widely`, `popularly` and `variously` read the same way
+and are absent, with the same LLM fallback as any other unlisted tail.
+"""
+
+_ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
+    # One alternation against one `$`, deliberately not a sequence of `sub`
+    # calls. Splitting the adverb off into its own pass would strip it with no
+    # predicate behind it, taking `owner formerly` down to `owner`; splitting
+    # the particle off would leave the participle to match alone and cut
+    # `publicly listed` to `publicly`. Backtracking across the whole tail at
+    # once is what lets `owner listed as` reach `owner` while those stay whole.
+    r"\s+(?:(?:"
+    + "|".join(_ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS)
+    + r")\s+)?(?:"
+    # Every member is ASCII letters plus at most one space, so they join raw and
+    # the space is relaxed to `\s+`; the callers normalise runs of whitespace,
+    # but the entity field is only `.strip()`ed, so `Sample Project known  as`
+    # reaches this. Alternation order is inert here -- unlike
+    # `_MEASUREMENT_UNIT_SPELLINGS`, which has no anchor to backtrack against --
+    # because `$` forces every alternative to be tried at the same end.
+    + "|".join(
+        m.replace(" ", r"\s+") for m in _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS
+    )
+    + r")\s*$"
+    # No flags. Case matters: names ending in this exact tail in title case are
+    # real -- `Sample Project Formerly Known As` stands in for them here -- and
+    # `re.IGNORECASE` would take an entity spelled that way apart, adverb
+    # included. The leading `\s+` is the other half of the guard
+    # and is not relaxable -- `\s*` reads `recalled` as `re`, and `\s*\b` spares
+    # that but still reads `re-called` as `re-`, because `-` is not a word
+    # character. Both relaxations are pinned as mutants in
+    # tests/test_query_intent.py.
+)
+
 # tests/test_query_measure_unit.py, now a module away, pins this string twice.
 # test_the_digit_requirement_keeps_ordinary_prose_out_of_the_caveat pins its
 # overlap with _MEASUREMENT_UNIT_SPELLINGS at 13, and
@@ -794,8 +882,61 @@ def _looks_like_korean_attribute_question(raw_label: str, question: str) -> bool
 
 
 def _clean_english_attribute_label(value: str) -> str:
+    """Normalise the label, drop a leading article, then drop a trailing predicate.
+
+    The article strip goes first, and the order changes the answer for exactly
+    one population: a label that is an article followed straight by the tail.
+    Measured on `the called` -- article first gives `called`, tail first gives
+    `the`, because the `\\s` in front of `called` is all the pattern needs, and
+    `removeprefix("the ")` then finds no prefix left to drop. Swept over the
+    label shapes this parser admits, that population is 90 labels and every one
+    of them is `the ` plus a member or `the ` plus an adverb and a member; 80
+    of the 90 carry the adverb, which is why the article has to be followed by
+    the *tail* and not merely by a predicate.
+
+    `the the called` is not in that population, though it reads as if it should
+    be: tail first cuts it to `the the`, and `removeprefix` then takes that to
+    `the`, which is exactly what article first gives. Both orders agree, and
+    only a single article makes them differ.
+
+    Neither reading of `the called` is a relation any schema is expected to
+    hold, so the order decides nothing between a right and a wrong answer. What
+    the chosen one buys is that the word carrying the content survives instead
+    of the article. That narrowness is visible in the mutant: swapping the two
+    lines reddens `test_the_strip_cannot_leave_the_field_empty` and nothing
+    else.
+
+    Emptying is impossible rather than merely unobserved: both fields are
+    stripped before the pattern is applied, so position 0 is not whitespace,
+    and the pattern consumes at least one leading `\\s`, so at least one
+    character always survives. That is an argument about the pattern, not about
+    which members the tuple happens to hold.
+
+    It says nothing about the residue being *useful*, and what the residue
+    costs depends on what the schema holds -- in both directions, where an
+    earlier draft of this docstring gave only one. Measured end to end against
+    a KB, for a question whose label this shortens:
+
+    - schema holds the cut name and not the spelled one: the question goes from
+      `review_required` plus a provider call to `translated` with none.
+      `date labeled` is then answered with `date` -- what the date *is*, for a
+      question asking what it is labeled.
+    - schema holds the spelled name and not the cut one: the move is the other
+      way, and it is the more expensive one. `translated` with no provider call
+      becomes `review_required` with one, giving up a correct deterministic
+      answer the parser used to produce. `also known as` is a real attribute
+      name, so this direction is not hypothetical.
+    - schema holds both: `translated` either way, but the relation that answers
+      silently changes from the spelled name to the cut one, with no change of
+      status to show for it.
+
+    So this is not priced in provider calls alone. `also` and `so` are the
+    harmless end of it, and they are pinned with the rest at the end of
+    `test_the_strip_cannot_leave_the_field_empty`.
+    """
     label = " ".join(value.strip().split())
-    return label.removeprefix("the ").strip()
+    label = label.removeprefix("the ").strip()
+    return _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE.sub("", label).strip()
 
 
 def _korean_attribute_relation_candidates(raw_label: str) -> tuple[str, ...]:

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -696,12 +696,21 @@ _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
     r"\s+(?:(?:"
     + "|".join(_ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS)
     + r")\s+)?(?:"
-    # Every member is ASCII letters plus at most one space, so they join raw and
-    # the space is relaxed to `\s+`; the callers normalise runs of whitespace,
-    # but the entity field is only `.strip()`ed, so `Sample Project known  as`
-    # reaches this. Alternation order is inert here -- unlike
-    # `_MEASUREMENT_UNIT_SPELLINGS`, which has no anchor to backtrack against --
-    # because `$` forces every alternative to be tried at the same end.
+    # Every member is ASCII letters plus at most one space, so they join raw
+    # and the space is relaxed to `\s+`. Nothing exercises that relaxation
+    # today: the only caller is `_clean_english_attribute_label`, which folds
+    # runs of whitespace on its first line, so a member always arrives with
+    # exactly one space in it. Measured -- replacing the relaxation with a
+    # literal space passes the whole suite, so no mutant can prove this line
+    # necessary. `What is the owner of Sample Project known  as?` does not
+    # reach it either: the `of` shape puts that tail on the entity, which this
+    # rule does not clean. It stays because the unreachability is a property
+    # of the caller and not of the pattern -- a caller handing over a field
+    # that is only `.strip()`ed, which is what an entity-site fix under #515
+    # would be, exercises it immediately. Alternation order is inert here --
+    # unlike `_MEASUREMENT_UNIT_SPELLINGS`, which has no anchor to backtrack
+    # against -- because `$` forces every alternative to be tried at the same
+    # end.
     + "|".join(
         m.replace(" ", r"\s+") for m in _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS
     )

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -626,15 +626,18 @@ these nor `called`/`named`, which #511 reports as already handled and are not:
 `_clean_english_attribute_label` normalised whitespace and dropped a leading
 `the ` and nothing else. So every member here is new: `What is Sample
 Project's owner called?` asked for a relation literally named `owner called`,
-and with any member of this tuple in place of `called` it is the same shape --
-a name no schema is expected to hold.
+and each of the other nine reads the same way -- measured at e032738, all ten
+`What is Sample Project's owner <member>?` questions parse to
+`('owner <member>',)` and to no other candidate, and none of those ten is a
+name a schema is expected to hold.
 
 What stands in front of the member decides that, though, and not the member.
 With `also` in front of `known as` the question asked for `also known as`,
 which is a real attribute name: measured at e032738 against a KB holding it,
 `What is Sample Person's also known as?` is `VERIFIED — engine` with no
 provider call, and this rule takes that same question to
-`UNVERIFIED — source exploration` with one. So the shape above is claimed for
+`UNVERIFIED — source exploration` and to a recorded
+`['extract_query_intent', 'answer_question']`. So the shape above is claimed for
 the `owner ` witnesses, not for every label a member can follow; the
 accepted-cost rows at the end of `test_the_strip_cannot_leave_the_field_empty`
 are where the rest of that population is pinned.
@@ -650,8 +653,9 @@ empty and the model is reached -- including where the schema does hold that
 relation for some *other* subject, because `all_relation_labels` is KB-wide
 (`query_schema.py`: "Every relation surface in the KB") and a plan is not.
 Measured with `Other Stock/stock worth/V9` beside `Sample Stock/price/V0`,
-`What is Sample Stock's stock worth?` is `UNVERIFIED — source exploration`
-with one provider call. `verinote/pipeline/query.py` already names that
+`What is Sample Stock's stock worth?` is `UNVERIFIED — source exploration`,
+recording `['extract_query_intent', 'answer_question']` where the answered
+branch records nothing. `verinote/pipeline/query.py` already names that
 population where it calls `_reinterpret_empty_plan` -- "a subject with no fact
 for an otherwise real relation is re-read too, and pays a provider call to
 arrive back at the same place".
@@ -741,7 +745,8 @@ _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
     # against the other: measured end to end, it moves questions in both.
     # `Also Known As` is a real attribute name a schema may spell in title
     # case, and the flag cuts it to `Also` -- `VERIFIED — engine` with no
-    # provider call here, the model with one under the flag. It also cuts
+    # provider call here, `UNVERIFIED — source exploration` and a re-read
+    # under the flag. It also cuts
     # `Date Labeled` to `Date` and `User Named` to `User`, which is the
     # opposite move: against a KB holding `Date`, `What is Sample Dataset's
     # Date Labeled?` reaches the model here and answers
@@ -1006,9 +1011,12 @@ def _clean_english_attribute_label(value: str) -> str:
 
     Each row is measured with the queried subject holding the fact, which is
     what the branch actually turns on. Where the schema holds the name for some
-    *other* subject the plan is empty either way and the model is reached with
-    a provider call, before this rule and after -- the case
-    `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS` records.
+    *other* subject the plan is empty either way and the model is reached both
+    before this rule and after: with `Other Dataset/date/2020-01-01` beside
+    `Sample Dataset/size/3`, `What is Sample Dataset's date labeled?` is
+    `UNVERIFIED — source exploration` recording
+    `['extract_query_intent', 'answer_question']` at e032738 and the same here.
+    That is the case `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS` records.
 
     These rows are not ranked against each other, and an earlier draft of this
     list ranked them: it called the second the more expensive direction. That

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -624,33 +624,54 @@ _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS = (
 the asking is phrased. Before this rule *no* member was stripped -- neither
 these nor `called`/`named`, which #511 reports as already handled and are not:
 `_clean_english_attribute_label` normalised whitespace and dropped a leading
-`the ` and nothing else. So every member here is new, and each one carried a
-relation candidate no schema is expected to hold.
+`the ` and nothing else. So every member here is new: `What is Sample
+Project's owner called?` asked for a relation literally named `owner called`,
+and with any member of this tuple in place of `called` it is the same shape --
+a name no schema is expected to hold.
+
+What stands in front of the member decides that, though, and not the member.
+With `also` in front of `known as` the question asked for `also known as`,
+which is a real attribute name: measured at e032738 against a KB holding it,
+`What is Sample Person's also known as?` is `VERIFIED — engine` with no
+provider call, and this rule takes that same question to
+`UNVERIFIED — source exploration` with one. So the shape above is claimed for
+the `owner ` witnesses, not for every label a member can follow; the
+accepted-cost rows at the end of `test_the_strip_cannot_leave_the_field_empty`
+are where the rest of that population is pinned.
 
 Not exhaustive, and cannot be: `referred to as`, `recorded as`, `written as`
 and their kin belong to the same class and are absent. A tail whose predicate
 is outside this tuple keeps whatever the question spelled, which is the cost
 that spelling paid before this rule rather than a new one. It is not the same
-as reaching the LLM, and which of the two it is depends on the schema. Where
-no schema holds the spelled name -- the ordinary case -- the plan is empty and
-the model is reached. Where a schema does hold it, the unstripped tail is
-answered outright, with no provider call.
+as reaching the LLM, and what separates the two is not the schema but whether
+the queried subject holds a fact under the spelled name. Where it does, the
+question is answered with no provider call. Where it does not, the plan is
+empty and the model is reached -- including where the schema does hold that
+relation for some *other* subject, because `all_relation_labels` is KB-wide
+(`query_schema.py`: "Every relation surface in the KB") and a plan is not.
+Measured with `Other Stock/stock worth/V9` beside `Sample Stock/price/V0`,
+`What is Sample Stock's stock worth?` is `UNVERIFIED — source exploration`
+with one provider call. `verinote/pipeline/query.py` already names that
+population where it calls `_reinterpret_empty_plan` -- "a subject with no fact
+for an otherwise real relation is re-read too, and pays a provider call to
+arrive back at the same place".
 
 Two words that end questions of this shape are deliberately out, both from
-#511, and it is that second branch they are held out to preserve. `worth` is
+#511, and it is the answered branch they are held out to preserve. `worth` is
 part of the measure, and `stock worth` is a plausible relation name on its
-own: measured against a schema holding `stock worth`, `What is Sample Stock's
-stock worth?` is `VERIFIED — engine` with no provider call, and a member
-`worth` would take that away. `like` asks for a description rather than for
-the object of a relation, so stripping it would answer a different question.
+own: measured against a KB where `Sample Stock` holds `stock worth`, `What is
+Sample Stock's stock worth?` is `VERIFIED — engine` with no provider call, and
+a member `worth` would take that away. `like` asks for a description rather
+than for the object of a relation, so stripping it would answer a different
+question.
 
 Adding a member is therefore not free either, though the cost lands narrowly.
 It cannot reach a label that *is* the predicate, because the leading `\\s` has
 nothing to match at position 0: `referred to as` stays whole with or without
 the member. What it moves is the labels carrying a word in front of the
-predicate. Measured against a schema holding `name referred to as`, that
-question is `VERIFIED — engine` with no provider call here and reaches the
-model once the member is added.
+predicate. Measured against a KB where `Sample Project` holds `name referred
+to as`, that question is `VERIFIED — engine` with no provider call here and
+reaches the model once the member is added.
 
 An adverb outside `_ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS` standing in front
 of a listed predicate is a third case, and leaves the field neither stripped
@@ -683,7 +704,8 @@ and are absent. An unlisted adverb does not spare the predicate it introduces:
 that predicate is still a member, so `owner widely known as` is cut to
 `owner widely` rather than left whole. What the residue then costs is the
 conditional the predicate tuple records -- a relation candidate no schema is
-expected to hold, and the model reached, unless the schema happens to hold it.
+expected to hold, and the model reached, unless the queried subject happens to
+hold a fact under that residue.
 """
 
 _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
@@ -715,12 +737,22 @@ _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
         m.replace(" ", r"\s+") for m in _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS
     )
     + r")\s*$"
-    # No flags. Case matters because a schema may spell an attribute name in
-    # title case: `Also Known As` is real, and `re.IGNORECASE` cuts it to
-    # `Also`, which no schema is expected to hold, so a question answered here
-    # with no provider call reaches the model instead. That is the more
-    # expensive of the two directions this rule can move a question, and it is
-    # pinned end to end in tests/test_ask.py by
+    # No flags. `re.IGNORECASE` is not a trade of one direction of this rule
+    # against the other: measured end to end, it moves questions in both.
+    # `Also Known As` is a real attribute name a schema may spell in title
+    # case, and the flag cuts it to `Also` -- `VERIFIED — engine` with no
+    # provider call here, the model with one under the flag. It also cuts
+    # `Date Labeled` to `Date` and `User Named` to `User`, which is the
+    # opposite move: against a KB holding `Date`, `What is Sample Dataset's
+    # Date Labeled?` reaches the model here and answers
+    # `Sample Dataset, Date, 2020-01-01` under `VERIFIED — engine` with no
+    # provider call under the flag, for a question that asked what the date is
+    # *labeled*. So the choice does not rest on ranking those two against each
+    # other. What it does give up is a gain: `owner Called` cuts to `owner`,
+    # and against a KB holding `owner` that question is answered
+    # deterministically under the flag and reaches the model here. A forgone
+    # gain, not a wrong answer. The first row is pinned end to end in
+    # tests/test_ask.py by
     # test_a_title_case_tail_in_the_label_is_left_alone. The leading `\s+` is
     # the other half of the guard and is not relaxable -- `\s*` reads
     # `recalled` as `re`, and `\s*\b` spares that but still reads `re-called`
@@ -956,10 +988,10 @@ def _clean_english_attribute_label(value: str) -> str:
       `date labeled` is then answered with `date` -- what the date *is*, for a
       question asking what it is labeled.
     - schema holds the spelled name and not the cut one: the move is the other
-      way, and it is the more expensive one. `translated` with no provider call
-      becomes `review_required` with one, giving up a correct deterministic
-      answer the parser used to produce. `also known as` is a real attribute
-      name, so this direction is not hypothetical.
+      way. `translated` with no provider call becomes `review_required` with
+      one, giving up a correct deterministic answer the parser used to
+      produce. `also known as` is a real attribute name, so this direction is
+      not hypothetical.
     - schema holds both: `translated` either way, but the relation that answers
       silently changes from the spelled name to the cut one, with no change of
       status to show for it.
@@ -971,6 +1003,23 @@ def _clean_english_attribute_label(value: str) -> str:
       cut label re-enters `PURPOSE_RELATION_CANDIDATES`, which the spelled one
       could not, so what the schema literally spells is not the only thing
       deciding this -- the synonym set is the third.
+
+    Each row is measured with the queried subject holding the fact, which is
+    what the branch actually turns on. Where the schema holds the name for some
+    *other* subject the plan is empty either way and the model is reached with
+    a provider call, before this rule and after -- the case
+    `_ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS` records.
+
+    These rows are not ranked against each other, and an earlier draft of this
+    list ranked them: it called the second the more expensive direction. That
+    ranking is withdrawn rather than quietly dropped, because it is the one the
+    rest of the repository refuses -- `verinote/store/tiers.py` ("A crash is
+    cheaper than a quiet wrong answer") and `verinote/store/db.py` ("the silent
+    wrong answer this filter exists to prevent") both price a quiet wrong
+    answer above a lost one, and the first and third rows are that shape.
+    Nothing in this rule's spelling rests on either ranking; the flag comment
+    on `_ENGLISH_ATTRIBUTE_TRAILING_PREDICATE` measures both directions and
+    reads them together.
 
     So this is not priced in provider calls alone. `also` and `so` are the
     harmless end of it, and they are pinned with the rest at the end of

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -951,6 +951,14 @@ def _clean_english_attribute_label(value: str) -> str:
     - schema holds both: `translated` either way, but the relation that answers
       silently changes from the spelled name to the cut one, with no change of
       status to show for it.
+    - schema holds neither, but holds a *synonym* of the cut name: the first
+      move again, by a route the first three do not name. Measured against a KB
+      whose only relation is `goal`, `What is Sample Dataset's purpose titled?`
+      reaches the model with a provider call before this rule and answers
+      `Sample Dataset, goal, V0` under `VERIFIED — engine` with none after. The
+      cut label re-enters `PURPOSE_RELATION_CANDIDATES`, which the spelled one
+      could not, so what the schema literally spells is not the only thing
+      deciding this -- the synonym set is the third.
 
     So this is not priced in provider calls alone. `also` and `so` are the
     harmless end of it, and they are pinned with the rest at the end of

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -706,14 +706,17 @@ _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(
         m.replace(" ", r"\s+") for m in _ENGLISH_ATTRIBUTE_TAIL_PREDICATE_MEMBERS
     )
     + r")\s*$"
-    # No flags. Case matters: names ending in this exact tail in title case are
-    # real -- `Sample Project Formerly Known As` stands in for them here -- and
-    # `re.IGNORECASE` would take an entity spelled that way apart, adverb
-    # included. The leading `\s+` is the other half of the guard
-    # and is not relaxable -- `\s*` reads `recalled` as `re`, and `\s*\b` spares
-    # that but still reads `re-called` as `re-`, because `-` is not a word
-    # character. Both relaxations are pinned as mutants in
-    # tests/test_query_intent.py.
+    # No flags. Case matters because a schema may spell an attribute name in
+    # title case: `Also Known As` is real, and `re.IGNORECASE` cuts it to
+    # `Also`, which no schema is expected to hold, so a question answered here
+    # with no provider call reaches the model instead. That is the more
+    # expensive of the two directions this rule can move a question, and it is
+    # pinned end to end in tests/test_ask.py by
+    # test_a_title_case_tail_in_the_label_is_left_alone. The leading `\s+` is
+    # the other half of the guard and is not relaxable -- `\s*` reads
+    # `recalled` as `re`, and `\s*\b` spares that but still reads `re-called`
+    # as `re-`, because `-` is not a word character. Both relaxations are
+    # pinned as mutants in tests/test_query_intent.py.
 )
 
 # tests/test_query_measure_unit.py, now a module away, pins this string twice.

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -625,18 +625,36 @@ the asking is phrased. Before this rule *no* member was stripped -- neither
 these nor `called`/`named`, which #511 reports as already handled and are not:
 `_clean_english_attribute_label` normalised whitespace and dropped a leading
 `the ` and nothing else. So every member here is new, and each one carried a
-relation candidate no schema holds.
+relation candidate no schema is expected to hold.
 
 Not exhaustive, and cannot be: `referred to as`, `recorded as`, `written as`
-and their kin belong to the same class and are absent. A tail outside this
-tuple is left in the field exactly as it was, which sends the question to the
-LLM rather than to a wrong answer -- the same cost the unstripped members paid
-before, not a new one.
+and their kin belong to the same class and are absent. A tail whose predicate
+is outside this tuple keeps whatever the question spelled, which is the cost
+that spelling paid before this rule rather than a new one. It is not the same
+as reaching the LLM, and which of the two it is depends on the schema. Where
+no schema holds the spelled name -- the ordinary case -- the plan is empty and
+the model is reached. Where a schema does hold it, the unstripped tail is
+answered outright, with no provider call.
 
 Two words that end questions of this shape are deliberately out, both from
-#511. `worth` is part of the measure, and `stock worth` is a plausible relation
-name on its own. `like` asks for a description rather than for the object of a
-relation, so stripping it would answer a different question.
+#511, and it is that second branch they are held out to preserve. `worth` is
+part of the measure, and `stock worth` is a plausible relation name on its
+own: measured against a schema holding `stock worth`, `What is Sample Stock's
+stock worth?` is `VERIFIED — engine` with no provider call, and a member
+`worth` would take that away. `like` asks for a description rather than for
+the object of a relation, so stripping it would answer a different question.
+
+Adding a member is therefore not free either, though the cost lands narrowly.
+It cannot reach a label that *is* the predicate, because the leading `\\s` has
+nothing to match at position 0: `referred to as` stays whole with or without
+the member. What it moves is the labels carrying a word in front of the
+predicate. Measured against a schema holding `name referred to as`, that
+question is `VERIFIED — engine` with no provider call here and reaches the
+model once the member is added.
+
+An adverb outside `_ENGLISH_ATTRIBUTE_TAIL_ADVERB_MEMBERS` standing in front
+of a listed predicate is a third case, and leaves the field neither stripped
+nor whole: `owner widely known as` comes out as `owner widely`.
 
 `known as`, `listed as` and `set to` carry their particle. Dropping it and
 matching the participle alone would cut `publicly listed`, `well known` and
@@ -661,7 +679,11 @@ predicate alternation already makes: it is not an alternative of its own, so a
 label ending in a bare `formerly` keeps it.
 
 Also not exhaustive -- `widely`, `popularly` and `variously` read the same way
-and are absent, with the same LLM fallback as any other unlisted tail.
+and are absent. An unlisted adverb does not spare the predicate it introduces:
+that predicate is still a member, so `owner widely known as` is cut to
+`owner widely` rather than left whole. What the residue then costs is the
+conditional the predicate tuple records -- a relation candidate no schema is
+expected to hold, and the model reached, unless the schema happens to hold it.
 """
 
 _ENGLISH_ATTRIBUTE_TRAILING_PREDICATE = re.compile(


### PR DESCRIPTION
Refs #511
Refs #515

> **리뷰 후 범위를 좁혔습니다.** 엔티티 사이트 커밋(`065cfc1`)을 **드롭**했습니다. 이 PR 은 이제 **라벨 사이트만** 고칩니다. `origin/main`(`e032738`) 위로 리베이스했고 머지 커밋은 없습니다. 아래 수치는 전부 **리베이스가 끝난 최종 트리에서 다시 잰 것**입니다.

## 이슈 본문이 낡았습니다

이슈는 "코드가 `called`/`named` 는 이미 뗀다"를 전제하지만 **main 에 그런 규칙이 없습니다.** `_clean_english_attribute_label` 은 공백 정규화 + `removeprefix("the ")` 가 전부이고, 어느 멤버도 떼지 않습니다. 깨진 행은 이슈의 8행이 아니라 **20행**입니다 — 두 어형 × 멤버 10.

## 두 어형이 서로 다른 필드를 망칩니다

- 소유격: entity 는 `'s` 앞에서 끊기고 label 그룹이 끝까지 먹음 → 꼬리가 **label** 에
- `of`: label 은 ` of ` 앞에서 끊기고 entity 그룹이 끝까지 먹음 → 꼬리가 **entity** 에

**이 PR 은 라벨 정리기만 고칩니다. 20행 중 10행을 고치고, 남는 10행은 전부 `of` 어형입니다:**
```
'What is the owner of Sample Project known as?' → ('lookup_object', 'Sample Project known as', ('owner',))
```
그래서 `Closes #511` 이 아니라 `Refs #511` 입니다.

## `of` 어형 엔티티를 건드리지 않는 이유

초안의 둘째 커밋이 같은 꼬리를 `of` 어형 엔티티에서도 뗐습니다. 드롭했습니다. 그 어형에서 엔티티는 **종단 필드**라, 이름의 일부인 후행 단어와 질문의 표현을 말하는 후행 술어가 파싱 시점에 구별되지 않습니다. 절단하면 **다른 주어**에 대해 답하고, 그 계획은 비어 있지 않으므로 `_reinterpret_empty_plan` 구제도 없습니다. 실패 양식이 "잃은 답"이 아니라 **`VERIFIED — engine` 을 단 오답**입니다.

`ask_question` 종단 측정, 세 provider 메서드가 전부 raise 하는 클라이언트 (`PROVIDER-REACHED` = 결정적 경로를 떠났다는 뜻):

| KB | 질문 | `e032738` | 이 PR | 드롭한 커밋 |
|---|---|---|---|---|
| `Company/owner/Alice`, `Company named/owner/Bob` | `What is the owner of Company named?` | `VERIFIED — engine` **Bob**, 0 calls | **동일** | `VERIFIED — engine` **Alice**, 0 calls |
| `Company/owner/Alice`, `Company Named/owner/Bob` | 같음 | `PROVIDER-REACHED` | **동일** | `VERIFIED — engine` **Alice**, 0 calls |
| `Company named/owner/Bob` | 같음 | `VERIFIED — engine` **Bob**, 0 calls | **동일** | `PROVIDER-REACHED` |
| `Wholegrain/supplier/Alice`, `Wholegrain spelt/supplier/Bob` | `What is the supplier of Wholegrain spelt?` | **Bob** | **동일** | **Alice** |

**모든 행에서 이 PR 은 `e032738` 과 같은 결과를 냅니다.** 드롭 비용은 0 입니다.

`#515` 가 이 결함을 기록합니다. 이 PR 은 `#515` 가 요구하는 수정(절단 전 store 조회, 또는 두 읽기가 모두 해석되면 어형 거절)을 **하지 않습니다** — 둘 다 `query_intent.py` 밖의 이음매입니다. 안전한 현 거동을 못박을 뿐이라 `Refs #515` 이고 `Closes` 가 아닙니다.

**범위를 정확히 적습니다:** `#515` 의 픽스처는 `Company Named` 로 **타이틀 케이스**입니다. 이 패턴은 플래그가 없어 `Named` 가 멤버 `named` 에 걸리지 않으므로, 타이틀 케이스 철자는 이 규칙의 어떤 철자에서도 안전하고 **테스트로 못박아도 아무것도 못박지 못합니다** — 이 규칙의 어떤 철자도 그 행을 red 로 만들지 않습니다. (엔티티 절단과 `re.IGNORECASE` 를 **함께** 넣은 복합 뮤턴트라면 red 가 됩니다. 그래서 범위를 '이 규칙의 철자'로 한정했지 '어떤 뮤턴트도'라고 쓰지 않았습니다.) 못박은 것은 절단이 실제로 발동하는 **소문자 철자**입니다.

## 열거이고, 패턴이 아닙니다

`-ed/-en` 패턴 대안은 부정만 망치는 게 아니라 **긍정도 놓칩니다** — `known as`/`set to`/`spelt` 는 `-ed/-en` 이 아닙니다(10 멤버 중 3개). 동시에 `date created`→`date`, `last modified`→`last` 등을 자릅니다. bare `set`/`listed`/`known` 을 넣으면 `data set`→`data`, `well known`→`well`, `publicly listed`→`publicly`. **다어절 멤버는 다어절로 유지합니다.** 아래 매트릭스의 `M3`·`M4` 가 이 둘입니다.

부사 슬롯도 열거입니다(`\w+ly` 아님). 슬롯이 새 절단을 만들 수 없다는 것은 정리(定理)입니다 — 슬롯이 매치하면 멤버 앞에 반드시 `\s+` 가 있으므로 맨 멤버형이 이미 매치합니다. **재측정**: 16 stem × 8 부사 × 10 멤버 = **1280 케이스에서 새 절단 0건, 기존 절단 연장 1120건.** 그리고 출하 정규식이 **맨 부사로 끝나는 라벨을 자르는 경우는 0건**입니다(`the also`→`also` 같은 16건은 정규식이 아니라 `removeprefix("the ")` 가 한 일입니다).

부정 코퍼스 **89 라벨행**을 **출하할 정규식**(플래그 없음)으로 재서 **위반 0**. 프로브 첫 줄에 `assert rx.flags == re.UNICODE`. 코퍼스 구성: 다어절 멤버의 첫 단어로 끝나는 평범한 관계명(`publicly listed`, `well known`, `data set`, `target/result/character/test set`, `skill set` …), 멤버가 더 긴 한 단어의 꼬리일 뿐인 것(`recalled`, `re-called`, `so_called`, `nicknamed`, `unnamed`, `entitled`, `mislabelled`, `misspelled`, `dispelled` …), 타이틀 케이스(`Also Known As`, `Formerly Known As`, `Owner Called` …), 멤버가 아닌 분사(`date created`, `last modified`, `invoices paid` …), 맨 부사로 끝나는 라벨(`owner formerly` …), 라벨이 술어 그 자체인 것(`called`, `known as` …), 배제한 두 단어(`stock worth`, `owner like`).

**엔티티 부정 코퍼스는 뺐습니다.** 엔티티 사이트를 드롭한 뒤로는 아무것도 자르지 않으므로 "위반 0" 이 공허합니다.

## 목록은 완결이 아니고, 멤버 추가는 공짜가 아닙니다

`referred to as`, `recorded as`, `written as`, `widely`, `popularly`, `variously` 는 같은 부류지만 넣지 않았습니다. 소스 docstring 두 곳에 명시했습니다. **그 부재를 못박는 테스트는 일부러 넣지 않았습니다** — 넣으면 "이 목록은 닫혀 있다"는 반대 주장을 테스트가 하게 됩니다.

리뷰 지적 4 를 고치면서 **멤버 추가의 비용을 실제로 쟀습니다.** 이전 초안은 `referred to as` 를 증인으로 들었는데, 재보니 **그 증인은 틀렸습니다** — 라벨이 술어 그 자체면 패턴의 필수 선행 `\s+` 가 위치 0 에서 매치할 수 없어, 멤버를 넣어도 움직이지 않습니다:

```
멤버 추가 후:  clean('referred to as')      -> 'referred to as'   (안 움직임)
               clean('name referred to as') -> 'name'             (움직임)
```

참인 증인은 **앞에 단어가 있는** 쪽입니다. 종단 측정:

```
KB: Sample Dataset / "name referred to as" / V0
Q : What is Sample Dataset's name referred to as?
  이 PR         : VERIFIED — engine, 0 calls
  멤버 추가 후  : PROVIDER-REACHED
```

## 리뷰 지적 4 — 거짓 전칭을 고쳤습니다

> A tail outside this tuple is left in the field exactly as it was, which sends the question to the LLM rather than to a wrong answer

목록 밖 꼬리는 **스키마가 그 이름을 가지면 LLM 으로 가지 않고 결정적으로 답합니다.** 측정:

```
KB: Sample Stock / "stock worth" / V0
Q : What is Sample Stock's stock worth?   ->  VERIFIED — engine, 0 calls
```

그리고 이전 초안은 `worth`/`like` 의 배제 이유를 **반대 분기에** 붙였습니다. `worth` 가 빠진 이유는 "스키마가 안 가져서 모델로 간다"가 아니라 정반대 — **`stock worth` 를 스키마가 실제로 가질 수 있어서**입니다. docstring 을 그 분기로 옮겼습니다.

논블로킹 8·9 도 같은 자리에서 닫았습니다: 목록에 **없는 부사**가 목록에 **있는 술어** 앞에 오면 필드가 있던 그대로 남지 않습니다(`owner widely known as` → `owner widely`) — 이 문장이 없었습니다. 맨 전칭 `no schema holds` 세 곳은 `no schema is expected to hold` 로 좁혔습니다.

**코드 무변경입니다.** 정규식 문자열·플래그·멤버 튜플 둘 다 바이트 동일하며, 컴파일된 `pattern` 과 `flags` 를 전후로 비교해 확인했습니다.

## 결과 집합이 움직입니다 — 그리고 네 번째 경우가 있었습니다

라벨이 짧아져 후보가 1→5 로 늘어납니다:
```
"What is Sample Project's purpose titled?"  ('purpose titled',) → ('목적','목표','purpose','objective','goal')
```

`_clean_english_attribute_label` docstring 은 절단 비용을 **세 경우**로 셌습니다(스키마가 잘린 이름을 가짐 / 쓰인 이름을 가짐 / 둘 다). **네 번째가 있습니다: 둘 다 없지만 잘린 이름의 동의어를 가진 경우.** 종단 측정:

```
KB: Sample Dataset / goal / V0   (관계는 goal 하나뿐)
Q : What is Sample Dataset's purpose titled?
  e032738 : PROVIDER-REACHED
  이 PR   : VERIFIED — engine  'Sample Dataset, goal, V0'  0 calls
```

기존 `test_a_shortened_label_re_enters_the_purpose_synonyms` 는 후보 집합 이동만 **파싱 수준**으로 못박습니다. 판정이 움직인 것은 파싱 단언으로는 보이지 않으므로 종단 테스트를 넣었습니다.

## 감수하는 비용 (측정, 테스트로 못박음)

```
"What is Sample Person's also known as?"   HEAD ('also known as',) → ('also',)
"What is Sample Dataset's hand labeled?"   HEAD ('hand labeled',)  → ('hand',)
"What is Sample Project's so called?"      HEAD ('so called',)     → ('so',)
```
`also known as`(aka)는 실재하는 속성명이라 **HEAD 대비 진짜 후퇴**입니다. 실제 KB(`date` 관계 보유)로 파이프라인을 돌린 측정:

```
"What is Sample Dataset's date labeled?"
  e032738  review_required  calls=1
  이 PR    translated       calls=0   answer_q1(O) :- relation("Sample Dataset", "date", O).
"What is Sample Dataset's date created?"   양쪽 다 review_required, calls=1   ← T4 가 지키는 대조군
```

**고정된 6행은 증인이지 모집단이 아닙니다.** `self titled` → `self`, `correctly spelled` → `correctly` 도 같은 부류이고 목록에 없습니다. 튜플이 열려 있으므로 모집단도 열려 있습니다 — 주석에 적었습니다.

## 대소문자 구분은 라벨 사이트에서도 값을 삽니다

`#527` 은 라벨 사이트에 대소문자 무시 교대를 제안합니다 — diff 에 `_ENGLISH_ATTRIBUTE_QUESTION_TAIL = r"(?:\s+(?i:called|named))?"` 가 실재합니다. 다만 **그 논거의 출처는 `#527` 이 아닙니다**: 대소문자 구분이 엔티티 사이트에서만 load-bearing 하다는 주장은 `#527` 본문·diff 에 없고(`대소문자`/`ignorecase` 0건), 그 PR 저자가 **이 PR 의 리뷰**에서 편 것입니다. 그 주장은 **엔티티 사이트에 대해서는 맞고, 라벨 사이트에서는 틀립니다.** 측정:

```
KB: Sample Project / "Also Known As" / Ada
Q : What is Sample Project's Also Known As?
  이 PR(대소문자 구분): VERIFIED — engine  'Sample Project, Also Known As, Ada'  0 calls
  re.IGNORECASE      : PROVIDER-REACHED        ('Also Known As' -> 'Also')
```

`_clean_english_attribute_label` 이 **"둘 중 더 비싼 방향"** 이라 부른 그 방향(맞는 결정적 답을 포기)입니다. 이 논거는 지금까지 산문이었고, 이제 테스트(`test_a_title_case_tail_in_the_label_is_left_alone`)입니다 — 플래그를 넓히면 red 가 납니다.

## 테스트 — 선언한 뮤턴트 30종, 생존자 0 (한정 사항 1건은 아래에 명시)

**전부 리베이스가 끝난 최종 트리(`ab84d89`)에서 다시 쟀습니다.** 측정 대상: `tests/test_query_intent.py tests/test_ask.py` (**clean 241 passed**). 이전 본문의 표는 리베이스 **전** 트리 값이라 아래로 전면 교체합니다.

멤버 dict + `assert set(FIXTURES) == set(MEMBERS)` 형식(`test_query_measure_unit.py` 선례). 집합 동등성이 사본을 자기검사로 만듭니다.

| # | 하네스 이름 | 무엇을 깨뜨리는가 | red | 잡은 테스트 |
|---|---|---|---|---|
| 1 | `R1` | 라벨 지점에서 tail strip 제거 (되돌리기) | 6 | multiword_predicate, purpose_synonyms, **synonym_the_spelled_one_missed**, tail_adverb, trailing_naming_predicate, strip_cannot_leave_empty |
| 2 | `R2` | tail strip 을 `removeprefix` 앞으로 (순서 교환) | 1 | strip_cannot_leave_empty |
| 3 | `M1` | 선행 `\s+`→`\s*` | 2 | word_a_predicate_only_ends, strip_cannot_leave_empty |
| 4 | `M2` | 선행 `\s+`→`\s*\b` | 2 | word_a_predicate_only_ends, strip_cannot_leave_empty |
| 5 | `M3` | 멤버 목록 → `[A-Za-z]+(?:ed\|en)(?:\s+(?:as\|to))?$` 패턴 | 6 | multiword_predicate, **past_participle_survives**, purpose_synonyms, tail_adverb, trailing_naming_predicate, strip_cannot_leave_empty |
| 6 | `M4` | `known as`/`listed as`/`set to` 에서 particle 제거 | 5 | multiword_predicate, purpose_synonyms, tail_adverb, trailing_naming_predicate, strip_cannot_leave_empty |
| 7 | `M5` | 부사 슬롯 삭제 | 1 | tail_adverb |
| 8 | `M6` | `worth` 를 멤버로 추가 | 2 | trailing_naming_predicate, worth_and_like |
| 9 | `M7` | `like` 를 멤버로 추가 | 2 | trailing_naming_predicate, worth_and_like |
| 10 | `M8` | `re.IGNORECASE` 추가 | 1 | **title_case_tail_in_the_label** |
| 11 | `N1` | `of` 분기 entity 에 같은 절단 추가 (= 드롭한 커밋 재도입) | 1 | **of_shape_entity_keeps_its_trailing_predicate** |
| 12 | `N2` | 소유격 분기 entity 에 같은 절단 추가 | 1 | **of_shape_entity_keeps_its_trailing_predicate** |
| 13 | `D-member` ×10 | 멤버 1개씩 개별 삭제 | 1~4 | 전부 trailing_naming_predicate 포함 |
| 14 | `D-adverb` ×8 | 부사 1개씩 개별 삭제 | 1 | 전부 tail_adverb |

**표 14행 = 뮤턴트 30종** (13·14 행이 18개를 담습니다). **선언한 30종에 대해 생존자 0.**

**그 30종이 덮지 않는 줄이 하나 있고, 여기에 적습니다.** 멤버의 공백을 `\s+` 로 완화하는 `m.replace(" ", r"\s+")` 는 **현재 호출자 아래서 도달 불가**입니다. 이 패턴의 호출 지점은 `_clean_english_attribute_label` 하나뿐이고 그 함수가 첫 줄에서 공백 런을 접기 때문입니다. 실측 — 완화를 리터럴 공백으로 되돌리면 **전체 스위트가 통과합니다**(`2992 passed`, 추출본의 `test_gitignore` 3건 제외). 즉 **어떤 뮤턴트도 이 줄의 필요성을 증명하지 못합니다.**

두 칸짜리 꼬리가 이 규칙에 도달하지 않는다는 것도 실측했습니다: `What is the owner of Sample Project known  as?` 는 엔티티 `'Sample Project known  as'` 를 두 칸 그대로 유지하고 절단되지 않습니다 — `of` 어형은 꼬리를 엔티티에 얹는데 이 규칙은 엔티티를 청소하지 않기 때문입니다.

**그럼에도 지웠지 않고 남겼습니다.** 도달 불가는 **패턴의 성질이 아니라 호출자의 성질**입니다. `.strip()` 만 한 필드를 넘기는 호출자 — `#515` 의 엔티티 사이트 수정이 정확히 그것입니다 — 가 생기면 즉시 발동하고, 리터럴 공백의 실패 양식은 조용한 미매치입니다. 소스 주석이 이 사실을 그대로 적습니다(도달 불가의 범위가 '현재 호출자 아래'이지 '원리적'이 아니라는 것 포함). 정규식 문자열·플래그·멤버 튜플은 이 라운드에서도 **바이트 동일**합니다.

`D-member` 개별 red 수: called 4 · named 3 · titled 4 · labelled 2 · labeled 2 · spelled 2 · spelt 1 · known as 4 · listed as 2 · set to 3.

**서명이 겹치는 세 쌍은 red 수와 잡은 테스트가 같으므로, 깨지는 단언 행으로 갈라 적습니다:**

| 쌍 | 깨지는 행 |
|---|---|
| `M1` | `assert ('re',) == ('recalled',)` |
| `M2` | `assert ('re-',) == ('re-called',)` |
| `M6` | `assert ('stock',) == ('stock worth',)` |
| `M7` | `assert ('owner',) == ('owner like',)` |
| `N1` | of 어형 행 — `assert 'Bob' in 'Company, owner, Alice ...'` |
| `N2` | 소유격 행 — `assert 'Bob' in 'Company, owner, Alice ...'` |

`N1`/`N2` 가 이 PR 이 남기는 가드입니다. **드롭한 엔티티 절단을 되붙이면 red 가 납니다** — 그리고 red 의 내용이 정확히 그 결함입니다: 라벨은 `VERIFIED — engine` 그대로이고 주어만 `Company named` 에서 `Company` 로, 답만 `Bob` 에서 `Alice` 로 바뀝니다.

## 검증

- 전체 스위트: `origin/main`(`e032738`) **2984 passed, 14 skipped** → 이 브랜치 **2995 passed, 14 skipped** (+11)
  - `tests/test_query_intent.py` 181 → **189** (+8)
  - `tests/test_ask.py` 49 → **52** (+3, 종단 테스트 3개)
  - (`e032738` 을 `git archive` 추출본에서 직접 재면 `2981 passed, 3 failed`; 실패 3건은 전부 `tests/test_gitignore.py` 로, `git ls-files` 를 셸아웃하므로 `.git` 없는 추출본에서 도는 테스트가 아닙니다. 그 파일은 이 브랜치와 main 에서 동일합니다.)
- `ruff check .` → **All checks passed!** (ruff 0.15.21 로컬; CI 는 0.15.18)
- 종단 테스트 3개는 `tests/test_ask.py` 에 있습니다. `tests/test_query_intent.py` 는 순수 파싱 모듈이라 `Store` 도 `ask_question` 도 라벨 단언도 없고, `test_ask.py` 는 `DeterministicOnlyClient` 와 라벨 단언을 이미 가지고 있습니다. 그 클라이언트는 세 provider 메서드가 전부 raise 하므로 **provider 호출 자체가 red** 입니다.

## `#527` 과의 관계 — 충돌이 사라졌습니다

엔티티 사이트를 드롭했으므로 `#527` 의 `test_english_of_attribute_question_deliberately_keeps_its_trailing_predicate` 가 단언하는 것(`of` 엔티티가 꼬리를 유지)이 **이 PR 에서 참입니다.** 두 PR 은 더 이상 직접 충돌하지 않고, `#527` 은 닫을 필요가 없습니다.

`#527` 에 남는 고유 가치는 두 가지이고, 둘 다 이 PR 에 **접어 넣지 않았습니다** — 변경 요청을 받은 PR 은 좁아져야지 넓어지면 안 되고, 리뷰어 자신이 이 둘을 논블로킹으로 분류했습니다:

1. **절단을 클리너에서 소유격 패턴의 선택적 그룹으로 이동.** 이 PR 의 최대 자산인 30종 매트릭스가 전부 클리너 사이트 뮤턴트라, 옮기면 통째로 다시 짜야 합니다. 수치도 정정합니다: 살아남는 라벨의 천장은 리뷰가 적은 34 가 아니라 **35** 이고(`named`, `spelt`), 멤버마다 다릅니다 — `called 34 · named 35 · titled 34 · labelled 32 · labeled 33 · spelled 33 · spelt 35 · known as 32 · listed as 31 · set to 34`. 구조는 `41 - (len(member) + 1)` 입니다. 따라서 회수 폭도 단일 값이 아니라 **6~10 (멤버 의존)** 입니다. `e032738` 은 양쪽 다 0 이므로 회귀가 아니라 "더 작은 승리"입니다.
2. **대소문자 무시.** 위에서 측정했듯 **공짜가 아닙니다.**

## 라운드 2 에서 고친 것 — 드롭이 남긴 산문 잔재

코드는 드롭으로 닫혔는데 소스 산문이 아직 엔티티 사이트 용어로 자기를 설명하던 세 자리를 고쳤습니다.

| 자리 | 무엇이 틀렸나 | 어떻게 고쳤나 |
|---|---|---|
| `query_intent.py` 교대 주석 | "the entity field is only `.strip()`ed, so `Sample Project known  as` reaches this" — **측정으로 거짓**. 드롭 후 호출자는 하나뿐이고 공백을 접는다 | 엔티티 근거 삭제. 완화가 현재 호출자 아래서 도달 불가라는 것, 어떤 뮤턴트도 필요성을 증명하지 못한다는 것, 그럼에도 남기는 이유를 명시 |
| `query_intent.py` 플래그 주석 | 증인 `Sample Project Formerly Known As` 가 **트리에 없고**(드롭된 테스트 픽스처였음), `re.IGNORECASE` 가 "엔티티를 분해한다"고 적혀 있었음 — 이 패턴은 엔티티에 적용되지 않음 | 증인을 `Also Known As` 로, 사이트를 라벨로, 그리고 `test_a_title_case_tail_in_the_label_is_left_alone` 를 이름으로 호출 |
| `test_query_intent.py` 픽스처 docstring | "the commit that cleans the entity widens each value to both spellings" — **드롭된 커밋을 현재형으로** 약속 | 삭제. `of` 어형을 일부러 남긴다는 것과 `Refs #515`, 그리고 답 수준으로 못박는 테스트를 지목 |

동반으로 닫은 것:

- `test_a_word_a_predicate_only_ends_is_left_alone` 의 **"eight"** 가 실측과 달랐습니다. 루프는 **열 행**이고, 실측 `\s*` 는 **열 전부**를 자르고 `\s*\b` 는 **아홉**을 살립니다. 게다가 근거로 든 `_` 는 `so_called` 에만 적용되는데 여덟이라는 셈이 그 행을 빼야 성립했습니다. 열/아홉으로 나눠 적었습니다.
- 위 두 곳의 헤지 없는 전칭(`어떤 뮤턴트도` / `no mutant would redden it`)을 T-B docstring 과 같은 범위 한정자로 좁혔습니다.
- `#527` 귀속을 diff(케이스 무시 교대는 실재)와 논거(그 저자의 이 PR 리뷰)로 분리했습니다.

**이 라운드는 산문만 바꿨습니다.** 정규식 `pattern`·`flags`·양쪽 멤버 튜플을 `d3c404c` 판과 비교해 **5/5 바이트 동일**, 30종 매트릭스 **전량 재측정해 라운드 1 과 red 수 30행 전부 일치**, 두 파일 **241 passed**, `ruff check .` clean.

## 후속

- `#511` 은 열어 둡니다 — `of` 어형 10행이 남습니다.
- `#515` 는 열어 둡니다 — 이 PR 은 그것이 요구하는 store 조회/어형 거절을 구현하지 않고, 안전한 현 거동을 못박을 뿐입니다.
- 부재 멤버(`referred to as`, `recorded as`, `written as`, `widely`, `popularly`, `variously`)는 후속 이슈감입니다. 위에서 쟀듯 추가는 공짜가 아닙니다.

## 2라운드 리뷰 반영 (산문 5건, 실행 코드 0줄)

`ab84d89` → `4cc2905`. 문자열 상수를 제거한 AST 대조에서 `verinote/pipeline/query_intent.py` · `tests/test_ask.py` · `tests/test_query_intent.py` 세 파일 **SAME**, 패턴 sha256 앞16 `1d384015b3e82088` / `flags 32` / 멤버·부사 튜플(10·8) 동일 — 순수 산문입니다. `241 passed`, `ruff check .` clean.

1. **give-up > invent 순위를 세 곳에서 철회.** 저장소가 반대 방향을 말합니다(`store/tiers.py` "A crash is cheaper than a quiet wrong answer", `store/db.py` "the silent wrong answer this filter exists to prevent"). **"No flags" 의 근거를 순위가 아니라 측정으로 바꿨습니다** — `re.IGNORECASE` 는 한 방향을 다른 방향과 맞바꾸는 선택이 아니라 두 방향을 **동시에** 움직입니다:

```
'Also Known As'  shipped VERIFIED — engine calls=[]  | +IGNORECASE UNVERIFIED — source exploration  (포기)
'Date Labeled'   shipped UNVERIFIED calls 2개         | +IGNORECASE VERIFIED — engine, calls=[]      (치환 신설)
'User Named'     shipped UNVERIFIED calls 2개         | +IGNORECASE VERIFIED — engine, calls=[]      (치환 신설)
'owner Called'   shipped UNVERIFIED calls 2개         | +IGNORECASE VERIFIED — engine, calls=[]      (포기된 이득)
```

어느 방향이 더 비싼지 정하지 않아도 플래그가 기각됩니다. 네 번째 행은 플래그가 **살 수 있었던 것**이라 "포기된 이득, 오답 아님" 으로 적었습니다.

2. **스키마 이분법을 세 갈래로.** 분기 키를 "질의된 주어가 그 관계로 사실을 갖는가" 로 재서술하고 세 번째 결과(스키마는 갖는데 **주어**는 안 갖는 경우 → 빈 계획 + 재해석 호출)를 `pipeline/query.py` 인용과 함께 명시했습니다. 측정:

```
{Other Stock/stock worth/V9, Sample Stock/price/V0} -> UNVERIFIED — source exploration, calls 2개
{Sample Stock/stock worth/V0}                       -> VERIFIED — engine, calls=[]
{Sample Stock/price/V0}                             -> UNVERIFIED — source exploration, calls 2개
```

3. **멤버 전칭을 측정으로 교체.** "any member of this tuple" 을 **`e032738` 에서 잰 10/10 파싱**으로 바꿨습니다 — `called·named·titled·labelled·labeled·spelled·spelt·known as·listed as·set to` 전부 `What is Sample Project's owner <member>?` 를 `('owner <member>',)` 로만 파싱합니다. 헤지하지 않고 측정으로 뒷받침했습니다. `also known as` 반례(실재 속성명이라 base 에서 `VERIFIED — engine`, 이 브랜치에서 fallback)도 함께 공개합니다.

4. **트리에 없는 테스트 참조 제거** — 드롭된 possessive-entity 테스트를 가리키던 문장을 실제로 해소되는 `test_the_of_shape_entity_keeps_its_trailing_predicate_at_the_answer` 로 교체.

5. **엔티티 절단 불일치 주장을 한쪽-지점 절단으로 한정.** 양쪽을 다 절단하면 두 어형이 **일치하며 둘 다 틀린 주어**를 냅니다(측정). 불일치는 한쪽만 절단할 때의 성질입니다.

```
head        of 'Company named, owner, Bob'   possessive 'Company named, owner, Bob'
of만        of 'Company, owner, Alice'       possessive 'Company named, owner, Bob'
possessive만 of 'Company named, owner, Bob'  possessive 'Company, owner, Alice'
양쪽        of 'Company, owner, Alice'       possessive 'Company, owner, Alice'   (일치·둘 다 틀림)
```

### 스스로 잡은 것

`17f0e1a` 이 give-up 쪽 비용을 "with one provider call" 로 **셌는데**, 세 메서드를 다 기록하는 계측으로 재면 두 번입니다(`extract_query_intent`, `answer_question`). `4cc2905` 가 세는 대신 **기록된 호출 이름**을 적도록 고쳤습니다. 소스 파일이 디스크에 있는 경우로 변수를 바꿔 재도 목록은 같습니다.

### 뮤테이션

이번 라운드는 실행 코드 0줄이므로 선언된 30종 값은 그대로 유효합니다. 그중 **22종을 재실행해 선언값과 일치**함을 확인했습니다 — 멤버 단독 삭제 10종(`4·3·4·2·2·2·1·4·2·3`), 부사 단독 삭제 8종(전부 red=1), 두 완화(`\s*` / `\s*\b`, red=2 로 **테스트 집합이 같아 죽는 행으로 갈랐습니다** — `recalled` vs `re-called`), 멤버 공백 완화(선언된 생존자, red=0), `re.IGNORECASE`(red=1). 나머지 12종은 이 라운드에 재도출하지 않았습니다 — 매트릭스 정의를 이 세션이 갖고 있지 않아 이름을 추측하면 다른 뮤턴트를 같은 이름으로 보고할 위험이 있습니다.

## 3라운드 리뷰 반영 (산문 4건 + 논블로킹 6건, 실행 코드 0줄)

`4cc2905` → `0d9c122`. 문자열 상수를 제거한 AST 대조에서 `query_intent.py` · `tests/test_ask.py` · `tests/test_query_intent.py` **세 파일 SAME**, 정규식·플래그·튜플 무변경. `241 passed`, `ruff check .` clean.

1. **철회한 스키마 서술이 여섯 줄 위에 살아남아 있었다.** `17f0e1a` 이 모듈을 "스키마가 갖고 있으면" → "**질의된 주어가** 그 이름으로 사실을 갖고 있으면" 으로 재키잉하면서 `tests/test_query_intent.py` 도 건드렸지만 `:1260-1265` 만 고쳤습니다(`git blame` 이 그 위 19줄을 옛 커밋 소유로 보여줍니다). 두 절을 주어 기준으로 다시 쓰고 각 절에 측정을 붙였으며, **다른-주어 쌍**을 새 문단으로 못박아 두 파일이 다시 갈라지지 않게 했습니다:

```
                     base e032738                    이 브랜치
SAME  date  review_required (call 1)   →   translated (call 0)
OTHER date  review_required (call 1)   →   review_required (call 1)
SAME  aka   translated (call 0)        →   review_required (call 1)
OTHER aka   review_required (call 1)   →   review_required (call 1)
```

2. **`"the other nine are what make the first one red at all"`** → `"red without it"` + 근거. 첫 완화는 **열 행을 전부** 자르므로(`recalled·unnamed·renamed·entitled·misspelled·nicknamed·subtitled·untitled·so_called·re-called`) 어느 한 행으로도 잡힙니다. 둘째 완화는 `re-called` 하나만 자릅니다.

3. **`"safe under every spelling of this rule"` 전칭 제거.** 반례를 명시하고 결론을 **kill 포함관계**로 재구성했습니다 — `re.IGNORECASE` + 엔티티 스트립 복합 뮤턴트는 타이틀케이스도 자르고 **#515 회귀를 재현**합니다(`Company, owner, Alice`). 그래도 타이틀케이스 행을 고정해도 kill 을 못 삽니다: 같은 뮤턴트가 아래 소문자 행들도 같은 오답으로 만들기 때문에, 여기서 잰 두 엔티티-스트립 스펠링 × 플래그 유무 전부에서 **타이틀케이스 행이 red 인데 소문자 행이 red 가 아닌 경우가 없습니다.**

4. **닫힌 PR 을 현재형으로 서술하던 문장 교체.** `"PR #527 proposes"` → 관찰 가능한 diff 사실로: **2026-08-14 에 닫힌** #527 이 `_ENGLISH_ATTRIBUTE_QUESTION_TAIL = r"(?:\s+(?i:called|named))?"` 를 담고 소유격 패턴에 붙인다는 것. 저장소 밖 대화 귀속도 삭제하고 논거를 자기완결로 다시 썼습니다.

논블로킹 여섯도 함께 닫았습니다 — `"a KB holding it"` → 주어 명시(같은 잔재 3곳 포함), `pinned` → `record … witnesses rather than the whole of it`, 네 행 키를 라벨 후보 기준으로, 낡은 `origin/main` 라벨 제거, 두-지점 뮤턴트의 보고 red 개수 정정, `called`/`named` 전제를 **#511 의 제목**에 귀속.

### 남긴 것 (명시적 유예)

리뷰 논블로킹 10 — 셋째 스키마 케이스(스키마는 갖고 **주어**는 안 갖는 경우)를 **답 수준**으로 고정하는 것은 넣지 않았습니다. 새 테스트가 필요하고 픽스처·kill target·수집 개수가 함께 바뀌므로, 실행/테스트 0 변경으로 유지한 이 라운드와 성격이 다릅니다. 현재는 그 경우가 위 표의 `OTHER` 두 행으로 `translate_questions` 수준에서만 기록돼 있습니다. 별도 라운드나 후속 이슈로 붙이는 편이 검증이 그 변경의 diff 안에서 닫힙니다.
