### PR TITLE
test(ask): 발췌는 '읽혔다'가 아니라 '매치됐다'를 뜻한다

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1424,6 +1424,23 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     so the `seen_paths` dedupe never drops one either. Outside those bounds the
     result is not simply "every registered source that scored".
 
+    The neighbouring mutant `if excerpt:` is equivalent rather than uncaught,
+    and the reason is a property of `_TOKEN` (`verinote/pipeline/ask.py:39`)
+    rather than of this fixture. A falsy `score` means `best_pos < 0` and the
+    early `return "", 0`, so only the other direction is open: a truthy score
+    carrying an empty excerpt needs `text` to be entirely whitespace while
+    some pattern is still found in `_fold(text)`. Neither half is reachable.
+    All 29 whitespace code points, and every pair and triple of them, keep
+    `_fold(s)` whitespace -- their combining classes are zero so nothing
+    composes across them, none of them is the target of a composition,
+    casefold maps none of them, and the two that NFC does rewrite (`U+2000`,
+    `U+2001`) go to other whitespace. And each of the 32,303 code points
+    `_TOKEN` can match folds to something non-empty and non-whitespace both
+    alone and doubled, so no token, whatever its length, folds to something an
+    all-whitespace `folded` could contain. A widened `_TOKEN` -- `\\S+`, say --
+    would split the two gates apart, and what it would let through is exactly
+    #468's defect: an `AskExcerpt` carrying an empty excerpt string.
+
     Not covered here: the order of what comes back (the next test), the
     truncation, the dedupe, and the window arithmetic inside `_best_excerpt`.
     """

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1361,30 +1361,40 @@ def test_search_source_excerpts_compares_nothing_from_a_missing_or_undecodable_s
 _UNRELATED_SOURCE_TEXT = "샘플기관은 샘플절차를 안내한다."
 
 
-def _seed_two_matching_and_one_unrelated_source(tmp_path):
-    """Three registered, readable sources scoring 2, 1 and 0 on one question.
+def _seed_three_matching_and_one_unrelated_source(tmp_path):
+    """Four registered, readable sources scoring 2, 1, 1 and 0 on one question.
 
     The question these fixtures are built for is `샘플조직의 역할은 무엇인가?`,
     whose patterns are `샘플조직의`, `역할은` and `무엇인가`. `roles.txt`
-    carries the first two, `history.txt` only the first, and `unrelated.txt`
-    none of them.
+    carries the first two, `history.txt` and `notice.txt` only the first, and
+    `unrelated.txt` none of them.
 
-    The file names are load-bearing rather than decorative. `store.sources()`
-    reads `ORDER BY path`, so the two matching sources arrive at the sort as
-    `history.txt` then `roles.txt` -- the reverse of their score order. That is
-    what lets a sort key which has lost `-item.score` show through instead of
-    happening to agree with the right answer. A rename that put the two orders
-    back in step would make the ordering test vacuous, so that test asserts
-    this property rather than trusting this docstring for it.
+    The file names and the texts are load-bearing rather than decorative.
+    `store.sources()` reads `ORDER BY path`, so the three matching sources
+    arrive at the sort as `history.txt`, `notice.txt`, `roles.txt`, which
+    disagrees with their score order of `roles.txt`, `history.txt`,
+    `notice.txt` -- and is not the reverse of it either, so reading the paths
+    backwards does not recover the right answer any more than reading them
+    forwards does. `notice.txt` is the long one for the same reason: its
+    excerpt outruns `roles.txt`'s, so ranking by excerpt length instead of by
+    score does not recover it either. A rename, or a rewrite that shortened
+    that text, would put one of those orders back in step and make the
+    ordering test vacuous, so that test asserts these properties rather than
+    trusting this docstring for them.
     """
     sources = tmp_path / "sources"
     sources.mkdir()
     (sources / "roles.txt").write_text("샘플조직의 역할은 샘플서비스 검토이다.", encoding="utf-8")
     (sources / "history.txt").write_text("샘플조직의 연혁은 다음과 같다.", encoding="utf-8")
+    (sources / "notice.txt").write_text(
+        "샘플조직의 안내문은 여러 항목으로 나뉘어 있으며 자세한 내용은 별도 문서에 있다.",
+        encoding="utf-8",
+    )
     (sources / "unrelated.txt").write_text(_UNRELATED_SOURCE_TEXT, encoding="utf-8")
     store = _store(tmp_path)
     store.add_source("sources/roles.txt")
     store.add_source("sources/history.txt")
+    store.add_source("sources/notice.txt")
     store.add_source("sources/unrelated.txt")
     return store
 
@@ -1409,7 +1419,7 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     still hold, for a reason that has nothing to do with the gate. The spy
     fails in that case instead of passing quietly.
 
-    The set equality is exact for this fixture only. Three sources cannot reach
+    The set equality is exact for this fixture only. Four sources cannot reach
     the `MAX_EXCERPTS` truncation, and no two of them resolve to the same path,
     so the `seen_paths` dedupe never drops one either. Outside those bounds the
     result is not simply "every registered source that scored".
@@ -1426,7 +1436,7 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
 
     monkeypatch.setattr(ask_module, "_best_excerpt", spy)
 
