### PR TITLE
fix(extract): 완료 청크를 쥔 실패 잡을 재구축하지 않고 이어간다

### DIFF
--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -395,10 +395,21 @@ def test_a_released_job_is_retried_rather_than_rebuilt_from_scratch(tmp_path):
 
     Compared as a whole `ExtractionJobPlan` on purpose: `retry_job_id` alone would
     also be satisfied if `resume_job_id`/`exhausted_job_id`/`busy_job_id` came
-    along with it. Release the chunk any other way while leaving the job to be
+    along with it.
+
+    WHAT THE COUNTERFACTUALS COST HAS CHANGED, and what survives is smaller but
+    still real. Release the chunk any other way while leaving the job to be
     written `failed` — rewind the chunk to `pending`, or mark it `done` — and the
-    job's `failed_chunks` drops to zero, planning falls through to "rebuild
-    fresh", and chunk 0's completed work is paid for twice.
+    job's `failed_chunks` drops to zero. That used to fall through to "rebuild
+    fresh" and pay for chunk 0 twice; since #524, planning continues a `failed`
+    job that holds a finished chunk, so this three-chunk job reaches
+    `retry_job_id` either way and the plan alone no longer separates them. The
+    chunk row still separates them. A chunk left `pending` is invisible to the
+    give-up gate — `failed_chunk_attempt_status` counts `failed` rows only — so
+    one that keeps failing never exhausts the budget
+    `test_a_released_chunk_burns_exactly_one_attempt` above pins, and marking it
+    `done` records an extraction that did not happen. Of the three, only
+    release-as-`failed` says something true about chunk 1.
 
     The qualifier is load-bearing, because one release DOES rewind the chunk to
     `pending`: a locked fact-term sidecar (`test_chunk_claim_sidecar_lock.py`).

--- a/tests/test_chunk_claim_sidecar_lock.py
+++ b/tests/test_chunk_claim_sidecar_lock.py
@@ -279,9 +279,10 @@ def test_a_locked_sidecar_requeues_the_chunk_and_rewinds_the_job(tmp_path):
     The `resume_job_id` assertion is the one that catches a half-fix. Rewind the
     chunk without rewinding the job and every state below still looks reasonable
     in isolation — until something writes `failed` over a job with no failed
