### PR TITLE
fix(web): the worker's terminal clauses re-read job state before writing failed (#525)

### DIFF
--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -628,13 +628,13 @@ def test_cli_sync_fails_the_job_and_never_leaves_the_chunk_claimed(
     and the two callers agree only so far — `_start_source_extraction`
     (`web/app.py`) and `cmd_sync` each end with a broad clause that writes
     `failed` after re-reading the job status, but on DIFFERENT predicates. The
-    `cmd_sync` clause wraps `process_extraction_job` alone, so the claim is always
-    held and `running` is the right question; the web clause also wraps
-    `get_client` and its schema hint, where a pre-claim failure is still `pending`
-    and must be recorded, so it refuses `done` only (#525). That partial agreement
-    is a fact about two call sites, not something the invariant may be re-phrased
-    over: `BaseException` and a lost ownership CAS still leave a job in no terminal
-    status at all (see the two tests above).
+    `cmd_sync` clause wraps `process_extraction_job` alone, with no pre-claim code
+    of its own; the web clause also wraps `get_client` and its schema hint, where
+    a pre-claim failure is still `pending` and must be recorded, so it refuses
+    `done` only (#525). That partial agreement is a fact about two call sites, not
+    something the invariant may be re-phrased over: `BaseException` and a lost
+    ownership CAS still leave a job in no terminal status at all (see the two tests
+    above).
 
     (a) WAS A CHARACTERISATION AND IS NOW A GUARANTEE. It used to read `running`
     and carried #488's instruction to turn it red; #488 is that fix, and this is

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -165,8 +165,12 @@ def _caller_marks_job_failed(store: Store, job_id: int, message: str) -> None:
 
     `process_extraction_job` leaves the job row alone when a non-`LLMError`
     escapes; a caller's broad clause is what writes `failed` — the worker thread's
-    in `_start_source_extraction` (`web/app.py`), or `cmd_sync`'s (`cli.py`,
-    #488). A test that wants the job in its post-failure resting state has to
+    in `_start_source_extraction` (`web/app.py`, #525), or `cmd_sync`'s (`cli.py`,
+    #488) — WHEN its status re-read permits. Both re-read now, and neither writes
+    over a job it no longer owns, so this stand-in reproduces the resting state of
+    the path where the re-read does permit the write: the job still `running` with
+    a chunk that failed for a non-`LLMError` reason. A test that wants the job in
+    its post-failure resting state has to
     perform that write itself, so it is spelled out here rather than hidden behind
     a fixture — nothing in `verinote/pipeline` will do it, which is why the tests
     below call `process_extraction_job` directly and then this.
@@ -621,11 +625,16 @@ def test_cli_sync_fails_the_job_and_never_leaves_the_chunk_claimed(
     is still stated over CHUNKS, and this test is still why: the release happens
     inside `process_extraction_job`, below every caller, so it holds no matter
     what the caller does with the job row. The job row is a caller's business,
-    and the two callers now agree about it — `_start_source_extraction`
+    and the two callers agree only so far — `_start_source_extraction`
     (`web/app.py`) and `cmd_sync` each end with a broad clause that writes
-    `failed`. That agreement is a fact about two call sites, not something the
-    invariant may be re-phrased over: `BaseException` and a lost ownership CAS
-    still leave a job in no terminal status at all (see the two tests above).
+    `failed` after re-reading the job status, but on DIFFERENT predicates. The
+    `cmd_sync` clause wraps `process_extraction_job` alone, so the claim is always
+    held and `running` is the right question; the web clause also wraps
+    `get_client` and its schema hint, where a pre-claim failure is still `pending`
+    and must be recorded, so it refuses `done` only (#525). That partial agreement
+    is a fact about two call sites, not something the invariant may be re-phrased
+    over: `BaseException` and a lost ownership CAS still leave a job in no terminal
+    status at all (see the two tests above).
 
     (a) WAS A CHARACTERISATION AND IS NOW A GUARANTEE. It used to read `running`
     and carried #488's instruction to turn it red; #488 is that fix, and this is
@@ -839,14 +848,16 @@ def test_a_job_that_already_finished_is_not_buried_by_a_later_failure(
     owns. Without the re-read the fix is a pure regression on this path — before
     #488 nothing wrote the job row here at all, so it stayed `done`.
 
-    `web/app.py` HAS NO EQUIVALENT, AND BURIES THE JOB ON THIS PATH. Its two local
-    guards wrap the stale-citation sweep and auto-accept only; `process_extraction_job`
-    itself sits bare inside the worker's try, and the worker's broad clause calls
-    `fail_extraction_job` with no status re-read at all. Driven through a real
-    worker, this same scenario leaves `failed: analysis failed: ...` over a job
-    that is `done` with its chunk complete. Not this change's doing and not its
-    scope — it is #525 — but nothing here should be read as saying the web path is
-    already safe.
+    `web/app.py` HAS AN EQUIVALENT SINCE #525, ON A DIFFERENT PREDICATE. It used to
+    have none: its two local guards wrap the stale-citation sweep and auto-accept
+    only, `process_extraction_job` sat bare inside the worker's try, and the broad
+    clause called `fail_extraction_job` with no re-read — driven through a real
+    worker, this same scenario left `failed: analysis failed: ...` over a job that
+    was `done` with its chunk complete. `_fail_job_unless_done` now makes the same
+    read. It refuses `done` and nothing else, where this clause requires `running`,
+    because the worker's try also spans `get_client` and its schema hint: a failure
+    there is still `pending` and must be recorded, so the predicates cannot be
+    swapped between the two files.
     """
     from verinote import cli
 

--- a/tests/test_chunk_claim_sidecar_lock.py
+++ b/tests/test_chunk_claim_sidecar_lock.py
@@ -263,9 +263,11 @@ def _caller_marks_job_failed(store: Store, job_id: int, message: str) -> None:
     """Stand-in for a caller's `except Exception`. NOT code under test.
 
     `process_extraction_job` does not write the job row when a non-`LLMError`
-    escapes; its callers do — `_start_source_extraction` (`web/app.py`), and
-    `cmd_sync` (`cli.py`) since #488. A test that needs a job in its post-failure
-    resting state performs that write itself.
+    escapes; its callers do — `_start_source_extraction` (`web/app.py`, #525), and
+    `cmd_sync` (`cli.py`) since #488 — when their status re-read permits. Both
+    re-read now, so neither writes over a job it no longer owns; this stand-in
+    stands in for the path where the write does happen. A test that needs a job in
+    its post-failure resting state performs that write itself.
     """
     store.fail_extraction_job(job_id, message)
 

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -831,11 +831,11 @@ def _put_job_in_the_edge_state(store: Store, job_id: int, message: str) -> None:
     """Write the `failed` row directly, where no pass is being run to write it.
 
     #488 landed, so both callers now end with a broad `except` that terminalises
-    the job (`web/app.py`; `cli.py` since then), and the tests below that DRIVE a
-    crash through `cli.main(["sync"])` get that row from the CLI itself — they no
-    longer call anything here. What is left are the two fixtures that build the
-    edge state without running a pass at all: there is no caller in play to do
-    the write, so they do it themselves.
+    the job when the re-read permits (`web/app.py`; `cli.py` since then), and the
+    tests below that DRIVE a crash through `cli.main(["sync"])` get that row from
+    the CLI itself — they no longer call anything here. What is left are the two
+    fixtures that build the edge state without running a pass at all: there is no
+    caller in play to do the write, so they do it themselves.
 
     NOT the code under test either way. Nothing in `verinote/pipeline` writes the
     job row on this path; that is the invariant `test_chunk_claim_release.py`
@@ -1172,10 +1172,13 @@ def test_a_failed_job_that_finished_everything_terminalises_without_the_llm(
 ):
     """The edge state can also arrive with nothing left to do, and it must settle.
 
-    A broad `except` that fires AFTER the chunk loop writes `failed` over a job
-    whose chunks are all `done`. Continuing it claims the job, finds no pending
-    chunk, and finishes: no LLM call, and the empty run it opens is opened ONCE,
-    unlike the rebuild it replaces, which re-extracted every chunk.
+    A broad `except` that fired after the chunk loop used to write `failed` over a
+    job whose chunks are all `done` — the web worker's, until #525; `cmd_sync`'s
+    could not since #488, because it requires `running`. Both re-read now, so this
+    fixture stages the row directly rather than driving a pass that produces it.
+    Continuing it claims the job, finds no pending chunk, and finishes: no LLM
+    call, and the empty run it opens is opened ONCE, unlike the rebuild it
+    replaces, which re-extracted every chunk.
     """
     _ingest(tmp_path, monkeypatch, body=_body(J_MARKERS))
     monkeypatch.setattr("verinote.llm.get_client", lambda cfg: _RecordingClient())

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2031,6 +2031,65 @@ def test_worker_leaves_a_done_job_done_when_finishing_it_raises_an_llm_error(
     assert "extraction_job_completed" not in _job_event_types(cfg, job_id)
 
 
+def test_worker_writes_nothing_when_the_job_row_is_gone(tmp_path, monkeypatch, fake_client):
+    """The `is not None` half of the guard, which nothing else reaches.
+
+    The docstring's own bullet says a deleted source reads back as `None` and the
+    write is then a no-op. Nothing measured that: with the conjunct removed the
+    guard raises `TypeError` on `None["status"]` before reaching the write, so the
+    decline and the no-op write are indistinguishable to every other test here.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    failures = _fail_job_spy(monkeypatch)
+
+    def delete_the_source_then_raise(self, job_id):
+        # `PRAGMA foreign_keys = ON` is set per connection (`store/db.py`) and
+        # `extraction_jobs.source_id` is `ON DELETE CASCADE` (`schema.sql`), so the
+        # job row goes with the source and the guard's re-read sees `None`.
+        self._conn.execute(
+            "DELETE FROM sources WHERE id = "
+            "(SELECT source_id FROM extraction_jobs WHERE id = ?)",
+            (job_id,),
+        )
+        raise RuntimeError("post-done store error")
+
+    monkeypatch.setattr(
+        store_db.Store, "finish_extraction_job", delete_the_source_then_raise
+    )
+
+    create_app(cfg)
+    _join_worker(job_id)
+
+    # FIRST, for the diagnosis rather than against a vacuous pass: this test cannot
+    # go green with the cascade not firing — the job row would survive as `done`,
+    # the guard would decline, and the write assertion below would fail anyway.
+    # MEASURED, both `PRAGMA foreign_keys` sites flipped to OFF: without these three
+    # lines it fails at the write assertion with a bare `[] != [(1, ...)]`, naming
+    # nothing; with them it fails here instead, saying which half broke.
+    with Store(cfg.db_path) as s:
+        s.init_schema()
+        assert s.get_extraction_job(job_id) is None
+    # The guard fell THROUGH to the write rather than raising on `None["status"]`.
+    # This is the assertion the conjunct owns, and it observes the CALL, nothing more.
+    # What the write then did is a separate fact, read off the store rather than
+    # measured here: `fail_extraction_job` is `UPDATE ... WHERE id = ?` (`store/db.py`)
+    # over a row the assertion above already read back as gone — that read happens
+    # after `_join_worker`, so after the write — and its event append sits behind
+    # `if after is not None`. Do not "strengthen" this with `_job_event_types`: TWO
+    # separate things empty it, and neither is about the guard. `fact_events.job_id`
+    # is `ON DELETE SET NULL` (`schema.sql`), so the events this run really did write
+    # drop out of a `WHERE job_id = ?` query; and `fail_extraction_job` appends
+    # nothing anyway once the row is gone. Probed with the write allowed: the table
+    # holds [('extraction_job_started', None), ('candidate_created', None)] and zero
+    # `extraction_job_failed` rows counted table-wide.
+    assert failures == [(job_id, "analysis failed: post-done store error")]
+
+
 def test_worker_still_fails_a_claimed_job_whose_chunk_crashed(
     tmp_path, monkeypatch, fake_client
 ):
@@ -2039,15 +2098,26 @@ def test_worker_still_fails_a_claimed_job_whose_chunk_crashed(
     THIS IS THE TEST THAT CONSTRAINS THE GUARD FROM BELOW, and the reason the
     predicate is "refuse `done`" rather than anything broader. Every other test
     around it reaches the terminal clauses with the job `pending` (stubbed before
-    the claim) or `done` (finished, then broken). None drives the ordinary case: a
+    the claim), `done` (finished, then broken), or gone altogether
+    (`test_worker_writes_nothing_when_the_job_row_is_gone`, whose source is deleted
+    from inside the raising callable). None drives the ordinary case: a
     job this worker genuinely claimed, whose chunk then failed for a non-`LLMError`
     reason. `process_extraction_job` releases the claim and re-raises, and
     `_refresh_extraction_job` deliberately keeps an owned job `running` across that
     (#337), so the exception arrives with the job `running` and MUST be recorded.
 
-    Widen the refusal set to `{"done", "running"}`, or invert the predicate, and
-    every other test in this file still passes while the failure the clause exists
-    to report is silently swallowed. This one goes red.
+    Widen the refusal set to `{"done", "running"}` and every other test in this file
+    still passes while the failure the clause exists to report is silently swallowed.
+    This one goes red — measured, and it is the only red in the whole suite.
+
+    OF THE THREE WAYS OF GETTING THIS PREDICATE WRONG NAMED HERE, THE WIDENING IS
+    THE ONE THIS TEST ISOLATES — the sentence used to say "or invert the predicate"
+    as if that were a second one. Measured, it is not: swapping
+    in `cmd_sync`'s `running` predicate leaves THIS test green (a `running` job is
+    exactly what it writes) and reddens the pre-claim tests instead, while inverting
+    to `!= "done"` reddens this test, both `done` tests and the pre-claim ones all
+    together. Either would be caught by something; only the widening is caught by
+    this test and nothing else.
 
     No stub stands in for `process_extraction_job`: the real one runs, so the status
     the clause sees is the one production would produce.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1971,7 +1971,10 @@ def test_worker_leaves_a_done_job_done_when_finishing_it_raises(
     # and the traceback is the only thing left naming what was raised. Asserting the
     # message text alone does not pin it — that string is in the message too.
     assert "RuntimeError" in caplog.text
-    assert caplog.records[-1].exc_info is not None
+    declined = next(
+        r for r in caplog.records if "not recording on the job row" in r.getMessage()
+    )
+    assert declined.exc_info is not None
     # nothing else recorded this run either, which is why the log line above is the
     # whole of the record: `finish_extraction_job` raised before its own event.
     assert "extraction_job_completed" not in _job_event_types(cfg, job_id)
@@ -2021,7 +2024,10 @@ def test_worker_leaves_a_done_job_done_when_finishing_it_raises_an_llm_error(
     assert "not recording on the job row" in caplog.text
     assert "post-done llm error" in caplog.text
     assert "LLMError" in caplog.text
-    assert caplog.records[-1].exc_info is not None
+    declined = next(
+        r for r in caplog.records if "not recording on the job row" in r.getMessage()
+    )
+    assert declined.exc_info is not None
     assert "extraction_job_completed" not in _job_event_types(cfg, job_id)
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1871,6 +1871,197 @@ def test_worker_busy_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_cl
     assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
 
 
+# --- #525: the worker's terminal clauses re-read before they write ------------
+
+
+def _join_worker(job_id, *, timeout: float = 5.0) -> None:
+    """Wait for THE worker thread, not for a clock.
+
+    `_wait_for(status == "done")` is useless as a settle point here: on the broken
+    tree `mark_chunk_done` has ALREADY written `done` before `finish_extraction_job`
+    runs, so it returns immediately and the whole verdict falls back onto whatever
+    sleep follows it. `_start_source_extraction` names its thread, so the test can
+    join the actual worker and know the handler has run — or find it already gone,
+    which is the same guarantee.
+    """
+    name = f"verinote-source-extract-{job_id}"
+    for thread in threading.enumerate():
+        if thread.name == name:
+            thread.join(timeout=timeout)
+            assert not thread.is_alive(), "the worker thread did not finish"
+
+
+def _fail_job_spy(monkeypatch):
+    """Count `fail_extraction_job` calls, so "declined" is a POSITIVE assertion.
+
+    `_join_worker` already rules out the "the write has not landed yet" reading of a
+    still-`done` row, so this is not about timing. It distinguishes a guard that
+    DECLINED from one that wrote a `failed` row some later step happened to restore:
+    the row and the event tell you the end state, and only the call count tells you
+    the write never happened.
+    """
+    calls = []
+    real = store_db.Store.fail_extraction_job
+
+    def spy(self, job_id, message):
+        calls.append((job_id, message))
+        return real(self, job_id, message)
+
+    monkeypatch.setattr(store_db.Store, "fail_extraction_job", spy)
+    return calls
+
+
+def _raise_on_finish(monkeypatch, exc):
+    """Make `finish_extraction_job` raise AFTER `mark_chunk_done` wrote `done`.
+
+    This is the reachable shape of #525 and needs no invention: the chunk loop marks
+    the last chunk `done` (which writes the JOB `done` too), and only then does
+    `process_extraction_job` call `finish_extraction_job`. Anything raised there
+    escapes with the job already complete.
+    """
+
+    def boom(self, job_id):
+        raise exc
+
+    monkeypatch.setattr(store_db.Store, "finish_extraction_job", boom)
+
+
+def test_worker_leaves_a_done_job_done_when_finishing_it_raises(
+    tmp_path, monkeypatch, fake_client, caplog
+):
+    """The regression #525 is about: a completed job buried by a later failure.
+
+    Measured on the tree before the fix, driving the real worker: the job came to
+    rest `failed` with 'analysis failed: post-done store error', its chunk `done`,
+    and an `extraction_job_failed` event appended beside it. Every chunk had
+    completed and its candidate facts were committed — the KB reporting a run it
+    finished as one that failed (#194/#239).
+
+    The event assertion is not redundant with the status one: the row could read
+    `done` while `fail_extraction_job` had appended the event anyway.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    failures = _fail_job_spy(monkeypatch)
+    _raise_on_finish(monkeypatch, RuntimeError("post-done store error"))
+
+    with caplog.at_level(logging.WARNING, logger="verinote.web.app"):
+        create_app(cfg)
+        _join_worker(job_id)
+
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "done", "a completed job was buried by a post-`done` error"
+    # the real completion message, not merely the absence of a failure one: a guard
+    # that declined the write but cleared the message would pass the weaker check.
+    assert job["message"] == "Analysis complete: 1/1 chunk(s)"
+    assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
+    assert failures == [], "the terminal clause wrote over a job it no longer owned"
+    # DECLINING IS NOT DROPPING. Nothing else records this error — the job keeps the
+    # `done` row `mark_chunk_done` wrote, and `finish_extraction_job` raised before
+    # its own completion event and before the run summary — so if the guard did not
+    # log, a real sqlite/WAL-class failure would leave no trace anywhere at all.
+    assert "not recording on the job row" in caplog.text
+    assert "post-done store error" in caplog.text
+    # `exc_info` specifically, not just the message: the web message is NOT
+    # type-qualified, so for a bare `ValueError()` it degrades to "analysis failed: "
+    # and the traceback is the only thing left naming what was raised. Asserting the
+    # message text alone does not pin it — that string is in the message too.
+    assert "RuntimeError" in caplog.text
+    assert caplog.records[-1].exc_info is not None
+    # nothing else recorded this run either, which is why the log line above is the
+    # whole of the record: `finish_extraction_job` raised before its own event.
+    assert "extraction_job_completed" not in _job_event_types(cfg, job_id)
+    with Store(cfg.db_path) as store:
+        store.init_schema()
+        assert [r["status"] for r in store.source_chunks(job_id)] == ["done"]
+
+
+def test_worker_leaves_a_done_job_done_when_finishing_it_raises_an_llm_error(
+    tmp_path, monkeypatch, fake_client, caplog
+):
+    """The `except LLMError` half of the same guard. CHARACTERISATION, not a scenario.
+
+    No production path raises an `LLMError` with the job already `done`: the chunk
+    loop swallows `LLMError` through `_release_claimed_chunk` and continues, the two
+    calls after `process_extraction_job` returns carry their own guards, and
+    `finish_extraction_job` raises no `LLMError` of its own. The exception is
+    injected here. What the test pins is that the guard on that clause is the same
+    guard — "does this call still own this job?" is not a question the exception
+    TYPE answers — so the two clauses cannot drift apart.
+
+    The clause ITSELF is live, and this test says nothing against that: an
+    unreadable prompt override reaches it through `_extraction_schema_hint` (#539),
+    and `process_extraction_job` raises `LLMError` for a missing job or source. On
+    all of those the job is still `pending` and the guard correctly permits the
+    write — which is what `test_a_broken_extraction_limit_hint_is_extraction_failed
+    _not_analysis_failed` pins.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    failures = _fail_job_spy(monkeypatch)
+    _raise_on_finish(monkeypatch, LLMError("post-done llm error"))
+
+    with caplog.at_level(logging.WARNING, logger="verinote.web.app"):
+        create_app(cfg)
+        _join_worker(job_id)
+
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "done"
+    assert job["message"] == "Analysis complete: 1/1 chunk(s)"
+    assert "extraction_job_failed" not in _job_event_types(cfg, job_id)
+    assert failures == []
+    assert "not recording on the job row" in caplog.text
+    assert "post-done llm error" in caplog.text
+    assert "LLMError" in caplog.text
+    assert caplog.records[-1].exc_info is not None
+    assert "extraction_job_completed" not in _job_event_types(cfg, job_id)
+
+
+def test_worker_still_fails_a_claimed_job_whose_chunk_crashed(
+    tmp_path, monkeypatch, fake_client
+):
+    """The other side of the predicate: `running` must still be written `failed`.
+
+    THIS IS THE TEST THAT CONSTRAINS THE GUARD FROM BELOW, and the reason the
+    predicate is "refuse `done`" rather than anything broader. Every other test
+    around it reaches the terminal clauses with the job `pending` (stubbed before
+    the claim) or `done` (finished, then broken). None drives the ordinary case: a
+    job this worker genuinely claimed, whose chunk then failed for a non-`LLMError`
+    reason. `process_extraction_job` releases the claim and re-raises, and
+    `_refresh_extraction_job` deliberately keeps an owned job `running` across that
+    (#337), so the exception arrives with the job `running` and MUST be recorded.
+
+    Widen the refusal set to `{"done", "running"}`, or invert the predicate, and
+    every other test in this file still passes while the failure the clause exists
+    to report is silently swallowed. This one goes red.
+
+    No stub stands in for `process_extraction_job`: the real one runs, so the status
+    the clause sees is the one production would produce.
+    """
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client(error=RuntimeError("chunk exploded")),
+    )
+
+    create_app(cfg)
+    _join_worker(job_id)
+
+    job = _job_row(cfg, job_id)
+    assert job["status"] == "failed", "a claimed job whose chunk crashed was not recorded"
+    assert "chunk exploded" in job["message"], "the cause was dropped from the job row"
+    assert "extraction_job_failed" in _job_event_types(cfg, job_id)
+
+
 def test_startup_revives_a_job_left_running_by_a_crash(tmp_path, monkeypatch, fake_client):
     """A job a crash left `running` (with a `running` chunk) is revived to `done` (#242).
 
@@ -2035,12 +2226,16 @@ def test_worker_leaves_a_done_job_done_when_auto_accept_raises(
     tmp_path, monkeypatch, fake_client
 ):
     # #340 exception-safety, the sibling of the #329 sweep guard directly above it:
-    # auto-accept is a call inside the worker's try/except, so WITHOUT the local
-    # guard an auto-accept error would reach the outer `except Exception ->
-    # fail_extraction_job` and retroactively flip an already-`done` extraction to
-    # `failed` — the KB lying about its own run state (#194/#239). The extraction
-    # genuinely succeeded and its facts are already committed, so the guard must
-    # keep the job `done`.
+    # auto-accept is a call inside the worker's try/except, so it USED TO BE that
+    # without the local guard an auto-accept error reached the outer `except
+    # Exception -> fail_extraction_job` and retroactively flipped an already-`done`
+    # extraction to `failed` — the KB lying about its own run state (#194/#239).
+    # Since #525 the outer clause re-reads and declines a `done` job, so this test
+    # no longer distinguishes the local guard: MEASURED, removing that guard leaves
+    # it green. What it still pins is that the job SURVIVES an auto-accept error,
+    # whichever layer contains it — the extraction genuinely succeeded and its
+    # facts are already committed. `test_worker_leaves_a_done_job_done_when_
+    # finishing_it_raises` is what now pins the outer re-read itself.
     cfg, job_id, _ = _auto_accept_kb(tmp_path)  # auto-accept on, policy present
     monkeypatch.setattr(
         webapp,
@@ -4313,10 +4508,16 @@ def test_worker_leaves_a_done_job_done_when_the_stale_sweep_raises(
     tmp_path, monkeypatch, fake_client
 ):
     # #329 exception-safety: the sweep is a sibling call inside the worker's
-    # try/except, so WITHOUT the local guard a sweep error would reach the outer
-    # `except Exception -> fail_extraction_job` and retroactively flip a completed
-    # extraction to `failed` (the "KB lies about its own run state" class #194/#239
-    # closed). The local guard must keep an already-`done` job `done`.
+    # try/except, so it USED TO BE that without the local guard a sweep error
+    # reached the outer `except Exception -> fail_extraction_job` and retroactively
+    # flipped a completed extraction to `failed` (the "KB lies about its own run
+    # state" class #194/#239 closed). Since #525 the outer clause re-reads and
+    # declines a `done` job, so this test no longer distinguishes the local guard:
+    # MEASURED, removing that guard leaves it green. What it still pins is that a
+    # sweep error leaves the completed job `done`, whichever layer contains it.
+    # Note the Config below leaves `auto_accept_recommendations` at its `False`
+    # default, so this fixture does NOT exercise the sweep guard's one remaining
+    # effect — letting auto-accept run after a failed sweep.
     cfg = Config(
         root=tmp_path,
         db_path=tmp_path / "kb.sqlite",

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -993,7 +993,8 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     # {e}"` renders a bare `ValueError()` as "analysis failed: "
                     # with no cause — the same empty-cause symptom
                     # `_release_claimed_chunk` type-qualifies against, still open
-                    # there (#525). So this clause is the web clause's counterpart,
+                    # there and outside the scope of the #525 re-read that clause
+                    # has since grown. So this clause is the web clause's counterpart,
                     # not its mirror. Neither bounds the message length; the store
                     # takes `str(exc)` whole, exactly as the web one does.
                     # (3) What this clause hands planning is a `failed` job whose
@@ -1054,9 +1055,14 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                 # the try above leaves the job `done` just the same, because the
                 # sweep runs only after `process_extraction_job` returned and the
                 # broad clause's status re-read declines to write a `done` job.
-                # Outside is scope narrowing, not a safety property. The web
-                # worker's local sweep guard IS load-bearing for it, because its
-                # broad clause has no such re-read (#525).
+                # Outside is scope narrowing, not a safety property. The web worker's
+                # local sweep guard is now in the same position for the same reason:
+                # since #525 its broad clause re-reads too, so that guard stopped
+                # being what keeps a `done` job `done` and is likewise scope
+                # narrowing. The two re-reads do NOT share a predicate — this one
+                # requires `running`, the web one only refuses `done` — because that
+                # clause also wraps `get_client` and its schema hint, where a
+                # pre-claim failure is still `pending` and must be recorded.
                 # `assert_writable` first so a policy lost post-completion routes to
                 # the PolicyMissingError handler below rather than demoting facts
                 # against a halted KB (#194) — the store trusts its caller for this.

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -992,8 +992,8 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     # here and is not in `web/app.py`, whose `f"analysis failed:
                     # {e}"` renders a bare `ValueError()` as "analysis failed: "
                     # with no cause — the same empty-cause symptom
-                    # `_release_claimed_chunk` type-qualifies against, still open
-                    # there and outside the scope of the #525 re-read that clause
+                    # `_release_claimed_chunk` type-qualifies against, open there as
+                    # #551 and outside the scope of the #525 re-read that clause
                     # has since grown. So this clause is the web clause's counterpart,
                     # not its mirror. Neither bounds the message length; the store
                     # takes `str(exc)` whole, exactly as the web one does.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1791,8 +1791,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             these clauses exist to report. Widening the refusal to
             `{"done", "running"}` is caught by exactly ONE test, measured:
             `test_worker_still_fails_a_claimed_job_whose_chunk_crashed` goes red
-            while the other thirteen `test_worker_*` tests stay green. Do not widen
-            this without reading that test.
+            while no other `test_worker_*` test does. Do not widen this without
+            reading that test.
 
             WHAT IT DOES NOT COVER — each bullet says which status it leaves the job
             in and how close to reachable it is; they do not share an answer:
@@ -1815,12 +1815,26 @@ def create_app(cfg: Config | None = None) -> FastAPI:
               Closing it means moving the predicate into the SQL, as the extraction
               path's ownership handshakes already do — a store change, not made here.
             - AN ALREADY-`failed` JOB, whose detailed per-chunk message this can
-              still overwrite. Unmeasured, but nameable: `finish_extraction_job`
-              runs on an autocommit connection, so its `_refresh_extraction_job(
-              final=True)` UPDATE commits BEFORE its `extraction_job_completed`
-              event is appended. A raise at that last step therefore leaves whatever
-              `final=True` computed — `failed` when a chunk failed — and this guard
-              permits the write over it.
+              still overwrite. `finish_extraction_job` runs on an autocommit
+              connection, so its `_refresh_extraction_job(final=True)` UPDATE
+              commits BEFORE its `extraction_job_completed` event is appended. A
+              raise at that last step therefore leaves whatever `final=True`
+              computed — `failed` when a chunk failed — and this guard permits the
+              write over it. MEASURED, driving the real worker on a 2-chunk job
+              whose first chunk raised `LLMError` and whose
+              `extraction_job_completed` append was forced to raise: the job comes
+              to rest `failed` with "analysis failed: post-final event append
+              failed" and a second `extraction_job_failed` event beside the
+              `chunk_failed` one, where a refusal set widened to
+              `("done", "failed")` keeps "Analysis failed: 1 chunk(s) failed, 1/2
+              complete: chunk one llm failure" and appends no second failure event.
+              Widening is still not the fix: the retry button's worker evaluates
+              `get_client(cfg)` and `_extraction_schema_hint(cfg)` while the job is
+              STILL the previous run's `failed` — the status only moves inside
+              `process_extraction_job`, at `claim_extraction_job_for_retry` — so
+              refusing `failed` would leave a retry that dies pre-claim showing the
+              old message and recording nothing on the job row. Nothing pins either
+              behaviour; #552 tracks it.
             - A JOB WHOSE SOURCE WAS DELETED, read back as `None`. The write goes
               ahead and is a no-op: `fail_extraction_job` matches no row and appends
               no event. Branching on it would be untested dead code.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1765,11 +1765,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             `get_client(cfg)` and the `_extraction_schema_hint(cfg)` argument
             expression, BOTH evaluated before `process_extraction_job` claims the
             job. Measured — the row read from inside the raising callable is
-            `pending` — and measured again through the suite: a `running` predicate
-            on these two clauses fails
-            `test_worker_still_fails_the_job_on_an_ordinary_error` and
+            `pending` — and measured again through the suite: substituting
+            `cmd_sync`'s `running` predicate on these two clauses reddens
+            `test_worker_still_fails_the_job_on_an_ordinary_error`, both
+            parametrizations of
             `test_a_broken_extraction_limit_hint_is_extraction_failed_not_analysis_failed`,
-            because a pre-claim failure would stop being recorded at all. The CLI
+            and `test_worker_writes_nothing_when_the_job_row_is_gone` — whose row is
+            gone, so no status matches and the write is declined instead of being
+            the no-op the bullet below describes. Measured: those four are the whole
+            red set in the suite. The two `done` tests reach these clauses too and
+            stay green — a `done` job is declined under either predicate — so being
+            not `running` is not by itself what reddens a test; requiring the write
+            is. The point is that a pre-claim failure would stop being recorded at
+            all. The CLI
             clause's `try` contains no pre-claim code of its own — `client` and
             `schema_hint` are both computed above it (`cli.py`), and none of the
             call's argument expressions is itself a call. The predicates differ
@@ -1850,7 +1858,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
               still ship this guard writing over the cancellation.
             - A JOB WHOSE SOURCE WAS DELETED, read back as `None`. The write goes
               ahead and is a no-op: `fail_extraction_job` matches no row and appends
-              no event. Branching on it would be untested dead code.
+              no event. Branching on it would be dead code, and no longer UNtested
+              dead code: `test_worker_writes_nothing_when_the_job_row_is_gone` asserts
+              the call is made, so an `if job_now is None: return` added here reddens
+              it. Measured both ways — that branch is green on the tree before that
+              test existed and red with it.
 
             DECLINING IS NOT DROPPING. The error that brought us here is real — on
             the #525 path it is a genuine sqlite/WAL-class failure — and refusing the

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1835,6 +1835,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
               refusing `failed` would leave a retry that dies pre-claim showing the
               old message and recording nothing on the job row. Nothing pins either
               behaviour; #552 tracks it.
+            - A `canceled` JOB. This guard refuses `done` BY NAME, so every other
+              status the CHECK on `extraction_jobs.status` admits (`schema.sql`) is
+              written over, and `canceled` is one of them. That contradicts what
+              the store itself does with such a job:
+              `Store.rollback_extraction_job` treats `canceled` as sacred and
+              returns above BOTH of its UPDATEs and its event append rather than
+              touch it, while this guard would put `failed` on that row with an
+              `extraction_job_failed` event beside it. Unreachable today — no
+              production code under `verinote/` writes `'canceled'` at all — which
+              makes it a third latent site for #526. That issue's two items are
+              `mark_extraction_job_running` and `_refresh_extraction_job`; neither
+              names this one, so a cancel feature that fixed #526 as written would
+              still ship this guard writing over the cancellation.
             - A JOB WHOSE SOURCE WAS DELETED, read back as `None`. The write goes
               ahead and is a no-op: `fail_extraction_job` matches no row and appends
               no event. Branching on it would be untested dead code.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1743,6 +1743,129 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         assert_settings_intact(cfg)
         assert_credentials_intact(cfg)
 
+        def _fail_job_unless_done(message: str) -> None:
+            """Record a worker-level failure — iff this call still owns the job.
+
+            THE JOB-LEVEL FLOOR FOR THE WEB WORKER (#525), and the third of three
+            siblings that all ask one question: `_release_claimed_chunk`
+            (`pipeline/extract.py`) asks it of a chunk, `cmd_sync`'s job-level
+            clause (`cli.py`, #488) asks it of a CLI job. As in theirs, the status
+            re-read is not a second decision about whether this pass failed. It
+            declines to write a job this call no longer owns. `mark_chunk_done`
+            writes the job `done` when the last chunk lands and
+            `finish_extraction_job` runs AFTER that, so a raise there escapes with
+            the job already `done`, every chunk complete and the candidates
+            committed — measured, and without this guard recorded as
+            `failed: analysis failed: ...` with an `extraction_job_failed` event
+            beside it.
+
+            IT ONLY REFUSES `done`, AND THAT IS NOT THE CLI'S PREDICATE. `cmd_sync`
+            writes only a `running` job, and copying that here would not tighten
+            this clause but silently gut it: this worker's `try` also spans
+            `get_client(cfg)` and the `_extraction_schema_hint(cfg)` argument
+            expression, BOTH evaluated before `process_extraction_job` claims the
+            job. Measured — the row read from inside the raising callable is
+            `pending` — and measured again through the suite: a `running` predicate
+            on these two clauses fails
+            `test_worker_still_fails_the_job_on_an_ordinary_error` and
+            `test_a_broken_extraction_limit_hint_is_extraction_failed_not_analysis_failed`,
+            because a pre-claim failure would stop being recorded at all. The CLI
+            clause wraps `process_extraction_job` ALONE, so its claim is always held
+            by the time it runs. The predicates differ because the scopes do.
+
+            REFUSING ONLY `done` ALSO KEEPS THE CLAUSE-ORDER TESTS HONEST.
+            `test_worker_halt_does_not_mark_the_job_failed` and
+            `test_worker_busy_does_not_mark_the_job_failed` both leave the job
+            `pending`, so this guard still WRITES on their paths and the clauses
+            above remain the only thing between a halted or foreign-owned job and a
+            `failed` row. Under a `running` predicate both would pass with those
+            clauses deleted, the way `cli.py` records its own pair going
+            non-distinguishing.
+
+            AND `running` MUST STILL BE WRITTEN, which is the other end of the same
+            decision. A chunk failing for a non-`LLMError` reason leaves the job
+            `running` — `_refresh_extraction_job` deliberately keeps an owned job
+            `running` across the release (#337) — and that is the ordinary failure
+            these clauses exist to report. Widening the refusal to
+            `{"done", "running"}` is caught by exactly ONE test, measured:
+            `test_worker_still_fails_a_claimed_job_whose_chunk_crashed` goes red
+            while the other thirteen `test_worker_*` tests stay green. Do not widen
+            this without reading that test.
+
+            WHAT IT DOES NOT COVER — each bullet says which status it leaves the job
+            in and how close to reachable it is; they do not share an answer:
+            - A FUTURE REWINDING PATH. The two paths that rewind a job to `pending`
+              (`_halt_extraction_job`, `_back_off_from_locked_sidecar`) re-raise
+              types the `PolicyMissingError` and `DuckDBFactTermStoreLockedError`
+              clauses take ABOVE these two, so no rewind reaches here. A new one
+              that did would arrive `pending` and be buried, since `done` is the
+              only status this refuses. A new rewinding path in this worker
+              therefore needs its own clause above `except LLMError`; it cannot
+              lean on this guard.
+            - A PEER THAT REWINDS IN THE WINDOW. The re-read and the write are two
+              statements on an autocommit connection, and `fail_extraction_job`
+              updates `WHERE id = ?` with no status predicate, so this holds against
+              a job that was already `done` when the read ran, not against one
+              rewound between the two. `_resume_source_extraction_jobs` rolls
+              `running` jobs back to `pending` at `create_app()` time and cannot
+              tell a crashed zombie from a live owner (#242), so for a web app a
+              second boot against the same KB is the concrete shape of that peer.
+              Closing it means moving the predicate into the SQL, as the extraction
+              path's ownership handshakes already do — a store change, not made here.
+            - AN ALREADY-`failed` JOB, whose detailed per-chunk message this can
+              still overwrite. Unmeasured, but nameable: `finish_extraction_job`
+              runs on an autocommit connection, so its `_refresh_extraction_job(
+              final=True)` UPDATE commits BEFORE its `extraction_job_completed`
+              event is appended. A raise at that last step therefore leaves whatever
+              `final=True` computed — `failed` when a chunk failed — and this guard
+              permits the write over it.
+            - A JOB WHOSE SOURCE WAS DELETED, read back as `None`. The write goes
+              ahead and is a no-op: `fail_extraction_job` matches no row and appends
+              no event. Branching on it would be untested dead code.
+
+            DECLINING IS NOT DROPPING. The error that brought us here is real — on
+            the #525 path it is a genuine sqlite/WAL-class failure — and refusing the
+            job row must not also refuse the record. Nothing else records it: the
+            job keeps a `done` row, and because `finish_extraction_job` raised
+            part-way there is no `extraction_job_completed` event and no run summary
+            either. So the decline logs, exactly as the four write-nothing clauses
+            above it do
+            (`PolicyMissingError`, `ExtractionJobBusyError`, the ConfigCorrupt pair,
+            `DuckDBFactTermStoreLockedError`). The CLI counterpart does not go quiet
+            on its own decline either — it re-raises, and `main` surfaces it — but a
+            daemon worker thread has nowhere to re-raise TO, so the log is the whole
+            of the record.
+
+            AND THE READ CARRIES A WRITE'S WORTH OF RISK. Both clauses already
+            opened a fresh `Store` and ran `init_schema()` inside the handler before
+            this helper existed, so a store error replacing the escaping exception
+            (the original left on `__context__`) is not new; this adds one SELECT to
+            that surface. It is deliberately NOT wrapped in a `try`: a raise here
+            reaches the thread excepthook, and the job state it leaves is the same
+            one a declining guard leaves — nothing written. Silence would be worse.
+            """
+            with Store(cfg.db_path) as worker_store:
+                worker_store.init_schema()
+                job_now = worker_store.get_extraction_job(job_id)
+                if job_now is not None and job_now["status"] == "done":
+                    # The status is interpolated rather than spelled "already done":
+                    # it is the second place the predicate would otherwise be
+                    # encoded in prose, and a widened refusal set would silently
+                    # make a hardcoded reason lie. `exc_info` is not decoration —
+                    # the web message is deliberately not type-qualified, so for a
+                    # bare `ValueError()` the formatted text degrades to
+                    # "analysis failed: " and the traceback is the only surviving
+                    # record of what was raised.
+                    logger.warning(
+                        "extraction job %s is %s; not recording on the job row: %s",
+                        job_id,
+                        job_now["status"],
+                        message,
+                        exc_info=True,
+                    )
+                    return
+                worker_store.fail_extraction_job(job_id, message)
+
         def run() -> None:
             try:
                 with Store(cfg.db_path) as worker_store:
@@ -1762,11 +1885,21 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     # inside it, for separation of concerns: extraction stays a pure
                     # primitive, while the sweep's return value (the demoted fact
                     # ids) is needed HERE to thread into `exclude_fact_ids` below.
-                    # Sibling placement does not by itself avoid the outer `except
-                    # Exception -> fail_extraction_job` — this call still sits in the
-                    # same try — so the local guard below is what actually keeps a
-                    # sweep error from retroactively flipping an already-`done` job
-                    # to `failed`. `assert_writable` runs first (and OUTSIDE that
+                    # Sibling placement does not by itself keep this call out of the
+                    # outer clauses — it still sits in the same try. Since #525 it no
+                    # longer has to: `_fail_job_unless_done` re-reads the status and
+                    # declines to write an already-`done` job, so a sweep error can
+                    # no longer flip a completed run to `failed` whether the guard
+                    # below catches it or not. MEASURED: with that guard removed the
+                    # worker/sweep/auto-accept tests all still pass, so no test
+                    # distinguishes deleting it. What it still buys is narrower and
+                    # currently untested — auto-accept below RUNS after a failed
+                    # sweep instead of being skipped with it — and untested because
+                    # the one fixture that raises here builds a Config leaving
+                    # `auto_accept_recommendations` at its `False` default. Kept as
+                    # defence in depth and as that scope narrowing, not as the thing
+                    # standing between a `done` job and a `failed` row.
+                    # `assert_writable` runs first (and OUTSIDE that
                     # guard) so a policy that vanished post-completion routes to the
                     # PolicyMissingError handler instead of demoting facts against a
                     # halted KB (#194) — the store layer trusts its caller for this,
@@ -1782,9 +1915,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         except Exception:  # noqa: BLE001 - a sweep error must not fail a done job
                             # The sweep does no LLM/network I/O, so a raise here is a
                             # rare sqlite/WAL-lock-class error. Contain it: the
-                            # extraction genuinely succeeded, so leave the job `done`
-                            # and take no demotions this pass rather than letting the
-                            # outer handler bury a completed run as `failed`.
+                            # extraction genuinely succeeded, so take no demotions
+                            # this pass and carry on to auto-accept. Since #525 the
+                            # job staying `done` is no longer this clause's doing —
+                            # the outer handler re-reads and declines — so what is
+                            # contained here is the SKIP, not the burial.
                             logger.warning(
                                 "stale-citation sweep failed for job %s; leaving it done",
                                 job_id,
@@ -1811,10 +1946,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         except Exception:  # noqa: BLE001 - an auto-accept error must not fail a done job
                             # Auto-accept does no LLM/network I/O, so a raise here is
                             # a rare sqlite/WAL-lock-class error. The extraction
-                            # genuinely succeeded and its facts are already
-                            # committed; leave the job `done` rather than letting the
-                            # outer handler bury a completed run as `failed` (#340;
-                            # sibling of the #329 sweep guard directly above).
+                            # genuinely succeeded and its facts are already committed
+                            # (#340; sibling of the #329 sweep guard directly above).
+                            # Since #525 this clause is no longer what leaves the job
+                            # `done` either — and being the LAST statement in the try,
+                            # it buys even less than the sweep guard does: MEASURED,
+                            # removing it leaves the same worker/sweep/auto-accept
+                            # tests green, because the error would reach the outer
+                            # handler and be declined there. What survives is the
+                            # targeted log line below, and the `raise` above it that
+                            # keeps a #194 halt on the halt path.
                             logger.warning(
                                 "auto-accept failed for job %s; leaving it done",
                                 job_id,
@@ -1896,13 +2037,25 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     exc,
                 )
             except LLMError as e:
-                with Store(cfg.db_path) as worker_store:
-                    worker_store.init_schema()
-                    worker_store.fail_extraction_job(job_id, f"extraction failed: {e}")
-            except Exception as e:  # noqa: BLE001 - keep background failures visible in UI
-                with Store(cfg.db_path) as worker_store:
-                    worker_store.init_schema()
-                    worker_store.fail_extraction_job(job_id, f"analysis failed: {e}")
+                # GUARDED LIKE THE CLAUSE BELOW, though only that one is known to
+                # need it. This clause is live — `_extraction_schema_hint(cfg)`
+                # turns an unreadable prompt override into an `LLMError` (#539),
+                # and `process_extraction_job` raises one for a missing job or
+                # source — but on every such path the job is still `pending`, so
+                # the guard permits the write and changes nothing. No production
+                # path raises an `LLMError` with the job already `done`: the chunk
+                # loop swallows `LLMError` through `_release_claimed_chunk`, and
+                # the two calls that run after `process_extraction_job` returns
+                # carry their own guards. It is guarded anyway because "does this
+                # call still own this job?" is not a question the exception TYPE
+                # answers, and these two clauses are one decision in two halves —
+                # `LLMError` is a `RuntimeError` subclass, so they are adjacent,
+                # not alternatives.
+                _fail_job_unless_done(f"extraction failed: {e}")
+            # Keep background failures visible: on the job row when this call still
+            # owns the job, in the log when it does not.
+            except Exception as e:  # noqa: BLE001
+                _fail_job_unless_done(f"analysis failed: {e}")
 
         threading.Thread(
             target=run,

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1983,8 +1983,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                             # removing it leaves the same worker/sweep/auto-accept
                             # tests green, because the error would reach the outer
                             # handler and be declined there. What survives is the
-                            # targeted log line below, and the `raise` above it that
-                            # keeps a #194 halt on the halt path.
+                            # targeted log line below — the `raise` above it is not
+                            # something THIS clause buys: it exists only to keep
+                            # this clause off the halt path, and deleting the whole
+                            # inner try/except lets a #194 halt reach the outer
+                            # handler unaided.
                             logger.warning(
                                 "auto-accept failed for job %s; leaving it done",
                                 job_id,

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1770,8 +1770,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             `test_worker_still_fails_the_job_on_an_ordinary_error` and
             `test_a_broken_extraction_limit_hint_is_extraction_failed_not_analysis_failed`,
             because a pre-claim failure would stop being recorded at all. The CLI
-            clause wraps `process_extraction_job` ALONE, so its claim is always held
-            by the time it runs. The predicates differ because the scopes do.
+            clause's `try` contains no pre-claim code of its own — `client` and
+            `schema_hint` are both computed above it (`cli.py`), and none of the
+            call's argument expressions is itself a call. The predicates differ
+            because the scopes do.
 
             REFUSING ONLY `done` ALSO KEEPS THE CLAUSE-ORDER TESTS HONEST.
             `test_worker_halt_does_not_mark_the_job_failed` and


### PR DESCRIPTION
## What changed

The web worker's two terminal exception clauses in `verinote/web/app.py` called `fail_extraction_job` **unconditionally**. A job that was already `done` — every chunk complete, candidate facts committed — was therefore buried as `failed` by any error that escaped afterwards.

`mark_chunk_done` writes the job `done` when the last chunk lands, and `finish_extraction_job` runs *after* that, so a raise there escapes `process_extraction_job` with the job already complete.

This adds `_fail_job_unless_done`, a single local helper both clauses now call. It re-reads the job status and declines to write a job this call no longer owns — the same question `_release_claimed_chunk` asks of a chunk one layer down, and the CLI job-level floor (#488) asks of a `verinote sync` job.

## Measurement

Driving the real worker through `create_app` with `Store.finish_extraction_job` forced to raise, on the tree before this change:

```
finish calls: [1]
job: failed | 'analysis failed: post-done store error'
chunks: [('done', 0)]
events: ['extraction_job_started', 'candidate_created', 'extraction_job_failed']
```

The `except LLMError` clause behaves the same way when reached (`'extraction failed: post-done llm error'`).

### Why the predicate is `done`, not the CLI's `running`

`cmd_sync`'s clause wraps `process_extraction_job` alone, with no pre-claim code of its own — `client` and `schema_hint` are both computed above its `try`, and none of the call's argument expressions is itself a call. This clause is wider: it also spans `get_client(cfg)` and the `_extraction_schema_hint(cfg)` argument expression, both evaluated **before** the job is claimed. Measured — reading the job row from inside the raising callable returns `pending` — and measured again through the suite: a `running` predicate here fails `test_worker_still_fails_the_job_on_an_ordinary_error` and `test_a_broken_extraction_limit_hint_is_extraction_failed_not_analysis_failed`, because every pre-claim failure would stop being recorded at all.

Refusing only `done` also keeps the clause-order tests discriminating: `test_worker_halt_does_not_mark_the_job_failed` and `test_worker_busy_does_not_mark_the_job_failed` both leave the job `pending`, so the guard still writes on their paths and the clauses above remain the only thing protecting them.

The other end is pinned too: widening the refusal to `{"done", "running"}` is caught by exactly one test — the new `test_worker_still_fails_a_claimed_job_whose_chunk_crashed` — while no other `test_worker_*` test does.

### Declining is not dropping

Nothing else records the error on that path: the job keeps a `done` row, and because `finish_extraction_job` raised part-way there is no `extraction_job_completed` event and no run summary. So the decline logs, as the four write-nothing clauses above it already do. A daemon worker thread has nowhere to re-raise to, so the log is the whole of the record. `exc_info` is load-bearing rather than decorative: the web message is deliberately not type-qualified, so for a bare `ValueError()` the text degrades to `analysis failed: ` and the traceback is all that names what was raised.

## Comments corrected

These stated in the present tense the property this change removes, so they ship corrected rather than left false. The set is **enumerated, not counted**: the first round wrote a closed count over a set nobody had enumerated, and that is exactly what missed `tests/test_job_resume.py`. Both enumerations were re-run this round and every hit triaged.

Over the tree:

```
grep -rn -E "broad .except|writes `?failed`? over|write .failed. over" --include="*.py" verinote/ tests/
```

Nine hits, every one triaged. Four — `verinote/pipeline/extract.py:303`, `:340`, `:675` and `verinote/store/db.py:1495` — describe routes that leave the job `running`, where both re-reads still permit the write; unchanged and still true. Two in `tests/test_chunk_claim_sidecar_lock.py` were triaged the same way. Three are in `tests/test_job_resume.py`: `:1245` is the same `running` route and is also unchanged, while `:833` and `:1175` were false and are corrected below.

Over this description, which the tree grep structurally cannot see:

```
gh pr view 548 --json body -q .body | grep -n "always held\|thirteen\|Four places\|wraps .process_extraction_job\|stale issue pointer"
```

Lines 24, 28, 36 and 38 — all four rewritten in this revision of the body. Line 24 was the third copy of the same false claim, alongside the two in `verinote/web/app.py` and `tests/test_chunk_claim_release.py` corrected below; it was the heading sentence of the section a reviewer reads first, not an aside.

Corrected sites:

- `verinote/cli.py` — "the web worker's local sweep guard IS load-bearing for it, because its broad clause has no such re-read", and the message-format-divergence pointer, which said only "still open there" with nothing to point at; it now cites #551, filed for that clause in this round. It stays out of scope for #525.
- `tests/test_chunk_claim_release.py` — "`web/app.py` HAS NO EQUIVALENT, AND BURIES THE JOB ON THIS PATH"; the "two callers now agree" claim, which is now agreement on *different* predicates; and the caller stand-in docstring.
- `tests/test_chunk_claim_sidecar_lock.py` — the matching caller stand-in docstring.
- `tests/test_job_resume.py` — **the fifth site, the one the count missed.** `test_a_failed_job_that_finished_everything_terminalises_without_the_llm`'s docstring stated the write in the present tense ("A broad `except` that fires AFTER the chunk loop writes `failed` over a job whose chunks are all `done`"); it now says which clause did it and until when — the web worker's, until #525, `cmd_sync`'s not since #488 because it requires `running`. `_put_job_in_the_edge_state`'s "both callers now end with a broad `except` that terminalises the job" gains the "when the re-read permits" qualifier the two chunk-claim stand-ins already carry.
- `verinote/web/app.py` — the two local guards are kept, but no longer credited with keeping a `done` job `done`. Measured: with the outer re-read in place, removing either guard leaves the worker/sweep/auto-accept tests green, so no test distinguishes deleting them. Two further corrections in `_fail_job_unless_done`'s own docstring: it claimed the CLI clause's "claim is always held by the time it runs" (now stated structurally — that clause's `try` contains no pre-claim code of its own), and it counted "the other thirteen `test_worker_*` tests", a number nothing enforces (now "no other `test_worker_*` test does"). The auto-accept clause's comment also stopped crediting itself with the `raise` above it, which is not something that clause buys.

## Validation

- `ruff check` (ruff 0.15.18) — All checks passed.
- `PYTHONUTF8=1 python -m pytest -q` on the committed tree — **51 failed, 3090 passed, 63 skipped**. The baseline on untouched `main` @ ed9332f is **51 failed, 3087 passed, 63 skipped**; the failing test *names* are byte-identical, and the +3 are the new tests. All 51 are pre-existing Windows-host artifacts (symlink privilege, POSIX file modes, a PATH-shadowing fixture), unrelated to this change. `PYTHONUTF8=1` is required on that host because its preferred encoding is cp949.
- `PYTHONUTF8=1 python -m pytest -q tests/test_web.py` — 3 consecutive runs, `3 failed, 261 passed, 6 skipped` each (the 3 are the pre-existing `[symlink…]` parametrizations).
- **Re-measured on macOS 26.6.2 (arm64), CPython 3.11.15**, at `111bfc0`: `python -m pytest -q -p no:randomly` → **3191 passed, 14 skipped, 0 failed**; `tests/test_web.py` → **271 passed**; `uvx ruff@0.15.18 check .` → All checks passed. The `02931cb` baseline on the same host is 3190 passed / 14 skipped, and the +1 is `test_worker_writes_nothing_when_the_job_row_is_gone`. Every commit in the series was also checked on its own tree: the four touched test files are green at each one (441 passed through the seventh, 442 at `111bfc0`), with ruff clean throughout. The Windows figures above are kept as they stand: they were true on the host that produced them and are labelled as such.
- Mutation checks re-run on macOS with the new test present: deleting ` job_now is not None and` reddens only `test_worker_writes_nothing_when_the_job_row_is_gone`, at `assert failures == [(job_id, "analysis failed: post-done store error")]` (`1 failed, 270 passed`); widening the refusal to `{"done","running"}` reddens exactly one test in the **whole suite**, `test_worker_still_fails_a_claimed_job_whose_chunk_crashed` (`1 failed, 3190 passed, 14 skipped`) — which is what the docstring's "no other `test_worker_*` test does" now asserts.
- Mutation checks, run independently during review: removing the guard reddens the two new `done` tests; widening to `{"done","running"}` reddens only the new `running` test; removing the decline log or `exc_info=True` reddens both `done` tests. The CLI `running` predicate reddens **four**, re-measured on macOS on the tree described above — `test_worker_still_fails_the_job_on_an_ordinary_error`, both parametrizations of `test_a_broken_extraction_limit_hint_is_extraction_failed_not_analysis_failed`, and `test_worker_writes_nothing_when_the_job_row_is_gone` (`4 failed, 3187 passed, 14 skipped`). The earlier "two pre-claim tests" figure predates that last test and is superseded here.

## Tests added

- `test_worker_leaves_a_done_job_done_when_finishing_it_raises` — the reachable #525 path.
- `test_worker_leaves_a_done_job_done_when_finishing_it_raises_an_llm_error` — the `except LLMError` half, documented as characterisation: no production path raises an `LLMError` post-`done`.
- `test_worker_still_fails_a_claimed_job_whose_chunk_crashed` — the `running` side, driving a real `process_extraction_job`; the only test that constrains the predicate from below.
- `test_worker_writes_nothing_when_the_job_row_is_gone` — the `job_now is not None` half of the guard, which nothing else reaches. The docstring's own bullet says a deleted source reads back as `None` and the write is then a no-op; nothing measured it, because with the conjunct removed the guard raises `TypeError` on `None["status"]` before reaching the write, so the decline and the no-op write are indistinguishable to every other test in the file. The fixture deletes the source from inside the raising `finish_extraction_job`, letting the `ON DELETE CASCADE` on `extraction_jobs.source_id` take the job row with it.

They settle by joining the named worker thread rather than sleeping: on the broken tree the job is already `done` before `finish_extraction_job` runs, so a status poll returns immediately and would prove nothing.

## Out of scope

The `fail_extraction_job` message-format divergence between CLI (`analysis failed: {TypeName}: {msg}`) and web (`analysis failed: {msg}`) is untouched, as the issue specifies. It is now tracked by #551, which the `verinote/cli.py` comment cites.

Closes #525