-    store = _seed_two_matching_and_one_unrelated_source(tmp_path)
+    store = _seed_three_matching_and_one_unrelated_source(tmp_path)
 
     excerpts = search_source_excerpts(
         store, root=tmp_path, question="샘플조직의 역할은 무엇인가?"
@@ -1436,43 +1446,54 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     assert {item.path for item in excerpts} == {
         "sources/roles.txt",
         "sources/history.txt",
+        "sources/notice.txt",
     }
 
 
 def test_search_source_excerpts_puts_the_stronger_match_first(tmp_path):
-    """Two matches come back best-first, not in the order the store read them.
+    """Three matches come back best-first, not in the order the store read them.
 
     `sorted(matches, key=lambda item: (-item.score, item.path))` is the whole
     of that promise. Drop `-item.score` from the key, or the `sorted` call, or
     flip the sign, and what shows through is `store.sources()`' own
-    `ORDER BY path`, which this fixture deliberately arranges to be the
-    reverse.
+    `ORDER BY path`, which this fixture deliberately arranges to disagree with
+    the score order.
 
-    The assertion above the ordering one is that arrangement, not decoration:
-    it re-derives from the returned scores that path order and score order
-    still disagree. Renaming these files so the two agree -- `a_roles.txt`,
-    `z_history.txt` -- would leave the ordering assertion passing under a
-    broken key, and the premise fails there instead, on the shipped code as
-    much as on a mutant.
+    The three assertions above the ordering one are that arrangement, not
+    decoration, and they read no score at all. Each takes a cheaper key the
+    ordering assertion would otherwise be satisfied by -- paths ascending,
+    paths descending, excerpt length descending -- and holds that it produces
+    some other list. A rename that put one of those keys back in step
+    (`a_roles.txt`, `notice.txt`, `z_history.txt`), or a shorter notice text,
+    would leave the ordering assertion passing under a broken key, and a
+    premise fails there instead, on the shipped code as much as on a mutant.
 
-    Mutations of that same key survive these tests, and the gap is named here
-    rather than implied away: the tie-break beyond `-item.score` is unpinned,
-    since pinning it needs two sources of *equal* score and this fixture has
-    none, and so is the `[:limit]` slice, which needs more matching sources
-    than `MAX_EXCERPTS`. What these assertions hold down is the sign on the
-    score, not the whole key.
+    Two mutations of that same key survive these tests, and the gap is named
+    here rather than implied away. Dropping the `item.path` tie-break to
+    `key=(-item.score,)` changes nothing even though two of these sources do
+    score equally: `store.sources()` reads `ORDER BY path`, so equal scores
+    arrive already in path order and a stable sort leaves them there whether
+    or not the key says so. The `[:limit]` slice is likewise unpinned, since
+    showing it needs more matching sources than `MAX_EXCERPTS`. Both are
+    tracked in #533 rather than left as a claim here that goes quietly stale
+    the day someone pins one of them.
     """
-    store = _seed_two_matching_and_one_unrelated_source(tmp_path)
+    store = _seed_three_matching_and_one_unrelated_source(tmp_path)
 
     excerpts = search_source_excerpts(
         store, root=tmp_path, question="샘플조직의 역할은 무엇인가?"
     )
 
+    order = [item.path for item in excerpts]
     by_path = sorted(excerpts, key=lambda item: item.path)
-    assert by_path[0].score < by_path[-1].score
-    assert [item.path for item in excerpts] == [
+    by_length = sorted(excerpts, key=lambda item: (-len(item.excerpt), item.path))
+    assert [item.path for item in by_path] != order
+    assert [item.path for item in reversed(by_path)] != order
+    assert [item.path for item in by_length] != order
+    assert order == [
         "sources/roles.txt",
         "sources/history.txt",
+        "sources/notice.txt",
     ]
 
 
@@ -1485,10 +1506,11 @@ def test_ask_hands_the_page_the_excerpts_already_ordered(tmp_path):
     the test above cannot see a caller that re-collected the result on the way
     out, and this one runs the assembled route end to end instead.
 
-    Same fixture, same premise: the two matching sources are named so that
-    their path order is the reverse of their score order.
+    Same fixture, same three premises: the matching sources are named, and
+    their texts sized, so that neither path order nor excerpt length can
+    reproduce the list the scores ask for.
     """
-    store = _seed_two_matching_and_one_unrelated_source(tmp_path)
+    store = _seed_three_matching_and_one_unrelated_source(tmp_path)
     client = FallbackClient(error=LLMError("synthetic outage"))
 
     result = ask_question(
@@ -1496,11 +1518,16 @@ def test_ask_hands_the_page_the_excerpts_already_ordered(tmp_path):
     )
 
     assert result.route == "fallback"
+    order = [item.path for item in result.excerpts]
     by_path = sorted(result.excerpts, key=lambda item: item.path)
-    assert by_path[0].score < by_path[-1].score
-    assert [item.path for item in result.excerpts] == [
+    by_length = sorted(result.excerpts, key=lambda item: (-len(item.excerpt), item.path))
+    assert [item.path for item in by_path] != order
+    assert [item.path for item in reversed(by_path)] != order
+    assert [item.path for item in by_length] != order
+    assert order == [
         "sources/roles.txt",
         "sources/history.txt",
+        "sources/notice.txt",
     ]
 
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1507,14 +1507,19 @@ def test_ask_hands_the_page_the_excerpts_already_ordered(tmp_path):
 def test_ask_body_promises_nothing_when_the_only_source_matched_nothing(tmp_path):
     """The body's last branch, reached through a source the gate dropped.
 
-    The other runs that land on this branch each get there without the gate:
-    `..._promises_nothing_when_there_is_no_evidence` registers no source at
-    all, `..._names_the_grounding_table_when_no_excerpt_renders` registers one
-    whose file is not on disk so `is_file()` turns it away first, and the body
-    rows in `tests/test_ask_verdict.py` build their `AskExcerpt` values by hand
-    and never run `search_source_excerpts`. This row is the assembled pipeline
+    Reaching it takes both collections empty, and every other run that lands
+    there lands there without reading a source at all: wrap
+    `_fallback_answer_body` and `_best_excerpt` for one full suite run,
+    resetting the read count per test, and this is the only run that arrives
+    at the branch with a read behind it. The rest leave `excerpts` empty
+    because no source text was ever compared against the question, so the gate
+    is not what emptied it for them. This row is the assembled pipeline
     reaching the branch the remaining way: a source that was registered, found,
     read, compared against the question, and kept out by `if score:` alone.
+
+    A list of those runs grows with the file and says nothing about the one
+    that gets added next; the property does, and the measurement above is how
+    a reader checks whether it still holds.
 
     That is the distinction the helper's own docstring turns on -- it says the
     branch reports what the page shows rather than why, *because* an excerpt

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1437,7 +1437,7 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     `U+2001`) go to other whitespace. And each of the 32,303 code points
     `_TOKEN` can match folds to something non-empty and non-whitespace both
     alone and doubled, so no token, whatever its length, folds to something an
-    all-whitespace `folded` could contain. A widened `_TOKEN` -- `\\S+`, say --
+    all-whitespace `folded` could contain. A widened `_TOKEN` -- `.+`, say --
     would split the two gates apart, and what it would let through is exactly
     #468's defect: an `AskExcerpt` carrying an empty excerpt string.
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1504,6 +1504,47 @@ def test_ask_hands_the_page_the_excerpts_already_ordered(tmp_path):
     ]
 
 
+def test_ask_body_promises_nothing_when_the_only_source_matched_nothing(tmp_path):
+    """The body's last branch, reached through a source the gate dropped.
+
+    The other runs that land on this branch each get there without the gate:
+    `..._promises_nothing_when_there_is_no_evidence` registers no source at
+    all, `..._names_the_grounding_table_when_no_excerpt_renders` registers one
+    whose file is not on disk so `is_file()` turns it away first, and the body
+    rows in `tests/test_ask_verdict.py` build their `AskExcerpt` values by hand
+    and never run `search_source_excerpts`. This row is the assembled pipeline
+    reaching the branch the remaining way: a source that was registered, found,
+    read, compared against the question, and kept out by `if score:` alone.
+
+    That is the distinction the helper's own docstring turns on -- it says the
+    branch reports what the page shows rather than why, *because* an excerpt
+    can be absent from text that was never read. This row supplies the other
+    half, where the text was read.
+
+    No fact is confirmed here, so the grounding table is empty too and the
+    sentence has to promise neither section.
+    """
+    (tmp_path / "sources").mkdir()
+    (tmp_path / "sources" / "unrelated.txt").write_text(
+        _UNRELATED_SOURCE_TEXT, encoding="utf-8"
+    )
+    store = _store(tmp_path)
+    store.add_source("sources/unrelated.txt")
+    client = FallbackClient(error=LLMError("synthetic outage"))
+
+    result = ask_question(
+        store, client, root=tmp_path, question="샘플조직의 역할은 무엇인가?"
+    )
+
+    assert result.route == "fallback"
+    assert result.excerpts == ()
+    assert result.grounding_facts == ()
+    assert result.answer == (
+        "The deterministic engine could not answer, and no source excerpt or "
+        "verified grounding fact is shown below."
+    )
+
+
 # --- Ask does not re-request a provider that just failed (#438) -------------
 
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1377,10 +1377,10 @@ def _seed_three_matching_and_one_unrelated_source(tmp_path):
     backwards does not recover the right answer any more than reading them
     forwards does. `notice.txt` is the long one for the same reason: its
     excerpt outruns `roles.txt`'s, so ranking by excerpt length instead of by
-    score does not recover it either. A rename, or a rewrite that shortened
-    that text, would put one of those orders back in step and make the
-    ordering test vacuous, so that test asserts these properties rather than
-    trusting this docstring for them.
+    score does not recover it either. A rename that sorted the paths back into
+    step, or a rewrite that cut that excerpt to `history.txt`'s 17 characters
+    or fewer, would make the ordering test vacuous, so that test asserts these
+    properties rather than trusting this docstring for them.
     """
     sources = tmp_path / "sources"
     sources.mkdir()
@@ -1429,17 +1429,27 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     rather than of this fixture. A falsy `score` means `best_pos < 0` and the
     early `return "", 0`, so only the other direction is open: a truthy score
     carrying an empty excerpt needs `text` to be entirely whitespace while
-    some pattern is still found in `_fold(text)`. Neither half is reachable.
-    All 29 whitespace code points, and every pair and triple of them, keep
-    `_fold(s)` whitespace -- their combining classes are zero so nothing
-    composes across them, none of them is the target of a composition,
-    casefold maps none of them, and the two that NFC does rewrite (`U+2000`,
-    `U+2001`) go to other whitespace. And each of the 32,303 code points
-    `_TOKEN` can match folds to something non-empty and non-whitespace both
-    alone and doubled, so no token, whatever its length, folds to something an
-    all-whitespace `folded` could contain. A widened `_TOKEN` -- `.+`, say --
-    would split the two gates apart, and what it would let through is exactly
-    #468's defect: an `AskExcerpt` carrying an empty excerpt string.
+    some pattern is still found in `_fold(text)`. Neither half is reachable,
+    and because `_fold` is `casefold(NFC(...))` neither answer turns on how
+    long the string is. Whitespace stays whitespace: each of the 29 whitespace
+    code points decomposes to whitespace only, none of them appears on either
+    side of the 941 pairs that compose under NFC, so nothing composes across
+    them, and casefold maps none of them -- the two NFC does rewrite
+    (`U+2000`, `U+2001`) go to other whitespace. Tokens stay non-whitespace:
+    none of the 32,303 code points `_TOKEN` can match is whitespace, no
+    non-whitespace code point in Unicode decomposes to anything containing
+    whitespace, no composition target is whitespace, and no non-whitespace
+    code point casefolds to whitespace or to nothing. So a token of any length
+    folds to a non-empty string carrying a non-whitespace character, which an
+    all-whitespace `folded` cannot contain. The finite sweeps behind those
+    lemmas did come back clean -- every pair and triple of the 29, every one
+    of the 32,303 alone and doubled -- but they are not what closes this:
+    doubling cannot fail where the single code point passed, since
+    `_fold(c*2)` is `_fold(c)*2` for all 32,303, and a sweep that stops at
+    three characters says nothing about the fourth. A widened `_TOKEN` --
+    `.+`, say -- would split the two gates apart, and what it would let
+    through is exactly #468's defect: an `AskExcerpt` carrying an empty
+    excerpt string.
 
     Not covered here: the order of what comes back (the next test), the
     truncation, the dedupe, and the window arithmetic inside `_best_excerpt`.
@@ -1481,23 +1491,28 @@ def test_search_source_excerpts_puts_the_stronger_match_first(tmp_path):
     ordering assertion would otherwise be satisfied by -- paths ascending,
     paths descending, excerpt length descending -- and holds that it produces
     some other list. A rename that put one of those keys back in step
-    (`a_roles.txt`, `notice.txt`, `z_history.txt`), or a shorter notice text,
-    would leave the ordering assertion passing under a broken key, and a
-    premise fails there instead, on the shipped code as much as on a mutant.
+    (`a_roles.txt`, `notice.txt`, `z_history.txt`), or a notice excerpt cut to
+    `history.txt`'s 17 characters or fewer, would leave the ordering assertion
+    passing under a broken key, and a premise fails there instead, on the
+    shipped code as much as on a mutant.
 
     Two gaps are named here rather than implied away: these assertions do not
     pin the tie-break beyond `-item.score` to `item.path`, and they do not pin
     the `[:limit]` slice. Dropping the tie-break to `key=(-item.score,)`
     changes nothing even though two of these sources do score equally:
-    `store.sources()` reads `ORDER BY path`, so equal scores arrive already in
-    path order and a stable sort leaves them there whether or not the key says
-    so. Nor is dropping it the only shape that gap has: replacing it with
-    `-len(item.path)` orders ties by descending path length, which is not path
-    order, and survives here only because this fixture's two equal-score paths
-    are already in that order (`sources/history.txt` at 19 characters ahead of
-    `sources/notice.txt` at 18). Rename `notice.txt` throughout to something
-    longer than `history.txt` and that mutant fails where the shipped key
-    still passes. Showing the `[:limit]` slice needs more matching sources
+    `store.sources()` reads `ORDER BY path`, so these three arrive at the sort
+    in path order and a stable sort leaves the equal pair there whether or not
+    the key says so. Nor is dropping it the only shape that gap has: replacing
+    it with `-len(item.path)` orders ties by descending path length, which is
+    not path order, and survives here only because this fixture's two
+    equal-score paths are already in that order (`sources/history.txt` at 19
+    characters ahead of `sources/notice.txt` at 18). Rename `notice.txt`
+    throughout to a name both longer than `history.txt` and sorting after it
+    (`notification.txt`, say) and that mutant fails where the shipped key
+    still passes. Longer alone will not do it: `announcement.txt` is longer
+    but sorts ahead of `history.txt`, so the shipped result reorders and the
+    expected lists have to be reordered with it -- after which both keys agree
+    again and the mutant is back to passing. Showing the `[:limit]` slice needs more matching sources
     than `MAX_EXCERPTS`. Both gaps are tracked in #533 rather than left as a
     claim here that goes quietly stale the day someone pins one of them.
     """

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1455,12 +1455,12 @@ def test_search_source_excerpts_puts_the_stronger_match_first(tmp_path):
     broken key, and the premise fails there instead, on the shipped code as
     much as on a mutant.
 
-    Two mutations of that same key survive both of these tests and the rest of
-    the suite, and are named here so the gap is on the record rather than
-    implied away: shortening the key to `(-item.score,)`, whose `item.path`
-    tie-break needs two sources of *equal* score before anything can pin it,
-    and deleting the `[:limit]` slice, which needs more matching sources than
-    `MAX_EXCERPTS`. Neither is covered anywhere in the suite today.
+    Mutations of that same key survive these tests, and the gap is named here
+    rather than implied away: the tie-break beyond `-item.score` is unpinned,
+    since pinning it needs two sources of *equal* score and this fixture has
+    none, and so is the `[:limit]` slice, which needs more matching sources
+    than `MAX_EXCERPTS`. What these assertions hold down is the sign on the
+    score, not the whole key.
     """
     store = _seed_two_matching_and_one_unrelated_source(tmp_path)
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1439,6 +1439,71 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     }
 
 
+def test_search_source_excerpts_puts_the_stronger_match_first(tmp_path):
+    """Two matches come back best-first, not in the order the store read them.
+
+    `sorted(matches, key=lambda item: (-item.score, item.path))` is the whole
+    of that promise. Drop `-item.score` from the key, or the `sorted` call, or
+    flip the sign, and what shows through is `store.sources()`' own
+    `ORDER BY path`, which this fixture deliberately arranges to be the
+    reverse.
+
+    The assertion above the ordering one is that arrangement, not decoration:
+    it re-derives from the returned scores that path order and score order
+    still disagree. Renaming these files so the two agree -- `a_roles.txt`,
+    `z_history.txt` -- would leave the ordering assertion passing under a
+    broken key, and the premise fails there instead, on the shipped code as
+    much as on a mutant.
+
+    Two mutations of that same key survive both of these tests and the rest of
+    the suite, and are named here so the gap is on the record rather than
+    implied away: shortening the key to `(-item.score,)`, whose `item.path`
+    tie-break needs two sources of *equal* score before anything can pin it,
+    and deleting the `[:limit]` slice, which needs more matching sources than
+    `MAX_EXCERPTS`. Neither is covered anywhere in the suite today.
+    """
+    store = _seed_two_matching_and_one_unrelated_source(tmp_path)
+
+    excerpts = search_source_excerpts(
+        store, root=tmp_path, question="샘플조직의 역할은 무엇인가?"
+    )
+
+    by_path = sorted(excerpts, key=lambda item: item.path)
+    assert by_path[0].score < by_path[-1].score
+    assert [item.path for item in excerpts] == [
+        "sources/roles.txt",
+        "sources/history.txt",
+    ]
+
+
+def test_ask_hands_the_page_the_excerpts_already_ordered(tmp_path):
+    """The order has to survive into `AskResult.excerpts` to reach a reader.
+
+    `ask.html` loops over `result.excerpts` as it receives them, so nothing
+    downstream re-sorts and nothing upstream of this tuple is visible on the
+    page. `_fallback_answer` makes its own call to `search_source_excerpts`;
+    the test above cannot see a caller that re-collected the result on the way
+    out, and this one runs the assembled route end to end instead.
+
+    Same fixture, same premise: the two matching sources are named so that
+    their path order is the reverse of their score order.
+    """
+    store = _seed_two_matching_and_one_unrelated_source(tmp_path)
+    client = FallbackClient(error=LLMError("synthetic outage"))
+
+    result = ask_question(
+        store, client, root=tmp_path, question="샘플조직의 역할은 무엇인가?"
+    )
+
+    assert result.route == "fallback"
+    by_path = sorted(result.excerpts, key=lambda item: item.path)
+    assert by_path[0].score < by_path[-1].score
+    assert [item.path for item in result.excerpts] == [
+        "sources/roles.txt",
+        "sources/history.txt",
+    ]
+
+
 # --- Ask does not re-request a provider that just failed (#438) -------------
 
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1430,23 +1430,33 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     early `return "", 0`, so only the other direction is open: a truthy score
     carrying an empty excerpt needs `text` to be entirely whitespace while
     some pattern is still found in `_fold(text)`. Neither half is reachable,
-    and because `_fold` is `casefold(NFC(...))` neither answer turns on how
-    long the string is. Whitespace stays whitespace: each of the 29 whitespace
-    code points decomposes to whitespace only, none of them appears on either
-    side of the 941 pairs that compose under NFC, so nothing composes across
-    them, and casefold maps none of them -- the two NFC does rewrite
-    (`U+2000`, `U+2001`) go to other whitespace. Tokens stay non-whitespace:
-    none of the 32,303 code points `_TOKEN` can match is whitespace, no
-    non-whitespace code point in Unicode decomposes to anything containing
-    whitespace, no composition target is whitespace, and no non-whitespace
-    code point casefolds to whitespace or to nothing. So a token of any length
-    folds to a non-empty string carrying a non-whitespace character, which an
-    all-whitespace `folded` cannot contain. The finite sweeps behind those
-    lemmas did come back clean -- every pair and triple of the 29, every one
-    of the 32,303 alone and doubled -- but they are not what closes this:
-    doubling cannot fail where the single code point passed, since
-    `_fold(c*2)` is `_fold(c)*2` for all 32,303, and a sweep that stops at
-    three characters says nothing about the fourth. A widened `_TOKEN` --
+    and neither turns on how long the string is. `_fold` is
+    `casefold(NFC(...))`, and NFC is the half that could have made length
+    matter -- casefold works a code point at a time, NFC composes across
+    neighbours -- so what closes it is that the lemmas below are quantified
+    over every code point and every composition rather than over a sample.
+    Whitespace stays whitespace: each of the 29 whitespace code points
+    canonically decomposes to whitespace only, none of the 29 is either side
+    or the target of any NFC composition -- there are 12,113 of those, the 941
+    pairs the decomposition table carries plus the 11,172 Hangul syllables NFC
+    composes algorithmically, which have no table entry to be found by -- and
+    casefold maps none of them; the two NFC does rewrite (`U+2000`, `U+2001`)
+    go to other whitespace. Tokens stay non-whitespace: none of the 32,303
+    code points `_TOKEN` can match is whitespace, no non-whitespace code point
+    in Unicode canonically decomposes to anything containing whitespace, no
+    composition target is whitespace, and no non-whitespace code point
+    casefolds to whitespace or to nothing. So a token of any length folds to a
+    non-empty string carrying a non-whitespace character, which an
+    all-whitespace `folded` cannot contain -- and nothing merges across two of
+    those code points on the way there, since none of the 32,303 can be the
+    right-hand side of a composition and no canonical decomposition of one
+    begins with something that can (11,222 do carry such a code point further
+    in, the jamo inside a Hangul syllable, but never in front). The finite
+    sweeps behind those lemmas did come back clean -- every pair and triple of
+    the 29, every one of the 32,303 alone and doubled -- but they are not what
+    closes this: doubling cannot fail where the single code point passed,
+    since `_fold(c*2)` is `_fold(c)*2` for all 32,303, and a sweep that stops
+    at three characters says nothing about the fourth. A widened `_TOKEN` --
     `.+`, say -- would split the two gates apart, and what it would let
     through is exactly #468's defect: an `AskExcerpt` carrying an empty
     excerpt string.
@@ -1508,13 +1518,15 @@ def test_search_source_excerpts_puts_the_stronger_match_first(tmp_path):
     equal-score paths are already in that order (`sources/history.txt` at 19
     characters ahead of `sources/notice.txt` at 18). Rename `notice.txt`
     throughout to a name both longer than `history.txt` and sorting after it
-    (`notification.txt`, say) and that mutant fails where the shipped key
-    still passes. Longer alone will not do it: `announcement.txt` is longer
-    but sorts ahead of `history.txt`, so the shipped result reorders and the
-    expected lists have to be reordered with it -- after which both keys agree
-    again and the mutant is back to passing. Showing the `[:limit]` slice needs more matching sources
-    than `MAX_EXCERPTS`. Both gaps are tracked in #533 rather than left as a
-    claim here that goes quietly stale the day someone pins one of them.
+    (`notification.txt`, say) and that mutant fails -- on the reversed-path
+    premise first, its own output having become that reversal -- where the
+    shipped key still passes. Longer alone will not do it: `announcement.txt`
+    is longer but sorts ahead of `history.txt`, so the shipped result reorders
+    and the expected lists have to be reordered with it, after which both keys
+    agree again and the mutant is back to passing. Showing the `[:limit]`
+    slice needs more matching sources than `MAX_EXCERPTS`. Both gaps are
+    tracked in #533 rather than left as a claim here that goes quietly stale
+    the day someone pins one of them.
     """
     store = _seed_three_matching_and_one_unrelated_source(tmp_path)
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1355,6 +1355,90 @@ def test_search_source_excerpts_compares_nothing_from_a_missing_or_undecodable_s
     assert len(compared) == 1
 
 
+# --- an excerpt means the source matched, not that it was readable (#468) ---
+
+
+_UNRELATED_SOURCE_TEXT = "샘플기관은 샘플절차를 안내한다."
+
+
+def _seed_two_matching_and_one_unrelated_source(tmp_path):
+    """Three registered, readable sources scoring 2, 1 and 0 on one question.
+
+    The question these fixtures are built for is `샘플조직의 역할은 무엇인가?`,
+    whose patterns are `샘플조직의`, `역할은` and `무엇인가`. `roles.txt`
+    carries the first two, `history.txt` only the first, and `unrelated.txt`
+    none of them.
+
+    The file names are load-bearing rather than decorative. `store.sources()`
+    reads `ORDER BY path`, so the two matching sources arrive at the sort as
+    `history.txt` then `roles.txt` -- the reverse of their score order. That is
+    what lets a sort key which has lost `-item.score` show through instead of
+    happening to agree with the right answer. A rename that put the two orders
+    back in step would make the ordering test vacuous, so that test asserts
+    this property rather than trusting this docstring for it.
+    """
+    sources = tmp_path / "sources"
+    sources.mkdir()
+    (sources / "roles.txt").write_text("샘플조직의 역할은 샘플서비스 검토이다.", encoding="utf-8")
+    (sources / "history.txt").write_text("샘플조직의 연혁은 다음과 같다.", encoding="utf-8")
+    (sources / "unrelated.txt").write_text(_UNRELATED_SOURCE_TEXT, encoding="utf-8")
+    store = _store(tmp_path)
+    store.add_source("sources/roles.txt")
+    store.add_source("sources/history.txt")
+    store.add_source("sources/unrelated.txt")
+    return store
+
+
+def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
+    tmp_path, monkeypatch
+):
+    """Being readable is not enough: `if score:` drops a source that scored zero.
+
+    `search_source_excerpts` appends a match only when `_best_excerpt` returned
+    a non-zero score. Without that gate a registered, readable source the
+    question never touched still becomes an `AskExcerpt` -- carrying the empty
+    string `_best_excerpt` returns when it found no pattern -- and the page
+    lists that file under a blank excerpt.
+
+    The test above this one makes the neighbouring point in the opposite
+    direction: there the source never reaches `_best_excerpt` at all, because
+    it is missing from disk or is not UTF-8. Here it is read and compared and
+    dropped afterwards. The spy is what makes that difference observable, and
+    it is also what keeps this test from rotting: were the fixture to stop
+    writing `unrelated.txt` or stop registering it, the exclusion below would
+    still hold, for a reason that has nothing to do with the gate. The spy
+    fails in that case instead of passing quietly.
+
+    The set equality is exact for this fixture only. Three sources cannot reach
+    the `MAX_EXCERPTS` truncation, and no two of them resolve to the same path,
+    so the `seen_paths` dedupe never drops one either. Outside those bounds the
+    result is not simply "every registered source that scored".
+
+    Not covered here: the order of what comes back (the next test), the
+    truncation, the dedupe, and the window arithmetic inside `_best_excerpt`.
+    """
+    compared: list[str] = []
+    real_best_excerpt = ask_module._best_excerpt
+
+    def spy(text, patterns):
+        compared.append(text)
+        return real_best_excerpt(text, patterns)
+
+    monkeypatch.setattr(ask_module, "_best_excerpt", spy)
+
+    store = _seed_two_matching_and_one_unrelated_source(tmp_path)
+
+    excerpts = search_source_excerpts(
+        store, root=tmp_path, question="샘플조직의 역할은 무엇인가?"
+    )
+
+    assert _UNRELATED_SOURCE_TEXT in compared
+    assert {item.path for item in excerpts} == {
+        "sources/roles.txt",
+        "sources/history.txt",
+    }
+
+
 # --- Ask does not re-request a provider that just failed (#438) -------------
 
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1451,7 +1451,8 @@ def test_search_source_excerpts_drops_a_source_it_read_and_matched_nothing_in(
     those code points on the way there, since none of the 32,303 can be the
     right-hand side of a composition and no canonical decomposition of one
     begins with something that can (11,222 do carry such a code point further
-    in, the jamo inside a Hangul syllable, but never in front). The finite
+    in -- the jamo inside a Hangul syllable for 11,172 of them, the voicing
+    mark inside a kana for the other 50 -- but never in front). The finite
     sweeps behind those lemmas did come back clean -- every pair and triple of
     the 29, every one of the 32,303 alone and doubled -- but they are not what
     closes this: doubling cannot fail where the single code point passed,

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1485,15 +1485,21 @@ def test_search_source_excerpts_puts_the_stronger_match_first(tmp_path):
     would leave the ordering assertion passing under a broken key, and a
     premise fails there instead, on the shipped code as much as on a mutant.
 
-    Two mutations of that same key survive these tests, and the gap is named
-    here rather than implied away. Dropping the `item.path` tie-break to
-    `key=(-item.score,)` changes nothing even though two of these sources do
-    score equally: `store.sources()` reads `ORDER BY path`, so equal scores
-    arrive already in path order and a stable sort leaves them there whether
-    or not the key says so. The `[:limit]` slice is likewise unpinned, since
-    showing it needs more matching sources than `MAX_EXCERPTS`. Both are
-    tracked in #533 rather than left as a claim here that goes quietly stale
-    the day someone pins one of them.
+    Two gaps are named here rather than implied away: these assertions do not
+    pin the tie-break beyond `-item.score` to `item.path`, and they do not pin
+    the `[:limit]` slice. Dropping the tie-break to `key=(-item.score,)`
+    changes nothing even though two of these sources do score equally:
+    `store.sources()` reads `ORDER BY path`, so equal scores arrive already in
+    path order and a stable sort leaves them there whether or not the key says
+    so. Nor is dropping it the only shape that gap has: replacing it with
+    `-len(item.path)` orders ties by descending path length, which is not path
+    order, and survives here only because this fixture's two equal-score paths
+    are already in that order (`sources/history.txt` at 19 characters ahead of
+    `sources/notice.txt` at 18). Rename `notice.txt` throughout to something
+    longer than `history.txt` and that mutant fails where the shipped key
+    still passes. Showing the `[:limit]` slice needs more matching sources
+    than `MAX_EXCERPTS`. Both gaps are tracked in #533 rather than left as a
+    claim here that goes quietly stale the day someone pins one of them.
     """
     store = _seed_three_matching_and_one_unrelated_source(tmp_path)
 


### PR DESCRIPTION
Closes #468

`search_source_excerpts` 의 `if score:` 게이트 — 읽히고 매치까지 된 소스만 발췌가 된다 — 를 못박는 회귀 테스트 4개. **프로덕션 코드 무변경** (`tests/test_ask.py` 단일 파일, +272/-0).

## 이슈 전제 정정

이슈 본문의 "게이트를 지워도 전체 스위트가 green" 은 지금 기준으로 **거짓**입니다. 부모 커밋(f3483e3)에서 `if score:` → `if True:` 로 전 스위트를 돌리면:

```
1 failed, 2975 passed, 14 skipped
FAILED tests/test_ask.py::test_ask_names_the_grounding_table_on_the_skipped_path
```

다만 그 포착은 **부수적**입니다. 해당 테스트의 픽스처에서 파일을 만드는 두 줄(`mkdir()`+`write_text()`)만 지우면 뮤턴트가 되살아납니다 — 게이트를 지키려고 있는 테스트가 아니라, 우연히 게이트를 밟고 있을 뿐입니다. 새 4개는 같은 조건에서 그대로 red 입니다.

## 테스트

| | 이름 | 붙잡는 것 |
|---|---|---|
| A | `..._drops_a_source_it_read_and_matched_nothing_in` | 읽혔지만 score 0 인 소스는 발췌에서 빠진다 (읽기 스파이 + 집합 상등) |
| B | `..._puts_the_stronger_match_first` | score 내림차순 정렬 (전제 단언 3줄 선행) |
| B2 | `test_ask_hands_the_page_the_excerpts_already_ordered` | 같은 순서가 `ask_question` → `AskResult.excerpts` 까지 살아남는다 |
| C | `test_ask_body_promises_nothing_when_the_only_source_matched_nothing` | 게이트를 실제로 통과해 떨어진 유일한 실행 경로의 본문 |

픽스처는 매치되는 소스 **셋**(`roles.txt` 2점, `history.txt` 1점, `notice.txt` 1점)과 매치 안 되는 하나(`unrelated.txt` 0점)입니다. 경로 순서 `[history, notice, roles]` 는 점수 순서 `[roles, history, notice]` 와 다르고 그 **역순도 아니며**, `notice.txt` 의 발췌(45자)가 `roles.txt`(21자)보다 길어 길이 기준 정렬과도 다릅니다 — 즉 점수를 담지 않은 어떤 키도 정답을 재현하지 못합니다.

## 뮤턴트 매트릭스 (12종, 테스트 이름까지 실측)

```
                                 d23de06 (리뷰 시점)      HEAD (세 번째 매치 추가 후)
CLEAN                            4 passed                4 passed
M_true       if True             4 failed  A,B,B2,C      4 failed  A,B,B2,C
M6           if excerpt          4 passed  ← 등가         4 passed  ← 등가
M_gt1        if score > 1        3 failed  A,B,B2        3 failed  A,B,B2
M2_pathonly  key=path            2 failed  B,B2          2 failed  B,B2
M3_nosort    sorted() 제거         2 failed  B,B2          2 failed  B,B2
M3b_ascend   key=(+score,path)   2 failed  B,B2          2 failed  B,B2
M_pathdesc   path, reverse=True  4 passed  ← 생존         2 failed  B,B2
M_len        key=(-len,path)     4 passed  ← 생존         2 failed  B,B2
M_revpath    reversed(by path)   4 passed  ← 생존         2 failed  B,B2
M_notie      key=(-score,)       4 passed  ← 생존         4 passed  ← 생존
M_nolimit    [:limit] 제거         4 passed  ← 생존         4 passed  ← 생존
```

**선언한 12종 매트릭스 기준으로 생존 뮤턴트가 5종에서 2종으로 줄었습니다.** 리뷰에서 지적된 "점수를 전혀 담지 않는 키로도 정렬 단언이 만족된다" 는 세 뮤턴트(`path reverse=True`, `(-len(excerpt), path)`, `reversed(sorted(by path))`)가 전부 죽습니다.

두 트리 모두 격리된 사본에서, 임포트된 `ask.__file__` 이 사본 경로임을 매 실행 단언하고 측정했습니다. **`PYTHONDONTWRITEBYTECODE=1` 이 필요합니다** — `key=item.path, reverse=True` 와 `key=(item.score, item.path)` 두 줄은 바이트 길이가 정확히 같아서, 같은 mtime 초 안에 쓰면 인터프리터가 앞 뮤턴트의 `.pyc` 를 재사용해 `M_pathdesc` 가 `M3b_ascend` 의 결과로 잘못 측정됩니다(실제로 처음 그렇게 나왔습니다).

**M6 은 등가 뮤턴트입니다.** 이제 탐색이 아니라 두 보조정리로 닫히고, 그 논증을 A 의 docstring 에 적어 두었습니다. `score` 가 falsy ⟺ `best_pos < 0` ⟺ 이른 `return "", 0`. 반대 방향은 `text` 전체가 공백인데 `_fold(text)` 에서 패턴이 발견되어야 하는데, (1) 공백 코드포인트 29개와 그 쌍·삼중 전수에서 `_fold(s).isspace()` 위반 0 — 결합등급이 전부 0 이고, 어느 것도 합성의 대상이 아니며, casefold 항등이고, NFC 가 실제로 바꾸는 둘(`U+2000→U+2002`, `U+2001→U+2003`)도 공백으로 갑니다 — 그리고 (2) `_TOKEN` 이 매치할 수 있는 32,303개 코드포인트 전수에서 `_fold(c)` 와 `_fold(c*2)` 가 비지도 공백이지도 않고, `_question_patterns(c*2)` 가 falsy·공백 패턴을 내는 경우가 0 입니다. 증인은 존재하지 않습니다.

**남은 생존 둘(`(-score,)` 타이브레이크, `[:limit]` 삭제)은 #533 이 추적합니다.** 세 번째 소스로 (1,1) 동점이 생겨도 `(-score,)` 는 여전히 생존하는데, `store.sources()` 가 `ORDER BY path`(`verinote/store/db.py:669`)로 넘기고 `sorted` 가 안정 정렬이라 동점이 이미 정답 순서로 도착하기 때문입니다. 이 사실과, #533 의 "What a fix needs" 가 `store.add_source` 경로로는 달성 불가능하다는 측정을 [#533 에 코멘트](https://github.com/semantic-reasoning/verinote/issues/533#issuecomment-5288165314)로 남겼습니다. B 의 docstring 이 그 두 **갭**을 성질로 이름하고 #533 을 가리킵니다.

## 우회 차단 확인

깨끗한 프로덕션 코드에서 **테스트·픽스처 쪽을** 변형해 측정했습니다:

```
CLEAN (control)                              4 passed
gate: if score or not matches                1 failed   C        ← C 만이 잡는다
fixture rename a_roles/z_history             2 failed   B, B2
fixture: notice.txt 쓰기·등록 삭제               3 failed   A, B, B2
fixture: notice.txt 텍스트 단축                 2 failed   B, B2
fixture: unrelated.txt 쓰기 삭제                1 failed   A        ← 읽기 스파이
```

- **이름 뒤집기**: 경로 순서가 점수 순서와 같아지면 B/B2 의 첫 전제(`[item.path for item in by_path] != order`)에서 먼저 red 입니다. 조용히 green 되는 경로가 없습니다.
- **텍스트 단축**: 길이 전제도 마찬가지로 load-bearing 입니다 — 장식이 아닙니다.
- **픽스처 부패**: 스파이를 빼면 `unrelated.txt` 삭제가 조용히 통과합니다. 즉 A 의 읽기 스파이는 vacuity 방지용입니다.

## 커버하지 않는 것

`MAX_EXCERPTS` 상한, `seen_paths` 중복 제거, 타이브레이크 순서, `[:limit]` — A 의 집합 상등은 이 픽스처가 소스 4개로 상한(8)에 못 미치고 중복 경로가 없기 때문에만 정확합니다. docstring 에 그대로 적었습니다.

## 리뷰 반영 (`d23de06` 이후 일곱 커밋)

1. `docs: name the property that makes this the only gated run, not the runs` — 블로킹 1. 닫힌 열거(테스트 이름 2개로 실제 11개 집합을 대신하던 문장, 그중 하나는 다른 분기로 반환)를 지우고, **측정된 성질과 재측정 방법**으로 대체했습니다. 전체 스위트 1회에 `_fallback_answer_body`·`_best_excerpt` 를 감싸고 **테스트마다 읽기 카운터를 리셋**하면:

```
본문 호출 20회 = NONE 11 / GROUNDING 4 / EXCERPTS 5
NONE 11 중 reads>0 은 정확히 하나:
  GATE-DROPPED reads=1  patterns=3 paths=1 on_disk=1  ..._body_promises_nothing_when_the_only_source_matched_nothing
  no-read      reads=0  patterns=3 paths=0 on_disk=0  (나머지 test_ask.py 9개 전부)
  no-read      reads=0  search_source_excerpts 미호출   test_ask_verdict.py::...[none]
```

2. `test: put a third match between the two so no path order reproduces the score order` — 논블로킹 2. 픽스처에 `notice.txt` 추가 + `_seed_three_matching_and_one_unrelated_source` 로 rename + 낡는 docstring 문장 전부 갱신 + B/B2 의 전제 단언 3줄 교체.
3. `docs: record why the excerpt gate cannot disagree with a non-empty excerpt` — 논블로킹 3. 두 보조정리를 A 의 docstring 에. **프로덕션은 여전히 무변경입니다.**

4. `docs: name a widening that actually splits the two excerpt gates` — 2라운드 블로킹. A 의 등가성 노트가 든 넓힘 예시를 `\S+` → `.+` 로 고쳤습니다. `\S+` 는 정의상 공백을 매치하지 못해 두 게이트를 가르는 증인이 **0** 입니다(`\S` 매치 코드포인트 1,114,083개 전수, `_fold(c)` 가 비거나 공백인 것 0). 실제로 가르는 것은 `.+` 이고, 그 아래에서만 빈 발췌를 실은 `AskExcerpt` 가 조립 경로로 나옵니다.

5. `docs(#468): name the two unpinned gaps by property, not as a count of key mutations` — 3라운드 블로킹. B 의 docstring 이 "그 키의 뮤테이션 둘이 생존" 이라고 **세던** 것을, 문장 자신이 열거하는 두 **갭**(타이브레이크를 `item.path` 까지 고정하지 않음 / `[:limit]` 미고정)으로 바꿨습니다. `[:limit]` 를 "그 키의 뮤테이션" 으로 분류하던 오분류도 사라집니다. 그리고 그 갭이 한 모양이 아님을 측정으로 실었습니다 — `key=(-item.score, -len(item.path))` 도 생존하며, 그것은 이 픽스처의 동점 두 경로가 **우연히** 이미 그 순서이기 때문입니다(`sources/history.txt` 19자가 `sources/notice.txt` 18자 앞). `notice.txt` 를 더 긴 이름으로 rename 하면 그 뮤턴트는 죽고 출하 키는 green 으로 남습니다(실측).

논블로킹 4(생존 뮤턴트의 이슈 등록)는 #533 으로 이미 등록되어 있고, 위 코멘트로 본문의 낡는 두 절을 갱신했습니다.

## 검증

```
전체 스위트:     2980 passed, 14 skipped
센서스 실행:     2980 passed, 14 skipped   (래퍼 3개 부착, -p no:randomly)
ruff check .  →  All checks passed!
```

기준선(f3483e3) 대비 `git diff f3483e3 HEAD -- verinote/` 는 빈 출력입니다. 픽스처 텍스트는 전부 합성(`샘플*`)이며 실제 문서·파일명은 쓰지 않았습니다.

6. `docs(#468): give the counterfactuals in these docstrings their missing conditions` — 3라운드 블로킹 2건. **docstring 제거 AST 가 `8ba0ab8` 과 SAME** 이라 산문만 바뀐 것이 기계적으로 증명됩니다.

   **(1) 재현 지시가 필요조건 하나를 빠뜨렸습니다.** 뮤턴트 `(-item.score, -len(item.path))` 가 출하 키와 갈리려면 새 이름이 (ㄱ) `history.txt` 보다 **길고** (ㄴ) 경로 정렬에서 그 **뒤**에도 와야 합니다. 뮤턴트는 길이 내림차순, 출하 키는 경로 오름차순이기 때문입니다. 우리 문장엔 (ㄱ)만 있었습니다. 전수 재측정:

```
NAME                       LEN  SORTS-AFTER  SHIPPED              MUTANT
notice.txt (현재)           18   yes          4 passed             4 passed
announcement.txt            24   NO           2 failed             2 failed   ← 조건(ㄱ) 만족, 그런데
notification.txt            24   yes          4 passed             2 failed
notice_much_longer.txt      30   yes          4 passed             2 failed
aaa_very_long_name.txt      30   NO           2 failed             2 failed
```

   `announcement.txt` 는 단순 치환 시 **출하 키가 먼저** 죽고(기대 리스트가 새 순서와 어긋남), 기대 리스트를 재배열하면 출하·뮤턴트 **둘 다 4 passed** 로 뮤턴트가 살아남습니다. 두 조건을 다 만족하는 이름은 단순 치환만으로 갈리므로 재배열 지시가 필요 없고, 그 차이를 문장에 적었습니다.

   **(2) 같은 모양이 근거문 두 곳에 이미 있었습니다** (`:1380`, `:1483`). 파일의 반사실 서술을 전수(`1380·1417·1440·1483·1498`) 훑어 확인했습니다 — `1417`·`1440` 은 이미 참이라 손대지 않았습니다. `:1380` 의 **"A rename" 도 무조건**이었습니다(`notification.txt` 로 개명해도 아무 순서도 back in step 이 되지 않습니다). 발췌 단축 임계값도 재측정했습니다:

```
notice 발췌 길이   by_length == order ?
18                 no
17                 YES  ← 전제가 죽는다 (동점 17=17 을 path 가 가르고 history < notice)
16                 YES
```

   그래서 "17자 **이하**" 로 썼습니다. 두 반사실 모두 최종 단언이 아니라 **전제 줄**에서 죽는 것도 출하 코드로 확인했습니다.

   논블로킹 셋도 함께 닫았습니다 — 유한 스윕으로 무한 결론을 내던 보조정리를 **길이 독립 구조 논거**로 교체(`_fold(c*2) == _fold(c)*2` 가 32,303 전부에서 성립하므로 두 배 검사가 단일에서 통과한 것을 실패시킬 수 없습니다). 나쁜 근거는 지우지 않고 **명시적으로 부인**했습니다. 결합등급 관련 비논리 연결 제거, `arrive already in path order` 의 범위를 세 소스로 한정(`_source_text_paths` 가 `ORDER BY path` 없는 `source_text_inputs()` 를 먼저 훑습니다).

7. `docs(#468): name the whole population the composition count stands for` — 4라운드 블로킹 1건 + 논블로킹 4건. **docstring 제거 AST 가 `bec1970` 과 SAME.**

   **(블로킹) `941` 이 이름하는 모집단이 틀렸습니다.** 그 수는 **분해 테이블 엔트리** 기반 계수라 한글이 구조적으로 보이지 않습니다 — 음절은 테이블 없이 알고리즘으로 합성됩니다(`NFC(U+1100 U+1161) → U+AC00`, `unicodedata.decomposition(chr(0xAC00)) == ''`).

```
합성 타깃 총계                                  12,113
  분해 테이블이 담는 2문자 쌍                      941
  NFC 가 알고리즘으로 합성하는 한글 음절        11,172   (= 19×21 + 399×27, 전부 U+AC00..U+D7A3)
  941 + 11,172 == 12,113                          ✓
공백: 좌 / 우 / 타깃                              0 / 0 / 0
```

   문장이 `"the 941 pairs … so nothing composes across them"` 형태라 **수가 스캔 모집단을 지목하고 거기서 전칭이 도출**됩니다. 재도출하는 독자는 정확히 한글 쌍을 건너뜁니다 — 그리고 **같은 문단이 두 문장 뒤에 세는 32,303 중 11,172 가 바로 그 한글 음절**이며, 이 파일의 픽스처는 전부 한국어입니다. 수를 빼는 대신 **둘 다 적는 쪽**을 택했습니다: 수를 지워도 재도출하는 독자는 여전히 테이블 방법론으로 한글을 건너뛰므로, 함정을 문장이 직접 가리키게 하는 편이 낫습니다.

   **(논블로킹 3 — 리뷰어가 제안한 문안이 그대로는 거짓이라 다르게 닫았습니다.)** 제안은 `"nothing in either set can be either side of a composition"` 이었는데, 토큰 코드포인트는 합성의 **왼쪽**에 설 수 있습니다(한글 LV + 라틴/가나). 참인 것은 **오른쪽**뿐이고, 합성이 NFD 뒤에 일어나므로 한 겹 더 필요합니다 — 코드포인트 자체가 아니라 **분해의 첫 글자**가 관건입니다:

```
32,303 중 합성의 오른쪽이 될 수 있는 것              0
32,303 중 NFD 가 오른쪽-가능 문자로 시작하는 것       0
32,303 중 NFD 가 그런 문자를 어딘가 담는 것      11,222   ← 음절 속 V/T, 그러나 앞에는 없음
```

   `begins with` 한정어가 load-bearing 입니다. 그리고 `NFC` 를 이유로 들던 것도 고쳤습니다 — **`NFC` 가 들어 있다는 것이야말로 길이가 문제될 수 있게 만드는 요인**입니다(인접 코드포인트를 가로질러 합성하므로 문자별 사상이 아닙니다). 실제로 닫는 것은 위 보조정리입니다.

   지적대로 문단 전체(1364-1545)의 `so`/`because` **10건을 전수 훑었고** 나머지 9건은 전부 타당합니다.

   나머지 논블로킹 셋: `decomposes` → **`canonically decomposes`**(NFD 참 / NFKD 52건 거짓), 101자 줄 재정렬(변경 구역에 78자 초과 신규 0줄), 개명 지시가 **전제에서 먼저** 빨개진다는 것을 한 절로 구분(`reversed-path premise first`).