-    chunk, filing a condition of the host as the job's own failure and, on this
-    tree, sending planning to a rebuild that extracts the finished chunk a second
-    time (#524). Today each caller's dedicated clause for this error is what
+    chunk. Since #524 that no longer sends the finished chunk to the LLM a
+    second time; what it costs is the record — a condition of the host filed as
+    this job's own failure, in the job row and in the `extraction_job_failed`
+    event beside it. Today each caller's dedicated clause for this error is what
     stops that write; this test is why the job rewind must not lean on it.
     """
     s = _store(tmp_path)

--- a/tests/test_chunk_claim_sidecar_lock.py
+++ b/tests/test_chunk_claim_sidecar_lock.py
@@ -14,9 +14,13 @@ So this release has its own shape, and all of it is load-bearing:
 
 * the CHUNK goes back to `pending` with its attempt refunded — the row exactly as
   `next_pending_chunk` handed it out;
-* the JOB is rolled back to `pending` too, without which a `failed` job with zero
-  failed chunks reads to planning as "rebuild fresh" and every finished chunk is
-  re-sent to the LLM;
+* the JOB is rolled back to `pending` too, because `pending` is what it is —
+  nothing is running, and nothing failed the content. Leave it for a caller's
+  broad clause to write `failed` over and planning used to read that as "rebuild
+  fresh" and re-send every finished chunk to the LLM; since #524 it continues the
+  job instead, and what the `failed` write still costs is a condition of the host
+  recorded as this job's own failure, in the row, in the `extraction_job_failed`
+  event, and on the Sources page;
 * the exception still propagates, so no caller mistakes this for a completed pass.
 
 THREE OUTCOMES MUST STAY APART, and the tests below separate them on purpose:

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -818,3 +818,571 @@ def test_a_crashed_sync_is_resumed_by_the_next_plain_sync(tmp_path, monkeypatch,
     out = capsys.readouterr().out
     assert "4 candidate(s) this run" in out
     assert f"resumed job #{job_id}: 6 candidate(s) in total" in out
+
+
+# --- J: a `failed` job that finished chunks is continued, not rebuilt (#524) --
+
+J_MARKERS = MARKERS[:3]
+J_CHUNK_CHARS = 60
+
+
+def _worker_marks_job_failed(store: Store, job_id: int, message: str) -> None:
+    """Stand-in for the caller's broad `except`. NOT the code under test.
+
+    A crash below the chunk loop gives `process_extraction_job` nothing to say
+    about the job row, so it leaves the job `running`; the broad `except` a caller
+    ends with is what writes `failed` over it. In this tree only `web/app.py` has
+    one, so a CLI-driven test has to perform that write itself. Spelled out here
+    rather than hidden behind a fixture, the idiom
+    `test_chunk_claim_release.py::_worker_marks_job_failed` uses for the same
+    reason — nothing in `verinote/pipeline` will do it.
+
+    DELETE THIS WHEN #488 LANDS. PR #523 gives `cmd_sync` the same broad clause,
+    at which point the sync below terminalises the job by itself and the correct
+    change is to drop the call and assert the `failed` row with zero failed chunks
+    that the CLI wrote — never to keep the stand-in so these lines stay green.
+    """
+    store.fail_extraction_job(job_id, message)
+
+
+class _CrashBelowChunkAccounting:
+    """Fail a pass where no chunk row can record that it happened.
+
+    THE INJECTION POINT IS THE WHOLE POINT, not the exception. Failing the client
+    puts the crash inside `_extract_chunk`, which marks the chunk `failed`; the
+    job then reaches the planner's failed-chunk branch, which already resumes.
+    `next_pending_chunk` raises before any claim, so no chunk changes status and
+    no `attempts` is spent — the job terminalises as `failed` with `failed_chunks`
+    zero while holding finished chunks, which is the state #524 is about.
+    """
+
+    def __init__(self, monkeypatch, *, before_chunk: int):
+        self._before_chunk = before_chunk
+        self.armed = True
+        real = Store.next_pending_chunk
+
+        def crashing(store, job_id):
+            row = real(store, job_id)
+            if self.armed and row is not None and int(row["chunk_index"]) == before_chunk:
+                raise RuntimeError("crash below chunk accounting")
+            return row
+
+        monkeypatch.setattr(Store, "next_pending_chunk", crashing)
+
+    def heal(self) -> None:
+        self.armed = False
+
+
+def _crashed_below_chunk_accounting(tmp_path, monkeypatch, *, before_chunk: int = 2):
+    """Drive a real sync that dies below the chunk accounting and terminalise it.
+
+    Built by the production pass rather than hand-written rows, so the fixture
+    cannot drift away from the state a real crash leaves.
+    """
+    _ingest(tmp_path, monkeypatch)
+    crash = _CrashBelowChunkAccounting(monkeypatch, before_chunk=before_chunk)
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RecordingClient())
+
+    with pytest.raises(RuntimeError):
+        cli.main(["sync"])
+
+    jobs = _jobs(tmp_path)
+    assert len(jobs) == 1
+    job_id = int(jobs[0]["id"])
+    store = _store(tmp_path)
+    _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
+    # The edge state, asserted rather than assumed: `failed`, nothing charged to a
+    # chunk, and finished chunks a rebuild would throw away.
+    job = store.get_extraction_job(job_id)
+    assert job["status"] == "failed"
+    assert int(job["failed_chunks"]) == 0
+    assert [c["status"] for c in store.source_chunks(job_id)] == (
+        ["done"] * before_chunk + ["pending"] * (len(MARKERS) - before_chunk)
+    )
+    store.close()
+    return job_id, crash
+
+
+def _edge_state_job(tmp_path, *, done: int = 1):
+    """A KB whose newest job is `failed`, has NO failed chunk, and `done` finished.
+
+    The unit-level twin of `_crashed_below_chunk_accounting`. Everything the
+    planner compares — artifact (`None`), provider, model, chunk text — matches
+    what `_plan_edge` hands it below, so only the chunk rows decide.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/a.txt")
+    job_id = create_chunked_extraction_job(
+        store,
+        source_id=source_id,
+        artifact_id=None,
+        source_text=_body(J_MARKERS),
+        provider="fake",
+        model="m",
+        chunk_chars=J_CHUNK_CHARS,
+        chunk_overlap_chars=0,
+    )
+    assert len(store.source_chunks(job_id)) == len(J_MARKERS)
+    store.mark_extraction_job_running(job_id)
+    for row in store.source_chunks(job_id)[:done]:
+        store.mark_chunk_running(int(row["id"]))
+        store.mark_chunk_done(int(row["id"]), candidates=1)
+    _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
+    assert int(store.get_extraction_job(job_id)["failed_chunks"]) == 0
+    return store, source_id, job_id
+
+
+def _plan_edge(store, source_id, **overrides):
+    kwargs = {
+        "source_id": source_id,
+        "artifact_id": None,
+        "source_text": _body(J_MARKERS),
+        "provider": "fake",
+        "model": "m",
+        "chunk_chars": J_CHUNK_CHARS,
+        "chunk_overlap_chars": 0,
+    }
+    kwargs.update(overrides)
+    return plan_source_extraction(store, **kwargs)
+
+
+def test_sync_resumes_a_failed_job_whose_crash_never_reached_a_chunk(
+    tmp_path, monkeypatch
+):
+    """THE #524 ASSERTION: the finished chunks are not sent to the LLM a second time.
+
+    A crash below the chunk accounting leaves `failed` with zero failed chunks, and
+    planning used to read that as "rebuild fresh" — a new job whose first act is to
+    re-extract every chunk the crashed pass had already paid for.
+    """
+    job_id, crash = _crashed_below_chunk_accounting(tmp_path, monkeypatch)
+    crash.heal()
+    healthy = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: healthy)
+
+    assert cli.main(["sync"]) == 0
+
+    # The load-bearing line: `alpha`/`bravo` are absent, so the two chunks the
+    # crashed pass finished were kept rather than re-sent.
+    assert healthy.markers == list(MARKERS[2:])
+    jobs = _jobs(tmp_path)
+    assert [int(job["id"]) for job in jobs] == [job_id]  # continued, not replaced
+    assert jobs[0]["status"] == "done"
+
+    store = _store(tmp_path)
+    assert [f["subject"] for f in store.facts()] == list(MARKERS)
+    store.close()
+
+
+def test_sync_reports_the_continued_job_rather_than_a_fresh_one(
+    tmp_path, monkeypatch, capsys
+):
+    """The stdout a user sees for the resumed pass, pinned.
+
+    Not the guard against the branch regressing — the tests either side of this
+    one catch that from the chunk text.
+
+    WHAT SEPARATES THE TWO PASSES IS THE PARENTHETICAL, NOT THE NUMBER. Run this
+    same scenario with the branch removed and the rebuild sends all six chunks to
+    the LLM and still prints a flat `sources/doc.txt: 4 candidate(s)` — the same
+    count this pass prints. `run_candidates` counts the candidates a run produced,
+    and the two re-sent chunks produce none, because their facts already exist and
+    dedupe away. That identity is why the re-send is silent, which is the issue's
+    second complaint, and it is the reason a test that pinned only the number
+    would pin nothing. Only the continued pass states the two scopes apart —
+    `4 candidate(s) this run (resumed job #1: 6 candidate(s) in total)` — so the
+    clause in parentheses is the whole visible difference and the only part worth
+    holding.
+    """
+    job_id, crash = _crashed_below_chunk_accounting(tmp_path, monkeypatch)
+    crash.heal()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RecordingClient())
+    capsys.readouterr()  # drop the crashed pass's output
+
+    assert cli.main(["sync"]) == 0
+
+    out = capsys.readouterr().out
+    assert "4 candidate(s) this run" in out
+    assert f"resumed job #{job_id}: 6 candidate(s) in total" in out
+
+
+def test_plan_retries_a_failed_job_that_holds_a_finished_chunk(tmp_path):
+    """Compared as a whole `ExtractionJobPlan` on purpose: asserting `retry_job_id`
+    alone would also pass if `resume_job_id`/`exhausted_job_id`/`busy_job_id` came
+    along with it, and each of those means something different to `cmd_sync`.
+
+    `retry_job_id` and not `resume_job_id`, which is what the issue's wording
+    suggests: `claim_pending_extraction_job`'s CAS is `WHERE status = 'pending'`,
+    so on a `failed` job it matches nothing, raises `ExtractionJobBusyError`, and
+    `cmd_sync` skips the source with "already running" and returns 0 — forever.
+    """
+    store, source_id, job_id = _edge_state_job(tmp_path, done=1)
+    plan = _plan_edge(store, source_id)
+    store.close()
+    assert plan == ExtractionJobPlan(retry_job_id=job_id)
+
+
+def test_plan_rebuilds_a_failed_job_that_finished_no_chunk(tmp_path):
+    """The branch is scoped to the harm the issue names, and no wider.
+
+    With nothing `done` there is no finished work for a rebuild to discard, and
+    both routes cost the same number of LLM calls, so this stays a rebuild.
+    """
+    store, source_id, _ = _edge_state_job(tmp_path, done=0)
+    plan = _plan_edge(store, source_id)
+    store.close()
+    assert plan == ExtractionJobPlan()
+
+
+def test_plan_reads_the_chunk_rows_not_the_job_counter(tmp_path):
+    """Pins WHICH source of truth decides, by injecting a disagreement.
+
+    The desync below is hypothetical: `completed_chunks` is written by
+    `_refresh_extraction_job` on every `mark_chunk_done`, and no production path
+    leaves it lower than the `done` rows. The reason to read the rows is not that
+    the counter lies — it is that the text gate above already read the rows, so
+    the decision costs no second query and cannot straddle two snapshots, and that
+    the sibling counter on the same row IS documented as untrustworthy after a
+    job-level failure (`store/db.py`, `surface_stale_engine_facts`). Believing one
+    counter and not the other in the same function would be the odd choice.
+    """
+    store, source_id, job_id = _edge_state_job(tmp_path, done=1)
+    store._conn.execute(
+        "UPDATE extraction_jobs SET completed_chunks = 0 WHERE id = ?", (job_id,)
+    )
+    plan = _plan_edge(store, source_id)
+    store.close()
+    assert plan == ExtractionJobPlan(retry_job_id=job_id)
+
+
+def test_plan_still_gives_up_when_an_exhausted_chunk_sits_beside_a_finished_one(
+    tmp_path,
+):
+    """ORDER IS LOAD-BEARING: the new branch lives BELOW the failed-chunk branch.
+
+    Hoist it above and a job whose chunk has spent every attempt would be offered
+    for retry again the moment any other chunk had finished — the give-up gate
+    bypassed and #323's empty-run loop back, on the sources most likely to hit it.
+    """
+    store, source_id, job_id = _edge_state_job(tmp_path, done=1)
+    failed_chunk = store.source_chunks(job_id)[1]
+    store.mark_chunk_running(int(failed_chunk["id"]))
+    store.mark_chunk_failed(int(failed_chunk["id"]), "provider down")
+    store._conn.execute(
+        "UPDATE source_chunks SET attempts = ? WHERE id = ?",
+        (MAX_CHUNK_ATTEMPTS, int(failed_chunk["id"])),
+    )
+    # Without this the fixture could silently fail to produce a failed chunk and
+    # the assertion below would pass through the new branch instead of the gate.
+    assert int(store.get_extraction_job(job_id)["failed_chunks"]) == 1
+
+    plan = _plan_edge(store, source_id)
+    store.close()
+    assert plan == ExtractionJobPlan(exhausted_job_id=job_id)
+
+
+def _cancel(store, job_id):
+    store._conn.execute(
+        "UPDATE extraction_jobs SET status = 'canceled' WHERE id = ?", (job_id,)
+    )
+
+
+def _make_running(store, job_id):
+    store._conn.execute(
+        "UPDATE extraction_jobs SET status = 'running' WHERE id = ?", (job_id,)
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "mutate", "overrides", "expected"),
+    [
+        ("canceled job", _cancel, {}, "empty"),
+        ("running job", _make_running, {}, "busy"),
+        ("artifact changed", None, {"artifact_id": 4242}, "empty"),
+        ("body changed", None, {"source_text": _body(SECOND_MARKERS[:3])}, "empty"),
+        ("chunk size changed", None, {"chunk_chars": 400}, "empty"),
+        ("model changed", None, {"model": "another-model"}, "empty"),
+    ],
+)
+def test_plan_does_not_continue_a_finished_chunk_job_that_is_stale_or_owned(
+    tmp_path, case, mutate, overrides, expected
+):
+    """The new branch is fenced by every gate that already fenced the others.
+
+    One condition is broken per case against the same fixture that
+    `test_plan_retries_a_failed_job_that_holds_a_finished_chunk` proves returns
+    `retry_job_id` — that test is this one's positive control, without which
+    "returns an empty plan" could mean the fixture never built the edge state.
+
+    A `done` job needs no case here: `test_sync_re_extracts_a_source_whose_job_
+    already_finished` above already covers a finished job being rebuilt, and it
+    goes red if the branch is hoisted to the top of the function.
+    """
+    store, source_id, job_id = _edge_state_job(tmp_path, done=1)
+    if mutate is not None:
+        mutate(store, job_id)
+    plan = _plan_edge(store, source_id, **overrides)
+    store.close()
+    if expected == "busy":
+        assert plan == ExtractionJobPlan(busy_job_id=job_id)
+    else:
+        assert plan == ExtractionJobPlan()
+
+
+def test_a_reproducing_crash_below_chunk_accounting_stops_paying_the_llm(
+    tmp_path, monkeypatch
+):
+    """The cost of a fault that keeps happening, measured over repeated syncs.
+
+    Rebuilding also reset the attempt budget, so the same source paid for the same
+    finished chunks on EVERY sync — 2, 4, 6 LLM calls over three passes on a
+    six-chunk source. Continuing the job pays once.
+
+    THE RUN COUNT BELOW IS A CHARACTERISATION, NOT A GUARANTEE. Nothing here
+    terminates: this state charges no chunk, `failed_chunk_attempt_status` counts
+    only `failed` chunks, and so the job is offered again every sync and burns an
+    empty run doing it — at exactly the rate it burned one before this fix, which
+    is why it is no regression and is out of scope for #524. Giving it an end
+    needs a job-level failure count (#536), and when that lands `runs` will stop
+    growing and this line MUST go red. Update it to the new ceiling then; do not
+    restore the growth to keep it green.
+    """
+    job_id, crash = _crashed_below_chunk_accounting(tmp_path, monkeypatch)
+    client = _RecordingClient()
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+    runs = []
+    for _ in range(3):
+        with pytest.raises(RuntimeError):
+            cli.main(["sync"])
+        # Each pass leaves the job `running` and each pass's caller terminalises
+        # it, the same write `_crashed_below_chunk_accounting` made — so the state
+        # under test recurs rather than being reached once.
+        store = _store(tmp_path)
+        _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
+        store.close()
+        runs.append(_run_count(tmp_path))
+
+    # Not one further chunk reached the LLM across three more passes.
+    assert client.markers == []
+    assert [int(job["id"]) for job in _jobs(tmp_path)] == [job_id]
+    assert runs == [2, 3, 4]  # CHARACTERISATION — see the docstring
+
+
+def test_a_failed_job_that_finished_everything_terminalises_without_the_llm(
+    tmp_path, monkeypatch
+):
+    """The edge state can also arrive with nothing left to do, and it must settle.
+
+    A broad `except` that fires AFTER the chunk loop writes `failed` over a job
+    whose chunks are all `done`. Continuing it claims the job, finds no pending
+    chunk, and finishes: no LLM call, and the empty run it opens is opened ONCE,
+    unlike the rebuild it replaces, which re-extracted every chunk.
+    """
+    _ingest(tmp_path, monkeypatch, body=_body(J_MARKERS))
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RecordingClient())
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    job_id = int(jobs[0]["id"])
+    assert jobs[0]["status"] == "done"
+    store = _store(tmp_path)
+    _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
+    assert [c["status"] for c in store.source_chunks(job_id)] == ["done"] * len(J_MARKERS)
+    store.close()
+    runs_before = _run_count(tmp_path)
+
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RefusingClient())
+    assert cli.main(["sync"]) == 0
+
+    jobs = _jobs(tmp_path)
+    assert [int(job["id"]) for job in jobs] == [job_id]
+    assert jobs[0]["status"] == "done"
+    assert _run_count(tmp_path) == runs_before + 1  # exactly one, then settled
+
+
+# --- J2: the same state with a `running` chunk in it, and what it may cost ----
+
+
+class _FailsOneChunk:
+    """A provider that is down for exactly one chunk, named by its marker.
+
+    `_RecordingClient(fail_on_call=N)` counts calls, which makes "the same chunk
+    fails again" depend on how many chunks a pass happens to reach — and the
+    passes below reach different numbers. Keying on the chunk's own text keeps
+    the fault attached to the chunk across every pass, and `down` is what a
+    recovered provider looks like.
+    """
+
+    name = "fake"
+
+    def __init__(self, marker: str):
+        self.marker = marker
+        self.down = True
+        self.seen: list[str] = []
+
+    @property
+    def markers(self) -> list[str]:
+        return [text.split()[0] for text in self.seen]
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        self.seen.append(source_text)
+        if self.down and source_text.startswith(self.marker):
+            raise LLMError("provider down")
+        return [ExtractedFact(source_text.split()[0], "seen_in", "source", 0.9)]
+
+
+class _ReleaseWriteFails:
+    """Lose the write that settles a claim, leaving the chunk `running`.
+
+    THE INJECTION POINT IS THE WHOLE POINT, one layer below
+    `_CrashBelowChunkAccounting`. The chunk's own LLM call fails, so
+    `process_extraction_job`'s broad clause reaches its release point,
+    `_release_claimed_chunk` — which settles the claim through
+    `Store.mark_chunk_failed`. Failing THAT write is what leaves a chunk `running`
+    under a job that then comes to rest: the store error escapes the pipeline
+    without the chunk ever being settled, and the caller's broad `except` writes
+    the job `failed`. `tests/test_sources_running_chunk_display.py` names the same
+    route on a live KB. So the state reached here is the edge state of section J
+    WITH a `running` chunk in it, which is the case the branch's cost argument has
+    to answer for.
+    """
+
+    def __init__(self, monkeypatch):
+        # Imported here, not in the module's import block: this section is the
+        # only reader of it, and the class it needs is the error the store raises.
+        import sqlite3
+
+        self.error = sqlite3.OperationalError
+        self.armed = True
+        real = Store.mark_chunk_failed
+
+        def failing(store, chunk_id, error):
+            if self.armed:
+                raise self.error("database is locked")
+            return real(store, chunk_id, error)
+
+        monkeypatch.setattr(Store, "mark_chunk_failed", failing)
+
+    def heal(self) -> None:
+        self.armed = False
+
+
+def _j_chunk_states(store, job_id) -> list[tuple[str, int]]:
+    return [(str(row["status"]), int(row["attempts"])) for row in store.source_chunks(job_id)]
+
+
+def _pass_that_loses_the_release(tmp_path, release) -> int:
+    """One sync that cannot record its chunk failure, terminalised by its caller.
+
+    The `failed` write is `_worker_marks_job_failed`, for the reason recorded
+    there: nothing in `verinote/pipeline` writes it, and today only `web/app.py`
+    has the broad clause that does.
+    """
+    with pytest.raises(release.error):
+        cli.main(["sync"])
+    jobs = _jobs(tmp_path)
+    assert len(jobs) == 1  # the job is continued, never rebuilt beside itself
+    job_id = int(jobs[0]["id"])
+    store = _store(tmp_path)
+    _worker_marks_job_failed(
+        store, job_id, "analysis failed: OperationalError: database is locked"
+    )
+    store.close()
+    return job_id
+
+
+def _release_write_failed(tmp_path, monkeypatch):
+    """A KB whose newest job is the edge state, with a `running` chunk in it."""
+    _ingest(tmp_path, monkeypatch, body=_body(J_MARKERS))
+    release = _ReleaseWriteFails(monkeypatch)
+    client = _FailsOneChunk(J_MARKERS[1])
+    monkeypatch.setattr("verinote.llm.get_client", lambda cfg: client)
+    job_id = _pass_that_loses_the_release(tmp_path, release)
+    return job_id, client, release
+
+
+def test_plan_continues_a_finished_chunk_job_that_also_holds_a_running_one(tmp_path):
+    """A `running` chunk does NOT keep the job out of the new branch.
+
+    The unit-level half of the pair: `_edge_state_job` is the same fixture
+    `test_plan_retries_a_failed_job_that_holds_a_finished_chunk` uses, with one
+    chunk claimed and never settled — the row a lost release leaves.
+    `test_a_recurring_lost_release_does_not_spend_the_chunks_attempt_budget` below
+    is what says a real pass produces this state rather than only this fixture.
+
+    The branch is deliberately unguarded against `running`, and what pays for that
+    is the refund in the claim, not an exclusion here: excluding it would send the
+    job back to being rebuilt, throwing the finished chunk away again.
+    """
+    store, source_id, job_id = _edge_state_job(tmp_path, done=1)
+    claimed = store.source_chunks(job_id)[1]
+    store.mark_chunk_running(int(claimed["id"]))
+    assert _j_chunk_states(store, job_id) == [("done", 1), ("running", 1), ("pending", 0)]
+    assert int(store.get_extraction_job(job_id)["failed_chunks"]) == 0
+
+    plan = _plan_edge(store, source_id)
+    store.close()
+
+    assert plan == ExtractionJobPlan(retry_job_id=job_id)
+
+
+def test_a_recurring_lost_release_does_not_spend_the_chunks_attempt_budget(
+    tmp_path, monkeypatch
+):
+    """THE COST OF THE `running` CASE: a lost release must not give up on a source.
+
+    The claim rewinds a stray `running` chunk as it takes the job, and it refunds
+    the attempt while doing so (`Store.claim_extraction_job_for_retry`). Keep the
+    attempt instead and this exact sequence walks the chunk to `attempts` 1/2/3/4
+    over four passes of a condition that is not the chunk's content; the first
+    genuine content failure after the write heals then takes it to 5, past
+    `MAX_CHUNK_ATTEMPTS`, and planning gives up on the source FOR GOOD — where the
+    rebuild this branch replaced recovered it as soon as the provider came back.
+    That is what the second half of this test buys: the budget assertion alone
+    would still pass a fix that stopped counting but left the source stranded.
+
+    The finished chunk's marker appearing exactly once across every pass is the
+    #524 property holding in this state too — the reason the fix is the refund and
+    not excluding `running` chunks from the branch, which recovers the source by
+    rebuilding and pays the LLM for `alpha` on all four passes.
+    """
+    job_id, client, release = _release_write_failed(tmp_path, monkeypatch)
+    budget = []
+    for _ in range(3):
+        assert _pass_that_loses_the_release(tmp_path, release) == job_id
+        store = _store(tmp_path)
+        budget.append(_j_chunk_states(store, job_id)[1][1])
+        store.close()
+
+    # Four passes of a host condition, no content budget spent on any of them.
+    assert budget == [1, 1, 1]
+    store = _store(tmp_path)
+    assert _j_chunk_states(store, job_id) == [("done", 1), ("running", 1), ("pending", 0)]
+    store.close()
+    # The finished chunk was never re-sent, and only the failing one was retried.
+    assert client.markers == [J_MARKERS[0]] + [J_MARKERS[1]] * 4
+
+    # The write heals while the provider is still down: NOW the chunk fails for
+    # real, and the failure it records is its first.
+    release.heal()
+    assert cli.main(["sync"]) == 1
+    store = _store(tmp_path)
+    assert _j_chunk_states(store, job_id) == [("done", 1), ("failed", 1), ("done", 1)]
+    store.close()
+
+    # And the provider comes back. The source is recovered, not given up on.
+    client.down = False
+    assert cli.main(["sync"]) == 0
+    store = _store(tmp_path)
+    assert _j_chunk_states(store, job_id) == [("done", 1), ("done", 2), ("done", 1)]
+    store.close()
+    assert [int(job["id"]) for job in _jobs(tmp_path)] == [job_id]
+    assert sorted(_facts(tmp_path)) == sorted(J_MARKERS)
+
+
+def _facts(tmp_path) -> list[str]:
+    store = _store(tmp_path)
+    try:
+        return [str(fact["subject"]) for fact in store.facts()]
+    finally:
+        store.close()

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -26,6 +26,7 @@ from verinote.engine import DEFAULT_POLICY
 from verinote.llm.base import ExtractedFact, LLMError
 from verinote.pipeline import (
     MAX_CHUNK_ATTEMPTS,
+    ExtractionJobPlan,
     create_chunked_extraction_job,
     plan_source_extraction,
 )

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -827,21 +827,20 @@ J_MARKERS = MARKERS[:3]
 J_CHUNK_CHARS = 60
 
 
