### PR TITLE
fix(llm): 프롬프트 렌더 실패를 어댑터 seam 에서 정규화하고 요청 가드 밖으로 뺀다

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -781,3 +781,74 @@ def test_one_unsendable_chunk_fails_alone_and_the_job_keeps_going(tmp_path, monk
     assert int(job["candidate_count"]) > 0
     assert len(store.facts()) >= 1  # zero before the fix
     store.close()
+
+
+# --- a prompt that cannot be rendered is still an `LLMError` (#500) ---
+
+
+def _unreadable_override(tmp_path, prompt_id: str) -> None:
+    """An override the render cannot decode.
+
+    Bytes, not `save_prompt_override`: that helper validates and writes UTF-8, so
+    it cannot produce this file. It also breaks every prompt id, where a missing
+    required placeholder only breaks the two that declare one -- see the #500
+    section in `tests/test_cloud_adapters.py`.
+    """
+    path = tmp_path / "policy" / "prompts" / f"{prompt_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe not utf-8\n")
+
+
+def test_a_prompt_that_cannot_be_read_is_a_normalised_failure(tmp_path, monkeypatch):
+    """This hole is not one #500's hoist opens -- it is already open here.
+
+    This adapter builds its prompt before `_run` is called, which is the shape
+    #500 asks the cloud adapters to adopt, so the `UnicodeDecodeError` that
+    `_render_prompt`'s `except PromptError` does not convert leaves the adapter
+    as itself and §10.1 is violated with nothing spawned. `_invoke` already
+    reached that conclusion for its own temp directory; this is the same rule
+    applied one statement earlier.
+    """
+    _unreadable_override(tmp_path, "extraction")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("spawned"))
+
+    with pytest.raises(LLMError, match="^prompt extraction could not be loaded"):
+        ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+
+def test_the_json_wrapper_render_is_normalised_too(tmp_path, monkeypatch):
+    """`_prompt` renders a second template the four methods never name.
+
+    `claude-json-wrapper` is this adapter's own, rendered inside `_prompt` after
+    the caller's system prompt is already in hand, and it is on three of the four
+    methods (`answer_question` builds its `_Prompt` directly). A fix applied only
+    to the prompt ids the methods spell out would leave this one escaping.
+    """
+    _unreadable_override(tmp_path, "claude-json-wrapper")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("spawned"))
+
+    with pytest.raises(LLMError, match="^prompt claude-json-wrapper could not be loaded"):
+        ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+
+def test_an_unlisted_render_failure_is_a_normalised_failure(tmp_path, monkeypatch):
+    """Coverage that does not depend on an enumeration.
+
+    The two failures reachable through a file today are `UnicodeDecodeError` and
+    `PermissionError`, and #500's reviewer refused to treat that pair as
+    complete: `render_prompt` reads two files and the `OSError` family they can
+    raise is open. A clause narrowed back to a list of types passes the tests
+    above and fails this one.
+    """
+
+    class _Unlisted(Exception):
+        pass
+
+    def boom(*args, **kwargs):
+        raise _Unlisted("nobody enumerated this")
+
+    monkeypatch.setattr("verinote.llm.claude_cli_adapter.render_prompt", boom)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("spawned"))
+
+    with pytest.raises(LLMError, match="^prompt extraction could not be loaded"):
+        ClaudeCliAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -674,3 +674,240 @@ def test_the_installed_openai_sdk_really_does_reject_an_unusable_base_url(tmp_pa
 
     with pytest.raises(LLMError, match="^openai client could not be created"):
         OpenAIAdapter(_unusable_url_cfg(tmp_path, "openai")).extract_facts(source_text="x")
+
+
+# --- a broken prompt template is not the provider's fault (#500) ---
+
+# Which template each method renders. The three cloud adapters share it:
+# `OpenRouterAdapter` inherits the four methods unchanged, and the anthropic
+# copies name the same four ids.
+_PROMPT_ID = {
+    "extract_facts": "extraction",
+    "translate_query": "query-translation",
+    "extract_query_intent": "query-intent",
+    "answer_question": "ask-fallback",
+}
+
+
+def _undecodable_override(tmp_path, prompt_id: str):
+    """An override the render cannot decode, written as bytes.
+
+    `save_prompt_override` validates and writes UTF-8, so it cannot produce this
+    file. The break has to be one that works for every prompt id: only
+    `query-translation` among these four declares a `required_placeholder`, so an
+    override "missing a placeholder" is not a break at all for the other three --
+    `_validate_prompt_text` passes it and the SDK is reached with a perfectly
+    usable prompt. Nine of the twelve cells below would assert nothing. The
+    missing-placeholder case gets its own test, on the one method where it bites.
+    """
+    path = tmp_path / "policy" / "prompts" / f"{prompt_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe not utf-8\n")
+    return path
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_prompt_that_cannot_be_read_is_not_a_request_failure(
+    tmp_path, monkeypatch, method, provider
+):
+    """The render used to sit in argument position inside the `try`, so a
+    template the user broke came back as "<provider> request failed" -- their own
+    file, reported as the provider's outage (#500). All four methods, because the
+    hoist is four separate edits per file and one left behind is one method still
+    lying; `openrouter` explicitly, because it inherits the four from
+    `OpenAIAdapter` and a reader should not have to know that to see it covered.
+
+    The SDK raises "dialled" if it is reached at all, so the assertions also say
+    nothing was sent.
+    """
+    _undecodable_override(tmp_path, _PROMPT_ID[method])
+    _raising_sdk(monkeypatch, provider, RuntimeError("dialled"))
+    adapter = _KEYED_ADAPTERS[provider](_cfg(tmp_path, provider=provider))
+
+    with pytest.raises(
+        LLMError, match=rf"^prompt {_PROMPT_ID[method]} could not be loaded"
+    ) as exc:
+        _INVOCATIONS[method](adapter)
+
+    assert "request failed" not in str(exc.value)
+    assert "dialled" not in str(exc.value)
+
+
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_missing_placeholder_keeps_the_library_s_own_words(tmp_path, monkeypatch, provider):
+    """`translate_query` is the one method here whose prompt declares a required
+    placeholder, and this is the exact string #500 quotes.
+
+    Anchored at both ends, which is the whole test. `_render_prompt` keeps
+    `except PromptError` above its catch-all so a prompt-contract violation --
+    something the user can read as an instruction and act on -- goes out as the
+    library wrote it. Delete that clause and the catch-all absorbs the case with
+    "prompt query-translation could not be loaded: " in front; put the render
+    back inside the `try` and "openai request failed: " goes in front. The `$`
+    kills the first, the `^` the second. The older
+    `test_*_prompt_validation_error_is_llm_error` pair above matches on `{qid}`
+    alone and survives both.
+    """
+    path = tmp_path / "policy" / "prompts" / "query-translation.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("Missing qid placeholder.\n", encoding="utf-8")
+    _raising_sdk(monkeypatch, provider, RuntimeError("dialled"))
+    adapter = _KEYED_ADAPTERS[provider](_cfg(tmp_path, provider=provider))
+
+    with pytest.raises(
+        LLMError,
+        match=r"^Datalog translation prompt must include required placeholder \{qid\}$",
+    ):
+        adapter.translate_query(question="Who?", qid=3)
+
+
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_an_unreadable_prompt_override_is_still_an_llm_error(tmp_path, monkeypatch, provider):
+    """The cheaper trigger, and a second way in through the same clause.
+
+    A non-UTF-8 override takes a hand-edited file; this takes one mode bit, which
+    a backup tool or an umask can set without anybody meaning to. `read_text`
+    raises `PermissionError`, which is not a `PromptError` either, so it arrives
+    at the same catch-all -- the reachability half of the argument that the
+    render's failures cannot be enumerated by type.
+
+    Carries T1's anchors rather than a bare `pytest.raises(LLMError)`. Bare, this
+    passes before the change too: inside the `try` the `PermissionError` was
+    still wrapped, just wrapped as the provider's fault.
+    """
+    path = tmp_path / "policy" / "prompts" / "extraction.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("Custom extraction prompt.\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+
+        _raising_sdk(monkeypatch, provider, RuntimeError("dialled"))
+        adapter = _KEYED_ADAPTERS[provider](_cfg(tmp_path, provider=provider))
+
+        with pytest.raises(LLMError, match=r"^prompt extraction could not be loaded") as exc:
+            adapter.extract_facts(source_text="x")
+
+        assert "request failed" not in str(exc.value)
+        assert "dialled" not in str(exc.value)
+    finally:
+        path.chmod(0o600)
+
+
+@pytest.mark.parametrize(
+    ("provider", "adapter_cls", "module"),
+    [
+        ("anthropic", AnthropicAdapter, "verinote.llm.anthropic_adapter"),
+        ("openai", OpenAIAdapter, "verinote.llm.openai_adapter"),
+    ],
+)
+def test_a_render_failure_of_a_kind_nobody_enumerated_is_still_an_llm_error(
+    tmp_path, monkeypatch, provider, adapter_cls, module
+):
+    """The guard that does not depend on a list of types.
+
+    `UnicodeDecodeError` and `PermissionError` are what the two tests above can
+    reach through a file, and #500's reviewer refused to treat that pair as
+    complete: `render_prompt` reads the packaged default and the override, and
+    the `OSError` family those two reads can raise is open. Narrow the clause
+    back to `except (UnicodeDecodeError, PermissionError)` and both of those stay
+    green while this one fails.
+    """
+
+    class _Unlisted(Exception):
+        pass
+
+    def boom(*args, **kwargs):
+        raise _Unlisted("nobody enumerated this")
+
+    monkeypatch.setattr(f"{module}.render_prompt", boom)
+    _raising_sdk(monkeypatch, provider, RuntimeError("dialled"))
+
+    with pytest.raises(LLMError, match=r"^prompt extraction could not be loaded") as exc:
+        adapter_cls(_cfg(tmp_path, provider=provider)).extract_facts(source_text="x")
+
+    assert "request failed" not in str(exc.value)
+
+
+def test_a_programming_error_in_the_render_is_deliberately_an_llm_error(tmp_path, monkeypatch):
+    """The cost of the catch-all, pinned so it cannot be quietly repaid.
+
+    A `TypeError` from inside `render_prompt` is a bug in this repo, and
+    "prompt extraction could not be loaded" points the reader at
+    `policy/prompts/extraction.md`, which is fine. That is the relabelling
+    `test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url`
+    in `tests/test_ollama_adapter.py` refuses for `Request()` -- and it is
+    accepted here, deliberately, because unlike `Request()` the render has more
+    than one reachable failure and no type separates a bug from a broken file.
+    §10.1 wins the trade at the adapter seam.
+
+    Without this test the trade looks like an oversight, and the next reader
+    narrows the clause to let programming errors through -- reopening §10.1 for
+    every `OSError` nobody listed. `_Unlisted` above cannot carry that: a test
+    exception class says "not enumerated", not "a bug in this file too".
+    """
+
+    def boom(*args, **kwargs):
+        raise TypeError("render_prompt() got an unexpected keyword argument")
+
+    monkeypatch.setattr("verinote.llm.openai_adapter.render_prompt", boom)
+    _raising_sdk(monkeypatch, "openai", RuntimeError("dialled"))
+
+    with pytest.raises(LLMError, match=r"^prompt extraction could not be loaded"):
+        OpenAIAdapter(_cfg(tmp_path, provider="openai")).extract_facts(source_text="x")
+
+
+def test_a_render_failure_keeps_the_original_error_as_the_cause(tmp_path, monkeypatch):
+    """`from exc` on the catch-all, which is what pays for the test above.
+
+    Relabelling a programming error as a load failure is only tolerable if the
+    original survives for a log. `_client_failed` has this guard already
+    (`test_a_client_that_cannot_be_built_keeps_the_sdk_error_as_the_cause`); the
+    render path did not, and the docstring now argues from it.
+    """
+    boom = TypeError("render_prompt() got an unexpected keyword argument")
+
+    def raiser(*args, **kwargs):
+        raise boom
+
+    monkeypatch.setattr("verinote.llm.openai_adapter.render_prompt", raiser)
+    _raising_sdk(monkeypatch, "openai", RuntimeError("dialled"))
+
+    with pytest.raises(LLMError) as exc:
+        OpenAIAdapter(_cfg(tmp_path, provider="openai")).extract_facts(source_text="x")
+
+    assert exc.value.__cause__ is boom
+
+
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_broken_template_does_not_outrank_a_missing_key(tmp_path, monkeypatch, provider):
+    """Order: `client = self._client()` first, then the render, then the `try`.
+
+    Hoisting the render above `_client()` would also satisfy #500 and would
+    change which of two simultaneous problems a user is told about. A KB with no
+    key configured and a broken template has one blocking problem and one that
+    only matters afterwards, and the shipped order reports the blocking one. This
+    fails if the render moves up.
+
+    The two halves are one test on purpose. The first `raises` passes with no
+    override written at all, so on its own it would keep passing if the fixture
+    ever stopped breaking the template -- for instance if `extract_facts` came to
+    render a different id. The second half re-runs the identical setup with a key
+    and requires the template to be broken, so the setup cannot go inert
+    unnoticed.
+    """
+    _undecodable_override(tmp_path, "extraction")
+    _raising_sdk(monkeypatch, provider, RuntimeError("dialled"))
+    adapter_cls = _KEYED_ADAPTERS[provider]
+
+    with pytest.raises(LLMError, match=rf"^{provider} requires an API key"):
+        adapter_cls(_keyed_cfg(tmp_path, provider, None)).extract_facts(source_text="x")
+
+    with pytest.raises(LLMError, match=r"^prompt extraction could not be loaded"):
+        adapter_cls(_keyed_cfg(tmp_path, provider, "key")).extract_facts(source_text="x")

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -914,3 +914,54 @@ def test_a_broken_template_does_not_outrank_a_missing_key(tmp_path, monkeypatch,
 
     with pytest.raises(LLMError, match=r"^prompt extraction could not be loaded"):
         adapter_cls(_keyed_cfg(tmp_path, provider, "key")).extract_facts(source_text="x")
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_render_failure_never_carries_the_key(tmp_path, monkeypatch, method, provider):
+    """The render path's half of `test_provider_error_never_carries_the_key`.
+
+    That test says "each raise site is its own chance to bypass the redacting
+    constructor", and #500 added a raise site to each of these eight methods:
+    hoisting the render above the `try` took it out from under
+    `_request_failed`. On `759eac0` this same setup produced
+    `anthropic request failed: [Errno 13] Permission denied: '.../kb-***/...'`;
+    between the hoist and this test it produced the key. `self._rendered` puts
+    the render back under a redactor and this is what holds it there.
+
+    Twelve cells, not twenty-four. The other break this section uses -- a
+    non-UTF-8 override -- cannot exercise redaction at all, because
+    `UnicodeDecodeError` names a byte offset and no path, so there is nothing
+    for the key to ride in on. An `OSError` from the override read spells out
+    `cfg.root`, which is why the unreadable file is the one that reaches this.
+    `openrouter` is in the parametrization rather than assumed: it inherits the
+    four methods and `_rendered` from `OpenAIAdapter` and redacts with its own
+    key.
+
+    The SDK raises with the key in it too, so a fix that reached only the render
+    and lost `_request_failed` would fail here as well.
+    """
+    root = tmp_path / f"kb-{_LONG_KEY}"
+    path = root / "policy" / "prompts" / _PROMPT_ID[method]
+    path = path.with_suffix(".md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("Custom prompt.\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+
+        _raising_sdk(monkeypatch, provider, RuntimeError(f"401 invalid key {_LONG_KEY}"))
+        adapter = _KEYED_ADAPTERS[provider](_keyed_cfg(root, provider, _LONG_KEY))
+
+        with pytest.raises(LLMError) as exc:
+            _INVOCATIONS[method](adapter)
+
+        assert _LONG_KEY not in str(exc.value)
+        assert "***" in str(exc.value)
+    finally:
+        path.chmod(0o600)

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -866,24 +866,38 @@ def test_a_programming_error_in_the_render_is_deliberately_an_llm_error(tmp_path
         OpenAIAdapter(_cfg(tmp_path, provider="openai")).extract_facts(source_text="x")
 
 
-def test_a_render_failure_keeps_the_original_error_as_the_cause(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("provider", "adapter_cls", "module"),
+    [
+        ("anthropic", AnthropicAdapter, "verinote.llm.anthropic_adapter"),
+        ("openai", OpenAIAdapter, "verinote.llm.openai_adapter"),
+    ],
+)
+def test_a_render_failure_keeps_the_original_error_as_the_cause(
+    tmp_path, monkeypatch, provider, adapter_cls, module
+):
     """`from exc` on the catch-all, which is what pays for the test above.
 
     Relabelling a programming error as a load failure is only tolerable if the
     original survives for a log. `_client_failed` has this guard already
     (`test_a_client_that_cannot_be_built_keeps_the_sdk_error_as_the_cause`); the
     render path did not, and the docstring now argues from it.
+
+    BOTH adapters, because each carries its own `_rendered` and each re-raises
+    `from exc.__cause__` in its own copy of that line. Covering one left the
+    other's unpinned while its docstring named this test as what pins it —
+    change either copy to `from exc` and the matching case here fails.
     """
     boom = TypeError("render_prompt() got an unexpected keyword argument")
 
     def raiser(*args, **kwargs):
         raise boom
 
-    monkeypatch.setattr("verinote.llm.openai_adapter.render_prompt", raiser)
-    _raising_sdk(monkeypatch, "openai", RuntimeError("dialled"))
+    monkeypatch.setattr(f"{module}.render_prompt", raiser)
+    _raising_sdk(monkeypatch, provider, RuntimeError("dialled"))
 
     with pytest.raises(LLMError) as exc:
-        OpenAIAdapter(_cfg(tmp_path, provider="openai")).extract_facts(source_text="x")
+        adapter_cls(_cfg(tmp_path, provider=provider)).extract_facts(source_text="x")
 
     assert exc.value.__cause__ is boom
 
@@ -938,8 +952,11 @@ def test_a_render_failure_never_carries_the_key(tmp_path, monkeypatch, method, p
     four methods and `_rendered` from `OpenAIAdapter` and redacts with its own
     key.
 
-    The SDK raises with the key in it too, so a fix that reached only the render
-    and lost `_request_failed` would fail here as well.
+    The SDK is never dialled on this path -- the render raises just after
+    `self._client()` and before the `try` -- so `_request_failed` is not what
+    these cells exercise; `test_provider_error_never_carries_the_key` keeps that
+    half. `_raising_sdk` is still armed so that a regression which let the call
+    through would surface as a dialled request rather than a quiet pass.
     """
     root = tmp_path / f"kb-{_LONG_KEY}"
     path = root / "policy" / "prompts" / _PROMPT_ID[method]

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -651,9 +651,12 @@ def test_the_installed_anthropic_sdk_really_does_reject_an_unusable_base_url(tmp
     with. Without it every test in this section could be green against an SDK
     that quietly accepted `::::`.
 
-    Skipped where the optional dependency is absent, which includes CI — it
-    installs `.[test,wirelog]` and neither vendor SDK. Local green therefore does
-    not speak for CI on this one axis, which is why the stubs carry the contract.
+    Skipped where the optional dependency is absent, which includes the `ci.yml`
+    pytest job — it installs `.[test,wirelog]` and neither vendor SDK.
+    (`provider-contract.yml` does install the openai extra, but it runs
+    `tests/contract/run.sh` on a schedule, not this suite.) Local green therefore
+    does not speak for that job on this one axis, which is why the stubs carry
+    the contract.
     """
     pytest.importorskip("anthropic")
 

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -754,3 +754,61 @@ def test_list_models_does_not_blame_the_base_url_for_a_non_valueerror(monkeypatc
 
     with pytest.raises(TypeError):
         list_models(None, 5.0)
+
+
+# --- a prompt that cannot be rendered is still an `LLMError` (#500) ---
+
+
+def _unreadable_override(tmp_path, prompt_id: str) -> None:
+    """An override the render cannot decode.
+
+    Bytes, not `save_prompt_override`: that helper validates and writes UTF-8, so
+    it cannot produce this file. A missing required placeholder would be the
+    cheaper break, but `ollama-extraction` is the only prompt on this adapter's
+    `extract_facts` path with one, and a non-UTF-8 override breaks every prompt
+    id regardless -- see the #500 section in `tests/test_cloud_adapters.py`,
+    which parametrizes over four of them.
+    """
+    path = tmp_path / "policy" / "prompts" / f"{prompt_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe not utf-8\n")
+
+
+def test_a_prompt_that_cannot_be_read_is_a_normalised_failure(tmp_path, monkeypatch):
+    """This hole is not one #500's hoist opens -- it is already open here.
+
+    This adapter has always rendered outside its `try`, which is the shape #500
+    asks the cloud adapters to adopt. So the `UnicodeDecodeError` that
+    `_render_prompt`'s `except PromptError` does not convert leaves the adapter
+    as itself, and §10.1 -- every LLM failure reaches its caller as an
+    `LLMError` -- is violated here today, with nothing dialled. The cloud
+    adapters were only hiding the same hole behind an argument-position render.
+    """
+    _unreadable_override(tmp_path, "ollama-extraction")
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError, match="^prompt ollama-extraction could not be loaded"):
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")
+
+
+def test_an_unlisted_render_failure_is_a_normalised_failure(tmp_path, monkeypatch):
+    """Coverage that does not depend on an enumeration.
+
+    The two failures reachable through a file today are `UnicodeDecodeError` and
+    `PermissionError`, and #500's reviewer refused to treat that pair as
+    complete: `render_prompt` reads two files and the `OSError` family they can
+    raise is open. A clause narrowed back to a list of types passes the test
+    above and fails this one.
+    """
+
+    class _Unlisted(Exception):
+        pass
+
+    def boom(*args, **kwargs):
+        raise _Unlisted("nobody enumerated this")
+
+    monkeypatch.setattr("verinote.llm.ollama_adapter.render_prompt", boom)
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: pytest.fail("dialled"))
+
+    with pytest.raises(LLMError, match="^prompt ollama-extraction could not be loaded"):
+        OllamaAdapter(_cfg(tmp_path)).extract_facts(source_text="Ada")

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -40,19 +40,26 @@ class AnthropicAdapter:
         to be narrowed rather than un-hedged. What it carries is now whatever
         the render raised, `str(exc)` and no filter, and that set is open: an
         `OSError` from the override read puts the KB's absolute path in the
-        message in full, `cfg.root` and all (measured). What survives is
-        narrower and is about the configured key and the provider response, and
-        only those. The function is module-level and takes a root path and a
-        prompt id -- the argument `ollama_adapter.list_models` makes about
-        itself -- so no `cfg` and no key are in scope for it to name, and a
-        render dials nothing, so a provider response cannot arrive in it either.
-        Mind the modality: `redact_secret` is not unnecessary here, it is
-        unreachable -- this function has nothing to hand it. That is not free.
-        A key spelled into a KB directory name arrives as a substring of the
-        path, and `redact_secret` is substring replacement, so it would have
-        masked it there; nothing on this path calls it. Both halves measured.
-        Lifting these four copies somewhere a redactor can be reached is the
-        follow-up that residue belongs to.
+        message in full, `cfg.root` and all (measured), and a key a user spelled
+        into a KB directory name is part of that path.
+
+        Which is why nothing in this class calls it directly. `_rendered` above
+        wraps it, and that wrapper is a member of the class precisely so it can
+        hand `self.cfg.api_key` to `redact_secret` -- the four generation
+        methods reach the render only through it. Measured on this branch, the
+        twelve cells that carry a path (this adapter, `openai`, `openrouter`,
+        four methods each, an unreadable override) come out `.../kb-***/...`
+        again, which is what `759eac0` did before the hoist and what the hoist
+        alone stopped doing. Whether `_render_prompt` itself redacts is
+        therefore not the question here; it does not, and it is not called from
+        anywhere in this file that a key can reach.
+
+        `ollama_adapter` and `claude_cli_adapter` are the other story. They call
+        their copies of `_render_prompt` bare, they import no `redact_secret`,
+        and they never masked this -- on `759eac0` the same override left them
+        as a raw `PermissionError` with the key in it, and they leak it as an
+        `LLMError` now. That is untouched residue rather than anything this
+        change moved, and it is what the consolidation follow-up is for.
 
         The schema helpers three of the four generation methods call just past
         their guarded region -- `parse_facts`, `parse_query`,
@@ -212,6 +219,43 @@ class AnthropicAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise SDK construction errors
             raise self._client_failed(exc) from exc
 
+    def _rendered(self, prompt_id: str, **values: object) -> str:
+        """Render a prompt, and put the result under the redacting constructor.
+
+        Two layers, and they are not the same job. Module-level `_render_prompt`
+        normalises: every render failure leaves it as an `LLMError`, which is
+        §10.1, and all four adapters need it. This wraps that in the one thing a
+        module-level function cannot do -- reach `self.cfg.api_key` -- and it
+        exists only here and in `openai_adapter`, because those are the two
+        classes that redact at all. Nothing else changes: no new exception type,
+        no new message shape, only whether a configured key survives in the text.
+
+        It is here because #500 took it away. Before the hoist the render was an
+        ARGUMENT to the SDK call, so a `PermissionError` on the override went
+        through `_request_failed`, which redacts (measured on `759eac0`: the KB
+        path came out as `.../kb-***/policy/prompts/extraction.md`). Lifting the
+        render above the `try` moved that raise site out from under the redactor
+        while `_render_prompt` gained a message that carries `str(exc)` whole --
+        and an `OSError` from the override read spells out `cfg.root`. A key a
+        user put in their KB directory name then rode into
+        `source_chunks.error`. Twelve cells: three adapters, four methods, and
+        the conditions whose exception text carries a path. A non-UTF-8 override
+        is not one of them -- `UnicodeDecodeError` names a byte offset and no
+        file -- so the fix is not "the render leaks", it is that these twelve
+        stopped being redacted and are redacted again.
+
+        `from exc.__cause__`, not `from exc`. `_render_prompt` already hung the
+        original failure there, and
+        `test_a_render_failure_keeps_the_original_error_as_the_cause` asserts on
+        it; re-raising `from exc` would bury that behind this wrapper's own
+        `LLMError` and break it. Tidying this to `from exc` is the way to make
+        that test fail.
+        """
+        try:
+            return _render_prompt(self.cfg.root, prompt_id, **values)
+        except LLMError as exc:
+            raise LLMError(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
+
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()
         tool = {
@@ -219,7 +263,7 @@ class AnthropicAdapter:
             "description": "Return the extracted facts.",
             "input_schema": FACT_ARRAY_SCHEMA,
         }
-        system = _with_schema_hint(_render_prompt(self.cfg.root, "extraction"), schema_hint)
+        system = _with_schema_hint(self._rendered("extraction"), schema_hint)
         try:
             msg = client.messages.create(
                 model=self.cfg.model,
@@ -245,7 +289,7 @@ class AnthropicAdapter:
             "input_schema": QUERY_SCHEMA,
         }
         system = _with_schema_hint(
-            _render_prompt(self.cfg.root, "query-translation", qid=qid), schema_hint
+            self._rendered("query-translation", qid=qid), schema_hint
         )
         try:
             msg = client.messages.create(
@@ -271,7 +315,7 @@ class AnthropicAdapter:
             "description": "Return the structured query intent.",
             "input_schema": QUERY_INTENT_SCHEMA,
         }
-        system = _with_schema_hint(_render_prompt(self.cfg.root, "query-intent"), schema_hint)
+        system = _with_schema_hint(self._rendered("query-intent"), schema_hint)
         try:
             msg = client.messages.create(
                 model=self.cfg.model,
@@ -291,7 +335,7 @@ class AnthropicAdapter:
 
     def answer_question(self, *, question: str, context: str) -> str:
         client = self._client()
-        system = _render_prompt(self.cfg.root, "ask-fallback")
+        system = self._rendered("ask-fallback")
         try:
             msg = client.messages.create(
                 model=self.cfg.model,

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -34,17 +34,30 @@ class AnthropicAdapter:
 
         Carriers outside the class are not covered by that, and there is more
         than one. Module-level `_render_prompt` builds an `LLMError` around a
-        caught exception and does NOT redact; nothing leaks through it, though
-        not for the reason the sentence this replaces gave. #500 widened its
-        second clause, so what it carries is now whatever the render raised.
-        What holds instead is the shape of the function: module-level, taking a
-        root path and a prompt id, so the configured key is not in scope for it
-        to put in a message -- the argument `ollama_adapter.list_models` makes
-        about itself -- and a render dials nothing, so a provider response
-        cannot arrive in it either. The schema helpers three of the four
-        generation methods call just past their guarded region -- `parse_facts`,
-        `parse_query`, `parse_query_intent`; `answer_question` calls none, it
-        joins the stripped text blocks -- do not redact either, and two of the
+        caught exception and does NOT redact. The sentence this replaces called
+        it harmless *today*, on the ground that it caught only `PromptError`;
+        #500 widened its second clause, so the ground is gone and the claim has
+        to be narrowed rather than un-hedged. What it carries is now whatever
+        the render raised, `str(exc)` and no filter, and that set is open: an
+        `OSError` from the override read puts the KB's absolute path in the
+        message in full, `cfg.root` and all (measured). What survives is
+        narrower and is about the configured key and the provider response, and
+        only those. The function is module-level and takes a root path and a
+        prompt id -- the argument `ollama_adapter.list_models` makes about
+        itself -- so no `cfg` and no key are in scope for it to name, and a
+        render dials nothing, so a provider response cannot arrive in it either.
+        Mind the modality: `redact_secret` is not unnecessary here, it is
+        unreachable -- this function has nothing to hand it. That is not free.
+        A key spelled into a KB directory name arrives as a substring of the
+        path, and `redact_secret` is substring replacement, so it would have
+        masked it there; nothing on this path calls it. Both halves measured.
+        Lifting these four copies somewhere a redactor can be reached is the
+        follow-up that residue belongs to.
+
+        The schema helpers three of the four generation methods call just past
+        their guarded region -- `parse_facts`, `parse_query`,
+        `parse_query_intent`; `answer_question` calls none, it joins the
+        stripped text blocks -- do not redact either, and two of the
         three are not harmless. Measured, `parse_facts` and `parse_query_intent`
         put what they were handed into the message they raise; `parse_query`
         cannot -- its two raise sites carry a missing key name, a builtin
@@ -89,14 +102,19 @@ class AnthropicAdapter:
         required placeholder {qid}", with no "request failed" in front of it.
 
         What that does not buy is a message that can speak about when. Measured
-        against anthropic 0.116.0 with `base_url` on a closed port,
-        `messages.create(max_tokens="x")` and `messages="hi"` both come back as
-        `APIConnectionError`, exactly as a well-formed call does: this SDK holds
-        nothing back locally. So the reading stays "the SDK call yielded no
-        result" rather than "the provider answered", and `_client_failed` is
-        still the one entitled to say when. What the hoist changed is that the
-        prompt error -- the one measured case of this message being worn by
-        something that never dialled -- no longer arrives here.
+        against anthropic 0.116.0, `base_url` on a closed port, the client built
+        the way `_client` builds it -- `timeout=` passed, which is the condition
+        and not a detail: `messages.create(max_tokens="x")` and `messages="hi"`
+        both come back as `APIConnectionError`, exactly as a well-formed call
+        does. Leave the timeout off and that same `max_tokens="x"` fails locally
+        with a `TypeError` instead, because the SDK derives a timeout from it;
+        that is why the condition is stated rather than a claim that this SDK
+        validates nothing locally. Under the condition this adapter is always in,
+        the reading stays "the SDK call yielded no result" rather than "the
+        provider answered", and `_client_failed` is still the one entitled to say
+        when. What the hoist changed is that the prompt error -- the one measured
+        case of this message being worn by something that never dialled -- no
+        longer arrives here.
 
         Rendering outside the guard is the shape `ollama_adapter` and
         `claude_cli_adapter` were already in, and it carries a hole this `try`
@@ -104,9 +122,10 @@ class AnthropicAdapter:
         hand-edited non-UTF-8 file raises `UnicodeDecodeError` and a mode bit
         raises `PermissionError`, and `_render_prompt`'s `except PromptError`
         converted neither. Measured on those two adapters before this change,
-        that is sixteen method-and-condition pairs leaving the adapter as
-        something that is not an `LLMError` -- §10.1 broken in the tree already,
-        not by the hoist. So the hoist ships with the second clause added to
+        that is eight method-and-condition pairs on each of them -- sixteen
+        cells -- leaving the adapter as something that is not an `LLMError`,
+        which is §10.1 broken in the tree already and not by the hoist. So the
+        hoist ships with the second clause added to
         `_render_prompt` in the same PR, which normalises the render's failures
         wherever the render sits.
 
@@ -303,11 +322,15 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
     """Render `prompt_id` under `root`, or raise `LLMError`.
 
-    Two clauses, and their order is the design. `PromptError` is the prompt
-    contract stated back to the user -- a required placeholder their override
-    left out -- so it goes out as the library wrote it, with nothing in front
-    of it. The clause below names the operation first, because what that one
-    catches is not always a sentence a user can act on.
+    Two clauses, and their order is the design. `PromptError` is whatever the
+    prompt library states in its own words -- a required placeholder the
+    override left out, an id nothing defines (`unknown prompt: extractoin`), a
+    value the caller never passed (`missing prompt value: qid`) -- so it goes
+    out as written, with nothing in front of it. Only the first of those three
+    is the user's doing; the other two are measured, and they reach the user
+    through the narrow clause with no operation named at all. The clause below
+    names the operation because what *it* catches is further still from a
+    sentence anybody can act on.
 
     Being that wide relabels a genuine programming error as something that
     reads like a broken file: `prompt <id> could not be loaded` points at
@@ -318,15 +341,18 @@ def _render_prompt(root, prompt_id: str, **values: object) -> str:
     for a reason that does not hold here. `Request()` has one reachable
     failure, so a type tells a real cause and a bug apart. `render_prompt`
     reads two files, the packaged default and the override, and the `OSError`
-    family those reads can raise is not closed by a list; #500's reviewer
-    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
-    an `LLMError` -- wins that trade at the adapter seam, because what the
-    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
-    override or a `PermissionError` from a mode bit, escaping as itself.
-    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
-    clause this wide: "ONE clause, out here", justified by what the caught type
-    is rather than by a list of the values it can carry. `from exc` pays for
-    the trade -- the original exception stays on `__cause__` for a log.
+    family those reads can raise is not closed by a list; #500's reviewer said
+    normalising the region is safer than enumerating it, and offered no list as
+    complete. §10.1 -- every LLM failure reaches its caller as an `LLMError` --
+    wins that trade at the adapter seam, because what the narrow clause alone
+    lets past is a `UnicodeDecodeError` from a hand-edited override or a
+    `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke` is the nearest precedent, and only for the
+    *form*: one `except OSError` "out here" rather than a copy per call site,
+    broad "where the `ValueError` above may not". Its reason does not carry
+    over -- `OSError` is not a domain type in this repo, and `except Exception`
+    catches every domain type there is. `from exc` pays for the trade -- the
+    original exception stays on `__cause__` for a log.
 
     `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
     """

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -77,27 +77,38 @@ class AnthropicAdapter:
         `_client` is protecting. "Before the request" is therefore not what
         separates these messages.
 
-        Timing is not what this name promises, either. Prompt rendering is an
-        ARGUMENT to `client.messages.create`, so it is evaluated inside the
-        guarded region: an override missing a required placeholder is reported
-        as "anthropic request failed" with nothing dialled (measured). Read this
-        message as "the SDK call yielded no result", not "the provider
-        answered"; `_client_failed` is the one entitled to speak about when.
-        That imprecision predates this change and is #500's. Its stated fix is
-        to hoist the render out of the `try` and leave only the SDK call inside
-        -- the shape `key = self._require_key()` already has in `_client`. Done
-        bare, that satisfies what #500 asks for: measured, the same broken
-        override then reports "Datalog translation prompt must include required
-        placeholder {qid}", with no "request failed" in front of it. Something
-        it also does is not in the issue, and is measured here. `get_prompt`
-        reads an override with `read_text`, so a hand-edited non-UTF-8 file
-        raises `UnicodeDecodeError`, which `_render_prompt`'s
-        `except PromptError` does not convert. Inside the guarded region that is
-        normalised like every other failure; hoisted out, it leaves this adapter
-        as itself -- an LLM failure that is not an `LLMError`, which is the
-        §10.1 violation this change closes at the client-construction site,
-        reopened at the render. So the hoist wants the render's other failures
-        normalised along with it.
+        Timing is not what this name promises, either, and it used to be worse.
+        Prompt rendering was an ARGUMENT to `client.messages.create`, evaluated
+        inside the guarded region, so an override missing a required placeholder
+        came back as "anthropic request failed" with nothing dialled (measured).
+        #500 lifted the render into a statement of its own -- below
+        `client = self._client()`, above the `try`, the shape
+        `key = self._require_key()` already has in `_client` -- leaving the
+        guarded region holding the SDK call and nothing else. Measured, the same
+        broken override now reports "Datalog translation prompt must include
+        required placeholder {qid}", with no "request failed" in front of it.
+
+        What that does not buy is a message that can speak about when. Measured
+        against anthropic 0.116.0 with `base_url` on a closed port,
+        `messages.create(max_tokens="x")` and `messages="hi"` both come back as
+        `APIConnectionError`, exactly as a well-formed call does: this SDK holds
+        nothing back locally. So the reading stays "the SDK call yielded no
+        result" rather than "the provider answered", and `_client_failed` is
+        still the one entitled to say when. What the hoist changed is that the
+        prompt error -- the one measured case of this message being worn by
+        something that never dialled -- no longer arrives here.
+
+        Rendering outside the guard is the shape `ollama_adapter` and
+        `claude_cli_adapter` were already in, and it carries a hole this `try`
+        was covering. `get_prompt` reads an override with `read_text`, so a
+        hand-edited non-UTF-8 file raises `UnicodeDecodeError` and a mode bit
+        raises `PermissionError`, and `_render_prompt`'s `except PromptError`
+        converted neither. Measured on those two adapters before this change,
+        that is sixteen method-and-condition pairs leaving the adapter as
+        something that is not an `LLMError` -- §10.1 broken in the tree already,
+        not by the hoist. So the hoist ships with the second clause added to
+        `_render_prompt` in the same PR, which normalises the render's failures
+        wherever the render sits.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.
@@ -189,13 +200,12 @@ class AnthropicAdapter:
             "description": "Return the extracted facts.",
             "input_schema": FACT_ARRAY_SCHEMA,
         }
+        system = _with_schema_hint(_render_prompt(self.cfg.root, "extraction"), schema_hint)
         try:
             msg = client.messages.create(
                 model=self.cfg.model,
                 max_tokens=4096,
-                system=_with_schema_hint(
-                    _render_prompt(self.cfg.root, "extraction"), schema_hint
-                ),
+                system=system,
                 tools=[tool],
                 tool_choice={"type": "tool", "name": "emit_facts"},
                 messages=[{"role": "user", "content": source_text}],
@@ -215,14 +225,14 @@ class AnthropicAdapter:
             "description": "Return the Datalog query line.",
             "input_schema": QUERY_SCHEMA,
         }
+        system = _with_schema_hint(
+            _render_prompt(self.cfg.root, "query-translation", qid=qid), schema_hint
+        )
         try:
             msg = client.messages.create(
                 model=self.cfg.model,
                 max_tokens=1024,
-                system=_with_schema_hint(
-                    _render_prompt(self.cfg.root, "query-translation", qid=qid),
-                    schema_hint,
-                ),
+                system=system,
                 tools=[tool],
                 tool_choice={"type": "tool", "name": "emit_query"},
                 messages=[{"role": "user", "content": question}],
@@ -242,13 +252,12 @@ class AnthropicAdapter:
             "description": "Return the structured query intent.",
             "input_schema": QUERY_INTENT_SCHEMA,
         }
+        system = _with_schema_hint(_render_prompt(self.cfg.root, "query-intent"), schema_hint)
         try:
             msg = client.messages.create(
                 model=self.cfg.model,
                 max_tokens=1024,
-                system=_with_schema_hint(
-                    _render_prompt(self.cfg.root, "query-intent"), schema_hint
-                ),
+                system=system,
                 tools=[tool],
                 tool_choice={"type": "tool", "name": "emit_query_intent"},
                 messages=[{"role": "user", "content": question}],
@@ -263,11 +272,12 @@ class AnthropicAdapter:
 
     def answer_question(self, *, question: str, context: str) -> str:
         client = self._client()
+        system = _render_prompt(self.cfg.root, "ask-fallback")
         try:
             msg = client.messages.create(
                 model=self.cfg.model,
                 max_tokens=1200,
-                system=_render_prompt(self.cfg.root, "ask-fallback"),
+                system=system,
                 messages=[
                     {
                         "role": "user",

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -33,20 +33,25 @@ class AnthropicAdapter:
         argument; the class's other `LLMError`s are a different kind.
 
         Carriers outside the class are not covered by that, and there is more
-        than one. Module-level `_render_prompt` builds `LLMError(str(exc))` and
-        does NOT redact; nothing leaks through it today, because it catches only
-        `PromptError` and those messages are fixed strings plus a prompt id,
-        placeholder name, or title. The schema helpers three of the four
+        than one. Module-level `_render_prompt` builds an `LLMError` around a
+        caught exception and does NOT redact; nothing leaks through it, though
+        not for the reason the sentence this replaces gave. #500 widened its
+        second clause, so what it carries is now whatever the render raised.
+        What holds instead is the shape of the function: module-level, taking a
+        root path and a prompt id, so the configured key is not in scope for it
+        to put in a message -- the argument `ollama_adapter.list_models` makes
+        about itself -- and a render dials nothing, so a provider response
+        cannot arrive in it either. The schema helpers three of the four
         generation methods call just past their guarded region -- `parse_facts`,
         `parse_query`, `parse_query_intent`; `answer_question` calls none, it
         joins the stripped text blocks -- do not redact either, and two of the
         three are not harmless. Measured, `parse_facts` and `parse_query_intent`
         put what they were handed into the message they raise; `parse_query`
-        cannot, and sits in the bounded column with `_render_prompt` above --
-        its two raise sites carry a missing key name, a builtin `TypeError`
-        phrase, or a JSON position, and nothing of the payload. What those two
-        parse is the provider's response payload, which in this adapter is the
-        already-decoded `tool_use` input rather than a string
+        cannot -- its two raise sites carry a missing key name, a builtin
+        `TypeError` phrase, or a JSON position, and nothing of the payload,
+        which is a boundedness `_render_prompt` above no longer has. What those
+        two parse is the provider's response payload, which in this adapter is
+        the already-decoded `tool_use` input rather than a string
         (`parse_facts(block.input)`), and `_require_key` below already
         establishes the mechanism that puts a credential in it:
         `base_url` is caller-supplied, so the endpoint dialled is one a user can
@@ -286,7 +291,38 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 
 
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
+    """Render `prompt_id` under `root`, or raise `LLMError`.
+
+    Two clauses, and their order is the design. `PromptError` is the prompt
+    contract stated back to the user -- a required placeholder their override
+    left out -- so it goes out as the library wrote it, with nothing in front
+    of it. The clause below names the operation first, because what that one
+    catches is not always a sentence a user can act on.
+
+    Being that wide relabels a genuine programming error as something that
+    reads like a broken file: `prompt <id> could not be loaded` points at
+    `policy/prompts/<id>.md`, and for a `TypeError` raised inside
+    `render_prompt` that file is fine. It is the same widening
+    `test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url`
+    in `tests/test_ollama_adapter.py` refuses for `Request()` -- refused there
+    for a reason that does not hold here. `Request()` has one reachable
+    failure, so a type tells a real cause and a bug apart. `render_prompt`
+    reads two files, the packaged default and the override, and the `OSError`
+    family those reads can raise is not closed by a list; #500's reviewer
+    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
+    an `LLMError` -- wins that trade at the adapter seam, because what the
+    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
+    override or a `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
+    clause this wide: "ONE clause, out here", justified by what the caught type
+    is rather than by a list of the values it can carry. `from exc` pays for
+    the trade -- the original exception stays on `__cause__` for a log.
+
+    `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
+    """
     try:
         return render_prompt(root, prompt_id, **values)
     except PromptError as exc:
         raise LLMError(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - normalise every render failure
+        raise LLMError(f"prompt {prompt_id} could not be loaded: {exc}") from exc

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -248,11 +248,15 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
     """Render `prompt_id` under `root`, or raise `LLMError`.
 
-    Two clauses, and their order is the design. `PromptError` is the prompt
-    contract stated back to the user -- a required placeholder their override
-    left out -- so it goes out as the library wrote it, with nothing in front
-    of it. The clause below names the operation first, because what that one
-    catches is not always a sentence a user can act on.
+    Two clauses, and their order is the design. `PromptError` is whatever the
+    prompt library states in its own words -- a required placeholder the
+    override left out, an id nothing defines (`unknown prompt: extractoin`), a
+    value the caller never passed (`missing prompt value: qid`) -- so it goes
+    out as written, with nothing in front of it. Only the first of those three
+    is the user's doing; the other two are measured, and they reach the user
+    through the narrow clause with no operation named at all. The clause below
+    names the operation because what *it* catches is further still from a
+    sentence anybody can act on.
 
     Being that wide relabels a genuine programming error as something that
     reads like a broken file: `prompt <id> could not be loaded` points at
@@ -263,15 +267,18 @@ def _render_prompt(root, prompt_id: str, **values: object) -> str:
     for a reason that does not hold here. `Request()` has one reachable
     failure, so a type tells a real cause and a bug apart. `render_prompt`
     reads two files, the packaged default and the override, and the `OSError`
-    family those reads can raise is not closed by a list; #500's reviewer
-    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
-    an `LLMError` -- wins that trade at the adapter seam, because what the
-    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
-    override or a `PermissionError` from a mode bit, escaping as itself.
-    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
-    clause this wide: "ONE clause, out here", justified by what the caught type
-    is rather than by a list of the values it can carry. `from exc` pays for
-    the trade -- the original exception stays on `__cause__` for a log.
+    family those reads can raise is not closed by a list; #500's reviewer said
+    normalising the region is safer than enumerating it, and offered no list as
+    complete. §10.1 -- every LLM failure reaches its caller as an `LLMError` --
+    wins that trade at the adapter seam, because what the narrow clause alone
+    lets past is a `UnicodeDecodeError` from a hand-edited override or a
+    `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke` is the nearest precedent, and only for the
+    *form*: one `except OSError` "out here" rather than a copy per call site,
+    broad "where the `ValueError` above may not". Its reason does not carry
+    over -- `OSError` is not a domain type in this repo, and `except Exception`
+    catches every domain type there is. `from exc` pays for the trade -- the
+    original exception stays on `__cause__` for a log.
 
     `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
     """

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -246,10 +246,41 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 
 
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
+    """Render `prompt_id` under `root`, or raise `LLMError`.
+
+    Two clauses, and their order is the design. `PromptError` is the prompt
+    contract stated back to the user -- a required placeholder their override
+    left out -- so it goes out as the library wrote it, with nothing in front
+    of it. The clause below names the operation first, because what that one
+    catches is not always a sentence a user can act on.
+
+    Being that wide relabels a genuine programming error as something that
+    reads like a broken file: `prompt <id> could not be loaded` points at
+    `policy/prompts/<id>.md`, and for a `TypeError` raised inside
+    `render_prompt` that file is fine. It is the same widening
+    `test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url`
+    in `tests/test_ollama_adapter.py` refuses for `Request()` -- refused there
+    for a reason that does not hold here. `Request()` has one reachable
+    failure, so a type tells a real cause and a bug apart. `render_prompt`
+    reads two files, the packaged default and the override, and the `OSError`
+    family those reads can raise is not closed by a list; #500's reviewer
+    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
+    an `LLMError` -- wins that trade at the adapter seam, because what the
+    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
+    override or a `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
+    clause this wide: "ONE clause, out here", justified by what the caught type
+    is rather than by a list of the values it can carry. `from exc` pays for
+    the trade -- the original exception stays on `__cause__` for a log.
+
+    `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
+    """
     try:
         return render_prompt(root, prompt_id, **values)
     except PromptError as exc:
         raise LLMError(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - normalise every render failure
+        raise LLMError(f"prompt {prompt_id} could not be loaded: {exc}") from exc
 
 
 def _cli_model(model: str) -> str:

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -217,11 +217,15 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
     """Render `prompt_id` under `root`, or raise `LLMError`.
 
-    Two clauses, and their order is the design. `PromptError` is the prompt
-    contract stated back to the user -- a required placeholder their override
-    left out -- so it goes out as the library wrote it, with nothing in front
-    of it. The clause below names the operation first, because what that one
-    catches is not always a sentence a user can act on.
+    Two clauses, and their order is the design. `PromptError` is whatever the
+    prompt library states in its own words -- a required placeholder the
+    override left out, an id nothing defines (`unknown prompt: extractoin`), a
+    value the caller never passed (`missing prompt value: qid`) -- so it goes
+    out as written, with nothing in front of it. Only the first of those three
+    is the user's doing; the other two are measured, and they reach the user
+    through the narrow clause with no operation named at all. The clause below
+    names the operation because what *it* catches is further still from a
+    sentence anybody can act on.
 
     Being that wide relabels a genuine programming error as something that
     reads like a broken file: `prompt <id> could not be loaded` points at
@@ -232,15 +236,18 @@ def _render_prompt(root, prompt_id: str, **values: object) -> str:
     for a reason that does not hold here. `Request()` has one reachable
     failure, so a type tells a real cause and a bug apart. `render_prompt`
     reads two files, the packaged default and the override, and the `OSError`
-    family those reads can raise is not closed by a list; #500's reviewer
-    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
-    an `LLMError` -- wins that trade at the adapter seam, because what the
-    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
-    override or a `PermissionError` from a mode bit, escaping as itself.
-    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
-    clause this wide: "ONE clause, out here", justified by what the caught type
-    is rather than by a list of the values it can carry. `from exc` pays for
-    the trade -- the original exception stays on `__cause__` for a log.
+    family those reads can raise is not closed by a list; #500's reviewer said
+    normalising the region is safer than enumerating it, and offered no list as
+    complete. §10.1 -- every LLM failure reaches its caller as an `LLMError` --
+    wins that trade at the adapter seam, because what the narrow clause alone
+    lets past is a `UnicodeDecodeError` from a hand-edited override or a
+    `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke` is the nearest precedent, and only for the
+    *form*: one `except OSError` "out here" rather than a copy per call site,
+    broad "where the `ValueError` above may not". Its reason does not carry
+    over -- `OSError` is not a domain type in this repo, and `except Exception`
+    catches every domain type there is. `from exc` pays for the trade -- the
+    original exception stays on `__cause__` for a log.
 
     `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
     """

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -215,7 +215,38 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 
 
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
+    """Render `prompt_id` under `root`, or raise `LLMError`.
+
+    Two clauses, and their order is the design. `PromptError` is the prompt
+    contract stated back to the user -- a required placeholder their override
+    left out -- so it goes out as the library wrote it, with nothing in front
+    of it. The clause below names the operation first, because what that one
+    catches is not always a sentence a user can act on.
+
+    Being that wide relabels a genuine programming error as something that
+    reads like a broken file: `prompt <id> could not be loaded` points at
+    `policy/prompts/<id>.md`, and for a `TypeError` raised inside
+    `render_prompt` that file is fine. It is the same widening
+    `test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url`
+    in `tests/test_ollama_adapter.py` refuses for `Request()` -- refused there
+    for a reason that does not hold here. `Request()` has one reachable
+    failure, so a type tells a real cause and a bug apart. `render_prompt`
+    reads two files, the packaged default and the override, and the `OSError`
+    family those reads can raise is not closed by a list; #500's reviewer
+    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
+    an `LLMError` -- wins that trade at the adapter seam, because what the
+    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
+    override or a `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
+    clause this wide: "ONE clause, out here", justified by what the caught type
+    is rather than by a list of the values it can carry. `from exc` pays for
+    the trade -- the original exception stays on `__cause__` for a log.
+
+    `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
+    """
     try:
         return render_prompt(root, prompt_id, **values)
     except PromptError as exc:
         raise LLMError(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - normalise every render failure
+        raise LLMError(f"prompt {prompt_id} could not be loaded: {exc}") from exc

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -39,20 +39,25 @@ class OpenAIAdapter:
         a caught exception with no redaction, a third carrier of caught text.
         The sentence this replaces called it harmless *as written*, because the
         only thing it caught was `PromptError`; #500 widened its second clause,
-        so that qualifier has to be replaced with a narrower claim rather than
-        dropped. It now carries `str(exc)` of whatever the render raised, an
-        open set -- an `OSError` from the override read arrives with the KB's
-        absolute path spelled out in full (measured). What is still true is
-        about the configured key and the provider, and only those: the function
-        is module-level and takes a root path and a prompt id, so no `cfg` and
-        no key are in scope for it to name, and a render dials nothing, so no
-        provider response can arrive in it either. `redact_secret` is for
-        exactly those two, and the accurate word is not that it is unneeded but
-        that it is out of reach -- there is nothing here to hand it. What that
-        costs shows up in the path: spell the key into a KB directory name and
-        it rides into the message inside `cfg.root`, where `redact_secret`,
-        being substring replacement, would have masked it. Both halves measured.
-        Consolidating these four copies is where that residue can be addressed.
+        so that qualifier has to be replaced rather than dropped. It now carries
+        `str(exc)` of whatever the render raised, an open set -- an `OSError`
+        from the override read arrives with the KB's absolute path spelled out
+        in full (measured), key included if the user named a directory after
+        one.
+
+        So the four generation methods do not call it. They go through
+        `_rendered` above, which is a method rather than a module-level function
+        for the single reason that a method can pass `self.cfg.api_key` to
+        `redact_secret`. `OpenRouterAdapter` inherits it and redacts with its
+        own key. Measured: the twelve cells that carry a path -- this adapter,
+        `openrouter`, `anthropic`, four methods each, an unreadable override --
+        mask again, as they did on `759eac0` before the render was hoisted out
+        of the `try` that used to redact them.
+
+        `ollama_adapter` and `claude_cli_adapter` call their copies bare and
+        import no `redact_secret` at all; they never masked this and still do
+        not. That residue is theirs and predates #500, and consolidating the
+        four copies somewhere a key can be passed is the follow-up for it.
         `openrouter_adapter.list_models` is the same shape -- a bare
         `LLMError(f"openrouter request failed: {exc}")`, in a module that
         imports no `redact_secret` at all -- and rests on the first half of that
@@ -215,9 +220,46 @@ class OpenAIAdapter:
         """
         return self.cfg.base_url
 
+    def _rendered(self, prompt_id: str, **values: object) -> str:
+        """Render a prompt, and put the result under the redacting constructor.
+
+        Two layers, and they are not the same job. Module-level `_render_prompt`
+        normalises: every render failure leaves it as an `LLMError`, which is
+        §10.1, and all four adapters need it. This wraps that in the one thing a
+        module-level function cannot do -- reach `self.cfg.api_key` -- and it
+        exists only here and in `openai_adapter`, because those are the two
+        classes that redact at all. Nothing else changes: no new exception type,
+        no new message shape, only whether a configured key survives in the text.
+
+        It is here because #500 took it away. Before the hoist the render was an
+        ARGUMENT to the SDK call, so a `PermissionError` on the override went
+        through `_request_failed`, which redacts (measured on `759eac0`: the KB
+        path came out as `.../kb-***/policy/prompts/extraction.md`). Lifting the
+        render above the `try` moved that raise site out from under the redactor
+        while `_render_prompt` gained a message that carries `str(exc)` whole --
+        and an `OSError` from the override read spells out `cfg.root`. A key a
+        user put in their KB directory name then rode into
+        `source_chunks.error`. Twelve cells: three adapters, four methods, and
+        the conditions whose exception text carries a path. A non-UTF-8 override
+        is not one of them -- `UnicodeDecodeError` names a byte offset and no
+        file -- so the fix is not "the render leaks", it is that these twelve
+        stopped being redacted and are redacted again.
+
+        `from exc.__cause__`, not `from exc`. `_render_prompt` already hung the
+        original failure there, and
+        `test_a_render_failure_keeps_the_original_error_as_the_cause` asserts on
+        it; re-raising `from exc` would bury that behind this wrapper's own
+        `LLMError` and break it. Tidying this to `from exc` is the way to make
+        that test fail.
+        """
+        try:
+            return _render_prompt(self.cfg.root, prompt_id, **values)
+        except LLMError as exc:
+            raise LLMError(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
+
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()
-        system = _with_schema_hint(_render_prompt(self.cfg.root, "extraction"), schema_hint)
+        system = _with_schema_hint(self._rendered("extraction"), schema_hint)
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
@@ -238,7 +280,7 @@ class OpenAIAdapter:
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
         client = self._client()
         system = _with_schema_hint(
-            _render_prompt(self.cfg.root, "query-translation", qid=qid), schema_hint
+            self._rendered("query-translation", qid=qid), schema_hint
         )
         try:
             resp = client.chat.completions.create(
@@ -259,7 +301,7 @@ class OpenAIAdapter:
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
         client = self._client()
-        system = _with_schema_hint(_render_prompt(self.cfg.root, "query-intent"), schema_hint)
+        system = _with_schema_hint(self._rendered("query-intent"), schema_hint)
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
@@ -283,7 +325,7 @@ class OpenAIAdapter:
 
     def answer_question(self, *, question: str, context: str) -> str:
         client = self._client()
-        system = _render_prompt(self.cfg.root, "ask-fallback")
+        system = self._rendered("ask-fallback")
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -77,25 +77,39 @@ class OpenAIAdapter:
         `_client`, and the reason "before the request" cannot be the line
         between these two messages.
 
-        Nor does this name promise timing. The prompt render is an ARGUMENT to
-        the SDK call and so is evaluated inside the guarded region: an override
-        missing a required placeholder surfaces as "openai request failed"
-        without a request (measured). The honest reading is "the SDK call
-        yielded no result"; `_client_failed` is the message that can speak about
-        when. The imprecision predates this change and is #500's, which
-        prescribes pulling the render out of the `try` so that only the SDK call
-        is left inside -- four methods here, plus `OpenRouterAdapter` by
-        inheritance. Two things follow from doing that, and only the first is in
-        the issue. A template error stops being announced as a request failure,
-        which is the outcome #500 is written to get. The second was measured
-        while writing this: a hand-edited non-UTF-8 override -- read by
-        `get_prompt` as `read_text`, so a `UnicodeDecodeError` and not the
-        `PromptError` that `_render_prompt` converts -- has nothing left to
-        catch it once the render sits outside, and leaves this adapter
-        unnormalised. §10.1 is that an LLM failure reaches its caller as an
-        `LLMError`; this change is closing that hole at the constructor, and a
-        bare hoist would open it again at the render. So the hoist belongs with
-        the rest of the render's failures normalised, not on its own.
+        Nor does this name promise timing, and it used to promise less. The
+        prompt render was an ARGUMENT to the SDK call, evaluated inside the
+        guarded region, so an override missing a required placeholder surfaced
+        as "openai request failed" without a request (measured). #500 lifted it
+        into a statement of its own -- below `client = self._client()`, above
+        the `try` -- in the four methods here, and in `OpenRouterAdapter` by
+        inheritance, which leaves the guarded region holding the SDK call and
+        nothing else. Measured, the same broken override now reports "Datalog
+        translation prompt must include required placeholder {qid}", with no
+        "request failed" in front of it.
+
+        What is left still reads as "the SDK call yielded no result" rather than
+        "the provider answered"; `_client_failed` is the message that can speak
+        about when. That is asserted here from the structure and from stubs,
+        which is all this file is entitled to: the openai SDK is an optional
+        dependency, absent in CI and in some development environments, so the
+        vendor-behaviour measurement behind this claim lives in the anthropic
+        twin of this paragraph and is not restated as if it had been taken here.
+        What the hoist did change is that the prompt error -- the one measured
+        case of this message covering something that never dialled -- no longer
+        arrives.
+
+        Rendering outside the guard is the shape `ollama_adapter` and
+        `claude_cli_adapter` were already in, and it carries a hole this `try`
+        was covering. `get_prompt` reads an override with `read_text`, so a
+        hand-edited non-UTF-8 file raises `UnicodeDecodeError` and a mode bit
+        raises `PermissionError`, and `_render_prompt`'s `except PromptError`
+        converted neither. Measured on those two adapters before this change,
+        that is sixteen method-and-condition pairs leaving the adapter as
+        something that is not an `LLMError` -- §10.1 broken in the tree already,
+        not by the hoist. So the hoist ships with the second clause added to
+        `_render_prompt` in the same PR, which normalises the render's failures
+        wherever the render sits.
 
         Redaction covers only the key this process knows about, which is why
         `_require_key` refuses to let the SDK authenticate with one it never saw.
@@ -191,16 +205,12 @@ class OpenAIAdapter:
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()
+        system = _with_schema_hint(_render_prompt(self.cfg.root, "extraction"), schema_hint)
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
                 messages=[
-                    {
-                        "role": "system",
-                        "content": _with_schema_hint(
-                            _render_prompt(self.cfg.root, "extraction"), schema_hint
-                        ),
-                    },
+                    {"role": "system", "content": system},
                     {"role": "user", "content": source_text},
                 ],
                 response_format={
@@ -215,19 +225,14 @@ class OpenAIAdapter:
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
         client = self._client()
+        system = _with_schema_hint(
+            _render_prompt(self.cfg.root, "query-translation", qid=qid), schema_hint
+        )
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
                 messages=[
-                    {
-                        "role": "system",
-                        "content": _with_schema_hint(
-                            _render_prompt(
-                                self.cfg.root, "query-translation", qid=qid
-                            ),
-                            schema_hint,
-                        ),
-                    },
+                    {"role": "system", "content": system},
                     {"role": "user", "content": question},
                 ],
                 response_format={
@@ -242,17 +247,12 @@ class OpenAIAdapter:
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
         client = self._client()
+        system = _with_schema_hint(_render_prompt(self.cfg.root, "query-intent"), schema_hint)
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
                 messages=[
-                    {
-                        "role": "system",
-                        "content": _with_schema_hint(
-                            _render_prompt(self.cfg.root, "query-intent"),
-                            schema_hint,
-                        ),
-                    },
+                    {"role": "system", "content": system},
                     {"role": "user", "content": question},
                 ],
                 response_format={
@@ -271,14 +271,12 @@ class OpenAIAdapter:
 
     def answer_question(self, *, question: str, context: str) -> str:
         client = self._client()
+        system = _render_prompt(self.cfg.root, "ask-fallback")
         try:
             resp = client.chat.completions.create(
                 model=self.cfg.model,
                 messages=[
-                    {
-                        "role": "system",
-                        "content": _render_prompt(self.cfg.root, "ask-fallback"),
-                    },
+                    {"role": "system", "content": system},
                     {
                         "role": "user",
                         "content": f"Question:\n{question}\n\nContext:\n{context}",

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -227,7 +227,7 @@ class OpenAIAdapter:
         normalises: every render failure leaves it as an `LLMError`, which is
         §10.1, and all four adapters need it. This wraps that in the one thing a
         module-level function cannot do -- reach `self.cfg.api_key` -- and it
-        exists only here and in `openai_adapter`, because those are the two
+        exists only here and in `anthropic_adapter`, because those are the two
         classes that redact at all. Nothing else changes: no new exception type,
         no new message shape, only whether a configured key survives in the text.
 

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -35,15 +35,18 @@ class OpenAIAdapter:
         turns on, so this is not a subclass that merely renames things.
 
         Redaction is not universal outside that class boundary, though.
-        Module-level `_render_prompt` in this file builds `LLMError(str(exc))`
-        with no redaction, a third carrier of caught text; it is harmless as
-        written, because the only thing it catches is `PromptError` and those
-        messages are fixed strings plus a prompt id, placeholder name, or title.
+        Module-level `_render_prompt` in this file builds an `LLMError` around
+        a caught exception with no redaction, a third carrier of caught text; it
+        is harmless, but not for the reason the sentence this replaces gave.
+        #500 widened its second clause, so what it carries is whatever the
+        render raised. What holds instead is the shape of the function:
+        module-level, taking a root path and a prompt id, so no key is in scope
+        for it to put in a message, and a render dials nothing, so no provider
+        response can arrive in it either.
         `openrouter_adapter.list_models` is the same shape -- a bare
         `LLMError(f"openrouter request failed: {exc}")`, in a module that
-        imports no `redact_secret` at all -- and is harmless for a different
-        reason: it is a module-level function precisely so that no key is in
-        scope for it to leak, which its own docstring argues at length. The
+        imports no `redact_secret` at all -- and rests on the first half of that
+        same argument, which its own docstring makes at length. The
         schema helpers three of the four generation methods call just past their
         guarded region -- `parse_facts`, `parse_query`, `parse_query_intent`;
         `answer_question` calls none, it strips the message text and returns --
@@ -51,8 +54,8 @@ class OpenAIAdapter:
         Measured, `parse_facts` and `parse_query_intent` copy what they were
         handed into the message they raise. `parse_query` does not: its two
         raise sites can carry a missing key name, a builtin `TypeError` phrase,
-        or a JSON position, which puts it beside `_render_prompt` above --
-        unredacted but bounded. For the other two the input is provider response
+        or a JSON position -- unredacted, and bounded in a way `_render_prompt`
+        above no longer is. For the other two the input is provider response
         text, and the threat model is the one `_require_key` sets out below,
         transposed: there an attacker-influenced endpoint -- `base_url` is
         caller-supplied -- echoes back a credential verinote never resolved, so
@@ -294,7 +297,38 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 
 
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
+    """Render `prompt_id` under `root`, or raise `LLMError`.
+
+    Two clauses, and their order is the design. `PromptError` is the prompt
+    contract stated back to the user -- a required placeholder their override
+    left out -- so it goes out as the library wrote it, with nothing in front
+    of it. The clause below names the operation first, because what that one
+    catches is not always a sentence a user can act on.
+
+    Being that wide relabels a genuine programming error as something that
+    reads like a broken file: `prompt <id> could not be loaded` points at
+    `policy/prompts/<id>.md`, and for a `TypeError` raised inside
+    `render_prompt` that file is fine. It is the same widening
+    `test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url`
+    in `tests/test_ollama_adapter.py` refuses for `Request()` -- refused there
+    for a reason that does not hold here. `Request()` has one reachable
+    failure, so a type tells a real cause and a bug apart. `render_prompt`
+    reads two files, the packaged default and the override, and the `OSError`
+    family those reads can raise is not closed by a list; #500's reviewer
+    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
+    an `LLMError` -- wins that trade at the adapter seam, because what the
+    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
+    override or a `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
+    clause this wide: "ONE clause, out here", justified by what the caught type
+    is rather than by a list of the values it can carry. `from exc` pays for
+    the trade -- the original exception stays on `__cause__` for a log.
+
+    `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
+    """
     try:
         return render_prompt(root, prompt_id, **values)
     except PromptError as exc:
         raise LLMError(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - normalise every render failure
+        raise LLMError(f"prompt {prompt_id} could not be loaded: {exc}") from exc

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -36,13 +36,23 @@ class OpenAIAdapter:
 
         Redaction is not universal outside that class boundary, though.
         Module-level `_render_prompt` in this file builds an `LLMError` around
-        a caught exception with no redaction, a third carrier of caught text; it
-        is harmless, but not for the reason the sentence this replaces gave.
-        #500 widened its second clause, so what it carries is whatever the
-        render raised. What holds instead is the shape of the function:
-        module-level, taking a root path and a prompt id, so no key is in scope
-        for it to put in a message, and a render dials nothing, so no provider
-        response can arrive in it either.
+        a caught exception with no redaction, a third carrier of caught text.
+        The sentence this replaces called it harmless *as written*, because the
+        only thing it caught was `PromptError`; #500 widened its second clause,
+        so that qualifier has to be replaced with a narrower claim rather than
+        dropped. It now carries `str(exc)` of whatever the render raised, an
+        open set -- an `OSError` from the override read arrives with the KB's
+        absolute path spelled out in full (measured). What is still true is
+        about the configured key and the provider, and only those: the function
+        is module-level and takes a root path and a prompt id, so no `cfg` and
+        no key are in scope for it to name, and a render dials nothing, so no
+        provider response can arrive in it either. `redact_secret` is for
+        exactly those two, and the accurate word is not that it is unneeded but
+        that it is out of reach -- there is nothing here to hand it. What that
+        costs shows up in the path: spell the key into a KB directory name and
+        it rides into the message inside `cfg.root`, where `redact_secret`,
+        being substring replacement, would have masked it. Both halves measured.
+        Consolidating these four copies is where that residue can be addressed.
         `openrouter_adapter.list_models` is the same shape -- a bare
         `LLMError(f"openrouter request failed: {exc}")`, in a module that
         imports no `redact_secret` at all -- and rests on the first half of that
@@ -93,8 +103,7 @@ class OpenAIAdapter:
         about when. That is asserted here from the structure and from stubs,
         which is all this file is entitled to: the openai SDK is an optional
         extra, absent from the `ci.yml` pytest job -- which installs
-        `.[test,wirelog]`, so `provider-contract.yml` is the only workflow that
-        has it -- and from some development environments, so the
+        `.[test,wirelog]` -- and from some development environments, so the
         vendor-behaviour measurement behind this claim lives in the anthropic
         twin of this paragraph and is not restated as if it had been taken here.
         What the hoist did change is that the prompt error -- the one measured
@@ -107,9 +116,10 @@ class OpenAIAdapter:
         hand-edited non-UTF-8 file raises `UnicodeDecodeError` and a mode bit
         raises `PermissionError`, and `_render_prompt`'s `except PromptError`
         converted neither. Measured on those two adapters before this change,
-        that is sixteen method-and-condition pairs leaving the adapter as
-        something that is not an `LLMError` -- §10.1 broken in the tree already,
-        not by the hoist. So the hoist ships with the second clause added to
+        that is eight method-and-condition pairs on each of them -- sixteen
+        cells -- leaving the adapter as something that is not an `LLMError`,
+        which is §10.1 broken in the tree already and not by the hoist. So the
+        hoist ships with the second clause added to
         `_render_prompt` in the same PR, which normalises the render's failures
         wherever the render sits.
 
@@ -299,11 +309,15 @@ def _with_schema_hint(prompt: str, schema_hint: str) -> str:
 def _render_prompt(root, prompt_id: str, **values: object) -> str:
     """Render `prompt_id` under `root`, or raise `LLMError`.
 
-    Two clauses, and their order is the design. `PromptError` is the prompt
-    contract stated back to the user -- a required placeholder their override
-    left out -- so it goes out as the library wrote it, with nothing in front
-    of it. The clause below names the operation first, because what that one
-    catches is not always a sentence a user can act on.
+    Two clauses, and their order is the design. `PromptError` is whatever the
+    prompt library states in its own words -- a required placeholder the
+    override left out, an id nothing defines (`unknown prompt: extractoin`), a
+    value the caller never passed (`missing prompt value: qid`) -- so it goes
+    out as written, with nothing in front of it. Only the first of those three
+    is the user's doing; the other two are measured, and they reach the user
+    through the narrow clause with no operation named at all. The clause below
+    names the operation because what *it* catches is further still from a
+    sentence anybody can act on.
 
     Being that wide relabels a genuine programming error as something that
     reads like a broken file: `prompt <id> could not be loaded` points at
@@ -314,15 +328,18 @@ def _render_prompt(root, prompt_id: str, **values: object) -> str:
     for a reason that does not hold here. `Request()` has one reachable
     failure, so a type tells a real cause and a bug apart. `render_prompt`
     reads two files, the packaged default and the override, and the `OSError`
-    family those reads can raise is not closed by a list; #500's reviewer
-    rejected enumerating it. §10.1 -- every LLM failure reaches its caller as
-    an `LLMError` -- wins that trade at the adapter seam, because what the
-    narrow clause alone lets past is a `UnicodeDecodeError` from a hand-edited
-    override or a `PermissionError` from a mode bit, escaping as itself.
-    `claude_cli_adapter._invoke`'s `except OSError` is the precedent for a
-    clause this wide: "ONE clause, out here", justified by what the caught type
-    is rather than by a list of the values it can carry. `from exc` pays for
-    the trade -- the original exception stays on `__cause__` for a log.
+    family those reads can raise is not closed by a list; #500's reviewer said
+    normalising the region is safer than enumerating it, and offered no list as
+    complete. §10.1 -- every LLM failure reaches its caller as an `LLMError` --
+    wins that trade at the adapter seam, because what the narrow clause alone
+    lets past is a `UnicodeDecodeError` from a hand-edited override or a
+    `PermissionError` from a mode bit, escaping as itself.
+    `claude_cli_adapter._invoke` is the nearest precedent, and only for the
+    *form*: one `except OSError` "out here" rather than a copy per call site,
+    broad "where the `ValueError` above may not". Its reason does not carry
+    over -- `OSError` is not a domain type in this repo, and `except Exception`
+    catches every domain type there is. `from exc` pays for the trade -- the
+    original exception stays on `__cause__` for a log.
 
     `except Exception` reaches neither `KeyboardInterrupt` nor `SystemExit`.
     """

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -92,7 +92,9 @@ class OpenAIAdapter:
         "the provider answered"; `_client_failed` is the message that can speak
         about when. That is asserted here from the structure and from stubs,
         which is all this file is entitled to: the openai SDK is an optional
-        dependency, absent in CI and in some development environments, so the
+        extra, absent from the `ci.yml` pytest job -- which installs
+        `.[test,wirelog]`, so `provider-contract.yml` is the only workflow that
+        has it -- and from some development environments, so the
         vendor-behaviour measurement behind this claim lives in the anthropic
         twin of this paragraph and is not restated as if it had been taken here.
         What the hoist did change is that the prompt error -- the one measured


### PR DESCRIPTION
A broken prompt template stops being reported as a provider outage, and every
render failure now leaves an adapter as an `LLMError`.

Closes #500.

## What the issue asked for, and two corrections to its framing

The issue is right about the symptom and about the fix's shape. Two sentences in
its "계약 위반은 아니다" section are wrong, and the second one changes the scope:

1. **`PromptError` is not an `LLMError`.** `PromptError(ValueError)`
   (`prompts/library.py:24`) and `LLMError(RuntimeError)` (`llm/base.py:15`) are
   unrelated -- `issubclass(PromptError, LLMError)` is `False`. The issue's
   conclusion for the cloud adapters ("§10.1 holds today") survives, but not for
   the reason given: what keeps it satisfied is `_render_prompt`'s
   `except PromptError` doing the conversion, not inheritance.

2. **§10.1 is already broken in the tree**, on the two adapters the issue holds
   up as the good example. `ollama` and `claude_cli` already render outside the
   `try` -- the shape #500 prescribes -- so a render failure that is not a
   `PromptError` escapes them unconverted. Measured at `759eac0`, 2 adapters ×
   4 methods × 2 conditions = **16 cells** leave the adapter as something that
   is not an `LLMError`:

   ```
   ##### COND: nonutf8      (override written as b"\xff\xfe ...")
     ollama     × 4    ESCAPE:UnicodeDecodeError  'utf-8' codec can't decode byte 0xff in position 0
     claudecli  × 4    ESCAPE:UnicodeDecodeError  ...
   ##### COND: unreadable   (override chmod 0o000)
     ollama     × 4    ESCAPE:PermissionError     [Errno 13] Permission denied: .../policy/prompts/...
     claudecli  × 4    ESCAPE:PermissionError     ...
   TOTAL NON-LLMError ESCAPES: 16
   ```

So this is not purely an attribution problem. It is an attribution problem
**plus a §10.1 hole that is already open**. The reviewer's comment measured the
same thing from the other direction and called it a hole the hoist *opens*;
what the hoisted shape actually is, is the shape `ollama` and `claude_cli` have
shipped in all along. The hole is in that shape already, and on the cloud
adapters the `try` was covering it. Normalising the render is therefore not a
precaution attached to the hoist -- it is the larger half of the fix, and the
bare relocation the issue body prescribes is not implemented on its own here.

## The change

Five commits, in this order. C3 and C4 correct prose the earlier two
introduced, and C5 closes a confidentiality regression C2 opened, found in
review on this PR. They are kept separate rather than squashed, which is the
shape #504 merged with, and squashing would hide that C2 shipped a leak.

**C1 -- `fix(llm): normalise every prompt-render failure at the adapter seam`**

`_render_prompt` in all four adapters gains a second clause below the existing
one:

```python
    except PromptError as exc:
        raise LLMError(str(exc)) from exc
    except Exception as exc:  # noqa: BLE001 - normalise every render failure
        raise LLMError(f"prompt {prompt_id} could not be loaded: {exc}") from exc
```

The order is load-bearing and is pinned by a mutant. A prompt-contract violation
is a sentence the user can act on, so it goes out as the library wrote it with
nothing prefixed; everything else gets the operation named first. The prompt id
is in the message because it is the override file's stem
(`query-translation` → `policy/prompts/query-translation.md`) and
`UnicodeDecodeError` carries no path of its own.

The four copies stay byte-identical: the span from `def _render_prompt` to its
last statement, trailing newline included, is 43 lines / 2725 bytes, md5
`5d375fd4…`, in all four files (5 lines / 205 bytes, `289c32b8…`, before).
Consolidating them is proposed as a follow-up rather than done here.

Not enumerated -- not `except (UnicodeDecodeError, PermissionError)`. #500's
reviewer said normalising the region is safer than enumerating it and declined
to offer their own list as complete, and the structure agrees: `get_prompt`
reads two files (the packaged default, then the override at
`prompts/library.py:123`) and the `OSError` family those reads can raise is not
closed by a list.

**This clause has a cost, and the PR does not pretend otherwise.** It turns a
programming error into something that reads like a broken user file: a
`TypeError` raised inside `render_prompt` comes out as
`prompt extraction could not be loaded: ...`, pointing at a file that is fine.
That is the same relabelling
`test_a_non_valueerror_from_the_request_constructor_is_not_blamed_on_the_base_url`
(`tests/test_ollama_adapter.py`) refuses for `Request()`. It is accepted here for
a reason that does not apply there: `Request()` has one reachable failure, so a
type separates a real cause from a bug, and the render does not. §10.1 wins the
trade at the adapter seam. `claude_cli_adapter._invoke`'s `except OSError` is
the nearest precedent and the docstring borrows only its *form* -- one clause
"out here" rather than a copy per call site, broad "where the `ValueError` above
may not". Its reason does not transfer, and the docstring says so: `OSError` is
not a domain type in this repo, whereas `except Exception` catches every domain
type there is. The cost is paid back by `from exc`, and both halves of that --
the accepted relabelling and the preserved cause -- now have their own tests, so
a later reader cannot narrow the clause thinking the trade was an oversight.

`except Exception` does not reach `KeyboardInterrupt` or `SystemExit` (measured:
both still escape `_render_prompt` as themselves).

**C2 -- `fix(llm): hoist the prompt render out of the request guard`**

The eight cloud call sites (anthropic ×4, openai ×4; `openrouter` follows by
inheritance) render into a local, placed **below `client = self._client()` and
above the `try`**. That position is deliberate and is pinned by a mutant: moving
the render above `_client()` also satisfies #500 and would change which of two
simultaneous problems a user with no key and a broken template is told about.

C1 comes first so that no intermediate commit has §10.1 open at the render.
C1 is not invisible on the cloud adapters, though: the exception type and the
`<provider> request failed:` prefix are unchanged, but the message body gains
`prompt <id> could not be loaded:` in the middle. Removing the misattribution on
the cloud adapters is C2's job.

**C3 -- `docs(llm): name the CI job the openai SDK is actually absent from`**

A one-sentence correction to C2's own docstring, caught in verification. It said
the openai SDK is "absent in CI"; `provider-contract.yml` installs
`.[test,openai,wirelog]`, so that is falsifiable as written. What is true is that
the `ci.yml` pytest job installs `.[test,wirelog]` and does not have it.

**C4 -- `docs(llm): state the conditions three claims are only true under`**

Prose only; no line of code or test logic changes. Four things, all found by
re-reading the merged text against a measurement:

1. The anthropic vendor measurement did not reproduce under the setup it stated.
   Without a client `timeout=`, `max_tokens="x"` fails locally with a `TypeError`
   because the SDK derives the timeout from it. The condition is now in the
   sentence, and the general claim it used to end on is gone.
2. The `_render_prompt` leak claim had lost its hedge (`today` / `as written`) in
   the same edit that widened what it carries. The claim is now scoped to the
   configured key and the provider response, and the reason is modal:
   `redact_secret` is not unnecessary at this seam, it is unreachable -- a
   module-level function with no `cfg` in scope has nothing to hand it. What
   *does* come through is stated rather than denied: the KB path in full, key
   included if the user spelled one into a directory name, which `redact_secret`
   would have masked had anything here been able to call it.
3. `_render_prompt`'s own first paragraph was false about the narrow clause:
   `unknown prompt: <id>` and `missing prompt value: <name>` are `PromptError`s
   and programming errors, and they go out through it with no operation named.
4. C3's replacement sentence had introduced its own over-general clause ("so
   `provider-contract.yml` is the only workflow that has it" — true today, and
   falsified by a third workflow). Dropped; the `ci.yml` half stands alone.
   The same imprecision C3 fixed was also sitting in
   `tests/test_cloud_adapters.py:654` ("which includes CI"), in the same file
   twenty-eight lines above the new `#500` section, and is fixed with it.

**C5 -- `fix(llm): put the hoisted render back under the redacting constructor`**

C2 opened a confidentiality regression and this closes it. On `759eac0` the
render was an ARGUMENT to the SDK call, so a `PermissionError` from reading the
override passed through `_request_failed`, **which redacts**. The hoist moved
that raise site out from under the redactor, and C1's `except Exception` gives
it a message carrying `str(exc)` whole — so an `OSError` spells out `cfg.root`,
and a key a user put in their KB directory name rode into
`source_chunks.error` (`web/app.py:1784`) and onto the pages that render it.

Measured on three trees, same setup — KB root named `kb-<key>`,
`cfg.api_key` the same string, override `chmod 0o000`, SDK stubbed, each ref a
clean `git archive` copy with `verinote.__file__` asserted inside it:

| tree | cells | leaking the configured key | the unreadable rows |
|---|---|---|---|
| `759eac0` (main) | 24 | **0** | `… '.../kb-***/policy/prompts/extraction.md'` |
| `755c1c4` (C4, as first reviewed) | 24 | **12** | `… '.../kb-<key>/policy/prompts/extraction.md'` |
| this branch | 24 | **0** | `… '.../kb-***/policy/prompts/extraction.md'` |

**Twelve cells, not twenty-four.** The other break this PR's tests use — a
non-UTF-8 override — raises `UnicodeDecodeError`, which names a byte offset and
no path, so there is nothing for a key to ride in on and those twelve cells are
unmasked on every tree including main. The regression is exactly the three cloud
adapters × four methods × the conditions whose exception text carries a path.

The fix is a thin `self._rendered(prompt_id, **values)` on `AnthropicAdapter`
and `OpenAIAdapter` — the two classes that redact at all; `OpenRouterAdapter`
inherits it and uses its own key — with the eight hoisted call sites going
through it. **The layers stay separate**: module-level `_render_prompt`
normalises, which is §10.1 and what all four adapters need, and `_rendered` adds
the one thing a module-level function cannot do, which is reach
`self.cfg.api_key`. No new exception type and no new message shape — the only
difference is whether a configured key survives in the text. The four
`_render_prompt` copies are untouched and still byte-identical.

`from exc.__cause__`, not `from exc`: `_render_prompt` already hung the original
failure there and `test_a_render_failure_keeps_the_original_error_as_the_cause`
asserts on it. Mutant R4 makes exactly that swap and kills that test alone.

`ollama_adapter` and `claude_cli_adapter` are not touched, and the two
`_request_failed` paragraphs now split the two cases instead of attributing both
to the module-level shape. Those two import no `redact_secret`; measured, they
leaked this on `759eac0` as a raw `PermissionError` and leak it as an `LLMError`
now. That is untouched residue and belongs to the consolidation follow-up. Only
the cloud three were a regression, because only there was a redactor covering it.

## Alternatives considered

- **Enumerate the render's failure types** instead of a catch-all. #500's
  reviewer said normalising the region is safer than enumerating it and offered
  no list as complete, and the measurement agrees: two files are read and the
  `OSError` family is open.
  `test_a_render_failure_of_a_kind_nobody_enumerated_is_still_an_llm_error`
  fails any narrowing back to a list.
- **Wrap each hoisted render in its own `try` in the method.** That replicates
  the same four-line `except` at eight sites. The failure mode this repo learned
  from #474 is exactly "one of the copied clauses misses a case", which
  `claude_cli_adapter._invoke` already writes down as one clause "out here"
  (inline comment at `:213`; the docstring makes the same point at `:172`).
- **A class-method helper `self._rendered(...)`.** Earlier revisions of this PR
  rejected it, and **one of the two reasons given was false**: "there is no key
  in scope for a render failure to carry, so redaction buys nothing here". A key
  spelled into a KB directory name arrives inside `cfg.root` on any `OSError`
  from the override read, `redact_secret` is substring replacement and masks it
  there, and on `759eac0` it *was* masking it. Review on this PR caught that,
  and C5 adopts the helper in its thinnest form on the two adapters that redact.
  The rest of that rejection still stands and is why the helper is thin rather
  than a replacement for `_render_prompt`: it does have to be copied per class
  (two copies, one per redacting class), and it does not cover `claude_cli`'s
  `claude-json-wrapper` render without changing the signature of `_prompt`,
  which is a module-level function — it already takes `root`, so that is a
  signature change rather than an impossibility. Not covering it costs nothing
  here, because `claude_cli` has no redactor to be kept under.
- **Consolidating the four copies into `llm/base.py`** is right and is proposed
  as a follow-up, and the residual above is one more reason for it. Not done
  here: touching `ollama`, `claude_cli` and `base` together widens the conflict
  surface against the other lanes in flight, and two statements plus a shared
  docstring on four functions that were five lines each is the narrowest edit
  that closes §10.1.

## Behaviour change

**Breaking, in message text.** Anything matching on these strings has to change:

| condition | before | after |
|---|---|---|
| cloud, non-UTF-8 override | `anthropic request failed: 'utf-8' codec can't decode byte 0xff…` | `prompt extraction could not be loaded: 'utf-8' codec can't decode byte 0xff…` |
| cloud, unreadable override | `openai request failed: [Errno 13] Permission denied: '.../kb-***/policy/prompts/extraction.md'` | `prompt extraction could not be loaded: [Errno 13] Permission denied: '.../kb-***/policy/prompts/extraction.md'` |
| cloud, missing placeholder | `openai request failed: Datalog translation prompt must include required placeholder {qid}` | `Datalog translation prompt must include required placeholder {qid}` |
| ollama/claudecli, non-UTF-8 or unreadable override | `UnicodeDecodeError` / `PermissionError` **escaping the adapter** | `LLMError: prompt <id> could not be loaded: …` |

The `***` in the unreadable row is not decoration: that path is redacted on main
and is redacted here, and C5 is what keeps it that way — between C2 and C5 it was
the key in clear. The non-UTF-8 row has no `***` on either side because
`UnicodeDecodeError` carries no path.

The last row is a type change at the adapter boundary, and it is the point. The
web extraction worker sorts adapter failures by type: `except LLMError`
(`web/app.py:1781`) writes `extraction failed: …` (`:1784`), and the generic
`except Exception` below it (`:1785`) writes `analysis failed: …` (`:1788`). An
escaping `UnicodeDecodeError` lands in the second one, so a user's own prompt
file is filed under the same wording `claude_cli_adapter.py:170` names as "the
exact shape #474 was reported as". In the CLI, `LLMError` is caught at
`cli.py:906`, `1085`, `1149`; nothing else is.

## Docstrings that #504 shipped

Four claims in the merged `_request_failed` docstrings go stale. Only those were
touched; a word-diff shows no other change in either file. Line numbers are
`759eac0`.

| where | before (#504) | after |
|---|---|---|
| `anthropic:36-39`, `openai:38-41` — `_render_prompt` leak safety | "builds `LLMError(str(exc))` … nothing leaks through it **today**, because it catches only `PromptError` and those messages are fixed strings plus a prompt id, placeholder name, or title" / "harmless **as written**, because the only thing it catches is `PromptError`" | The hedge is not dropped — it is replaced by a narrower claim, because the ground it stood on is what C1 removed. What the function carries is now `str(exc)` of whatever the render raised, an open set: an `OSError` from the override read arrives with the KB's absolute path in full, `cfg.root` and all (measured — put a secret in your KB directory name and it is in the message). What is still true is about two things only, and they are named: no `cfg` and no key are in scope (module-level, takes a root path and a prompt id — the argument `ollama_adapter.list_models` makes about itself), and a render dials nothing, so no provider response can arrive. Those are the two `redact_secret` is for, and the modality is the point — **not that it is unneeded but that it is out of reach**, since this function has nothing to hand it. The paragraph states the residual rather than denying it: a key inside a KB directory name rides in with the path, and `redact_secret` **would** have masked it there (measured, both halves). **No replacement list of carriable strings is offered** — the set is open, which is the reason the clause is a catch-all. |
| `openai:44-46` — `openrouter_adapter.list_models` | "is harmless **for a different reason**: it is a module-level function precisely so that no key is in scope" | "for a different reason" became false when `_render_prompt`'s reason became that same argument. Now: "rests on the first half of that same argument, which its own docstring makes at length" (`openrouter_adapter.py:43-50`). |
| `anthropic:45`, `openai:54-55` — the "**bounded**" pairing | "`parse_query` cannot, and **sits in the bounded column with `_render_prompt` above**" / "which puts it beside `_render_prompt` above -- **unredacted but bounded**" | `parse_query`'s own claim kept verbatim; the pairing cut. anthropic: "…and nothing of the payload, **which is a boundedness `_render_prompt` above no longer has**". openai: "…or a JSON position -- unredacted, and **bounded in a way `_render_prompt` above no longer is**". |
| `anthropic:75-95`, `openai:77-94` — the timing paragraph | Render described as "an ARGUMENT to `client.messages.create`"; #500's fix stated in the future tense ("Its stated fix is to hoist…", "a bare hoist **would** open it again"); only `UnicodeDecodeError` named. | Past tense, split into three paragraphs: what the hoist did; what it did not buy (still "the SDK call yielded no result" — anthropic carries the vendor measurement, openai declines to restate it, C3); and that the hoisted shape is the one `ollama`/`claude_cli` already had, with the sixteen escaping cells attributed to the tree rather than to the hoist. `PermissionError` named alongside `UnicodeDecodeError`. |

The anthropic vendor measurement, taken here, **and the condition is part of it**:
anthropic 0.116.0, `base_url` on a closed port, client built the way `_client`
builds it — with `timeout=` passed. Under that condition
`messages.create(max_tokens="x")` and `messages="hi"` both come back
`APIConnectionError`, exactly as a well-formed call does. Leave the timeout off
and the same `max_tokens="x"` fails locally with
`TypeError: unsupported operand type(s) for /: 'str' and 'int'` — the SDK derives
a timeout from `max_tokens`. So the docstring states the condition instead of
claiming the SDK validates nothing locally; `_client` passes
`timeout=self.cfg.llm_timeout_seconds`, so the adapter is always inside it.

`_client_failed` in both files, the `_client` hoist comments, `_require_key`, and
`openrouter_adapter.py` itself are untouched. The AST guard
`test_each_adapter_names_only_its_own_vendor_base_url_variable` reads
`_client_failed` only.

### The `_render_prompt` docstring's own dichotomy

Its first paragraph originally read `PromptError` as "the prompt contract stated
back to the user" against a catch-all that "is not always a sentence a user can
act on". That is false about the narrow clause, measured:

```
_render_prompt(root, "extractoin")          LLMError: unknown prompt: extractoin
_render_prompt(root, "query-translation")   LLMError: missing prompt value: qid
```

Both are `PromptError` (`prompts/library.py:98`, `:143`), both are programming
errors here — a mistyped id, an omitted kwarg — and both go out through the
*narrow* clause with no operation named at all, which is less context than the
relabelling the catch-all is apologised for. The paragraph now names the three
`PromptError`s reachable through `render_prompt` — `library.py` raises it at
five sites, but `:152` is `save_prompt_override`'s and `:172` needs an empty
packaged default — and says only the first of the three is the user's doing.
The docstring itself says "whatever the prompt library states in its own words",
so it is not claiming the list is closed. The trade argument in the second
paragraph is unaffected.

## Tests

42 new test cases in 13 functions (11 distinct names — the ollama and claudecli
halves reuse two of them). `tests/test_cloud_adapters.py` gets a `#500`
section (8 functions / 37 cases, of which 12 are C5's redaction guard);
`tests/test_ollama_adapter.py` (2) and
`tests/test_claude_cli_adapter.py` (3) get the C1 half, which is red at
`759eac0` with no mutant needed.

The 12-cell matrix breaks the template with a **non-UTF-8 override, not a missing
placeholder**. Only `query-translation` of the four ids these methods render
declares a `required_placeholder`, so "an override missing a placeholder" is not
a break at all for the other three -- `_validate_prompt_text` passes it and the
SDK is reached with a usable prompt. Read literally, the issue's non-regression
condition would make **9 of its 12 cells assert nothing**. The placeholder case
gets its own test, anchored at both ends, on the one method where it bites.

**29 of the 30 are red at `759eac0`** with the source untouched (the three test
files copied onto the base tree):

```
29 failed, 171 passed, 1 skipped
```

The one that is green there is
`test_a_render_failure_keeps_the_original_error_as_the_cause`: at `759eac0` the
render sits inside the `try`, so `from exc` on `_request_failed` already
preserves the cause. It is a guard on the new clause's `from exc` and is
non-vacuous by mutant F1 below, not by red-first.

## Mutants

Re-measured against the tests in this PR, not copied from the plan.
`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` purged, each run in a fresh copy with
`verinote.__file__` printed and asserted to point inside that copy. Test set: the
three adapter files. Unmutated baseline: `200 passed, 1 skipped`.

| # | mutant | red | failing rows |
|---|---|---|---|
| A1 | anthropic `extract_facts` hoist reverted | 4 | t1[anthropic-extract_facts], t3[anthropic], t4[anthropic], t5[anthropic] |
| A2 | anthropic `translate_query` hoist reverted | 2 | t1[**anthropic-translate_query**], t2[anthropic] |
| A3 | anthropic `extract_query_intent` hoist reverted | 1 | t1[**anthropic-extract_query_intent**] |
| A4 | anthropic `answer_question` hoist reverted | 1 | t1[**anthropic-answer_question**] |
| O1 | openai `extract_facts` hoist reverted | 9 | t1[openai\|openrouter-extract_facts], t3[openai], t3[openrouter], t4[openai], t5[openai], t5[openrouter], t6, t7 |
| O2 | openai `translate_query` hoist reverted | 4 | t1[openai\|openrouter-translate_query], t2[openai], t2[openrouter] |
| O3 | openai `extract_query_intent` hoist reverted | 2 | t1[**openai-extract_query_intent**], t1[**openrouter-extract_query_intent**] |
| O4 | openai `answer_question` hoist reverted | 2 | t1[**openai-answer_question**], t1[**openrouter-answer_question**] |
| N-anthropic | anthropic catch-all deleted | 11 | t1[anthropic × 4], t3[anthropic], t4[anthropic], t5[anthropic], t8[anthropic × 4] |
| N-openai | openai catch-all deleted | 23 | t1[openai\|openrouter × 4], t3 × 2, t4[openai], t5 × 2, t6, t7, t8[openai\|openrouter × 4] |
| N-ollama | ollama catch-all deleted | 2 | **both ollama** #500 tests |
| N-claudecli | claudecli catch-all deleted | 3 | all three claudecli #500 tests |
| P1 | `except PromptError` deleted (all 4) | 3 | t2 × 3 |
| P2 | the two clauses swapped (all 4) | 3 | t2 × 3 -- **equivalent to P1**: identical red set, identical observable behaviour |
| R1 | render moved above `client = self._client()` | 3 | t5 × 3 |
| S1 | `"request failed"` inserted into the catch-all message | 26 | t1 × 12, t3 × 3, t4 × 2, t5 × 3, t6, and all 5 ollama/claudecli #500 tests |
| D1 | ollama + claudecli catch-alls deleted | 5 | all 5 ollama/claudecli #500 tests |
| F1 | `from exc` dropped from `_render_prompt`'s catch-all | 1 | t7 |
| R2 | `_rendered` re-raises without calling `redact_secret` | 12 | t8 × 12 |
| R3 | `_rendered`'s `except` clause deleted (bare pass-through) | 12 | t8 × 12 -- **equivalent to R2**: identical red set, and both leave the same message with the same `__cause__` |
| R4 | `from exc.__cause__` → `from exc` in `_rendered` | 1 | t7 |

Where t1 = `test_a_prompt_that_cannot_be_read_is_not_a_request_failure`,
t2 = `test_a_missing_placeholder_keeps_the_library_s_own_words`,
t3 = `test_an_unreadable_prompt_override_is_still_an_llm_error`,
t4 = `test_a_render_failure_of_a_kind_nobody_enumerated_is_still_an_llm_error`,
t5 = `test_a_broken_template_does_not_outrank_a_missing_key`,
t6 = `test_a_programming_error_in_the_render_is_deliberately_an_llm_error`,
t7 = `test_a_render_failure_keeps_the_original_error_as_the_cause`,
t8 = `test_a_render_failure_never_carries_the_key`.

All 21 runs are red, no survivors; 19 distinct mutants (P1 ≡ P2, R2 ≡ R3).
Count does not identify a mutant here -- five groups tie: **1** = A3/A4/F1/R4,
**2** = A2/O3/O4/N-ollama, **3** = N-claudecli/P1/P2/R1, **4** = A1/O2,
**12** = R2/R3. Most are separated by their failing rows (the 3-group's four
members fail four different test sets; A1 and O2 differ on both provider and
method).

**F1 and R4 are not**, and the table says so rather than implying otherwise:
both are 1 red and both red rows are t7. They are different edits -- F1 drops
the cause at `_render_prompt`, R4 buries it one layer up in `_rendered` -- and
t7 is the single guard that catches either. What the pair shows is that the
cause chain has exactly one test holding it and that test is sensitive at both
layers, not that the two mutants are interchangeable.

N-anthropic and N-openai gained four and eight rows against the previous
revision: deleting `_render_prompt`'s catch-all lets a `PermissionError` past
`_rendered`'s `except LLMError` as itself, so t8 fails on normalisation before
it can fail on redaction.

`t3` carries t1's anchors (`^prompt extraction could not be loaded` plus
`"request failed" not in`) rather than a bare `pytest.raises(LLMError)`. Bare, it
is green at `759eac0` and survives all twelve hoist-revert mutants: inside the
`try` the `PermissionError` was already wrapped, just wrapped as the provider's
fault.

`t5`'s two halves are one test on purpose. The `requires an API key` assertion
passes with no override written at all, so alone it would go inert unnoticed if
`extract_facts` ever rendered a different id; the second half re-runs the same
setup with a key and requires the template to actually be broken.

## Verification

Run in the worktree (so `tests/test_gitignore.py` has a real `.git`),
`PYTHONDONTWRITEBYTECODE=1`, private `--basetemp`:

```
ruff check verinote tests            All checks passed!
pytest (full suite)                  3101 passed, 15 skipped
```

Narrow set -- `test_cloud_adapters.py`, `test_ollama_adapter.py`,
`test_claude_cli_adapter.py`, `test_openrouter_adapter.py`, `test_llm_base.py`,
`test_prompts.py`: `280 passed, 1 skipped`. The one skip throughout is
`test_the_installed_openai_sdk_really_does_reject_an_unusable_base_url`, which
`importorskip`s the openai SDK.

C1 is green on its own (`175 passed, 1 skipped` over the three adapter test files
at that commit), so a bisect never lands on a tree with §10.1 open at the render.

`ruff format` was not run: `check` is what `ci.yml` gates on, and the tree
already has unrelated files that `format` would rewrite.

## Not in this PR

The `except PromptError → LLMError(str(exc)) from exc` idiom appears at **7**
render sites: the four adapters plus `cmd_sync.extraction_schema_hint`
(`cli.py:660`), `create_app._extraction_schema_hint` (`web/app.py:1033`), and
`_focused_role_schema_hint` (`pipeline/extract.py:850`). (The same idiom at
`extract.py:861` catches `CorroborationPolicyError`, not a render.) Only the four
adapters are closed here.

An eighth site is worse and is not this idiom: `create_app._prompts_page`
(`web/app.py:1076`) catches `PromptError` and renders it into the page, so a
non-UTF-8 override escapes it too. Measured at `759eac0` **and still at this
branch's HEAD**, one such override makes `GET /prompts` return **500** -- the
page you go to in order to fix a broken override is the page that dies on it.

Two follow-ups are proposed: normalising those four non-adapter sites, and
lifting the four byte-identical `_render_prompt` copies into `llm/base.py`.
