### PR TITLE
fix(prompts): an unreadable override no longer escapes raw, nor takes /prompts down (#539)

### DIFF
--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -762,19 +762,24 @@ def test_a_source_that_crashes_does_not_bury_a_sibling_job_that_finished(
 
 
 def test_a_prompt_that_cannot_be_read_leaves_the_untouched_job_pending(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, capsys
 ):
     """A failure BEFORE the job-owning call must not write the job row.
 
     `cmd_sync` creates the job row — this source has none to continue — and then
     resolves the extraction schema hint, which reads `policy/prompts/` off disk.
-    `extraction_schema_hint` wraps `PromptError` and nothing else, so an override
-    that is not valid UTF-8 escapes as the `UnicodeDecodeError` `Path.read_text`
-    raised — a real path, and one that reaches this line before
-    `process_extraction_job` is entered. The job is left exactly as planning found
-    it — `pending` here, `failed` on a retry pass (both measured): no chunk was
+    An override that is not valid UTF-8 makes `Path.read_text` raise, and
+    `extraction_schema_hint`'s second clause turns that into an `LLMError` naming
+    the prompt (#539); before #539 the `UnicodeDecodeError` escaped `cli.main`
+    itself. Either way it is a real path, and one that reaches this line before
+    `process_extraction_job` is entered. What this test is about is what the job
+    row does, and that did not move: the job is left exactly as planning found it
+    — `pending` here, `failed` on a retry pass (both measured): no chunk was
     claimed, nothing was attempted, and fixing the file must let the next sync
-    pick it up untouched.
+    pick it up untouched. The exit path changed with the type — `cmd_sync`'s own
+    `except LLMError` prints `extraction failed: …` and returns 1 (measured) —
+    which is why the assertion below is an exit code and a message rather than a
+    `pytest.raises`.
 
     TWO THINGS KEEP THAT TRUE and this test does not distinguish them, deliberately
     — it asserts the outcome both are there for. The hint is resolved OUTSIDE the
@@ -801,8 +806,11 @@ def test_a_prompt_that_cannot_be_read_leaves_the_untouched_job_pending(
         lambda cfg: _ChunkClient(),  # must never be reached
     )
 
-    with pytest.raises(UnicodeDecodeError):
-        cli.main(["sync"])
+    assert cli.main(["sync"]) == 1
+    # Not decoration: a bare `== 1` is a proposition an unrelated failure path
+    # could satisfy, and this test's client is deliberately unreachable, so a
+    # silent behaviour change could turn it green for the wrong reason.
+    assert "prompt extraction-limit-hint could not be loaded" in capsys.readouterr().err
 
     store = Store(tmp_path / "kb.sqlite")
     jobs = list(store._conn.execute("SELECT id, status FROM extraction_jobs"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
+from contextlib import contextmanager
 import sqlite3
 import sys
 import unicodedata
@@ -2766,3 +2767,65 @@ def test_ui_is_exempt_from_corrupt_config(tmp_path, monkeypatch, capsys):
 
     assert cli.main(["ui", "--no-browser"]) == 0
     assert started == [True]  # dispatch reached cmd_ui, not the refusal
+
+
+@contextmanager
+def _broken_override(path: Path, mode: str):
+    """Make a saved prompt override unreadable, the two ways these tests use.
+
+    Copy per test file rather than a shared import: the repo keeps its chmod
+    probe local (`tests/test_cloud_adapters.py`). The skip is a RUNTIME one after
+    an actual read attempt, not a `geteuid` marker, so it also covers a
+    filesystem that ignores the mode bit.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if mode == "non_utf8":
+        path.write_bytes(b"at most {max_facts} facts \xff\xfe and a bad byte")
+        yield
+        return
+    path.write_text("at most {max_facts} facts\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+        yield
+    finally:
+        # `exists()` because a caller may legitimately REMOVE the file inside
+        # the block (`tests/test_web.py`'s reset test does).
+        if path.exists():
+            path.chmod(0o600)
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_an_unreadable_extraction_limit_hint_is_still_an_llm_error(
+    tmp_path, monkeypatch, capsys, fake_client, mode
+):
+    """An unreadable override reaches the user as `extraction failed:` (#539).
+
+    Separate from the sibling in `test_chunk_claim_release.py` rather than a
+    parametrisation of it: that test's subject is the job row, and a host that
+    skips the `chmod` cell must not leave that subject conditionally unproven.
+    This one takes a path argument, so it runs `sync`'s legacy branch — the same
+    observable, reached a second way.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    _env(monkeypatch, tmp_path)
+    src = tmp_path / "note.txt"
+    src.write_text("Ada was born in London.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client([ExtractedFact("Ada", "born_in", "London", 0.9)]),
+    )
+
+    with _broken_override(prompt_override_path(tmp_path, "extraction-limit-hint"), mode):
+        assert cli.main(["sync", str(src)]) == 1
+
+    assert (
+        "extraction failed: prompt extraction-limit-hint could not be loaded"
+        in capsys.readouterr().err
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
+from contextlib import contextmanager
 import json
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +13,11 @@ from verinote.pipeline import (
     process_extraction_job,
     sync_sources,
 )
-from verinote.pipeline.extract import _canonical_fact
+from verinote.pipeline.extract import (
+    _canonical_fact,
+    _extract_chunk_facts,
+    _focused_role_schema_hint,
+)
 from verinote.pipeline.query import query_path
 from verinote.pipeline.verify import verify
 from verinote.policy_defaults import RELATION_ALIASES_RELPATH
@@ -1516,3 +1522,60 @@ def test_multi_source_demotes_only_the_edited_source_and_a_witness_still_answers
     assert s.get_fact(b_fact["id"])["status"] == "confirmed"  # the witness is untouched
     # The engine still answers London -- through B, the live witness.
     assert verify(s).answers == ["q1: London"]
+
+
+@contextmanager
+def _broken_override(path: Path, mode: str):
+    """Make a saved prompt override unreadable, the two ways these tests use.
+
+    Copy per test file rather than a shared import: the repo keeps its chmod
+    probe local (`tests/test_cloud_adapters.py`). The skip is a RUNTIME one after
+    an actual read attempt, not a `geteuid` marker, so it also covers a
+    filesystem that ignores the mode bit.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if mode == "non_utf8":
+        path.write_bytes(b"at most {max_facts} facts \xff\xfe and a bad byte")
+        yield
+        return
+    path.write_text("at most {max_facts} facts\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+        yield
+    finally:
+        # `exists()` because a caller may legitimately REMOVE the file inside
+        # the block (`tests/test_web.py`'s reset test does).
+        if path.exists():
+            path.chmod(0o600)
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_a_broken_focused_role_override_is_an_llm_error(tmp_path, fake_client, mode):
+    """An unreadable focused-role override is named, not raised raw (#539).
+
+    The second half is about PLACEMENT, not normalisation: the hint is resolved
+    OUTSIDE the `except LLMError: pass` that guards the focused second pass, so
+    a broken override still reaches the caller. Move the resolution inside that
+    `try` and this assertion goes red — which it could not do before #539,
+    because what the read raised was not an `LLMError` for that clause to
+    swallow.
+    """
+    path = tmp_path / "policy" / "prompts" / "focused-role-extraction.md"
+    named = r"^prompt focused-role-extraction could not be loaded"
+
+    with _broken_override(path, mode):
+        with pytest.raises(LLMError, match=named):
+            _focused_role_schema_hint("", root=tmp_path)
+
+        with pytest.raises(LLMError, match=named):
+            _extract_chunk_facts(
+                fake_client([ExtractedFact("Ada", "role", "CTO", 0.9)]),
+                source_text="Ada는 이 회사의 CTO다.",
+                root=tmp_path,
+            )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 import builtins
+from contextlib import contextmanager
 from dataclasses import replace
 import functools
 import importlib.resources
@@ -7,6 +8,7 @@ import importlib.util
 import inspect
 import json
 import logging
+from pathlib import Path
 import re
 import sqlite3
 import sys
@@ -6347,3 +6349,395 @@ def test_the_module_body_runs_the_clearing_provider_check(monkeypatch):
 
     with pytest.raises(RuntimeError, match="clears the Base URL"):
         spec.loader.exec_module(module)
+
+
+@contextmanager
+def _broken_override(path: Path, mode: str):
+    """Make a saved prompt override unreadable, the two ways these tests use.
+
+    Copy per test file rather than a shared import: the repo keeps its chmod
+    probe local (`tests/test_cloud_adapters.py`). The skip is a RUNTIME one after
+    an actual read attempt, not a `geteuid` marker, so it also covers a
+    filesystem that ignores the mode bit.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if mode == "non_utf8":
+        path.write_bytes(b"at most {max_facts} facts \xff\xfe and a bad byte")
+        yield
+        return
+    path.write_text("at most {max_facts} facts\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+        yield
+    finally:
+        # `exists()` because a caller may legitimately REMOVE the file inside
+        # the block (`tests/test_web.py`'s reset test does).
+        if path.exists():
+            path.chmod(0o600)
+
+
+def _prompts_client(tmp_path) -> TestClient:
+    """`_client`'s app, but surfacing a server error as a status, not a raise.
+
+    `_client` builds `TestClient(app)`, i.e. `raise_server_exceptions=True`, under
+    which an unhandled render failure comes back as the exception itself rather
+    than the 500 these tests are about. That would make a mutant look like an
+    error instead of a status regression.
+    """
+    cfg = Config(
+        root=tmp_path, db_path=tmp_path / "kb.sqlite",
+        provider="anthropic", model="m", api_key=None, base_url=None,
+    )
+    return TestClient(create_app(cfg), raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_a_broken_extraction_limit_hint_is_extraction_failed_not_analysis_failed(
+    tmp_path, monkeypatch, fake_client, mode
+):
+    """An unreadable override is this machine's condition, not the provider's.
+
+    `_extraction_schema_hint(cfg)` is an argument expression inside the worker's
+    `try`, so without #539's clause the read failure lands on the generic handler
+    and the job says `analysis failed` — blaming the analysis for a file the user
+    saved here. Measured without the clause, the message is `analysis failed: `
+    plus whatever the read raised: the codec error under `non_utf8`,
+    `[Errno 13] Permission denied: <the override>` under `chmod`. Neither of the
+    two assertions at the end of this test holds of such a string (the
+    `startswith` one aborts first, so only it is observed failing; the `not in`
+    one is false of the same message). The `not in` one is spelled out because
+    the misattribution, not the wording, is what #539 and #474 are about.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    c = _client(tmp_path)
+
+    with _broken_override(prompt_override_path(tmp_path, "extraction-limit-hint"), mode):
+        upload = c.post(
+            "/sources",
+            files={"file": ("note.txt", b"some text", "text/plain")},
+            follow_redirects=False,
+        )
+        assert upload.status_code == 303
+
+        def failed():
+            jobs = c.app.state.store.source_extraction_jobs()
+            assert jobs and jobs[0]["status"] == "failed"
+
+        _wait_for(failed)
+        message = c.app.state.store.source_extraction_jobs()[0]["message"]
+
+    assert message.startswith(
+        "extraction failed: prompt extraction-limit-hint could not be loaded"
+    )
+    assert "analysis failed" not in message
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_the_prompts_page_survives_the_override_it_exists_to_repair(tmp_path, mode):
+    """The page you go to in order to fix a broken override must open (#539).
+
+    200 and not the 409 of `sidecar_unreadable.html`, `config_corrupt.html` and
+    `credentials_corrupt.html`: those three replace the page the caller asked
+    for with a refusal template and end there, while this one is still a working
+    page. The selector and reset assertions are what that distinction turns on,
+    so they are pinned here rather than left implied by the status: the selector
+    still routes to the other prompts, and the broken prompt itself still
+    carries a control that repairs it. What the page does not carry is that
+    prompt's text or its Save form — see
+    `test_a_broken_override_page_offers_no_editor_to_overwrite_it_with`.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+
+    with _broken_override(prompt_override_path(tmp_path, "extraction"), mode):
+        for url in ("/prompts", "/prompts?prompt=extraction"):
+            r = c.get(url)
+            assert r.status_code == 200, url
+            assert "prompt extraction could not be loaded" in r.text, url
+            # Still a delivered page: the selector lists the other prompts, so the
+            # user can reach one that works and see which file is broken.
+            assert 'value="query-translation"' in r.text, url
+            assert 'value="ask-fallback"' in r.text, url
+            # And it can still be repaired from here: `delete_prompt_override`
+            # only `unlink()`s, so reset survives a file this process could not
+            # read.
+            assert "Reset to default" in r.text, url
+            assert 'action="/prompts/reset"' in r.text, url
+            assert 'name="prompt_id" value="extraction"' in r.text, url
+            # The copy says the button "deletes the override file named above",
+            # so the page has to name it. Measured: deleting that span reddens
+            # this assertion for `non_utf8` and not for `chmod`, because the
+            # codec error in the banner carries no path while the
+            # `PermissionError` does. So for a non-UTF-8 user the span is the
+            # whole of what tells them which file they are about to destroy.
+            assert str(prompt_override_path(tmp_path, "extraction")) in r.text, url
+
+
+def test_a_broken_override_does_not_blank_the_other_prompts(tmp_path):
+    """The new clause must not swallow the page, nor the `unknown prompt` 400.
+
+    Green before #539 as well — this row pins what must NOT change. The
+    mutations these assertions exist for: a `_prompts_page` that returned
+    `prompt=None` on the SUCCESS path too would blank the editor; folding the
+    existing `except PromptError` into the new clause would turn `unknown
+    prompt: nope` from 400 into 200; gating the reset control on `prompt is
+    None` instead of on `reset_only` would offer to reset `nope`, an id
+    `prompt_definition` has already rejected.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+
+    with _broken_override(prompt_override_path(tmp_path, "extraction"), "non_utf8"):
+        good = c.get("/prompts?prompt=query-translation")
+
+        assert good.status_code == 200
+        assert 'name="prompt_text"' in good.text  # the editor is still there
+        # The query parameter is `prompt` (not `prompt_id`), and it is honoured:
+        # this is query-translation's own text, not the broken default's.
+        assert "<code>query-translation</code>" in good.text
+        assert "You translate a natural-language question" in good.text
+        assert "You are a fact extractor" not in good.text
+
+        unknown = c.get("/prompts?prompt=nope")
+
+        assert unknown.status_code == 400
+        assert "unknown prompt: nope" in unknown.text
+        # `prompt is None` for `nope` too, and for `nope` there is nothing to
+        # reset — no definition and no file. The reset affordance keys off
+        # `reset_only`, not off `prompt`, which is what keeps them apart.
+        assert 'action="/prompts/reset"' not in unknown.text
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_a_refused_save_keeps_its_400_and_still_says_why(tmp_path, mode):
+    """The load banner is composed with the caller's, and does not relabel a 400.
+
+    Two independent properties, one per mutation (measured). A hardcoded 200 in
+    the new clause would answer 200 to a request the app declined to perform,
+    while the banner still says "prompt text is required". A clause that
+    ASSIGNED `error` instead of composing it keeps the 400 and drops that
+    string, telling the user the wrong reason their save failed.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+
+    with _broken_override(prompt_override_path(tmp_path, "extraction"), mode):
+        r = c.post(
+            "/prompts",
+            data={"prompt_id": "extraction", "prompt_text": ""},
+            follow_redirects=False,
+        )
+
+    assert r.status_code == 400
+    assert "prompt text is required" in r.text
+    assert "prompt extraction could not be loaded" in r.text
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_a_broken_override_can_be_reset_from_the_page_that_names_it(tmp_path, mode):
+    """#539's opening symptom: no way out of a broken override from inside the UI.
+
+    Serving 200 with a banner answers the issue's non-regression list but not
+    that complaint — a page that names the broken file and offers nothing that
+    acts on it is still a dead end. Reset survives an unreadable override —
+    `delete_prompt_override` only `unlink()`s and never reads it — so reset is
+    the repair this page carries.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+
+    with _broken_override(override, mode):
+        broken = c.get("/prompts?prompt=extraction")
+        assert broken.status_code == 200
+        assert 'action="/prompts/reset"' in broken.text
+
+        reset = c.post(
+            "/prompts/reset",
+            data={"prompt_id": "extraction"},
+            follow_redirects=False,
+        )
+
+        assert reset.status_code == 303
+        assert not override.exists()
+
+    healthy = c.get("/prompts?prompt=extraction")
+
+    assert healthy.status_code == 200
+    assert "could not be loaded" not in healthy.text
+    assert 'name="prompt_text"' in healthy.text  # the editor is back
+    assert "You are a fact extractor" in healthy.text  # showing the default again
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_a_broken_override_page_offers_no_editor_to_overwrite_it_with(tmp_path, mode):
+    """Reset, deliberately, and NOT a textarea seeded with the default.
+
+    A Save form pre-filled with default text turns one careless click into a
+    silent overwrite of a file this process could not read — the user's own
+    customisation, gone, with nothing having displayed it. So the broken
+    prompt's page carries the reset control and no editor, and the opening line
+    of the default text is not in the response.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+
+    with _broken_override(prompt_override_path(tmp_path, "extraction"), mode):
+        r = c.get("/prompts?prompt=extraction")
+
+    assert r.status_code == 200
+    assert 'name="prompt_text"' not in r.text
+    assert "Save prompt" not in r.text
+    assert "You are a fact extractor" not in r.text
+
+
+@pytest.mark.parametrize("kind", ["non_utf8", "chmod"])
+def test_no_reset_is_offered_when_the_override_is_not_what_failed(
+    tmp_path, monkeypatch, kind
+):
+    """This page's one destructive control must not be offered on a guess.
+
+    `get_prompt` reads the packaged default as well as the KB override, and the
+    clause above it is deliberately broad, so a load failure does not by itself
+    say which file broke. Both states below were driven against a REAL damaged
+    install (packaged `defaults/extraction.md` at `0o000`) before the gate
+    existed: with nothing saved the page offered a Reset that deleted nothing
+    and fixed nothing, and with a healthy override beside it the same button
+    destroyed the user's file and left the page just as broken. The exception is
+    raised here rather than by corrupting the installed package, because what is
+    under test is the gate, which reads the disk and not the exception.
+    """
+    from verinote.prompts import library
+    from verinote.prompts.library import prompt_override_path
+
+    # The state this stands in for exists because `get_prompt` reads the
+    # packaged default too: `prompts/library.py` calls `default_prompt_text`
+    # before it looks at the override. (It is not the only way into the clause —
+    # see `test_an_unreadable_prompts_directory_still_renders_the_page` — but it
+    # is the one this test describes.) Couple the two, so this test cannot
+    # quietly outlive that read.
+    reached = []
+    real_default_text = library.default_prompt_text
+
+    def spy_default_text(prompt_id):
+        reached.append(prompt_id)
+        return real_default_text(prompt_id)
+
+    monkeypatch.setattr(library, "default_prompt_text", spy_default_text)
+    library.get_prompt(tmp_path, "extraction")
+
+    assert reached == ["extraction"]
+
+    if kind == "non_utf8":
+        exc = UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte")
+    else:
+        exc = PermissionError(13, "Permission denied")
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+
+    def raise_it(root, prompt_id):
+        raise exc
+
+    monkeypatch.setattr(webapp, "get_prompt", raise_it)
+
+    nothing_saved = c.get("/prompts?prompt=extraction")
+
+    assert nothing_saved.status_code == 200
+    assert "prompt extraction could not be loaded" in nothing_saved.text
+    assert 'action="/prompts/reset"' not in nothing_saved.text
+
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("My own extraction prompt.\n", encoding="utf-8")
+
+    healthy_override = c.get("/prompts?prompt=extraction")
+
+    assert healthy_override.status_code == 200
+    assert 'action="/prompts/reset"' not in healthy_override.text
+    assert override.read_text(encoding="utf-8") == "My own extraction prompt.\n"
+
+
+def test_no_reset_is_offered_for_a_directory_at_the_override_path(tmp_path, monkeypatch):
+    """The gate answers about a file `get_prompt` would open, not about any path.
+
+    `get_prompt` opens the override only behind `override_path.is_file()`, so a
+    directory there is not something it ever read, and `delete_prompt_override`
+    could not remove it either — `unlink()` on a directory raises. Without the
+    same guard on the gate the read fails, the page takes that for "unreadable",
+    and it offers a Reset whose POST is a bare 500.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+    override.mkdir(parents=True)
+
+    def raise_it(root, prompt_id):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(webapp, "get_prompt", raise_it)
+
+    r = c.get("/prompts?prompt=extraction")
+
+    assert r.status_code == 200
+    assert "prompt extraction could not be loaded" in r.text
+    assert 'action="/prompts/reset"' not in r.text
+    assert override.is_dir()  # the GET left it alone
+
+
+def test_an_unreadable_prompts_directory_still_renders_the_page(tmp_path):
+    """The gate must not raise: it runs inside the handler that builds this page.
+
+    `Path.is_file()` propagates a `PermissionError` from an unreadable parent
+    directory rather than answering False, and `get_prompt` reaches it too — it
+    guards its own read with `is_file()` — so this state gets to the load
+    failure clause with no corrupt file and no damaged install. The clause then
+    calls the gate, from a line inside no `try` of its own. Hoisting the gate's
+    `is_file()` guard above its `try` makes the raise escape both, and
+    `GET /prompts` answers 500: the page #539 exists to keep alive, killed by
+    the guard added to make its Reset control honest. Measured over every test
+    in this file, nothing else catches that mutation, which is why this test is
+    here.
+
+    The POST is a different matter and is not asserted: `delete_prompt_override`
+    calls `path.exists()`, which raises the same way. What is pinned here is the
+    GET, and 200 is what it answers today.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    prompts_dir = prompt_override_path(tmp_path, "extraction").parent
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    prompts_dir.chmod(0o000)
+    try:
+        try:
+            (prompts_dir / "extraction.md").is_file()
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user stats straight through mode 0o000")
+
+        r = c.get("/prompts?prompt=extraction")
+
+        assert r.status_code == 200
+        assert "prompt extraction could not be loaded" in r.text
+        assert 'value="query-translation"' in r.text  # the selector still routes away
+    finally:
+        prompts_dir.chmod(0o700)

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -660,6 +660,14 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
             return cfg.extraction_schema_hint()
         except PromptError as exc:
             raise LLMError(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001 - normalise every render failure
+            # `render_prompt` reads `policy/prompts/*` off disk, so an override the
+            # user saved and then made unreadable arrives here as whatever
+            # `Path.read_text` raised. Name the prompt: `str(UnicodeDecodeError)`
+            # names no file at all.
+            raise LLMError(
+                f"prompt extraction-limit-hint could not be loaded: {exc}"
+            ) from exc
 
     # `--recover` rewinds a stuck `running` extraction job so this run can resume
     # it, and those jobs exist only for registered sources: the path branch of
@@ -809,13 +817,13 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                 # prompt resolution — which reads `policy/prompts/*` off disk —
                 # under a handler whose whole subject is "the call that owns this
                 # job". SCOPE ONLY, and measured so: against the inline shape
-                # the outcome is identical — same escaping `UnicodeDecodeError`
-                # (`extraction_schema_hint` wraps only `PromptError`), the job
-                # left exactly as planning found it (`pending` on a fresh or
-                # resumed job, `failed` on a retry pass; both measured), no event
-                # — because the job is not `running` yet and the broad clause's
-                # re-read declines either way. That is why no test pins this
-                # line. It stays INSIDE the per-source loop:
+                # the outcome is identical — the same escaping `LLMError`, which
+                # is what `extraction_schema_hint` turns an unreadable override
+                # into (#539), the job left exactly as planning found it
+                # (`pending` on a fresh or resumed job, `failed` on a retry pass;
+                # both measured), no event — because the job is not `running` yet
+                # and the broad clause's re-read declines either way. That is why
+                # no test pins this line. It stays INSIDE the per-source loop:
                 # hoisting it out of the loop too would change how many times it
                 # runs, which is not this line's business.
                 schema_hint = extraction_schema_hint()

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -940,6 +940,10 @@ def _focused_role_schema_hint(schema_hint: str, *, root=None) -> str:
         focused_role_prompt = render_prompt(root, "focused-role-extraction")
     except PromptError as exc:
         raise LLMError(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - normalise every render failure
+        raise LLMError(
+            f"prompt focused-role-extraction could not be loaded: {exc}"
+        ) from exc
     if not schema_hint:
         return focused_role_prompt
     return f"{schema_hint}\n{focused_role_prompt}"

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -112,6 +112,7 @@ from verinote.prompts import (
     delete_prompt_override,
     get_prompt,
     list_prompts,
+    prompt_override_path,
     save_prompt_override,
 )
 from verinote.engine.terms import StringLit, render_term
@@ -1032,6 +1033,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return cfg.extraction_schema_hint()
         except PromptError as exc:
             raise LLMError(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001 - normalise every render failure
+            # This call is an argument expression inside the extraction worker's
+            # `try`, so without this clause an unreadable override lands on the
+            # generic handler and the job says `analysis failed` — a diagnosis of
+            # the provider for a file on this machine. Name the prompt:
+            # `str(UnicodeDecodeError)` names no file at all.
+            raise LLMError(
+                f"prompt extraction-limit-hint could not be loaded: {exc}"
+            ) from exc
 
     def _relation_aliases_path() -> Path:
         return _active_cfg().root / RELATION_ALIASES_RELPATH
@@ -1059,6 +1069,47 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
         return f"{text.rstrip()}\n\n# Default aliases not yet saved in this KB\n{missing_text}\n"
 
+    def _override_is_unreadable(path: Path) -> bool:
+        """Is the KB's override for this prompt the file that could not be read?
+
+        `get_prompt` reads TWO files — the packaged default and this override —
+        so a failed load does not by itself say which one broke, and Reset
+        deletes only this one. Measured on a damaged install (packaged default
+        at `0o000`) with a healthy override beside it: resetting destroyed the
+        user's file and left the page exactly as broken. So the destructive
+        control is offered only when the override path is one this process could
+        not read. A missing override reads as False — there is nothing there to
+        delete, and nothing a reset could fix.
+
+        `is_file()` FIRST, mirroring `get_prompt`, which opens the override only
+        behind the same guard, and narrowing this to what `unlink()` can act on:
+        without it a directory at that path reads as "unreadable" (measured) and
+        the page offers to delete something the loader never opened and
+        `unlink()` cannot remove. It sits inside the `try` rather than above it
+        because `Path.is_file()` propagates a `PermissionError` from an
+        unreadable parent directory (measured), and this whole function runs
+        inside the handler that renders the error page — a raise here would take
+        that page down instead of the load failure it exists to report.
+
+        This costs an extra `stat` of the override, and a read of it only when
+        that `stat` says it is a regular file — a second read when `get_prompt`
+        had already reached it, the first when the packaged default is what
+        failed. Going back to the disk at all is a stand-in: the exception
+        `get_prompt` raises need not say which of the two files it was reading —
+        the `PermissionError` from an unreadable one names its path, the
+        `UnicodeDecodeError` from a non-UTF-8 one names no file at all
+        (measured) — and its text is not a contract to parse.
+        """
+        try:
+            if not path.is_file():
+                return False
+            path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return False
+        except Exception:  # noqa: BLE001 - unreadable by any means is the point
+            return True
+        return False
+
     def _prompts_page(
         request: Request,
         *,
@@ -1084,8 +1135,66 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     "prompt_text": prompt_text,
                     "message": message,
                     "error": str(exc),
+                    "reset_only": False,
+                    "override_path": None,
                 },
                 status_code=400,
+            )
+        except Exception as exc:  # noqa: BLE001 - the page that repairs a broken override
+            # `get_prompt` reads the override off disk, so a file the user saved
+            # here and then made unreadable took this page down with it. Diagnose
+            # it in the banner instead: `str(UnicodeDecodeError)` names no file at
+            # all (measured — it names a byte offset).
+            #
+            # NOT the 409 the corrupt-file pages use (`sidecar_unreadable.html`,
+            # `config_corrupt.html`, `credentials_corrupt.html`): each of those
+            # REPLACES the page the caller asked for with a refusal template and
+            # ends there. This one is still a working page: the selector routes
+            # to every other prompt, the banner names the prompt that failed,
+            # and where the override is itself what cannot be read `reset_only`
+            # adds the control that deletes it — `delete_prompt_override` only
+            # `unlink()`s, so that repair survives a file this process could not
+            # read (measured: 303, the override gone, the page healthy again, in
+            # both modes the tests cover). What the page does NOT carry is the
+            # broken prompt's own text or its Save form: `prompt=None` collapses
+            # the editor, and seeding the textarea with the default would invite
+            # overwriting a file this process could not read. So it is a
+            # delivered page, not a refused one, and #539's non-regression
+            # condition asks for 200 in as many words.
+            #
+            # `status_code` rather than a literal 200 because
+            # `save_prompt_route`/`reset_prompt_route` render this page with 400
+            # for a POST they refused; that refusal is still the truth about
+            # their request. Their `error` is composed with, not replaced by, the
+            # load diagnosis, so such a caller is still told why the save was
+            # rejected.
+            load_error = f"prompt {prompt_id} could not be loaded: {exc}"
+            override_path = prompt_override_path(cfg.root, prompt_id)
+            return templates.TemplateResponse(
+                request,
+                "prompts.html",
+                {
+                    "prompts": list_prompts(),
+                    "prompt": None,
+                    "selected_prompt": prompt_id,
+                    "prompt_text": prompt_text,
+                    "message": message,
+                    "error": load_error if error is None else f"{error}; {load_error}",
+                    # The only branch that can set this True; the other two
+                    # returns of this function pass `False` rather than leaving
+                    # it undefined, and those three are every renderer of
+                    # `prompts.html` there is (grep). NOT `prompt is None`: the
+                    # `except PromptError` branch above renders that way too,
+                    # and `unknown prompt: <id>` is one of the things it catches
+                    # — no definition, no file, nothing a reset could act on. It
+                    # also catches a readable override that fails validation,
+                    # where a reset WOULD repair the page and none is offered
+                    # (measured); that gap is a follow-up, not this change,
+                    # whose subject is an override that cannot be READ.
+                    "reset_only": _override_is_unreadable(override_path),
+                    "override_path": override_path,
+                },
+                status_code=status_code,
             )
         return templates.TemplateResponse(
             request,
@@ -1097,6 +1206,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "prompt_text": prompt.text if prompt_text is None else prompt_text,
                 "message": message,
                 "error": error,
+                "reset_only": False,
+                "override_path": None,
             },
             status_code=status_code,
         )

--- a/verinote/web/templates/prompts.html
+++ b/verinote/web/templates/prompts.html
@@ -48,4 +48,19 @@
   {% endif %}
 </section>
 {% endif %}
+
+{% if reset_only %}
+<section class="prompt-editor">
+  <div class="prompt-meta">
+    <span class="badge">Could not load</span>
+    <span><code>{{ selected_prompt }}</code></span>
+    <span>{{ override_path }}</span>
+  </div>
+  <p class="muted">This prompt's text is not shown and cannot be edited here. Reset to default deletes the override file named above; this prompt then falls back to the built-in default.</p>
+  <form class="prompt-reset" action="/prompts/reset" method="post">
+    <input type="hidden" name="prompt_id" value="{{ selected_prompt }}">
+    <button class="btn ghost" type="submit">Reset to default</button>
+  </form>
+</section>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Closes #539.

`get_prompt` reads a KB's override with `read_text(encoding="utf-8")`, and `PromptError` is a `ValueError` subclass — so neither the `UnicodeDecodeError` from a non-UTF-8 file nor the `PermissionError` from a mode bit was caught at four sites outside the modules #500 already fixed.

**The one that matters most to a user:** a broken override took down the page you would go to in order to repair it. `GET /prompts` was a **500**; it is now **200** with a banner naming the prompt and a **Reset** control.

## What changed

| site | before | after |
|---|---|---|
| `cmd_sync.extraction_schema_hint` | traceback out of `cli.main` | `extraction failed: prompt … could not be loaded`, rc 1, job row untouched |
| `_extraction_schema_hint` | job says `analysis failed` (blames the provider) | `extraction failed` (names the file) |
| `_focused_role_schema_hint` | raw exception propagates | `LLMError` naming the prompt |
| `_prompts_page` | **500** | **200** + banner + reset-only control |

Reset only — never an editor seeded with the default text, which would turn one careless click into a silent overwrite of a file this process could not read. `status_code` is passed through rather than written as `200`, so a POST that `save_prompt_route` refused keeps its 400 and its own reason, composed with the load diagnosis rather than replaced by it.

## The gate

The Reset control is gated on `_override_is_unreadable(override_path)` — not unconditional, and not `.exists()`. Both of those were **measured wrong**: with a healthy override beside a packaged default at mode `0o000`, either spelling renders a button that **deletes the user's healthy file** and leaves the page broken.

Its `is_file()` sits *inside* the gate's own `try`, because `Path.is_file()` propagates a `PermissionError` from an unreadable parent directory and the gate is called from a line inside no `try`. Above the `try` it turns that state's 200 back into a 500 — pinned by `test_an_unreadable_prompts_directory_still_renders_the_page`.

## Verification

- **3187 passed, 14 skipped**, zero failures (parent: 3168).
- `ruff@0.15.18` (the version `.github/workflows/ci.yml` pins) — clean.
- **20-row mutation matrix.** Reverting any one of the four clauses reddens that site's tests and no others. Both failure modes — non-UTF-8 and mode `0o000` — are exercised at each of the four, with the repo's existing runtime skip for hosts that read through mode bits.
- Notable rows: `M19` (drop the `is_file()` guard) reddens exactly the directory test; `M21` (hoist the guard) reddens exactly the new placement test — 1 failed / 266 passed across `tests/test_web.py`.

One pre-existing test changed: `test_a_prompt_that_cannot_be_read_leaves_the_untouched_job_pending` asserted the old escaping exception type. Its subject was always the job row, which did not move; it now asserts the exit code and the message.

## Scoped out, measured and filed

- **#544** — retyping the focused-role failure to `LLMError` moves it into the chunk loop's `except Exception … continue`, so a local unreadable file is charged to the content retry budget once per role-cued chunk and bills a discarded provider call per chunk (1 → 5 calls, 1 → 4 charged chunks on a five-chunk source). `extract.py` states twice that an availability condition must not spend a content budget.
- **#545** — the save/reset **write** paths still answer 500. The Reset this PR renders is what now reaches them.
- **#546** — a readable override that *fails validation* gets a 400 with no repair offered. The gate excludes it deliberately: deleting a file the user can read, for a reason they cannot see, is the wrong trade.
- **#540** — commented that the normalisation family has grown, and that pushing normalisation down into `get_prompt` would make these clauses redundant.

`Config.extraction_schema_hint` is not where this goes — that is compliance with #539's own condition that each site's clause be separately falsifiable, **not** a claim that four local clauses beat one shared one.

`cfg.root` reaching `source_chunks.error` unredacted is real, and was measured **not** to widen here: the parent already persists it through the generic clause.