-def _worker_marks_job_failed(store: Store, job_id: int, message: str) -> None:
-    """Stand-in for the caller's broad `except`. NOT the code under test.
+def _put_job_in_the_edge_state(store: Store, job_id: int, message: str) -> None:
+    """Write the `failed` row directly, where no pass is being run to write it.
 
-    A crash below the chunk loop gives `process_extraction_job` nothing to say
-    about the job row, so it leaves the job `running`; the broad `except` a caller
-    ends with is what writes `failed` over it. In this tree only `web/app.py` has
-    one, so a CLI-driven test has to perform that write itself. Spelled out here
-    rather than hidden behind a fixture, the idiom
-    `test_chunk_claim_release.py::_worker_marks_job_failed` uses for the same
-    reason — nothing in `verinote/pipeline` will do it.
+    #488 landed, so both callers now end with a broad `except` that terminalises
+    the job (`web/app.py`; `cli.py` since then), and the tests below that DRIVE a
+    crash through `cli.main(["sync"])` get that row from the CLI itself — they no
+    longer call anything here. What is left are the two fixtures that build the
+    edge state without running a pass at all: there is no caller in play to do
+    the write, so they do it themselves.
 
-    DELETE THIS WHEN #488 LANDS. PR #523 gives `cmd_sync` the same broad clause,
-    at which point the sync below terminalises the job by itself and the correct
-    change is to drop the call and assert the `failed` row with zero failed chunks
-    that the CLI wrote — never to keep the stand-in so these lines stay green.
+    NOT the code under test either way. Nothing in `verinote/pipeline` writes the
+    job row on this path; that is the invariant `test_chunk_claim_release.py`
+    states, and the reason this write is spelled out rather than hidden behind a
+    fixture.
     """
     store.fail_extraction_job(job_id, message)
 
@@ -891,9 +890,9 @@ def _crashed_below_chunk_accounting(tmp_path, monkeypatch, *, before_chunk: int 
     assert len(jobs) == 1
     job_id = int(jobs[0]["id"])
     store = _store(tmp_path)
-    _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
-    # The edge state, asserted rather than assumed: `failed`, nothing charged to a
-    # chunk, and finished chunks a rebuild would throw away.
+    # The edge state, asserted rather than assumed, and written by `cmd_sync`'s own
+    # broad clause since #488 rather than staged here: `failed`, nothing charged to
+    # a chunk, and finished chunks a rebuild would throw away.
     job = store.get_extraction_job(job_id)
     assert job["status"] == "failed"
     assert int(job["failed_chunks"]) == 0
@@ -928,7 +927,7 @@ def _edge_state_job(tmp_path, *, done: int = 1):
     for row in store.source_chunks(job_id)[:done]:
         store.mark_chunk_running(int(row["id"]))
         store.mark_chunk_done(int(row["id"]), candidates=1)
-    _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
+    _put_job_in_the_edge_state(store, job_id, "analysis failed: RuntimeError: crash")
     assert int(store.get_extraction_job(job_id)["failed_chunks"]) == 0
     return store, source_id, job_id
 
@@ -1159,7 +1158,6 @@ def test_a_reproducing_crash_below_chunk_accounting_stops_paying_the_llm(
         # it, the same write `_crashed_below_chunk_accounting` made — so the state
         # under test recurs rather than being reached once.
         store = _store(tmp_path)
-        _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
         store.close()
         runs.append(_run_count(tmp_path))
 
@@ -1187,7 +1185,7 @@ def test_a_failed_job_that_finished_everything_terminalises_without_the_llm(
     job_id = int(jobs[0]["id"])
     assert jobs[0]["status"] == "done"
     store = _store(tmp_path)
-    _worker_marks_job_failed(store, job_id, "analysis failed: RuntimeError: crash")
+    _put_job_in_the_edge_state(store, job_id, "analysis failed: RuntimeError: crash")
     assert [c["status"] for c in store.source_chunks(job_id)] == ["done"] * len(J_MARKERS)
     store.close()
     runs_before = _run_count(tmp_path)
@@ -1275,20 +1273,16 @@ def _j_chunk_states(store, job_id) -> list[tuple[str, int]]:
 def _pass_that_loses_the_release(tmp_path, release) -> int:
     """One sync that cannot record its chunk failure, terminalised by its caller.
 
