### PR TITLE
fix(llm): 200 본문이 에코한 API 키가 파싱 경로에서 redact 없이 저장된다 (#514)

### DIFF
--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import ast
+import json
 import inspect
 import sys
 from pathlib import Path
@@ -982,3 +983,103 @@ def test_a_render_failure_never_carries_the_key(tmp_path, monkeypatch, method, p
         assert "***" in str(exc.value)
     finally:
         path.chmod(0o600)
+
+
+# --- the parse path: a 200 body that echoes the key (#514) --------------------
+
+#: The parsers that can put the payload they rejected into their own message,
+#: with a body shape that makes each one do it. Measured, not assumed:
+#: `schema.parse_facts` interpolates the offending object with `{item!r}`, and
+#: `parse_query_intent` interpolates the caller's `kind` string. `parse_query`
+#: is deliberately absent -- across a body that is not JSON, one missing
+#: `datalog`, a non-string `datalog` and a top-level list, its raise sites carried
+#: a JSON position, a missing key name and a builtin `TypeError` phrase and never
+#: the payload, which is what `_request_failed`'s docstring already says of it. It
+#: still goes through `parsed_under_redaction`, because that is a property of
+#: today's raise sites rather than a guarantee about them.
+_LEAKING_PARSE_INVOCATIONS = {
+    "extract_facts": (
+        lambda a: a.extract_facts(source_text="x"),
+        lambda key: {"facts": [{"subject": key, "oops": 1}]},
+    ),
+    "extract_query_intent": (
+        lambda a: a.extract_query_intent(question="What?"),
+        lambda key: {"kind": key},
+    ),
+}
+
+
+def _echoing_sdk(monkeypatch, provider: str, body: dict) -> None:
+    """Stub a 200 response whose BODY carries the configured key.
+
+    Not a 401 echo -- that path goes through `_request_failed`, which redacts and
+    is pinned by `test_provider_error_never_carries_the_key`. This is the other
+    one: a well-formed HTTP success whose payload is off-schema, which the parsers
+    reject by interpolating what they were handed. `base_url` is caller-supplied,
+    so a body under someone else's control reaches here (#514).
+    """
+
+    class _Responds:
+        def create(self, **kwargs):
+            if provider == "anthropic":
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type="tool_use", name="emit", input=body)]
+                )
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=json.dumps(body)))]
+            )
+
+    if provider == "anthropic":
+        monkeypatch.setattr(
+            AnthropicAdapter, "_client", lambda self: SimpleNamespace(messages=_Responds())
+        )
+    else:
+        cls = OpenRouterAdapter if provider == "openrouter" else OpenAIAdapter
+        monkeypatch.setattr(
+            cls,
+            "_client",
+            lambda self: SimpleNamespace(chat=SimpleNamespace(completions=_Responds())),
+        )
+
+
+@pytest.mark.parametrize("method", sorted(_LEAKING_PARSE_INVOCATIONS))
+@pytest.mark.parametrize("provider", sorted(_KEYED_ADAPTERS))
+def test_a_parse_failure_never_carries_the_key(tmp_path, monkeypatch, method, provider):
+    """The parse path's half of `test_provider_error_never_carries_the_key`.
+
+    That test says "each raise site is its own chance to bypass the redacting
+    constructor". The parsers are raise sites the adapters reach just PAST the
+    `try`, so `_request_failed` never sees them, and two of the three interpolate
+    the payload they rejected. Measured before `parsed_under_redaction`: every
+    cell here printed `sk-test-DEADBEEFDEADBEEF` into the message that
+    `pipeline/extract.py` stores as `source_chunks.error` and `sources.html`
+    renders (#514).
+
+    Both halves are asserted. Absence alone passes when the message stops
+    carrying the payload for some unrelated reason, at which point it has stopped
+    being about redaction.
+    """
+    invoke, body_for = _LEAKING_PARSE_INVOCATIONS[method]
+    _echoing_sdk(monkeypatch, provider, body_for(_LONG_KEY))
+
+    with pytest.raises(LLMError) as exc:
+        invoke(_KEYED_ADAPTERS[provider](_keyed_cfg(tmp_path, provider, _LONG_KEY)))
+
+    assert _LONG_KEY not in str(exc.value)
+    assert "***" in str(exc.value)
+
+
+def test_a_parse_failure_keeps_the_original_error_as_the_cause(tmp_path, monkeypatch):
+    """Redacting must not cost the cause the parsers already chain.
+
+    `schema.parse_facts` raises `... from exc` with the `KeyError` that named the
+    missing field. `parsed_under_redaction` re-raises `from exc.__cause__`, so the
+    original survives for a log rather than being buried behind the wrapper's own
+    `LLMError`. Re-raising `from exc` instead is the way to make this fail.
+    """
+    _echoing_sdk(monkeypatch, "openai", {"facts": [{"subject": _LONG_KEY, "oops": 1}]})
+
+    with pytest.raises(LLMError) as exc:
+        OpenAIAdapter(_keyed_cfg(tmp_path, "openai", _LONG_KEY)).extract_facts(source_text="x")
+
+    assert isinstance(exc.value.__cause__, KeyError)

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -4,7 +4,12 @@
 from __future__ import annotations
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError, redact_secret
+from verinote.llm.base import (
+    ExtractedFact,
+    LLMError,
+    parsed_under_redaction,
+    redact_secret,
+)
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -278,7 +283,9 @@ class AnthropicAdapter:
 
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
-                return parse_facts(block.input)
+                return parsed_under_redaction(
+                    parse_facts, block.input, self.cfg.api_key
+                )
         raise LLMError("anthropic response contained no tool_use block")
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
@@ -305,7 +312,9 @@ class AnthropicAdapter:
 
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
-                return parse_query(block.input)
+                return parsed_under_redaction(
+                    parse_query, block.input, self.cfg.api_key
+                )
         raise LLMError("anthropic response contained no tool_use block")
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
@@ -330,7 +339,9 @@ class AnthropicAdapter:
 
         for block in msg.content:
             if getattr(block, "type", None) == "tool_use":
