### PR TITLE
fix(query): 영어 속성 질문의 라벨에서 후행 술어를 걷어낸다

### DIFF
--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -425,6 +425,150 @@ def test_generic_korean_attribute_requires_question_shape():
     assert intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED
 
 
+def test_english_possessive_attribute_question_drops_a_trailing_predicate():
+    """Kill target: the tail group in the possessive pattern.
+
+    Dropping it, or reverting the label to a greedy match, asks the schema for a
+    relation named `owner called`. Both halves are needed: measured, greedy plus
+    the tail group still yields `owner called`, because a greedy label reaches
+    the end of the string before the optional tail is ever tried.
+    """
+    intent = deterministic_query_intent("What is Sample Project's owner called?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "Sample Project")
+    assert intent.relation_candidates == ("owner",)
+
+
+def test_english_of_attribute_question_deliberately_keeps_its_trailing_predicate():
+    """Kill target: `_ENGLISH_ATTRIBUTE_QUESTION_TAIL` appended to the `of` pattern.
+
+    This pins a limitation rather than a fix. In the `of` shape the terminal
+    field is the entity, so the predicate stays in it and this question asks
+    about an entity named `Sample Project called`, which matches nothing.
+
+    Stripping it here is the obvious change and it is the wrong one. Measured
+    through `ask_question` with every provider method raising, against a KB
+    holding facts on both `Company` and `Company Named`:
+    `What is the owner of Company Named?` answers `Company Named, owner, Bob` as
+    the pattern stands, and `Company, owner, Alice` once the tail is appended --
+    both labelled `VERIFIED — engine`, so the truncation turns a correct answer
+    into a wrong one under the system's strongest label, grounded on a fact that
+    does not answer the question. #515 carries the same measurement.
+
+    Leaving the predicate in the entity is the safer failure, because
+    `Sample Project called` matches nothing and the question reaches the model.
+    So this is pinned with its reason, the way the stemless Korean endings are,
+    rather than left looking like an oversight for someone to tidy up.
+    """
+    intent = deterministic_query_intent("What is the owner of Sample Project called?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "Sample Project called")
+    assert intent.relation_candidates == ("owner",)
+
+
+def test_english_attribute_tail_strips_only_a_space_bound_predicate():
+    """Kill target: the tail's `\\s+`, relaxed so it can begin inside a label.
+
+    The label is lazy, so it stops as soon as the remainder can match, and any
+    relaxation that lets the tail start mid-label eats into it. Two relaxations
+    reach different probes here, which is why both are pinned. `\\s*` cuts a
+    relation named `recalled` down to `re` and `unnamed` down to `un`. `\\s*\\b`
+    leaves those two alone -- no word boundary falls inside them -- but the
+    label charset holds `-`, so a boundary does fall after the hyphen and
+    `re-called` is cut to `re-`. All measured. The underscore probe adds no kill
+    against the tail's binding that the `recalled` probe does not already
+    deliver, `\\s*` cutting both and `\\s*\\b` neither; it is here to pin what
+    the docstrings claim about it, that `so_called` tells the two relaxations
+    apart rather than escaping both, `\\s*` cutting it to `so_` while `\\s*\\b`
+    leaves it whole, `_` being a word character. Outside that class it does kill
+    alone: dropping `_` from the label charset, and binding the tail with
+    `[\\s_]+`, are each caught by this probe and no other in the file. This is
+    the English analogue of the hazard `개요` -> `개` that keeps the Korean
+    interrogative suffixes bound to a stem.
+    """
+    recalled = deterministic_query_intent("What is Sample Product's recalled?")
+    unnamed = deterministic_query_intent("What is Sample Org's unnamed?")
+    hyphenated = deterministic_query_intent("What is Sample Product's re-called?")
+    underscored = deterministic_query_intent("What is Sample Product's so_called?")
+
+    assert recalled.relation_candidates == ("recalled",)
+    assert unnamed.relation_candidates == ("unnamed",)
+    assert hyphenated.relation_candidates == ("re-called",)
+    assert underscored.relation_candidates == ("so_called",)
+
+
+def test_english_attribute_label_spelled_like_the_tail_predicate_survives_whole():
+    """Kill target: an empty-preferring label plus a `\\s*(?<=\\s)`-bound tail.
+
+    A relation really named `called` must stay askable. Two properties keep it
+    so, and the kill target is their conjunction because neither alone moves
+    this question: the label must match at least one character, and the tail's
+    `\\s+` has no space left to bind to, `'s\\s+` having already consumed it.
+    Measured, an empty-preferring label still yields `called` while the tail
+    keeps `\\s+`, and the rebound tail still yields `called` while the label
+    keeps its first character; only together do they hand the whole label to the
+    tail and leave the question unclaimed.
+
+    The rebinding is `\\s*(?<=\\s)` and not `\\s*\\b` because `\\b` is not
+    confined to this question -- it also cuts `re-called` to `re-`, which is the
+    space-bound test's probe above, not this one's. A lookbehind for whitespace
+    reaches the label's first position without reaching inside a hyphenated
+    label, so this test's conjunction is falsified on its own terms.
+    """
+    intent = deterministic_query_intent("What is Sample Project's called?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == ("called",)
+
+
+def test_english_attribute_tail_strips_a_capitalised_predicate():
+    """Kill target: the `(?i:)` on the tail alternation.
+
+    The label charset admits an uppercase letter anywhere, so a case-sensitive
+    tail does not fail to match -- it leaks, and the question asks the schema for
+    a relation named `model Called`.
+    """
+    intent = deterministic_query_intent("What is Sample Product's model Called?")
+
+    assert intent.relation_candidates == ("model",)
+
+
+def test_english_attribute_tail_leaves_other_trailing_predicates_unstripped():
+    """Kill target: the tail alternation widened past `called|named`.
+
+    `called` and `named` are a sample of the predicates that can trail an
+    attribute question, not the class of them; #511 carries the members left
+    unstripped, including `known as`, and records why `like` was excluded. This
+    pins the current boundary so that widening it is a deliberate edit to this
+    test rather than a silent change of what these questions ask for.
+    """
+    known_as = deterministic_query_intent("What is Sample Project's owner known as?")
+    like = deterministic_query_intent("What is Sample Project's owner like?")
+
+    assert known_as.relation_candidates == ("owner known as",)
+    assert like.relation_candidates == ("owner like",)
+
+
+def test_english_attribute_tail_does_not_spend_the_possessive_label_budget():
+    """Kill target: the tail moved into `_clean_english_attribute_label`.
+
+    Stripping after the match instead of during it makes the predicate compete
+    with the label for the possessive pattern's 41-character label group. Swept
+    over labels of 30 to 45 characters, `main` claimed this shape up to 34 and
+    left it `unknown_or_unsupported` from 35 on, because 34 plus the seven
+    characters of ` called` is exactly that ceiling. 41 is the longest label the
+    group admits at all, so it is the widest gap between stripping inside the
+    pattern and stripping after it.
+    """
+    label = "a" * 41
+    intent = deterministic_query_intent(f"What is Sample Project's {label} called?")
+
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.relation_candidates == (label,)
+
+
 # Built as an actual cross-product rather than a hand-written list, so that
 # every added stem really is pinned against every suffix form the rule admits.
 # A hand-list drifts: with `이에요` written out for one stem only, dropping it

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -435,10 +435,79 @@ _KOREAN_ATTRIBUTE_QUESTION = re.compile(
     r'^\s*["“”\']?(?P<entity>[^"“”\'?？\n]{1,100}?)["“”\']?\s*'
     r"(?:의|에\s*대한)\s*(?P<label>[^?？\n]{1,80})\s*[?？]?\s*$"
 )
+_ENGLISH_ATTRIBUTE_QUESTION_TAIL = r"(?:\s+(?i:called|named))?"
+r"""A trailing predicate the possessive attribute question keeps out of its label.
+
+`What is Sample Project's owner called?` asked the schema for a relation named
+`owner called` -- a label no schema holds, so a question naming its relation
+exactly was answered UNVERIFIED.
+
+The group is interpolated into the pattern rather than stripped afterwards in
+`_clean_english_attribute_label` because the label group is capped at 41
+characters, and a predicate removed after the match must first fit inside that
+cap alongside the label it trails. Swept over label lengths 1 to 59,
+`What is X's <label> called?` is claimed up to a 34-character label without this
+group -- 34 plus the seven characters of ` called` is exactly the cap -- and up
+to 41 with it, 41 being the longest label the group admits at all. A label of 35
+to 41 characters is therefore claimed only from the pattern site: a cleaner
+never sees one, because the pattern has already failed to match by the time a
+cleaner would run.
+
+`called` and `named` are a sample of the predicates that can trail an English
+attribute question, not the class of them. #511 lists the ones measured so far
+that this rule leaves unstripped -- `known as`, `titled`, `labelled`,
+`listed as`, `spelled`, `set to` -- and records why `worth` and `like` were
+deliberately excluded there.
+
+The tail binds with `\s+`, and that is the load-bearing safety property: the
+possessive label is lazy and stops as soon as the remainder of the pattern can
+match, so any binding that lets the tail begin inside a label eats into it.
+Measured, `\s*` cuts a relation named `recalled` down to `re` and `unnamed` down
+to `un`; `\s*\b` spares those two but cuts `re-called` down to `re-`, because
+the label charset holds `-` and a word boundary falls after it. `so_called`
+tells the two relaxations apart rather than escaping both -- `\s*` cuts it to
+`so_`, `\s*\b` leaves it whole, `_` being a word character. This is the English
+analogue of `_KOREAN_INTERROGATIVE_TAIL`'s stem binding, which is what keeps
+`개요` from becoming `개`.
+
+One optional group strips one predicate and not a run of them, so
+`What is Sample Project's owner called named?` asks for `owner called`.
+
+The alternation is case-insensitive because the label charset already admits
+`Called`: a case-sensitive tail leaves `What is Sample Product's model Called?`
+asking for a relation named `model Called`.
+
+A label that is itself one of these verbs survives whole --
+`What is Sample Project's called?` still asks for `called` -- because the label
+must match at least one character and the tail must be preceded by a space that
+`'s\s+` has already consumed.
+
+`_ENGLISH_OF_ATTRIBUTE_QUESTION` has the same defect in its entity, which is the
+terminal field in that shape, and deliberately keeps it:
+`What is the owner of Sample Project called?` still asks about an entity named
+`Sample Project called`. This constant is interpolated into one pattern and not
+both because appending it there truncates an entity whose own name ends in one
+of these verbs, and that is not a worse parse but a worse failure. Measured end
+to end through `ask_question` against a client raising on every provider method,
+so that no answer can have come from a model: with facts held on both `Company`
+and `Company Named`, `What is the owner of Company Named?` answers
+`VERIFIED — engine` / `Company Named, owner, Bob` as the pattern stands, and
+`VERIFIED — engine` / `Company, owner, Alice` with the tail appended -- the same
+strongest label the system has, now carrying the wrong fact as its grounding.
+
+The wrong answer needs the truncated name to exist in the KB and to hold the
+relation asked for. With only `Company Named` present, the truncated subject
+plans empty and the question reaches the model instead, which is why this shows
+up as a silent wrong answer rather than as a failure. #515 carries the same
+measurement and what a real fix would have to do, which is to consult the KB at
+parse time -- something no pattern here can do.
+"""
+
 _ENGLISH_POSSESSIVE_ATTRIBUTE_QUESTION = re.compile(
     r"^\s*(?i:what\s+is|what\s+was|find|show)\s+(?:the\s+)?"
     r"(?P<entity>[A-Z][^?]{0,100}?)'s\s+"
-    r"(?P<label>[A-Za-z][A-Za-z0-9 _-]{0,40})\s*\??\s*$"
+    r"(?P<label>[A-Za-z][A-Za-z0-9 _-]{0,40}?)"
+    rf"{_ENGLISH_ATTRIBUTE_QUESTION_TAIL}\s*\??\s*$"
 )
 _ENGLISH_OF_ATTRIBUTE_QUESTION = re.compile(
     r"^\s*(?i:what\s+is|what\s+was|find|show)\s+(?:the\s+)?"


### PR DESCRIPTION
`Refs #433` — **자동으로 닫지 않는다.** 아래 "범위 한계" 참조.

## 무엇을 고치나

`What is Sample Project's owner called?` 는 스키마에 `owner called` 라는 이름의 관계를 물었다. 어떤 스키마도 그런 것을 담지 않으므로, 자기 관계를 정확히 이름한 질문이 UNVERIFIED 로 답해졌다. 소유격 패턴에 선택적 후행 그룹을 붙여 술어를 라벨 밖에 둔다.

## 클리너가 아니라 패턴에 둔 이유

한국어 선례(`_KOREAN_INTERROGATIVE_TAIL`)는 라벨 클리너에서 고쳤다. 여기서는 **클리너가 정작 문제되는 질문을 보지 못한다.**

라벨 길이 1..59 를 훑으면, 그룹 없이는 `What is X's <label> called?` 가 34자까지 주장되고 그룹이 있으면 41자까지 주장된다 — 34 에 ` called` 7자를 더하면 정확히 그룹의 상한이고, 41 이 그룹이 admit 하는 가장 긴 라벨이다. 클리너 사이트 구현은 HEAD 와 같은 1..34 대역에 착지한다. 클리너가 돌 시점에는 패턴이 이미 매치에 실패한 뒤이기 때문이다.

즉 35–41자 라벨은 패턴 사이트에서만 주장된다. `test_english_attribute_tail_does_not_spend_the_possessive_label_budget` 가 그 대역을 못박고, 절단을 클리너로 옮기는 뮤테이션이 그것을 빨갛게 만든다.

## 결합은 `\s+`, 그리고 그것이 유일한 안전 성질이 아니었다

tail 은 `\s*` 가 아니라 `\s+` 로 결합한다. 그것이 `recalled` 라는 이름의 관계가 `re` 로, `unnamed` 가 `un` 으로 잘리는 것을 막는다.

작업 중 **같은 위험 부류의 두 번째 완화**를 발견했다. `\s*\b` 는 그 둘을 살려두지만 `re-called` 를 `re-` 로 자른다 — `_` 는 단어 문자이고 `-` 는 아니기 때문이다. 둘 다 고정했고, `so_called` 와 `re-called` 가 둘을 가르는 프로브다. `recalled` 프로브만으로는 첫 번째밖에 못 잡는다. #511 의 가드 서술을 둘 다 담도록 갱신했다.

## `called|named` 는 표본이지 부류가 아니다

#511 이 이 규칙이 남겨두는, 지금까지 측정된 멤버들(`known as`, `titled`, `labelled`, `listed as`, `spelled`, `set to`)을 열거하고, `worth` 와 `like` 를 의도적으로 제외한 이유를 기록한다. docstring 은 그 집합을 다시 세지 않으며 #511 을 가리킬 뿐이다.

## `of` 형태는 후행 술어를 의도적으로 유지한다

`test_english_of_attribute_question_deliberately_keeps_its_trailing_predicate` 가 그것을 이유와 함께 못박는다.

같은 그룹을 거기에 붙이면 자기 이름이 이 술어들로 끝나는 엔티티가 잘린다. 그리고 그것은 단순한 오파싱이 아니다. 모든 provider 메서드가 raise 하는 클라이언트로 `ask_question` 을 종단 측정했다 — `Company` 와 `Company Named` 양쪽에 confirmed fact 를 가진 KB 에서:

```
그룹 없음(현재): subject='Company Named'  VERIFIED — engine  'Company Named, owner, Bob'   ← 정답
그룹 붙임:       subject='Company'        VERIFIED — engine  'Company, owner, Alice'       ← 오답, 같은 라벨
```

구제 경로가 없다. `_reinterpret_empty_plan` 은 계획이 비었을 때만 발동하는데 이 계획은 해석된다. 오답은 절단된 이름이 KB 에 **존재하고 또한 물어진 관계를 가질 때**만 나온다. 아니면 계획이 비어 모델에 도달하고, 그래서 이 결함은 조용하다.

술어를 엔티티에 남겨두는 쪽이 안전한 실패다 — `Sample Project called` 는 아무것도 매치하지 않으므로 질문이 모델에 도달한다. #515 가 이 누수와 위험을 기록한다.

## 범위 한계 — 이슈의 의문사 표는 이 PR 에 없다

#433 의 표(`who is`, `how much is`, `when is`, `where is` 가 결정적 읽기를 못 얻음)는 **보류**다. 헤드 확장은 두 줄짜리 변경이지만, 구현 전 게이팅 측정에서 막혔다.

현재 허용된 네 헤드(`what is`, `what was`, `find`, `show`)는 전부 **타입 중립**인데, 추가하려던 네 개는 전부 **타입 보유**다. `LOOKUP_OBJECT` 는 기대 타입을 싣지 않으므로 계획자가 의문사와 대조할 것이 없고, 이름한 관계를 그냥 답한다. 고유명사도 `of` 도 필요 없이, 평범한 사실 하나짜리 KB 에서:

```
Q: Where is Sample Project's owner?     KB [('Sample Project','owner','Alice')]
   VERIFIED — engine | 'Sample Project, owner, Alice ← sources/sample.txt'
   (현재 트리: unknown_or_unsupported → provider 도달, 2-hop 으로 읽힐 수 있음)
```

소유자의 **위치**를 묻는 2-hop 질문이 소유자의 **이름**으로, 최상위 라벨을 달고 답해진다. 모집단은 의문사와 관계의 값 타입이 어긋나는 모든 확장-헤드 질문이다.

#433 의 네 행이 모두 타입이 **일치하는** 질문이라 순진한 확장에서도 동작한다는 점이 이 결함을 표만 봐서는 보이지 않게 만든다. #520 이 사유와 측정값을 담는다. **그래서 `Closes` 가 아니라 `Refs` 다.**

## 검증

- 커밋 1개. `pytest tests/test_query_intent.py tests/test_query.py tests/contract/test_query_intent_contract.py` → `486 passed, 1 skipped`.
- 전체 스위트 `2883 passed, 14 skipped`. `main` 기준선 `2876 passed, 14 skipped` + 신규 7.
- `_ENGLISH_OF_ATTRIBUTE_QUESTION` 은 base 와 **바이트 동일**.
- 독립 회귀 스윕 280문항: base 가 주장하던 질문 중 거절된 것 **0**, `of` 형태 델타 **0**.
- 뮤테이션 16종, 신규 테스트 7개가 전부 자기 kill target 에서 죽는다. `of_tail_readded` 는 한계-고정 테스트만, `tail_ws_star`/`tail_ws_star_b`/`[\s_]+`/두 라벨 charset 뮤턴트는 각각 결합 테스트만, `tail_in_cleaner` 는 예산 테스트만 죽인다.
- A4 의 kill target 은 결합(≥1자 라벨 ∧ 공백 결합 tail)이고, 두 반쪽이 각각 무해한 것으로 최소성을 확인했다. docstring 이 단일 kill 을 주장하지 않고 결합임을 밝힌다.
- `ruff` 는 venv 에 없어 로컬에서 돌리지 못했다. CI 가 덮는다.

## 후속으로 분리한 것

| | |
|---|---|
| #511 | 후행 술어 계열 — `called`/`named` 가 표본인 이유와 남은 멤버들 |
| #515 | `of` 형태 누수와, 순진한 수정이 만드는 검증 결함 |
| #517 | 두 패턴의 미고정 수량자 비대칭 |
| #520 | 타입 보유 의문사 — 이 PR 이 #433 을 닫지 못하는 이유 |
| #521 | `of` 포함 고유명사 오파싱. 기존 결함이고 지금도 살아 있다 |