-    The `failed` write is `_worker_marks_job_failed`, for the reason recorded
-    there: nothing in `verinote/pipeline` writes it, and today only `web/app.py`
-    has the broad clause that does.
+    The `failed` row is written by `cmd_sync`'s own broad clause since #488 —
+    nothing in `verinote/pipeline` writes it, and this test asserts the row that
+    clause left rather than staging one.
     """
     with pytest.raises(release.error):
         cli.main(["sync"])
     jobs = _jobs(tmp_path)
     assert len(jobs) == 1  # the job is continued, never rebuilt beside itself
     job_id = int(jobs[0]["id"])
-    store = _store(tmp_path)
-    _worker_marks_job_failed(
-        store, job_id, "analysis failed: OperationalError: database is locked"
-    )
-    store.close()
+    assert str(jobs[0]["status"]) == "failed"  # written by cmd_sync, not staged
     return job_id
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1382,6 +1382,53 @@ def test_claim_extraction_job_for_retry_reclaims_a_stray_running_chunk_on_a_fail
     assert s.get_source_chunk(chunk_id)["status"] == "pending"  # stray reclaimed
 
 
+def test_claim_extraction_job_for_retry_refunds_the_stray_running_chunks_attempt(
+    tmp_path,
+):
+    """The stray rewind is the whole inverse of the claim, `attempts` included (#524).
+
+    A chunk left `running` under a job that came to rest `failed` is a claim that
+    reached no verdict — the frame died before it could record `done` or `failed`
+    — so the attempt was spent on the frame, not on the chunk's content. Keeping
+    it lets a condition of the host walk a chunk to `MAX_CHUNK_ATTEMPTS` and give
+    up on the source permanently, which is what `pipeline/extract.py` means by an
+    availability condition not spending a content budget.
+
+    The second chunk pins the clamp. This rewind has no compare-and-set, unlike
+    `requeue_chunk_claim`, so it sweeps rows nothing here claimed — including one
+    reset out of band to `running` at `attempts = 0`, which a bare `attempts - 1`
+    would drive negative.
+    """
+    s = _store(tmp_path)
+    sid = s.add_source("sources/a.txt")
+    job_id = s.create_extraction_job(
+        source_id=sid, provider="fake", model="m", total_chunks=2
+    )
+    claimed, out_of_band = s.add_source_chunks(
+        job_id=job_id, source_id=sid, chunks=["a", "b"]
+    )
+    s.mark_extraction_job_running(job_id)
+    s.mark_chunk_running(claimed)  # 'running', attempts = 1
+    s._conn.execute(
+        "UPDATE source_chunks SET status = 'running' WHERE id = ?", (out_of_band,)
+    )
+    s._conn.execute(
+        "UPDATE extraction_jobs SET status = 'failed' WHERE id = ?", (job_id,)
+    )
+    assert [(c["status"], c["attempts"]) for c in s.source_chunks(job_id)] == [
+        ("running", 1),
+        ("running", 0),
+    ]
+
+    assert s.claim_extraction_job_for_retry(job_id, max_attempts=3) is True
+
+    # Back exactly as `next_pending_chunk` first handed them out, and no negatives.
+    assert [(c["status"], c["attempts"]) for c in s.source_chunks(job_id)] == [
+        ("pending", 0),
+        ("pending", 0),
+    ]
+
+
 def test_mark_chunk_done_keeps_an_owned_job_running_against_a_second_claim(tmp_path):
     """W1 (#337): a chunk finishing mid-run must not drop an owned job to `pending`
     where a second connection's pending-claim could steal it.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1394,7 +1394,13 @@ def test_claim_extraction_job_for_retry_refunds_the_stray_running_chunks_attempt
     up on the source permanently, which is what `pipeline/extract.py` means by an
     availability condition not spending a content budget.
 
-    The second chunk pins the clamp. This rewind has no compare-and-set, unlike
+    THREE ROWS, because "inverse of the claim" says more than "back to zero" and
+    a fixture of first claims cannot tell the two apart. The first chunk is on its
+    first claim (`attempts` 1 -> 0). The second is on its SECOND (2 -> 1): give
+    back one attempt, not the whole count — a rewind that reset instead would
+    hand a chunk that has really failed once a fresh budget, and one that
+    subtracted two would take back an attempt the chunk did spend on its content.
+    The third pins the clamp: this rewind has no compare-and-set, unlike
     `requeue_chunk_claim`, so it sweeps rows nothing here claimed — including one
     reset out of band to `running` at `attempts = 0`, which a bare `attempts - 1`
     would drive negative.
@@ -1402,13 +1408,22 @@ def test_claim_extraction_job_for_retry_refunds_the_stray_running_chunks_attempt
     s = _store(tmp_path)
     sid = s.add_source("sources/a.txt")
     job_id = s.create_extraction_job(
-        source_id=sid, provider="fake", model="m", total_chunks=2
+        source_id=sid, provider="fake", model="m", total_chunks=3
     )
-    claimed, out_of_band = s.add_source_chunks(
-        job_id=job_id, source_id=sid, chunks=["a", "b"]
+    claimed, retried, out_of_band = s.add_source_chunks(
+        job_id=job_id, source_id=sid, chunks=["a", "b", "c"]
     )
     s.mark_extraction_job_running(job_id)
     s.mark_chunk_running(claimed)  # 'running', attempts = 1
+    # The second chunk failed once for real and was retried, so the claim this
+    # rewind is undoing is its second. Raw SQL for the requeue half: the method
+    # under test must not be what builds its own fixture.
+    s.mark_chunk_running(retried)
+    s.mark_chunk_failed(retried, "provider down")
+    s._conn.execute(
+        "UPDATE source_chunks SET status = 'pending' WHERE id = ?", (retried,)
+    )
+    s.mark_chunk_running(retried)  # 'running', attempts = 2
     s._conn.execute(
         "UPDATE source_chunks SET status = 'running' WHERE id = ?", (out_of_band,)
     )
@@ -1417,14 +1432,16 @@ def test_claim_extraction_job_for_retry_refunds_the_stray_running_chunks_attempt
     )
     assert [(c["status"], c["attempts"]) for c in s.source_chunks(job_id)] == [
         ("running", 1),
+        ("running", 2),
         ("running", 0),
     ]
 
     assert s.claim_extraction_job_for_retry(job_id, max_attempts=3) is True
 
-    # Back exactly as `next_pending_chunk` first handed them out, and no negatives.
+    # Back exactly as each row was before its last claim, and no negatives.
     assert [(c["status"], c["attempts"]) for c in s.source_chunks(job_id)] == [
         ("pending", 0),
+        ("pending", 1),
         ("pending", 0),
     ]
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4636,9 +4636,13 @@ def test_worker_sidecar_lock_does_not_overwrite_the_rollback(tmp_path, monkeypat
     handler takes it and calls `fail_extraction_job`. That is worse here than in
     the sibling cases: `process_extraction_job` has ALREADY rolled the job back to
     `pending` so the next pass resumes it, and the `failed` write lands on top of
-    that rollback. The result is a `failed` job with no failed chunk, which
-    `plan_source_extraction` treats as an edge state and rebuilds from scratch —
-    every chunk the pass finished is sent to the LLM again.
+    that rollback. The result is a `failed` job with no failed chunk. Since #524
+    `plan_source_extraction` continues such a job on the strength of the chunks it
+    finished rather than rebuilding from scratch, so those chunks are no longer
+    sent to the LLM again; what the overwrite still does is file a condition of
+    the host as this job's own failure — in the job row, in the
+    `extraction_job_failed` event, and on the Sources page — for a pause that
+    clears when the other process lets go.
 
     The stand-in raises after rewinding the job, which is the state the real
     pipeline hands the worker (`_back_off_from_locked_sidecar`).

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -783,9 +783,11 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     )
                     continue
                 # A resume picks a rolled-back job back up; a retry re-runs a failed
-                # job through the atomic claim, which resets its failed chunks under
-                # the same lock that takes ownership. Both continue an existing job;
-                # neither means build a fresh one.
+                # job through the atomic claim, which resets whatever failed chunks
+                # it has under the same lock that takes ownership — since #524 that
+                # may be none, and the claim is then only the lock, taking the job
+                # over so the chunks it already finished are not rebuilt away. Both
+                # continue an existing job; neither means build a fresh one.
                 continued_job_id = plan.resume_job_id or plan.retry_job_id
                 retry = plan.retry_job_id is not None
                 job_id = continued_job_id

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -784,9 +784,10 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     continue
                 # A resume picks a rolled-back job back up; a retry re-runs a failed
                 # job through the atomic claim, which resets whatever failed chunks
-                # it has under the same lock that takes ownership — since #524 that
-                # may be none, and the claim is then only the lock, taking the job
-                # over so the chunks it already finished are not rebuilt away. Both
+                # it has under the same lock that takes ownership — since #524 there
+                # may be none to reset, and the claim is then taken for the
+                # ownership alone, rewinding any stray `running` chunk on the way,
+                # so the chunks the job already finished are not rebuilt away. Both
                 # continue an existing job; neither means build a fresh one.
                 continued_job_id = plan.resume_job_id or plan.retry_job_id
                 retry = plan.retry_job_id is not None

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -331,7 +331,7 @@ def plan_source_extraction(
     production path reaches it today — #489 closed the read-back window that could
     leave a chunk `running`, and the chunk loop settles its claim to `failed` or
     `pending` or leaves the job `running`, which plans as `busy` — so the branch
-    is still worth offering, and this belongs to the same follow-up as the
+    is still worth offering, and this belongs to the same follow-up (#536) as the
     termination residue below.
 
     So the branch is offered unguarded, with one honest residue — a fault that
@@ -339,8 +339,8 @@ def plan_source_extraction(
     budget doing it, because `failed_chunk_attempt_status` counts `failed` chunks
     and this state has none. The LLM calls stop after the first pass; the run row
     and the two job events do not. Closing that needs a failure counter the chunk
-    rows cannot carry, so it is deliberately left to a follow-up rather than
-    charged to a chunk that did nothing wrong.
+    rows cannot carry, so it is deliberately left to a follow-up (#536) rather
+    than charged to a chunk that did nothing wrong.
 
     A `running` job is neither resumed nor replaced. It may belong to a live UI
     worker, and resuming would have `claim_pending_extraction_job`'s reclaim yank

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -222,8 +222,9 @@ class ExtractionJobPlan:
     back up where it left off; `retry_job_id` re-runs a `failed` job whose chunks
     are still worth continuing — either it has failed chunks with retry budget
     left, which the atomic claim resets under the lock that takes ownership, or it
-    has no failed chunk at all and the claim resets nothing, taking ownership so
-    the chunks it already finished are not thrown away (#524);
+    has no failed chunk to reset and the claim is taken for the ownership alone —
+    it still rewinds any stray `running` chunk — so the chunks it already finished
+    are not thrown away (#524);
     `exhausted_job_id` names a `failed` job that has given up — a chunk has failed
     every attempt, so the pass skips it instead of spinning the same dead chunk
     every sync (#323); `busy_job_id` says another process owns it and this pass must
@@ -299,21 +300,41 @@ def plan_source_extraction(
     chunk accounting: a caller's broad `except` writing `failed` over a crash that
     happened below the chunk loop, or a human resetting the rows out of band. When
     any chunk is `done`, rebuilding throws that finished work away and pays the LLM
-    for it again, so the job goes through the same retry claim — with nothing to
-    reset, the claim is only the lock that takes ownership, and the pass carries on
-    from the chunks left `pending`. When NO chunk is `done` there is no finished
-    work to lose and the two routes cost the same, so it still rebuilds.
+    for it again, so the job goes through the same retry claim — with no failed
+    chunk to reset, what the claim contributes is the ownership, plus a rewind of
+    any stray `running` chunk, and the pass carries on from the chunks left
+    `pending`. When NO chunk is `done` there is no finished work to lose and the
+    two routes cost the same, so it still rebuilds.
 
     THAT SECOND RETRY HAS NO EXHAUSTION GATE ABOVE IT, and the asymmetry is
     deliberate rather than an oversight. The gate exists because an all-exhausted
-    job can never make progress, so re-offering it is pure loss. Re-offering here
-    is never loss. Where the condition has cleared, the pass finishes the job;
-    where it reproduces, the alternative is strictly worse rather than better,
-    because rebuilding burns the same run row and the same two job events AND pays
-    the LLM for every finished chunk on top of them — measured over four syncs of
-    a reproducing fault on a six-chunk source, 2/4/6/8 cumulative calls rebuilding
-    against 2/2/2/2 continuing, with the run rows at 1/2/3/4 either way. So
-    the branch is offered unguarded, with one honest residue — a fault that
+    job can never make progress, so re-offering it is pure loss. For the chunk set
+    this state carries in practice — `done` and `pending`, nothing charged to any
+    chunk — re-offering is never loss. Where the condition has cleared the pass
+    finishes the job; where it reproduces, rebuilding burns the same run row and
+    the same two job events AND pays the LLM for every finished chunk on top of
+    them: measured over four syncs of a reproducing fault on a six-chunk source,
+    2/4/6/8 cumulative calls rebuilding against 2/2/2/2 continuing, with the run
+    rows at 1/2/3/4 either way.
+
+    A `running` chunk is the case that argument does NOT cover, and the code does
+    not exclude one. The retry claim rewinds a stray `running` chunk to `pending`
+    but does not refund the attempt it already spent (`store/db.py`,
+    `claim_extraction_job_for_retry`), so a host condition that keeps recurring
+    accumulates a CONTENT budget. Measured with the claim committing and the frame
+    then dying, four such passes leave the chunk at `attempts = 4` here against
+    `attempts = 1` under a rebuild, and one genuine content failure after that
+    takes it to 5 — past `max_chunk_attempts`, so the source is given up for good
+    (rc 1, five of six facts) exactly where the rebuild recovers it (rc 0, six of
+    six). That is this file's own rule about `MAX_CHUNK_ATTEMPTS` coming out the
+    wrong way: an availability condition must not spend a content budget. No
+    production path reaches it today — #489 closed the read-back window that could
+    leave a chunk `running`, and the chunk loop settles its claim to `failed` or
+    `pending` or leaves the job `running`, which plans as `busy` — so the branch
+    is still worth offering, and this belongs to the same follow-up as the
+    termination residue below.
+
+    So the branch is offered unguarded, with one honest residue — a fault that
     reproduces below the chunk accounting is re-offered every sync and spends no
     budget doing it, because `failed_chunk_attempt_status` counts `failed` chunks
     and this state has none. The LLM calls stop after the first pass; the run row

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -219,8 +219,11 @@ class ExtractionJobPlan:
     """What a sync pass should do about one source's newest extraction job.
 
     At most one field is set. `resume_job_id` picks a rolled-back `pending` job
-    back up where it left off; `retry_job_id` re-runs a `failed` job that still has
-    retry budget, resetting its failed chunks through the atomic claim;
+    back up where it left off; `retry_job_id` re-runs a `failed` job whose chunks
+    are still worth continuing — either it has failed chunks with retry budget
+    left, which the atomic claim resets under the lock that takes ownership, or it
+    has no failed chunk at all and the claim resets nothing, taking ownership so
+    the chunks it already finished are not thrown away (#524);
     `exhausted_job_id` names a `failed` job that has given up — a chunk has failed
     every attempt, so the pass skips it instead of spinning the same dead chunk
     every sync (#323); `busy_job_id` says another process owns it and this pass must
@@ -271,24 +274,50 @@ def plan_source_extraction(
     * its provider and model match the ones this run would use. Resume across a
       model change and the job row ends up mis-describing its own output.
 
-    These staleness gates guard the retry branch too, not just resume: a human can
-    fix the source text, chunk config, or model between one sync and the next, and
-    re-running a `failed` job against content it no longer describes is exactly as
-    wrong as resuming a `pending` one — either way the job is stale and rebuilt
-    fresh, which is why the gates run before the failed-chunk handling below.
+    These staleness gates guard both retry branches too, not just resume: a human
+    can fix the source text, chunk config, or model between one sync and the next,
+    and re-running a `failed` job against content it no longer describes is exactly
+    as wrong as resuming a `pending` one — either way the job is stale and rebuilt
+    fresh, which is why the gates run before all of the chunk handling below.
 
-    A `failed` job that is NOT stale is decided by its failed chunks. A failed
+    A `failed` job that is NOT stale is decided by its chunks: first the failed
+    ones, then — if it has none — the finished ones. A failed
     chunk is invisible to resume (`claim_pending_extraction_job`'s reclaim
     rewinds only `running`, `next_pending_chunk` claims only `pending`), so the
     job is re-run through the
     atomic retry claim, which resets the failed chunks under the same lock that
     takes ownership. But the moment ANY failed chunk has spent its whole attempt
     budget (`attempts >= max_chunk_attempts`) the job has given up: it is surfaced
-    as `exhausted` so the pass SKIPS it. Checking exhaustion BEFORE offering a
+    as `exhausted` so the pass SKIPS it. Checking exhaustion BEFORE offering THAT
     retry is the anti-spurious-run gate — retrying an all-exhausted job would claim
     it, reset nothing, and burn an empty run every sync, which is exactly the loop
     #323 exists to break. The web retry button stays the human escape hatch: it
     resets every failed chunk regardless of attempt count.
+
+    A `failed` job with NO failed chunk is decided by its finished chunks (#524).
+    Nothing charged the content, so the job was terminalised from outside the
+    chunk accounting: a caller's broad `except` writing `failed` over a crash that
+    happened below the chunk loop, or a human resetting the rows out of band. When
+    any chunk is `done`, rebuilding throws that finished work away and pays the LLM
+    for it again, so the job goes through the same retry claim — with nothing to
+    reset, the claim is only the lock that takes ownership, and the pass carries on
+    from the chunks left `pending`. When NO chunk is `done` there is no finished
+    work to lose and the two routes cost the same, so it still rebuilds.
+
+    THAT SECOND RETRY HAS NO EXHAUSTION GATE ABOVE IT, and the asymmetry is
+    deliberate rather than an oversight. The gate exists because an all-exhausted
+    job can never make progress, so re-offering it is pure loss. This branch
+    usually DOES make progress, because what terminalises a job from outside the
+    chunk accounting is typically a condition of the host that clears by itself.
+    And where it does not, the alternative is worse, not better: rebuilding burns
+    the same empty run AND pays the LLM for every finished chunk on top of it. So
+    the branch is offered unguarded, with one honest residue — a fault that
+    reproduces below the chunk accounting is re-offered every sync and spends no
+    budget doing it, because `failed_chunk_attempt_status` counts `failed` chunks
+    and this state has none. The LLM calls stop after the first pass; the run row
+    and the two job events do not. Closing that needs a failure counter the chunk
+    rows cannot carry, so it is deliberately left to a follow-up rather than
+    charged to a chunk that did nothing wrong.
 
     A `running` job is neither resumed nor replaced. It may belong to a live UI
     worker, and resuming would have `claim_pending_extraction_job`'s reclaim yank
@@ -312,7 +341,10 @@ def plan_source_extraction(
         return ExtractionJobPlan()
     if (job["provider"], job["model"]) != (provider, model):
         return ExtractionJobPlan()
-    persisted = [str(row["text"]) for row in store.source_chunks(latest_id)]
+    # One read, reused below: the text gate and the chunk-status decision then run
+    # on the same snapshot, so no chunk can change status between them.
+    chunk_rows = store.source_chunks(latest_id)
+    persisted = [str(row["text"]) for row in chunk_rows]
     current = _chunks_for(
         source_text,
         chunk_chars=chunk_chars,
@@ -328,8 +360,16 @@ def plan_source_extraction(
             return ExtractionJobPlan(exhausted_job_id=latest_id)
         return ExtractionJobPlan(retry_job_id=latest_id)
     if job["status"] != "pending":
-        # `failed` with no chunk currently failed is an edge state (e.g. a human
-        # reset them out of band) — nothing to resume or retry, so rebuild fresh.
+        # `failed` with no chunk currently failed: the job was terminalised from
+        # outside the chunk accounting. The chunk ROWS decide, not the job's
+        # `completed_chunks` counter — they are the authority the gate above
+        # already read, on the one snapshot.
+        if any(str(row["status"]) == "done" for row in chunk_rows):
+            # Finished chunks to lose, so continue the job rather than rebuild it.
+            # The retry claim has no failed chunk to reset here; it is being used
+            # for the ownership half of what it does (#524).
+            return ExtractionJobPlan(retry_job_id=latest_id)
+        # Nothing finished, so rebuilding discards nothing and costs the same.
         return ExtractionJobPlan()
     return ExtractionJobPlan(resume_job_id=latest_id)
 

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -212,8 +212,8 @@ def is_live_extraction_job(job, latest_job_ids: dict[int, int]) -> bool:
 # #524) — so a chunk claimed six times can still sit at one attempt if five of
 # those stopped on a peer process or a lost frame rather than on this chunk. That
 # is the point of the refund — an availability condition must not spend a content
-# budget. The web retry button is
-# a human override and ignores this cap (`max_attempts=None`).
+# budget. The web retry button is a human override and ignores this cap
+# (`max_attempts=None`).
 MAX_CHUNK_ATTEMPTS = 3
 
 
@@ -311,19 +311,26 @@ def plan_source_extraction(
 
     THAT SECOND RETRY HAS NO EXHAUSTION GATE ABOVE IT, and the asymmetry is
     deliberate rather than an oversight. The gate exists because an all-exhausted
-    job can never make progress, so re-offering it is pure loss. Nothing in the
-    chunk set this state carries can be exhausted: its statuses are `done`,
-    `pending` and `running`, while the give-up gate counts `failed` chunks
-    (`failed_chunk_attempt_status` is scoped to them) and this state has none by
-    the branch it arrived through. A `done` chunk does carry an attempt of its own
-    — the pass that finished it spent one — but no chunk here carries a FAILURE
-    for the gate to count, so re-offering is never loss. Where the condition has
-    cleared the pass
-    finishes the job; where it reproduces, rebuilding burns the same run row and
-    the same two job events AND pays the LLM for every finished chunk on top of
-    them: measured over four syncs of a reproducing fault on a six-chunk source,
-    2/4/6/8 cumulative calls rebuilding against 2/2/2/2 continuing, with the run
-    rows at 1/2/3/4 either way.
+    job can never make progress, so re-offering it is pure loss. Ordinarily
+    nothing here can be exhausted: what this branch passed is the job's
+    `failed_chunks` counter at zero, `mark_chunk_failed` keeps that counter in
+    step with the rows it writes, and the give-up gate counts `failed` rows
+    (`failed_chunk_attempt_status` is scoped to them). A `done` chunk does carry
+    an attempt of its own — the pass that finished it spent one — but a chunk that
+    spent its BUDGET carries a `failed` row, and the counter would have routed the
+    job to the gate above instead. The exception is the out-of-band reset named in
+    the paragraph above, which moves rows without the counter: a stale zero can
+    carry an exhausted `failed` row into this branch, and it costs one extra pass
+    — the pass's own `_refresh_extraction_job` puts the counter back and the next
+    plan answers `exhausted_job_id` (measured: counter 0 beside a `('failed', 99)`
+    row plans as `retry_job_id`, then `exhausted_job_id`).
+
+    Where the condition has cleared the pass finishes the job; where it
+    reproduces, rebuilding burns the same run row and the same two job events AND
+    pays the LLM for every finished chunk on top of them: measured over four syncs
+    of a reproducing fault on a six-chunk source, 2/4/6/8 cumulative calls
+    rebuilding against 2/2/2/2 continuing, with the run rows at 1/2/3/4 either
+    way.
 
     A `running` CHUNK reaches this branch, and the attempt it spent is refunded as
     the claim rewinds it. The route is the release write itself failing:

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -205,11 +205,14 @@ def is_live_extraction_job(job, latest_job_ids: dict[int, int]) -> bool:
 # counts the attempts a chunk has SPENT ON ITS OWN CONTENT — the initial pass plus
 # each auto-retry — so a chunk with `attempts >= MAX_CHUNK_ATTEMPTS` has spent the
 # whole budget and its job is surfaced as exhausted rather than retried forever
-# (#323). Not the same as "every `mark_chunk_running`": a claim released because
-# the fact-term sidecar was locked is refunded (`Store.requeue_chunk_claim`), so a
-# chunk claimed six times can still sit at one attempt if five of those stopped on
-# a peer process rather than on this chunk. That is the point of the refund — an
-# availability condition must not spend a content budget. The web retry button is
+# (#323). Not the same as "every `mark_chunk_running`": two releases refund the
+# claim instead of charging it — a chunk released because the fact-term sidecar
+# was locked (`Store.requeue_chunk_claim`), and a chunk a dead frame left
+# `running` for the retry claim to rewind (`Store.claim_extraction_job_for_retry`,
+# #524) — so a chunk claimed six times can still sit at one attempt if five of
+# those stopped on a peer process or a lost frame rather than on this chunk. That
+# is the point of the refund — an availability condition must not spend a content
+# budget. The web retry button is
 # a human override and ignores this cap (`max_attempts=None`).
 MAX_CHUNK_ATTEMPTS = 3
 
@@ -223,8 +226,8 @@ class ExtractionJobPlan:
     are still worth continuing — either it has failed chunks with retry budget
     left, which the atomic claim resets under the lock that takes ownership, or it
     has no failed chunk to reset and the claim is taken for the ownership alone —
-    it still rewinds any stray `running` chunk — so the chunks it already finished
-    are not thrown away (#524);
+    it still rewinds any stray `running` chunk, refunding its attempt — so the
+    chunks it already finished are not thrown away (#524);
     `exhausted_job_id` names a `failed` job that has given up — a chunk has failed
     every attempt, so the pass skips it instead of spinning the same dead chunk
     every sync (#323); `busy_job_id` says another process owns it and this pass must
@@ -301,38 +304,48 @@ def plan_source_extraction(
     happened below the chunk loop, or a human resetting the rows out of band. When
     any chunk is `done`, rebuilding throws that finished work away and pays the LLM
     for it again, so the job goes through the same retry claim — with no failed
-    chunk to reset, what the claim contributes is the ownership, plus a rewind of
-    any stray `running` chunk, and the pass carries on from the chunks left
-    `pending`. When NO chunk is `done` there is no finished work to lose and the
+    chunk to reset, what the claim contributes is the ownership, plus a refunding
+    rewind of any stray `running` chunk, and the pass carries on from the chunks
+    left `pending`. When NO chunk is `done` there is no finished work to lose and the
     two routes cost the same, so it still rebuilds.
 
     THAT SECOND RETRY HAS NO EXHAUSTION GATE ABOVE IT, and the asymmetry is
     deliberate rather than an oversight. The gate exists because an all-exhausted
-    job can never make progress, so re-offering it is pure loss. For the chunk set
-    this state carries in practice — `done` and `pending`, nothing charged to any
-    chunk — re-offering is never loss. Where the condition has cleared the pass
+    job can never make progress, so re-offering it is pure loss. Nothing in the
+    chunk set this state carries can be exhausted: its statuses are `done`,
+    `pending` and `running`, while the give-up gate counts `failed` chunks
+    (`failed_chunk_attempt_status` is scoped to them) and this state has none by
+    the branch it arrived through. A `done` chunk does carry an attempt of its own
+    — the pass that finished it spent one — but no chunk here carries a FAILURE
+    for the gate to count, so re-offering is never loss. Where the condition has
+    cleared the pass
     finishes the job; where it reproduces, rebuilding burns the same run row and
     the same two job events AND pays the LLM for every finished chunk on top of
     them: measured over four syncs of a reproducing fault on a six-chunk source,
     2/4/6/8 cumulative calls rebuilding against 2/2/2/2 continuing, with the run
     rows at 1/2/3/4 either way.
 
-    A `running` chunk is the case that argument does NOT cover, and the code does
-    not exclude one. The retry claim rewinds a stray `running` chunk to `pending`
-    but does not refund the attempt it already spent (`store/db.py`,
-    `claim_extraction_job_for_retry`), so a host condition that keeps recurring
-    accumulates a CONTENT budget. Measured with the claim committing and the frame
-    then dying, four such passes leave the chunk at `attempts = 4` here against
-    `attempts = 1` under a rebuild, and one genuine content failure after that
-    takes it to 5 — past `max_chunk_attempts`, so the source is given up for good
-    (rc 1, five of six facts) exactly where the rebuild recovers it (rc 0, six of
-    six). That is this file's own rule about `MAX_CHUNK_ATTEMPTS` coming out the
-    wrong way: an availability condition must not spend a content budget. No
-    production path reaches it today — #489 closed the read-back window that could
-    leave a chunk `running`, and the chunk loop settles its claim to `failed` or
-    `pending` or leaves the job `running`, which plans as `busy` — so the branch
-    is still worth offering, and this belongs to the same follow-up (#536) as the
-    termination residue below.
+    A `running` CHUNK reaches this branch, and the attempt it spent is refunded as
+    the claim rewinds it. The route is the release write itself failing:
+    `_release_claimed_chunk` settles the loop's last claim through
+    `Store.mark_chunk_failed`, and when THAT write raises, the chunk stays
+    `running`, the store error leaves `process_extraction_job`, and the caller's
+    broad `except` writes the job `failed` — this state, with a `running` chunk in
+    it (`tests/test_sources_running_chunk_display.py` names the same route). The
+    endings that settle the claim to `failed` or `pending`, and the caller with no
+    broad clause that leaves the job `running` to plan as `busy`, are the other
+    ways the loop can end, not the only ones. Keeping the attempt would make each
+    such pass spend a CONTENT budget on a condition of the host, which is this
+    file's own `MAX_CHUNK_ATTEMPTS` rule coming out the wrong way: measured on a
+    three-chunk source whose release write always fails, four passes put the chunk
+    at `attempts` 1/2/3/4 and the first genuine content failure after the write
+    heals takes it to 5 — past `max_chunk_attempts` — so the source is given up
+    for good at two facts of three, where a rebuild recovers all three. So the
+    retry claim refunds as it rewinds (`store/db.py`,
+    `claim_extraction_job_for_retry`), the inverse `requeue_chunk_claim` already
+    performs for the sidecar case: the same measurement then holds at `attempts`
+    1/1/1/1 and recovers all three facts, at the continuing pass's price of 2/3/4/5
+    cumulative LLM calls against a rebuild's 2/4/6/8.
 
     So the branch is offered unguarded, with one honest residue — a fault that
     reproduces below the chunk accounting is re-offered every sync and spends no
@@ -390,7 +403,8 @@ def plan_source_extraction(
         if any(str(row["status"]) == "done" for row in chunk_rows):
             # Finished chunks to lose, so continue the job rather than rebuild it.
             # The retry claim has no failed chunk to reset here; it is being used
-            # for the ownership half of what it does (#524).
+            # for the ownership half of what it does, and for the refunding rewind
+            # of a chunk a dead frame left `running` (#524).
             return ExtractionJobPlan(retry_job_id=latest_id)
         # Nothing finished, so rebuilding discards nothing and costs the same.
         return ExtractionJobPlan()
@@ -653,11 +667,13 @@ def process_extraction_job(
         # above its broad one and both write nothing (`web/app.py`; `cli.py` too
         # since #488). Take that pair away and the broad `except Exception` under
         # them would file a condition of the host as this job's own failure, in
-        # the job row and in the `extraction_job_failed` event beside it, and cost
-        # the chunks this pass finished for as long as planning reads such a job
-        # as "rebuild fresh" (#524) — measured with this rewind disabled: the job
-        # is left `running` and no `extraction_job_failed` event is written. The
-        # rewind is what keeps the next pass on this job and the record true.
+        # the job row and in the `extraction_job_failed` event beside it —
+        # measured with this rewind disabled: the job is left `running` and no
+        # `extraction_job_failed` event is written. Since #524 that write no
+        # longer costs the chunks this pass finished on top of that: a `failed`
+        # job holding finished chunks is continued through the retry claim
+        # rather than rebuilt, so the LLM is not paid for them a second time.
+        # The rewind is what keeps the next pass on this job and the record true.
         _back_off_from_locked_sidecar(
             store,
             job_id=job_id,

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -306,11 +306,13 @@ def plan_source_extraction(
 
     THAT SECOND RETRY HAS NO EXHAUSTION GATE ABOVE IT, and the asymmetry is
     deliberate rather than an oversight. The gate exists because an all-exhausted
-    job can never make progress, so re-offering it is pure loss. This branch
-    usually DOES make progress, because what terminalises a job from outside the
-    chunk accounting is typically a condition of the host that clears by itself.
-    And where it does not, the alternative is worse, not better: rebuilding burns
-    the same empty run AND pays the LLM for every finished chunk on top of it. So
+    job can never make progress, so re-offering it is pure loss. Re-offering here
+    is never loss. Where the condition has cleared, the pass finishes the job;
+    where it reproduces, the alternative is strictly worse rather than better,
+    because rebuilding burns the same run row and the same two job events AND pays
+    the LLM for every finished chunk on top of them — measured over four syncs of
+    a reproducing fault on a six-chunk source, 2/4/6/8 cumulative calls rebuilding
+    against 2/2/2/2 continuing, with the run rows at 1/2/3/4 either way. So
     the branch is offered unguarded, with one honest residue — a fault that
     reproduces below the chunk accounting is re-offered every sync and spends no
     budget doing it, because `failed_chunk_attempt_status` counts `failed` chunks

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1504,13 +1504,16 @@ class Store:
         spend a content budget, and `requeue_chunk_claim` is the same refund for
         the sidecar case.
 
-        NO GATE THAT WAS OPERATING IS WEAKENED, and where the give-up gate reads
-        is why. `failed_chunk_attempt_status` is scoped `WHERE status = 'failed'`
-        and planning consults it only under `failed_chunks > 0`, so the attempts
-        on a chunk sitting `running` gate nothing while it sits there; every
-        attempt that ended in a recorded `failed` is still counted, and the
-        un-refunded count never stopped a spin — it only ever surfaced later, as
-        the over-charge above. What the refund does move is WHEN exhaustion
+        EXHAUSTION IS STILL REACHED; WHAT MOVES IS WHEN. Where the give-up gate
+        reads is why. `failed_chunk_attempt_status` is scoped
+        `WHERE status = 'failed'` and planning consults it only under
+        `failed_chunks > 0`, so the attempts on a chunk sitting `running` gate
+        nothing while it sits there; every attempt that ended in a recorded
+        `failed` is still counted. The un-refunded count did stop spins, just
+        earlier than the content justified — measured at the cap of 3, it gave
+        up two passes and two LLM calls sooner in both patterns below, on one
+        and two recorded failures rather than three. Being early IS the
+        over-charge above, not a second property. What the refund does move is WHEN exhaustion
         arrives for a chunk that both fails for real and loses frames: it now
         always takes `MAX_CHUNK_ATTEMPTS` recorded failures however many frames
         died, where the charged rewind reached the cap on fewer — measured at the
@@ -1525,16 +1528,28 @@ class Store:
         `mark_chunk_running` put there (>= 1); this one sweeps every `running` row
         on the job, including rows reset out of band, and a `running` row carrying
         `attempts = 0` would otherwise go negative. THE OTHER THING THAT CAS
-        BUYS — never refunding a claim that is somebody else's — is bought here by
-        the job CAS a few lines above instead: it matches only `pending`/`failed`,
-        and a live worker holds its job `running` for the whole pass (#337). The
-        one path that writes a job `pending` under a live chunk,
-        `rollback_extraction_job`, rewinds that chunk itself under the same lock.
+        BUYS — never refunding a claim that is somebody else's — is bought on the
+        ordinary paths by the job CAS a few lines above: it matches only
+        `pending`/`failed`, and a live worker holds its job `running` for the
+        whole pass (#337). It is NOT bought in the window #242 already names.
+        `self._lock` is a `threading.RLock`, so it fences nothing across
+        processes, and `rollback_extraction_job` rewinds only the chunks that
+        are `running` when it runs — a worker that keeps going claims its NEXT
+        chunk afterwards, under a job another process may then write `failed`.
+        Measured with two live connections in separate processes: this claim
+        rewound and refunded a chunk the other process was holding.
+        `web/app.py` states the same boundary for the rollback itself ("in that
+        rare case this rollback still resets that live job's in-flight chunk"),
+        and `cli.py`'s `sync --recover` records that there is no liveness check.
+        Closing it is that follow-up, not this one; the refund's direction here
+        is toward retrying again, not toward giving up early.
 
         THE TWO REWINDS THAT DO NOT REFUND stay that way, one for a reason and one
         as residue. `claim_pending_extraction_job`'s sweep is this one minus the
-        refund, and by its own account "a defensive no-op" that fires in no real
-        path — there is no charge to give back. `rollback_extraction_job` is the
+        refund. Its own comment calls it "a defensive no-op", and on the
+        ordinary paths it is; in the same #242 window as above it does fire, and
+        the row it sweeps carries the attempt `mark_chunk_running` charged
+        (measured, two processes). Refunding there belongs with the window. `rollback_extraction_job` is the
         one with a live gap: the reason `requeue_chunk_claim` records for it — a
         halt freezes the whole KB against writes, so the count is not what stands
         in the way — covers its two halt callers (`_halt_extraction_job` and the

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1386,10 +1386,13 @@ class Store:
         locked sidecar clears the moment the other process lets go, and the very
         next pass should find the budget it started with.
 
-        WHO READS `attempts`. Planning reads it in exactly two places,
-        `failed_chunk_attempt_status` and `claim_extraction_job_for_retry`, and
-        both are scoped `WHERE status = 'failed'` — so a refunded `pending` chunk
-        is invisible to them, and the refund reaches planning only later, if this
+        WHO READS `attempts`. Planning reads it in exactly two places, and both
+        READINGS are scoped to `failed` chunks: `failed_chunk_attempt_status`
+        (`WHERE status = 'failed'`) and `claim_extraction_job_for_retry`, whose
+        `attempts < max_attempts` reset carries the same scope. That second method
+        also WRITES `attempts` outside it — its stray rewind refunds `running`
+        rows (#524) — but it reads none. So a refunded `pending` chunk is
+        invisible to both, and the refund reaches planning only later, if this
         chunk goes on to fail for real. There is a third reader, and it is not
         scoped: `_chunk_event_payload` carries `attempts` into every
         `chunk_failed`/`chunk_retried` payload in `fact_events`, so a refund does
@@ -1501,33 +1504,50 @@ class Store:
         spend a content budget, and `requeue_chunk_claim` is the same refund for
         the sidecar case.
 
-        NOTHING IS UN-GATED BY THE REFUND, and where the give-up gate reads is
-        why. `failed_chunk_attempt_status` is scoped `WHERE status = 'failed'` and
-        planning consults it only under `failed_chunks > 0`, so the attempts on a
-        chunk sitting `running` gate nothing while it sits there; every attempt
-        that ended in a recorded `failed` is still counted, and the un-refunded
-        count never stopped a spin — it only ever surfaced later, as the
-        over-charge above. The one behavioural edge is a chunk that alternates
-        between failing for real and dying with the frame: it now needs one more
-        RECORDED failure to exhaust. That is the intended reading of `attempts` —
-        a claim that reached no verdict left no evidence about the content.
+        NO GATE THAT WAS OPERATING IS WEAKENED, and where the give-up gate reads
+        is why. `failed_chunk_attempt_status` is scoped `WHERE status = 'failed'`
+        and planning consults it only under `failed_chunks > 0`, so the attempts
+        on a chunk sitting `running` gate nothing while it sits there; every
+        attempt that ended in a recorded `failed` is still counted, and the
+        un-refunded count never stopped a spin — it only ever surfaced later, as
+        the over-charge above. What the refund does move is WHEN exhaustion
+        arrives for a chunk that both fails for real and loses frames: it now
+        always takes `MAX_CHUNK_ATTEMPTS` recorded failures however many frames
+        died, where the charged rewind reached the cap on fewer — measured at the
+        cap of 3, two recorded failures when a death alternates with each failure
+        and one when two deaths land ahead of the first — because it counted the
+        deaths as if the content had failed. The cap's own number is the right
+        one: a claim that reached no verdict left no evidence about the content.
 
         `MAX(attempts - 1, 0)` rather than a bare `attempts - 1` because this
         UPDATE has no compare-and-set. `requeue_chunk_claim` pins the count its
         own claim wrote, so it can only ever decrement a value
         `mark_chunk_running` put there (>= 1); this one sweeps every `running` row
         on the job, including rows reset out of band, and a `running` row carrying
-        `attempts = 0` would otherwise go negative.
+        `attempts = 0` would otherwise go negative. THE OTHER THING THAT CAS
+        BUYS — never refunding a claim that is somebody else's — is bought here by
+        the job CAS a few lines above instead: it matches only `pending`/`failed`,
+        and a live worker holds its job `running` for the whole pass (#337). The
+        one path that writes a job `pending` under a live chunk,
+        `rollback_extraction_job`, rewinds that chunk itself under the same lock.
 
-        THE TWO REWINDS THAT DO NOT REFUND stay that way for their own reasons.
-        `claim_pending_extraction_job`'s identical sweep is by its own account "a
-        defensive no-op" that fires in no real path — there is no charge to give
-        back. `rollback_extraction_job` leaves `attempts` alone deliberately, for
-        the reason `requeue_chunk_claim` records: a halt freezes the whole KB
-        against writes, so the count is not what stands in the way. What #536 still
-        owns is the residue no chunk row can carry — a fault reproducing below the
-        chunk accounting burns a run row and two job events every pass, and this
-        refund does not touch that.
+        THE TWO REWINDS THAT DO NOT REFUND stay that way, one for a reason and one
+        as residue. `claim_pending_extraction_job`'s sweep is this one minus the
+        refund, and by its own account "a defensive no-op" that fires in no real
+        path — there is no charge to give back. `rollback_extraction_job` is the
+        one with a live gap: the reason `requeue_chunk_claim` records for it — a
+        halt freezes the whole KB against writes, so the count is not what stands
+        in the way — covers its two halt callers (`_halt_extraction_job` and the
+        sidecar back-off, both `pipeline/extract.py`) and NOT its other two, which
+        are crash recovery rather than halts (`web/app.py`'s restart resume,
+        `cli.py`'s `sync --recover`). The `running` chunk those two rewind is the
+        very class this refund is about, and its attempt stays charged there — the
+        same over-charge reached by a different path. Pre-existing, outside #524,
+        and named here rather than covered: it is not the residue #536 owns
+        either, and wants a ticket of its own. What #536 does own is the residue no
+        chunk row can carry — a fault reproducing below the chunk accounting burns
+        a run row and two job events every pass, and this refund does not touch
+        that.
         """
         with self._lock:
             before = self.get_extraction_job(job_id)

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1482,6 +1482,52 @@ class Store:
         can surface the job as given up. Raw SQL, never `_refresh_extraction_job`:
         the status is ours by the CAS above and stays `running` for the whole owned
         pass (#337), so re-deriving it from the chunks here would only be redundant.
+
+        THE STRAY `running` REWIND REFUNDS ITS ATTEMPT (#524). A chunk left
+        `running` under a job that came to rest `failed` is a claim that never
+        reached a verdict — the frame holding it died without recording `done` or
+        `failed`. The live route is the release write itself failing:
+        `process_extraction_job`'s broad clause releases through
+        `mark_chunk_failed`, and when THAT write raises, the chunk stays `running`,
+        the error leaves the pipeline, and the caller's own broad `except` writes
+        the job `failed` (`tests/test_sources_running_chunk_display.py` names the
+        same route). Planning routes such a job here now instead of rebuilding it,
+        so charging the claim would let a condition of the host spend the content
+        budget `MAX_CHUNK_ATTEMPTS` guards: four passes of a recurring one leave
+        the chunk at `attempts = 4`, and the first genuine content failure after
+        that takes it past the cap and gives up on the source for good — where the
+        rebuild used to recover it as soon as the condition cleared.
+        `pipeline/extract.py` states the rule an availability condition must not
+        spend a content budget, and `requeue_chunk_claim` is the same refund for
+        the sidecar case.
+
+        NOTHING IS UN-GATED BY THE REFUND, and where the give-up gate reads is
+        why. `failed_chunk_attempt_status` is scoped `WHERE status = 'failed'` and
+        planning consults it only under `failed_chunks > 0`, so the attempts on a
+        chunk sitting `running` gate nothing while it sits there; every attempt
+        that ended in a recorded `failed` is still counted, and the un-refunded
+        count never stopped a spin — it only ever surfaced later, as the
+        over-charge above. The one behavioural edge is a chunk that alternates
+        between failing for real and dying with the frame: it now needs one more
+        RECORDED failure to exhaust. That is the intended reading of `attempts` —
+        a claim that reached no verdict left no evidence about the content.
+
+        `MAX(attempts - 1, 0)` rather than a bare `attempts - 1` because this
+        UPDATE has no compare-and-set. `requeue_chunk_claim` pins the count its
+        own claim wrote, so it can only ever decrement a value
+        `mark_chunk_running` put there (>= 1); this one sweeps every `running` row
+        on the job, including rows reset out of band, and a `running` row carrying
+        `attempts = 0` would otherwise go negative.
+
+        THE TWO REWINDS THAT DO NOT REFUND stay that way for their own reasons.
+        `claim_pending_extraction_job`'s identical sweep is by its own account "a
+        defensive no-op" that fires in no real path — there is no charge to give
+        back. `rollback_extraction_job` leaves `attempts` alone deliberately, for
+        the reason `requeue_chunk_claim` records: a halt freezes the whole KB
+        against writes, so the count is not what stands in the way. What #536 still
+        owns is the residue no chunk row can carry — a fault reproducing below the
+        chunk accounting burns a run row and two job events every pass, and this
+        refund does not touch that.
         """
         with self._lock:
             before = self.get_extraction_job(job_id)
@@ -1511,12 +1557,15 @@ class Store:
                 f"updated_at = datetime('now') WHERE {where}",
                 params,
             )
-            # Reclaim any stray `running` chunk a crashed run left behind, exactly
-            # as `claim_pending_extraction_job` does — raw update, no event, no
-            # refresh; a claimed job has no legitimate `running` chunk here.
+            # Reclaim any stray `running` chunk a crashed run left behind — raw
+            # update, no event, no refresh, as `claim_pending_extraction_job`
+            # does; a claimed job has no legitimate `running` chunk here. The
+            # attempt goes back with it: that claim reached no verdict, and the
+            # docstring above says why keeping it gives up on the source (#524).
             self._conn.execute(
                 "UPDATE source_chunks SET status = 'pending', error = '', "
-                "updated_at = datetime('now') WHERE job_id = ? AND status = 'running'",
+                "attempts = MAX(attempts - 1, 0), updated_at = datetime('now') "
+                "WHERE job_id = ? AND status = 'running'",
                 (job_id,),
             )
             for chunk in failed_chunks:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1767,11 +1767,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # This handler writes NOTHING, and here that is not merely
                 # conservative — `process_extraction_job` has already rolled the job
                 # back to `pending` so the next pass RESUMES it, and
-                # `fail_extraction_job` would overwrite that with `failed`. A
-                # `failed` job whose chunks are all `pending`/`done` has no failed
-                # chunk for planning to retry, so `plan_source_extraction` reads it
-                # as an edge state and rebuilds from scratch, paying the LLM again
-                # for every chunk this pass finished. Log and leave it.
+                # `fail_extraction_job` would overwrite that with `failed`. That
+                # overwrite no longer costs what it used to: a `failed` job whose
+                # chunks are all `pending`/`done` has no failed chunk for planning
+                # to retry, and planning now continues it on the strength of the
+                # chunks it finished instead of rebuilding from scratch (#524), so
+                # the LLM is not paid twice for them. What the overwrite still
+                # costs is the truth. `pending` is what this job is — nothing is
+                # running and nothing failed the content — while `failed` files a
+                # condition of the host as this job's own failure, in the job row,
+                # in the `extraction_job_failed` event beside it, and on the
+                # Sources page that reads them. Log and leave it.
                 logger.warning(
                     "extraction job %s paused (fact-term store locked by another "
                     "process): %s",


### PR DESCRIPTION
# PR body draft — issue #524

- 브랜치 `fix/524-rebuild-discards-finished-chunks`, base `origin/main` = `e032738`
- 커밋 6개: `30b2355`, `cdbc5ff`, `96af62b`, `beff39c`, `0368f1c`, `5a62f02`
- **인용 규칙:** 코드는 **심볼명 + 짧은 인용**으로 가리킨다. 줄번호는 리뷰어가 diff 를
  뜰 base(`e032738`) 기준으로만 쓰고, 팁 번호는 쓰지 않는다 — 산문 커밋이 계속
  들어가면서 팁 번호가 라운드마다 어긋났다.

---

## 무엇

청크 회계 **바깥**에서 죽은 잡 — `failed` 인데 `failed_chunks` 는 0 — 중 **이미 청크를 하나 이상 끝낸** 것을 `plan_source_extraction` 이 "rebuild fresh" 로 읽었다. 다음 `verinote sync` 는 새 잡을 만들고, 그 첫 동작이 크래시한 패스가 **이미 지불한** 청크를 전부 LLM 에 다시 보내는 것이었다. Closes #524.

범위는 그 문장 그대로다. "회계 바깥 실패" 전부가 아니다 — 청크 0의 claim read-back 에서 죽어 `done` 청크가 0개면 폐기되는 완료 작업이 없고 두 경로의 LLM 비용이 같으므로, 그 경우는 **여전히 rebuild** 다. 이슈가 범위 밖으로 명시한 *"`verinote sync` 가 소스를 전부 건너뛰고도 rc 0 과 완료 메시지를 찍는 문제"* 도 포함하지 않는다.

## 무엇을 했나

**둘이다.** (1) `plan_source_extraction` 이 `failed_chunks == 0` 인 비-`pending` 잡에서 **청크 행**을 보고, `done` 이 하나라도 있으면 `retry_job_id` 로 라우팅한다. (2) 그 라우팅이 죽은 프레임이 남긴 `running` 청크를 재시도 클레임으로 데려오므로, 클레임의 stray-`running` 되감기가 **그 시도를 환불한다**(`store/db.py`, 리뷰 블로킹 2 에 대한 응답 — 아래 "`running` 청크와 환불"). `e032738` 의 315행이 이미 부르고 버리던 `store.source_chunks(latest_id)` 를 붙잡아 재사용했다 — 추가 쿼리 없음, store 신규 메서드 없음. 텍스트 게이트와 status 판정이 **같은 한 번의 읽기** 위에서 돈다(잡 행은 여전히 별도 읽기다 — 한 스냅샷을 공유하는 것은 그 둘뿐이다).

**이슈는 "resume" 이라고 썼지만 `resume_job_id` 로 구현하면 지금보다 나빠진다.** 실측:

```
INJECT=next_pending_chunk, 5회 sync
  run 1: RuntimeError, LLM +2
  run 2..5: rc=0, LLM +0
  stderr × 4: "skipping sources/doc.txt: extraction job #1 is already running
               (another process owns its chunks)"
  stdout × 4: "sync complete: 0 candidate(s) from 0 source(s) (run #0)"
  job 1: failed, chunks [(0,done),(1,done),(2,pending),(3,pending)] — 5회 내내 불변
```

`claim_pending_extraction_job` 의 CAS 가 `WHERE id = ? AND status = 'pending'` 이라 `failed` 잡에는 rowcount 0 → `ExtractionJobBusyError` → CLI 가 **아무도 소유하지 않은 잡을 "남이 돌리는 중"이라고 거짓 보고하며 rc 0 으로 영구 정지**한다. `claim_extraction_job_for_retry` 의 CAS 는 `status IN ('pending','failed')` 이고, 같은 락 안에서 소유권을 잡고 `failed` 청크를 리셋한 뒤(여기선 0개) **떠도는 `running` 청크를 `pending` 으로 되감는다**(그 두 번째 UPDATE 는 되감으면서 `attempts` 를 **환불한다** — 아래 "`running` 청크와 환불" 참고). **`done` 행에 닿는 SQL 은 없다.**

새 분기는 **다섯 개 staleness 게이트 아래, `failed_chunks > 0` 분기 아래**에 있다.

## 측정 — 무엇이 닫히고 무엇이 안 닫히나

6청크 소스, 청크 2 앞에서 재현되는 결함, 매 패스마다 호출자의 broad clause 가 잡을 종료시키는 조건으로 `verinote sync` 4회:

```
CONTINUED (this PR)          REBUILD (pre-#524)
pass 1  llm=2 runs=1 jobs=[1]      llm=2 runs=1 jobs=[1]
pass 2  llm=2 runs=2 jobs=[1]      llm=4 runs=2 jobs=[2,1]
pass 3  llm=2 runs=3 jobs=[1]      llm=6 runs=3 jobs=[3,2,1]
pass 4  llm=2 runs=4 jobs=[1]      llm=8 runs=4 jobs=[4,3,2,1]
잡 이벤트는 양쪽 모두 매 패스 extraction_job_started +1 / extraction_job_failed +1
```

| | base (`e032738`) | 이 PR |
|---|---|---|
| 누적 LLM 호출 (4패스) | 2 / 4 / 6 / 8 | **2 / 2 / 2 / 2** |
| 생성된 잡 | 4 | **1** |
| 폐기된 완료 청크 | 매 패스 2개 | **0** |
| `runs` 행 | 1 / 2 / 3 / 4 | **1 / 2 / 3 / 4 (변화 없음)** |
| 잡 이벤트 (`started` + `failed`) | 패스마다 +2 | **패스마다 +2 (변화 없음)** |
| 예산 소진 / give-up | 없음 | **없음 (미해결)** |

닫히는 것은 **LLM 비용과 완료 청크 폐기**다. **종료성은 닫히지 않는다.** `failed_chunk_attempt_status` 가 `WHERE job_id = ? AND status = 'failed'` 라, 회계 바깥에서 죽는 결함은 어떤 청크 예산도 쓰지 않는다. 지속 결함에서 run 행과 잡 이벤트는 base 와 **같은 속도로** 계속 쌓인다. 잡 레벨 실패 카운터(스키마 변경)를 요구하므로 별도 이슈로 뺐고, 여기서 억지로 닫으면 이 레포가 명시적으로 거부하는 "호스트 조건을 콘텐츠 예산에 청구" 를 하게 된다. `test_a_reproducing_crash_below_chunk_accounting_stops_paying_the_llm` 의 `assert runs == [2, 3, 4]` 가 그 비용을 **CHARACTERISATION 으로** 못박아 두었다.

## `running` 청크와 환불 — 이 PR 의 유일한 코드 변경

`failed_chunks > 0` 분기의 소진 게이트는 **소진된 잡이 절대 진전할 수 없기 때문에** 있다. 새 분기의 재제안은 이 상태가 나르는 청크 집합에 대해서는 순손실이 아니다 — 조건이 풀리면 그 패스가 잡을 끝내고, 재현되면 rebuild 가 같은 run 행·같은 잡 이벤트를 태우면서 LLM 까지 더 낸다(위 표).

**그 집합에 `running` 청크가 들어오고, 도달 경로는 실재한다.** 청크 루프의 마지막 해제 지점 `_release_claimed_chunk` 가 `Store.mark_chunk_failed` 로 클레임을 정리하는데 **그 쓰기가 raise 하면** 청크는 `running` 으로 남고, 스토어 오류가 `process_extraction_job` 을 탈출하며, 호출자의 광범위 `except` 가 잡을 `failed` 로 쓴다 — `failed` 잡 + 실패 청크 0 + `done` 청크 + `running` 청크. `main` 의 `tests/test_sources_running_chunk_display.py` 모듈 docstring 이 같은 경로를 이름한다.

되감기가 `attempts` 를 환불하지 않으면 그 청크가 **호스트 조건에 콘텐츠 예산을 낸다.** 3청크 소스에서 해제 쓰기를 항상 실패시키고 4패스, 그 뒤 쓰기가 낫고 프로바이더도 복귀하는 조건으로 측정:

```
                       문제 청크 attempts   누적 LLM 호출   잡 행   치유+복귀 후
환불 없음 (이전)        1, 2, 3, 4          2, 3, 4, 5      1      attempts=5 → exhausted
                                                                   → 소스 영구 포기, 사실 2/3
`running` 배제 (대안)   1, 1, 1, 1          2, 4, 6, 8      4      복구, 사실 3/3
                                                                   — 단 매 패스 완료 청크 재전송
환불 (채택)            1, 1, 1, 1          2, 3, 4, 5      1      복구, 사실 3/3
```

그래서 수정은 `claim_extraction_job_for_retry` 의 stray-`running` 되감기에 `attempts = MAX(attempts - 1, 0)` 을 넣는 것이다 — `requeue_chunk_claim` 이 사이드카 케이스에 대해 수행한다고 자기 docstring 에 적어 둔 바로 그 역연산. 대안(`running` 을 분기에서 배제)은 영구 포기를 닫지만 이 상태에 대해 **이 PR 의 존재 이유를 되돌린다**(2/4/6/8, 잡 4개). **실행 델타는 SQL 문자열 상수 하나**이고, 클램프는 이 UPDATE 에 CAS 가 없어 손으로 만든 `running`+`attempts = 0` 행이 음수로 가지 않게 한다.

### #323 give-up 게이트는 약화되지 않는다

`failed_chunk_attempt_status` 는 `WHERE job_id = ? AND status = 'failed'` 이고, 계획은 `int(job["failed_chunks"]) > 0` 안에서만 그것을 본다. **그래서 `running` 에 앉아 있는 청크의 `attempts` 는 그동안 아무것도 게이팅하지 않는다** — `running` 행에 `attempts = 99` 를 심어도 `failed_chunk_attempt_status` 는 `(0, 0)` 이고 plan 은 `retry_job_id` 다. 무환불 누적은 스핀을 멈춘 적이 없고, 나중에 첫 진짜 판정이 기록되는 순간 **과청구로만** 나타났다. 그게 이 버그다.

기록된 `failed` 로 끝난 시도는 전부 그대로 센다. 바뀌는 것은 **소진 시점**이고, 방향은 cap 쪽이다: 프레임이 몇 번 죽든 소진은 이제 항상 `MAX_CHUNK_ATTEMPTS` 회의 **기록된** 실패를 요구한다. cap 3 에서 측정 — 무환불 쪽은 사망이 실패와 번갈아 나면 2회에, 사망 2회가 첫 실패보다 앞서면 1회에 cap 에 닿았다. 환불 쪽은 두 배치 모두 3회다.

### 이 라운드에서 이름만 붙이고 남기는 것

- `rollback_extraction_job` 도 `running` 청크를 되감으면서 환불하지 않는다. 호출자 4곳 중 halt 둘(`_halt_extraction_job`, 사이드카 백오프)은 KB 가 얼어 있어 카운트가 문제되지 않지만 **`web/app.py` 의 재시작 복구와 `cli.py` 의 `sync --recover` 는 크래시 복구**라 같은 과청구가 그 경로에 남는다. 선재 사항, #524 범위 밖 — `claim_extraction_job_for_retry` docstring 에 호출자 이름과 함께 적어 두었다.
- 잡의 `failed_chunks` 카운터를 갱신하지 않는 **out-of-band 리셋**은 소진된 `failed` 행을 이 분기로 들여보낼 수 있다. 손해는 **여분 패스 1회**다 — 그 패스의 `_refresh_extraction_job` 이 카운터를 고치고 다음 plan 이 `exhausted_job_id` 로 간다(측정: 카운터 0 + `('failed', 99)` 행 → `retry_job_id`, 그 다음 `exhausted_job_id`). 분기 문단에 그대로 적었다.
- 종료성(run 행 + 잡 이벤트)은 닫히지 않는다 — 위 표대로 base 와 같은 속도, #536.

## 다른 호출자를 깨지 않는다

`failed_chunks == 0` 을 **rebuild 신호로 읽는 곳은 `plan_source_extraction` 단 한 곳**이다. 나머지 히트는 전부

- **보고**: `_SourceSyncOutcome.failed_chunks` 필드와 `failed_sources` 의 `> 0` 필터(`cli.py:71/101` @base), 잡 메시지 전달(`cli.py:828` @base), `process_extraction_job` 의 완료 요약 문자열과 `ChunkedExtractionResult.failed_chunks`, `pipeline/trust.py` 의 리포트 필드, `sources.html`/`provenance.html`;
- **sweep 빠른 경로**: `cmd_sync` 와 `web/app.py` 의 `outcome.failed_chunks == 0` → stale-citation sweep. store 가 재검증하므로 판정을 위임하지 않는다;
- **이미 못 믿을 것으로 문서화된 벨트**: `surface_stale_engine_facts` 의 `int(job["failed_chunks"]) != 0`. 진짜 게이트는 바로 앞의 `job["status"] != "done"` 이고, 그 위 주석이 *"`fail_extraction_job` 은 `failed_chunks` 를 건드리지 않아 stale 한 0 이 남을 수 있다"* 고 이미 적어 두었다.

그리고 더 짧은 답: **`plan_source_extraction` 의 프로덕션 호출자는 `verinote/cli.py:747` (@base) 의 `cmd_sync` 하나뿐이다** — 나머지 히트는 import, 재export, 주석이다. 폭발 반경은 CLI sync 경로로 한정된다.

## 테스트 (`tests/test_job_resume.py` 섹션 J, 16개 추가 — 파일 19 → 35)

크래시는 클라이언트가 아니라 `Store.next_pending_chunk` 에 주입한다. 클라이언트를 실패시키면 `_extract_chunk` 안이라 청크가 `failed` 가 되어 **기존** 경로로 새 버린다.

뮤턴트 14개, 대상은 `test_job_resume` + `test_chunk_claim_release` + `test_chunk_claim_sidecar_lock` + **`test_store`**(수정이 store 에 있으므로 이번엔 포함), 베이스라인 **151 passed**. 각 행에 뮤테이션 정의를 붙인다 — 정의 없이는 숫자를 검증할 수 없다.

| # | 뮤테이션 (정확히 무엇을 바꿨나) | red | 죽는 테스트 |
|---|---|---|---|
| M1 | 새 분기 블록 전체를 삭제하고 `return ExtractionJobPlan()` 으로 되돌림 (= 수정 이전) | 8 | J1, J2, J3, J5, J8, J9 + 신규 J10, J11 |
| M2 | 새 분기의 `retry_job_id=latest_id` → `resume_job_id=latest_id` | 8 | 같은 8개 |
| M3 | 새 분기 조건 `any(... == "done" ...)` → `True` | 1 | `test_plan_rebuilds_a_failed_job_that_finished_no_chunk` |
| M4 | `if job["status"] != "pending" and any(done)` 로 합쳐 **artifact 게이트 바로 위**로 이동 | 6 | J7[artifact/body/chunk size/model] + J6 + `…_still_gives_up_…` |
| M5 | 같은 형태로 **함수 최상단**(`running` 가드 위)으로 이동 | 9 | J7 6개 전부 + J6 + `…_still_gives_up_…` + `test_sync_re_extracts_a_source_whose_job_already_finished` |
| M6 | `any(...)` → `all(...)` | 7 | M1 의 8개 중 `…_finished_everything_terminalises_…` 를 뺀 7개 |
| M7 | `any(... chunk_rows)` → `int(job["completed_chunks"]) > 0` | 1 | `test_plan_reads_the_chunk_rows_not_the_job_counter` |
| M8 | **새 retry 분기만** `failed_chunks > 0` 게이트 위로 이동 (순수 순서 변경) | **1** | `test_plan_still_gives_up_when_an_exhausted_chunk_sits_beside_a_finished_one` |
| M16 | **`running` 청크를 새 분기에서 배제** (검토한 대안) | 2 | `…_plan_continues_a_finished_chunk_job_that_also_holds_a_running_one`, `…_a_recurring_lost_release_…` |
| **M9** | **환불 제거** (`attempts = MAX(attempts - 1, 0)` 삭제) | 2 | `…_a_recurring_lost_release_does_not_spend_the_chunks_attempt_budget`, `…_refunds_the_stray_running_chunks_attempt` |
| M10 | 클램프 제거 (`attempts - 1`) | 1 | `…_refunds_the_stray_running_chunks_attempt` |
| M12 | 환불량을 2로 (`MAX(attempts - 2, 0)`) | 1 | 같음 |
| M13 | 환불 대신 리셋 (`attempts = 0`) | 1 | 같음 |
| M11 | `claim_pending_extraction_job` 의 같은 sweep 에도 환불 추가 | **0 (생존)** | **결함이 아니다** — 그 sweep 이 실경로에서 돌지 않는다는(자기 주석이 "a defensive no-op" 이라 부르는) 주장의 방증이다. 유일한 생존자이고, 의도된 것이다 |

**M8 의 1 이 이 표에서 가장 중요한 숫자다.** 순서 불변식 전체가 테스트 **하나**에 걸려 있다. `test_sync_gives_up_on_a_permanently_failing_chunk` 는 green 으로 남는다 — 그 잡에는 `done` 청크가 없어 새 분기를 아예 안 타기 때문이다.

**M12/M13 은 환불의 *크기* 를 노린다.** 처음에는 둘 다 살아남았다 — store 테스트가 `attempts` 1 과 0 인 행만 써서 "역연산"과 "0으로 밀기"를 구별하지 못했다. **두 번째 클레임 위에 있는 행(`running`, `attempts = 2` → `('pending', 1)`)을 추가**해 둘 다 죽였다.

M1 과 M2 는 red **집합**이 같아 실패한 **행과 값**으로 갈랐다 — 신규 테스트 하나가 혼자 가른다:
```
M1: assert len(jobs) == 1        →  E  assert 2 == 1                  # 옆에 새 잡을 지었다(재구축)
M2: with pytest.raises(...)      →  E  Failed: DID NOT RAISE OperationalError
                                                                       # resume CAS 가 안 맞아 해제 지점에 닿지도 못한다
```

**뮤턴트를 재현할 때 주의:** M4 와 M5 는 산출 파일 **크기가 같다.** 같은 초 안에 쓰면 CPython 의 pyc 무효화(mtime 1초 해상도 + size)가 M4 바이트코드를 재사용해 **M5 가 4 red 로 잘못 나온다.** `__pycache__` 를 매 뮤턴트마다 지워라(또는 `PYTHONDONTWRITEBYTECODE=1`). 위 표는 삭제 후 값이다.

전체 스위트 **3001 passed, 14 skipped** (실패 0). `ruff check verinote tests` clean. **스키마 변경 없음, 공개 시그니처 변경 없음.** `store/db.py` 는 **변경된다** — 리뷰 블로킹 2 에 대한 응답으로 넣은 환불 한 줄과 그 근거 docstring 이고, 이 PR 의 유일한 실행 델타다.

## 보고 문자열에 대한 주의 — 재전송은 조용하다

이슈 본문의 둘째 불만("조용합니다 … 재전송이 일어났다는 표시가 없습니다")은 문자 그대로 참이고, 이 PR 도 그것을 고치지 않는다. 두 팔을 나란히 돌린 실측:

```
CONTINUED  LLM 4청크   sources/doc.txt: 4 candidate(s) this run (resumed job #1: 6 candidate(s) in total)
REBUILD    LLM 6청크   sources/doc.txt: 4 candidate(s)
```

**rebuild 도 같은 숫자 4 를 찍는다.** `run_candidates` 는 그 실행이 만든 후보 수이지 청크 수가 아니고, 재전송된 alpha/bravo 의 사실은 이미 존재해 중복 제거된다. 갈라지는 것은 숫자가 아니라 **괄호의 유무**다. 이슈의 후보 수정 3번("재전송을 말하게 하기")을 채택하지 않은 이유도 여기 있다 — 이 수정 이후 완료 청크를 가진 rebuild 는 staleness 게이트가 정당하게 발동한 경우만 남아, 거기에 경고를 찍는 것은 낭비가 아닌 비용을 낭비로 보고하는 것이 된다.

## 선재 사항 하나 (이 PR 이 만들지 않았고 고치지도 않는다)

`sync complete: … (run #N)` 의 `N` 은 run 행 번호가 아니라 잡 id 다(`cmd_sync`, 선재). rebuild 는 매번 새 잡 id 를 받아 **우연히** run 수를 따라갔다. 잡을 이어붙이면 잡 id 가 고정되므로 run 행이 쌓여도 표시는 계속 첫 잡 번호를 가리킨다. resume 경로에는 원래 있던 성질이라 새 종류의 버그는 아니고, `cli.py` 출력 변경은 #523 과 충돌하므로 여기서는 손대지 않는다.

## #523 과의 경계 — 유예 **0곳**, 충돌 **3건**

이전 개정판은 낡은 산문 2곳을 **충돌 회피를 이유로 유예**했다. 리뷰가 그 두 곳을 정확히 지목했으므로 **유예는 해제됐고, 그 대가로 충돌이 1건에서 3건이 됐다.** 그것이 옳은 거래다 — 유예해 둔 문장들은 이 PR 이 거짓으로 만든 문장들이었다.

| 파일 | 충돌 | 해소 |
|---|---|---|
| `verinote/pipeline/extract.py` | 1 hunk — 잡 레벨 `except DuckDBFactTermStoreLockedError` 주석을 양쪽이 다시 쓴다 | **이쪽 취하기.** 두 정정을 합쳐 뒀다 |
| `tests/test_chunk_claim_sidecar_lock.py` | 1 hunk — 같은 docstring | **이쪽 취하기.** 같은 이유 |
| `tests/test_job_resume.py` | 1 hunk — add/add (섹션 I vs J, 둘 다 파일 끝에 붙는다) | **양쪽 유지.** 블록이 독립이고 최상위 이름도 겹치지 않는다 |

앞의 두 곳은 **두 PR 이 같은 문장을 서로 다른 축으로 고쳤다** — #523 은 귀속(`the worker` → `a caller's broad clause`: 잡 행을 쓰는 호출자가 둘이다), #524 는 비용(LLM 청구서가 아니라 귀속). **한쪽 고르기가 아니라 두 정정의 병합이 정답**이므로, 이쪽 문안이 #523 의 정정을 이미 담고 있게 써 두었다. 그래서 어느 쪽이 먼저 착지해도 해소는 "이쪽 취하기" 이고 잃는 정정이 없다.

문장은 **어느 트리에서도 참이 되게** 썼다 — `cli.py` 에 아직 광범위 절이 없으므로 ``(`web/app.py` today; `cli.py` too once #488 lands)`` 이고 `both callers` 가 아니라 `a caller` 다. #488 이 먼저 착지하면 그 두 표현은 리베이스 때 조여야 한다(표시해 둔다).

역방향도 하나 있다: **#523 의 현재 문안이 #524 착지 후 거짓이 된다** — `verinote-issue-488` 트리의 `extract.py` 가 아직 *"a `failed` job is the edge state planning reads as 'rebuild fresh', throwing away the chunks this pass already finished and re-sending them to the LLM"* 라고 쓴다. 나중에 착지하는 쪽이 정정해야 하고, 착지 순서상 그건 #535 다.

테스트의 `_worker_marks_job_failed` 스탠드인은 **#523 이 착지하면 삭제 대상**이고, docstring 에 그 지시(`DELETE THIS WHEN #488 LANDS`)와 "드롭하고 CLI 가 쓴 `failed`/`failed_chunks == 0` 를 단언하라, 스탠드인을 남겨 green 을 유지하지 마라"를 적어 두었다.

## 동작 변경 여부

**breaking 아님.** 스키마 변경 없음, 공개 API 시그니처 변경 없음. 동작이 바뀌는 지점은 둘이다.

1. `plan_source_extraction` 이 **하나의 상태**(`failed` + `failed_chunks == 0` + `done` 청크 존재 + staleness 게이트 전부 통과)에서 빈 plan 대신 `retry_job_id` 를 돌려준다. 그 상태에서 이전 동작은 이슈가 이름한 버그다.
2. `Store.claim_extraction_job_for_retry` 가 stray `running` 행의 `attempts` 를 **쓴다** — 되감으면서 1 을 환불한다. 이 메서드를 지나는 것은 `cmd_sync` 의 자동 재시도와 **웹 재시도 버튼**(`max_attempts=None`) 둘이고, 후자는 사람 오버라이드라 환불 방향과 일치한다. `done` 행과 소진된 `failed` 행에는 닿지 않는다(되감기 WHERE 가 `status = 'running'` 이다).

마이그레이션 불필요하고, 기존 KB 에 좌초돼 있는 `running` 청크의 누적분은 패스당 1씩 회수된다. 나머지 모든 입력에서 반환값과 행이 동일하다(전체 스위트 회귀 0).