-                return parse_query_intent(block.input)
+                return parsed_under_redaction(
+                    parse_query_intent, block.input, self.cfg.api_key
+                )
         raise LLMError("anthropic response contained no tool_use block")
 
     def answer_question(self, *, question: str, context: str) -> str:

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -48,6 +48,39 @@ def redact_secret(text: str, secret: str | None) -> str:
     return text.replace(secret, "***")
 
 
+def parsed_under_redaction(parse, payload, secret):
+    """Run a response parser, and put what it raises under `redact_secret`.
+
+    The parsers live below the adapters and take a payload, not a `Config`, so
+    they cannot reach the key -- and they interpolate what they caught:
+    `schema.parse_facts` puts the offending object in with `{item!r}`, which on
+    a malformed response IS the response. `redact_secret` says the secret should
+    never enter an `LLMError` in the first place; this is the construction site
+    that has to call it for that to hold on the parse path.
+
+    NOT inside the adapters' request `try`. Moving the parse in there would fix
+    the redaction and break the attribution, reporting a schema failure as
+    "request failed" -- the misattribution #500 took out of this very region.
+    A separate wrapper redacts without moving the blame, the shape `_rendered`
+    already has for the render.
+
+    `from exc.__cause__`, not `from exc`. Every parser raises `... from exc`
+    with the `json`/`Key`/`Type` error that caused it, so the original is
+    already on `__cause__`; re-raising `from exc` would bury it behind this
+    wrapper's own `LLMError`. Where a parser raised with no cause at all
+    (`query translation was empty`), `__cause__` is `None` and the re-raise
+    carries none either, which is what it had.
+
+    ONLY `LLMError` is caught. A parser that fails some other way is a bug in
+    this repo rather than a message about the provider's payload, and it is not
+    this function's business to relabel it.
+    """
+    try:
+        return parse(payload)
+    except LLMError as exc:
+        raise LLMError(redact_secret(str(exc), secret)) from exc.__cause__
+
+
 def base_url_unusable(provider: str, url: str, exc: Exception) -> LLMError:
     """The configured endpoint is not something a request can even be built for.
 

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -4,7 +4,12 @@
 from __future__ import annotations
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError, redact_secret
+from verinote.llm.base import (
+    ExtractedFact,
+    LLMError,
+    parsed_under_redaction,
+    redact_secret,
+)
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -275,7 +280,9 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
-        return parse_facts(resp.choices[0].message.content or "")
+        return parsed_under_redaction(
+            parse_facts, resp.choices[0].message.content or "", self.cfg.api_key
+        )
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
         client = self._client()
@@ -297,7 +304,9 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
-        return parse_query(resp.choices[0].message.content or "")
+        return parsed_under_redaction(
+            parse_query, resp.choices[0].message.content or "", self.cfg.api_key
+        )
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
         client = self._client()
@@ -321,7 +330,9 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
-        return parse_query_intent(resp.choices[0].message.content or "")
+        return parsed_under_redaction(
+            parse_query_intent, resp.choices[0].message.content or "", self.cfg.api_key
+        )
 
     def answer_question(self, *, question: str, context: str) -> str:
         client = self._client()


### PR DESCRIPTION
`base_url` 이 사용자 입력이므로 적대적 엔드포인트가 **200 본문에 설정된 API 키를 에코**할 수 있다. 그 본문은 응답 파서로 가는데, 클라우드 어댑터는 파서를 `try` **밖**에서 부른다 — 요청 경로에서 유일하게 리댁션하는 `_request_failed` 가 파서가 내는 것을 보지 못하고, 세 파서 중 둘은 거부한 페이로드를 그대로 보간한다.

`main` 에서 두 어댑터 모두 재현:

```
LLMError: malformed fact object {'subject': 'sk-test-CONFIGURED-SECRET-0001', 'oops': 1}: 'relation'
KEY PRESENT UNREDACTED: True   '***' present: False
```

이 메시지는 `source_chunks.error` 에 저장되어 Sources 페이지에 렌더된다. `redact_secret` 의 docstring 이 *"redacting at construction means the secret never enters an `LLMError` in the first place"* 라고 적는데, 여기가 그것을 호출하지 않는 생성 지점이었다.

## 수정

`llm/base.py` 에 `parsed_under_redaction` 을 두고 여섯 호출부를 통과시킨다.

```
after:  malformed fact object {'subject': '***', 'oops': 1}: 'relation'
        KEY PRESENT UNREDACTED: False   '***' present: True
```

**어댑터마다 메서드를 두지 않은 이유.** 이슈의 3안이 그 모양인데, `_rendered` 사본 둘이 이미 바이트 단위로 동일하고 그중 하나가 자기 파일을 "다른 파일" 로 지칭하는 거짓 문장을 실어 나른 적이 있다(#538 에서 수정). #540 이 그 계열을 `llm/base.py` 로 통합하려고 열려 있으므로, 같은 문장이 낡을 자리를 하나 더 만들지 않았다.

**파싱 호출을 `try` 안으로 넣지 않은 이유.** 이슈의 1안이다. 리댁션은 고쳐지지만 스키마 실패가 "request failed" 로 보고되는 오귀속이 되살아난다 — #500 이 바로 이 구간에서 걷어낸 것이다.

## 이슈가 놓친 것 하나

이슈는 `parse_facts` 를 지목한다. 나머지 둘을 재보니 **`parse_query_intent` 도 샌다** — `unknown query intent kind: <...>` 로 호출자의 `kind` 문자열을 보간한다.

`parse_query` 는 네 가지 본문 모양(JSON 아님 / `datalog` 없음 / `datalog` 가 dict / 최상위 리스트)에서 페이로드를 싣게 만들지 못했다 — JSON 위치, 없는 키 이름, 빌트인 `TypeError` 문구뿐이고, 이는 `_request_failed` 의 docstring 이 이미 그 파서에 대해 적어 둔 그대로다. 그래서 테스트는 그것이 샌다고 주장하지 않는다. 다만 래퍼는 통과시킨다 — 오늘의 raise site 성질이지 보장은 아니기 때문이다.

## 범위

- `openrouter` 는 `OpenAIAdapter` 상속으로 함께 덮인다(테스트가 파라미터로 확인).
- `ollama_adapter` / `claude_cli_adapter` 는 `redact_secret` 을 import 조차 하지 않는다 — 이슈와 #538 이 각각 기록한 별개 잔여이고 여기서 건드리지 않는다.

## 검증

- 신규 `test_a_parse_failure_never_carries_the_key` — 어댑터 3 × 새는 메서드 2 = 6셀. 키 부재와 `***` 존재를 **양쪽 다** 단언한다(부재만으로는 메시지가 무관한 이유로 페이로드를 안 싣게 돼도 통과한다).
- 신규 `test_a_parse_failure_keeps_the_original_error_as_the_cause` — 파서가 이미 체이닝한 원인이 리댁션 때문에 사라지지 않음을 고정. `from exc` 로 바꾸면 실패한다.
- **공허하지 않음**: 래퍼는 그대로 두고 `redact_secret` 호출만 뺀 뮤턴트에서 6셀 전부 실패.
- 전체 스위트 `3168 passed, 14 skipped`.

Closes #514
