### PR TITLE
fix(extract): count a job's candidates from the fact rows, not from what the pipeline reported (#482)

### DIFF
--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -51,7 +51,7 @@ def _done_job(store: Store, source_id: int) -> int:
     )[0]
     store.mark_extraction_job_running(job_id)
     store.mark_chunk_running(chunk_id)
-    store.mark_chunk_done(chunk_id, candidates=1)
+    store.mark_chunk_done(chunk_id)
     store.finish_extraction_job(job_id)
     return job_id
 

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -271,10 +271,11 @@ def test_a_chunk_already_written_done_is_not_flipped_to_failed(tmp_path, monkeyp
     """The release asks whether the claim is still held — it does not re-decide.
 
     `mark_chunk_done` writes in several steps and can raise *after* the chunk row
-    already says `done` (the job's `candidate_count` update, or
-    `_refresh_extraction_job`). Overwriting that with `failed` would destroy real
-    work. Counters are deliberately not asserted here: the stand-in aborts
-    part-way through `mark_chunk_done`, so they are mid-write by construction.
+    already says `done` (`_refresh_extraction_job`, which since #482 is where the
+    job's `candidate_count` update lives). Overwriting that with `failed` would
+    destroy real work. Counters are deliberately not asserted here: the stand-in
+    aborts part-way through `mark_chunk_done`, so they are mid-write by
+    construction.
     """
     s = _store(tmp_path)
     _source_id, job_id = _three_chunk_job(s)
@@ -283,7 +284,7 @@ def test_a_chunk_already_written_done_is_not_flipped_to_failed(tmp_path, monkeyp
         s._conn.execute(
             "UPDATE source_chunks SET status = 'done' WHERE id = ?", (chunk_id,)
         )
-        raise RuntimeError("counter update failed")
+        raise RuntimeError("refresh failed after the chunk row said done")
 
     monkeypatch.setattr(s, "mark_chunk_done", _done_then_boom)
 

--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -249,7 +249,7 @@ def test_no_chunk_stays_claimed_when_mark_chunk_done_raises(tmp_path, monkeypatc
     s = _store(tmp_path)
     _source_id, job_id = _three_chunk_job(s)
 
-    def _boom(chunk_id, *, candidates=0):
+    def _boom(chunk_id):
         raise RuntimeError("completion write failed")
 
     monkeypatch.setattr(s, "mark_chunk_done", _boom)
@@ -279,7 +279,7 @@ def test_a_chunk_already_written_done_is_not_flipped_to_failed(tmp_path, monkeyp
     s = _store(tmp_path)
     _source_id, job_id = _three_chunk_job(s)
 
-    def _done_then_boom(chunk_id, *, candidates=0):
+    def _done_then_boom(chunk_id):
         s._conn.execute(
             "UPDATE source_chunks SET status = 'done' WHERE id = ?", (chunk_id,)
         )

--- a/tests/test_chunk_partial_insert_accounting.py
+++ b/tests/test_chunk_partial_insert_accounting.py
@@ -1,28 +1,32 @@
 # SPDX-License-Identifier: MPL-2.0
-"""Characterisation: what the job counters say when a chunk dies mid-insert.
+"""What the job counters say when a chunk dies mid-insert. Now a guard, not a note.
 
-CHARACTERISATION, NOT A GUARANTEE. This file records current behaviour so that a
-later change to it is visible, and it describes a known defect. It makes no claim
-that the behaviour below is correct and must not be read as a no-regression
-guard.
-
-`_extract_chunk` writes its candidate facts one at a time and only returns the
-count once every one of them has landed; `mark_chunk_done` — which adds that
-count to the job's `candidate_count` — runs after it. So a chunk that raises
-part-way through its insert loop leaves facts in the KB that no counter accounts
-for: the facts are real, carry this run's `run_id`, and are visible on the
-provenance pages, while the job reports `candidate_count = 0`.
-
-The chunk itself is released as `failed` (#475), which is the part that is fixed.
-The counter drift is not.
-
-FOLLOW-UP ISSUE: #482
-
-That issue owns the drift; this file only records it. #482 says in its own text
-that fixing it must turn the assertions below RED, and this docstring says the
-same thing from the other side, so neither can be read without finding the other.
-When they do go red, the correct response is to update them to the new, counted
+THIS FILE CHANGED SIDES IN #482, DELIBERATELY. It arrived with #475 as a
+CHARACTERISATION test: it recorded that a chunk which raised part-way through its
+insert loop left facts in the KB that no counter accounted for, asserted
+`candidate_count == 0`, and said in its own docstring that this described a defect
+rather than a guarantee. It also said that fixing #482 must turn those assertions
+RED, and that the correct response then was to update them to the counted
 behaviour — never to restore the drift in order to keep them green.
+
+That is what happened here. `mark_chunk_done` no longer accumulates the column;
+`Store._refresh_extraction_job` recomputes it as
+`SELECT COUNT(*) FROM facts WHERE job_id = ?`, so the fact this chunk wrote before
+it died is counted the moment the chunk is released as `failed`. The assertion
+below is `== 1` where it was `== 0`, and the file is now a NO-REGRESSION GUARD: it
+fails if the counter ever goes back to being accumulated from what the pipeline
+reports instead of counted from what the KB holds.
+
+WHAT DID NOT CHANGE is `completed_chunks == 0`, and keeping it is the point. The
+chunk genuinely did not complete. "Its facts are counted" and "it failed" are two
+independent statements, both true; the old behaviour made them look like one by
+letting the failure suppress the count.
+
+The wider scenarios — the retry that used to make the shortfall permanent, the
+locked fact-term sidecar, and the guard against someone adding a `status` filter
+to the count — live in `tests/test_job_candidate_count_is_derived.py`. This file
+keeps the narrow case #475 first noticed, so the two records stay findable from
+each other.
 """
 
 import pytest
@@ -44,7 +48,7 @@ class _TwoFactClient:
         ]
 
 
-def test_facts_written_before_a_mid_chunk_failure_are_not_counted(tmp_path):
+def test_facts_written_before_a_mid_chunk_failure_are_counted(tmp_path):
     s = Store(tmp_path / "kb.sqlite")
     s.init_schema()
     source_id = s.add_source("sources/a.txt")
@@ -69,9 +73,10 @@ def test_facts_written_before_a_mid_chunk_failure_are_not_counted(tmp_path):
 
     # The first fact is in the KB, with evidence, attributed to this run.
     assert [f["subject"] for f in s.facts()] == ["alpha"]
-    # ...and no counter knows about it. This is the defect being characterised.
+    # ...and the job counts it now. This assertion read `== 0` before #482.
     job = s.get_extraction_job(job_id)
-    assert job["candidate_count"] == 0
+    assert job["candidate_count"] == 1
+    # The chunk still did not complete: counting its facts does not finish it.
     assert job["completed_chunks"] == 0
     # The claim, by contrast, is released — that part is #475's fix.
     chunk = s.source_chunks(job_id)[0]

--- a/tests/test_chunk_partial_insert_accounting.py
+++ b/tests/test_chunk_partial_insert_accounting.py
@@ -17,6 +17,17 @@ below is `== 1` where it was `== 0`, and the file is now a NO-REGRESSION GUARD: 
 fails if the counter ever goes back to being accumulated from what the pipeline
 reports instead of counted from what the KB holds.
 
+THE "INSTEAD OF" IS LOAD-BEARING, and this file's reach stops there. What it
+catches is the count being REPLACED by an accumulator: neutralise
+`Store._refresh_extraction_job`'s `candidate_count` subquery and the assertion
+below goes red (measured in this tree, along with others elsewhere in the suite).
+What it does NOT catch is an accumulator re-added BENEATH the surviving recount --
+an `UPDATE ... SET candidate_count = candidate_count + 1` inserted into
+`mark_chunk_done` ahead of its `_refresh_extraction_job` call left the entire suite
+green (measured, same tree), because the recount runs last and overwrites the `+=`.
+That variant is harmless while the recount survives; it is dead code, and nothing
+here would report it.
+
 WHAT DID NOT CHANGE is `completed_chunks == 0`, and keeping it is the point. The
 chunk genuinely did not complete. "Its facts are counted" and "it failed" are two
 independent statements, both true; the old behaviour made them look like one by

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2082,11 +2082,19 @@ def test_read_only_commands_still_accept_a_kb_predating_the_job_id_column(
     store.close()
     conn = sqlite3.connect(root / "kb.sqlite")
     # The indexes go first, and that is part of rolling the schema back rather than
-    # a workaround. Both are created by `_ensure_schema_migrations` (#482) AFTER
-    # the columns they cover are added -- `idx_facts_job` on `job_id`,
-    # `idx_facts_run` on `(run_id, job_id)` -- so a KB genuinely predating `job_id`
-    # carries neither. Dropping the column while an index still references it is a
-    # state no verinote KB has ever been in, and SQLite rejects it outright.
+    # a workaround. Both are created by `_ensure_schema_migrations` (#482), and the
+    # two rest on different footings. `idx_facts_job` covers `job_id`, a column
+    # that same method `ADD COLUMN`s earlier -- which is exactly why the index
+    # cannot live in `schema.sql`. `idx_facts_run` covers `(run_id, job_id)`, and
+    # only `job_id` of that pair is migrated: `run_id` is created solely by
+    # `schema.sql`'s `CREATE TABLE facts` (`store/schema.sql:116`) and no migration
+    # adds it, so this index ASSUMES the column rather than guaranteeing it -- a
+    # `facts` table without `run_id` would fail at the `CREATE INDEX` itself
+    # (measured on a bare sqlite3 table: `OperationalError: no such column:
+    # run_id`). Either way, a KB genuinely predating `job_id` carries neither index,
+    # which is all this rollback needs. Dropping the column while an index still
+    # references it is a state no verinote KB has ever been in, and SQLite rejects
+    # it outright.
     conn.execute("DROP INDEX IF EXISTS idx_facts_job")
     conn.execute("DROP INDEX IF EXISTS idx_facts_run")
     conn.execute("ALTER TABLE facts DROP COLUMN job_id")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2081,6 +2081,14 @@ def test_read_only_commands_still_accept_a_kb_predating_the_job_id_column(
     store.init_schema()
     store.close()
     conn = sqlite3.connect(root / "kb.sqlite")
+    # The indexes go first, and that is part of rolling the schema back rather than
+    # a workaround. Both are created by `_ensure_schema_migrations` (#482) AFTER
+    # the columns they cover are added -- `idx_facts_job` on `job_id`,
+    # `idx_facts_run` on `(run_id, job_id)` -- so a KB genuinely predating `job_id`
+    # carries neither. Dropping the column while an index still references it is a
+    # state no verinote KB has ever been in, and SQLite rejects it outright.
+    conn.execute("DROP INDEX IF EXISTS idx_facts_job")
+    conn.execute("DROP INDEX IF EXISTS idx_facts_run")
     conn.execute("ALTER TABLE facts DROP COLUMN job_id")
     conn.commit()
     conn.close()

--- a/tests/test_job_candidate_count_is_derived.py
+++ b/tests/test_job_candidate_count_is_derived.py
@@ -154,9 +154,10 @@ def test_a_sidecar_lock_mid_chunk_leaves_the_job_count_true(tmp_path):
 def test_a_sidecar_lock_summary_counts_the_fact_it_wrote(tmp_path):
     """The run summary must not say "0 candidate(s)" over a fact it just wrote.
 
-    `_back_off_from_locked_sidecar`'s sibling `_halt_extraction_job` promises
-    "every number below is read back from the KB rather than assumed"; the
-    per-run tally was the one that was assumed, via `candidates += inserted`.
+    `_back_off_from_locked_sidecar`'s sibling `_halt_extraction_job` promises the
+    numbers in its summary are "read back from the KB rather than assumed", and
+    names `run_chunks` as its one exception; the per-run CANDIDATE tally is not
+    that exception, and was assumed all the same, via `candidates += inserted`.
     Measured pre-fix: this summary read "this run wrote 0 candidate(s) from 0
     chunk(s)" while one fact carrying that `run_id` sat in the KB.
     """

--- a/tests/test_job_candidate_count_is_derived.py
+++ b/tests/test_job_candidate_count_is_derived.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: MPL-2.0
+"""#482: the job's candidate tally is COUNTED from the fact rows, not accumulated.
+
+`candidate_count` used to be accumulated: `mark_chunk_done` added each chunk's
+reported insert count to the column. That runs AFTER `_extract_chunk` returns, so
+a chunk whose insert loop raised part-way had already written facts that nothing
+counted -- and the shortfall was permanent, because a retry re-ran the chunk and
+`reconcile_fact` deduped those same facts (`if not result.created`), returning a
+smaller number the second time round. Measured on the pre-fix code with three
+facts and a failure on the second: the job came to rest `done` holding three fact
+rows while reporting `candidate_count = 2`.
+
+The column is now `SELECT COUNT(*) FROM facts WHERE job_id = ?`, recomputed by
+`Store._refresh_extraction_job`. Counting rows cannot drift from the rows.
+
+The last test here is a GUARD, not a scenario: the count deliberately carries no
+`status` predicate, because the column records what a job CREATED and must not
+shrink as reviewers work through the queue. A future tidy-up that adds
+`AND status = 'candidate'` looks like a tightening and is a silent change of
+meaning; that test is what stops it.
+
+Fixtures are synthetic throughout (AGENTS.md): `s_alpha`/`s_beta`/`s_gamma`.
+"""
+
+import pytest
+
+from verinote.llm.base import ExtractedFact
+from verinote.pipeline.extract import process_extraction_job
+from verinote.store import Store
+from verinote.store.duckdb_fact_terms import DuckDBFactTermStoreLockedError
+
+
+class _ThreeFactClient:
+    """Three facts for the one chunk, so the insert loop has a middle to die in."""
+
+    name = "stub"
+
+    def extract_facts(self, *, source_text: str, schema_hint: str = ""):
+        return [
+            ExtractedFact("s_alpha", "seen_in", "source", 0.9),
+            ExtractedFact("s_beta", "seen_in", "source", 0.9),
+            ExtractedFact("s_gamma", "seen_in", "source", 0.9),
+        ]
+
+
+def _one_chunk_job(store, *, chunks=("alpha beta gamma",)):
+    source_id = store.add_source("sources/a.txt")
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=len(chunks)
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=list(chunks))
+    return job_id
+
+
+def _fact_rows_for_job(store, job_id):
+    return int(
+        store._conn.execute(
+            "SELECT COUNT(*) FROM facts WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    )
+
+
+def _raise_on_nth_reconcile(store, n, exc):
+    """Let the first (n-1) reconciles land, then raise from inside the insert loop."""
+    real = store.reconcile_fact
+    calls = {"n": 0}
+
+    def _patched(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == n:
+            raise exc
+        return real(*args, **kwargs)
+
+    store.reconcile_fact = _patched
+    return real
+
+
+def test_a_partial_chunk_and_its_retry_agree_with_the_fact_rows(tmp_path):
+    """The #482 reproduction: a retry must not record the deduped short count.
+
+    Pre-fix this asserted 2 == 3 and failed, which is the point of the test.
+    """
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    job_id = _one_chunk_job(s)
+
+    real = _raise_on_nth_reconcile(s, 2, RuntimeError("write failed mid-chunk"))
+    with pytest.raises(RuntimeError):
+        process_extraction_job(s, _ThreeFactClient(), job_id=job_id)
+
+    # What the real callers (`cli.py`, `web/app.py`) do with an escaped exception.
+    s.fail_extraction_job(job_id, "RuntimeError: write failed mid-chunk")
+    s.reconcile_fact = real
+    process_extraction_job(s, _ThreeFactClient(), job_id=job_id, retry=True)
+
+    job = s.get_extraction_job(job_id)
+    # The literal pins the scenario; the equality pins the invariant.
+    assert _fact_rows_for_job(s, job_id) == 3
+    assert job["candidate_count"] == 3
+    assert job["candidate_count"] == _fact_rows_for_job(s, job_id)
+    s.close()
+
+
+def test_a_partial_chunk_publishes_the_facts_it_did_write(tmp_path):
+    """The fact that landed before the raise is counted immediately, not eventually.
+
+    `_release_claimed_chunk` -> `mark_chunk_failed` -> `_refresh_extraction_job` is
+    the route. The chunk is still `failed` and still incomplete: "the facts are
+    counted" and "the chunk did not finish" are two independent, both-true
+    statements about this job.
+    """
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    job_id = _one_chunk_job(s)
+
+    _raise_on_nth_reconcile(s, 2, RuntimeError("write failed mid-chunk"))
+    with pytest.raises(RuntimeError):
+        process_extraction_job(s, _ThreeFactClient(), job_id=job_id)
+
+    job = s.get_extraction_job(job_id)
+    assert [f["subject"] for f in s.facts()] == ["s_alpha"]
+    assert job["candidate_count"] == 1
+    assert job["completed_chunks"] == 0
+    assert s.source_chunks(job_id)[0]["status"] == "failed"
+    s.close()
+
+
+def test_a_sidecar_lock_mid_chunk_leaves_the_job_count_true(tmp_path):
+    """A locked fact-term sidecar strikes INSIDE the loop, and rolls the job back.
+
+    `add_fact` writes the DuckDB term, so `DuckDBFactTermStoreLockedError` is
+    reachable mid-loop (#169) -- unlike `PolicyMissingError`, whose
+    `assert_writable` gate sits ahead of the loop. `rollback_extraction_job` is
+    then the one rewind a part-written chunk reaches without passing
+    `_refresh_extraction_job`, which is why it recounts the column itself.
+    """
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    job_id = _one_chunk_job(s, chunks=("alpha beta",))
+
+    _raise_on_nth_reconcile(
+        s, 2, DuckDBFactTermStoreLockedError("held by another process")
+    )
+    with pytest.raises(DuckDBFactTermStoreLockedError):
+        process_extraction_job(s, _ThreeFactClient(), job_id=job_id)
+
+    job = s.get_extraction_job(job_id)
+    assert job["status"] == "pending"
+    assert job["candidate_count"] == 1
+    assert job["candidate_count"] == _fact_rows_for_job(s, job_id)
+    s.close()
+
+
+def test_a_sidecar_lock_summary_counts_the_fact_it_wrote(tmp_path):
+    """The run summary must not say "0 candidate(s)" over a fact it just wrote.
+
+    `_back_off_from_locked_sidecar`'s sibling `_halt_extraction_job` promises
+    "every number below is read back from the KB rather than assumed"; the
+    per-run tally was the one that was assumed, via `candidates += inserted`.
+    Measured pre-fix: this summary read "this run wrote 0 candidate(s) from 0
+    chunk(s)" while one fact carrying that `run_id` sat in the KB.
+    """
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    job_id = _one_chunk_job(s, chunks=("alpha beta",))
+
+    _raise_on_nth_reconcile(
+        s, 2, DuckDBFactTermStoreLockedError("held by another process")
+    )
+    with pytest.raises(DuckDBFactTermStoreLockedError):
+        process_extraction_job(s, _ThreeFactClient(), job_id=job_id)
+
+    run_id = int(s.facts()[0]["run_id"])
+    summary = s.get_run(run_id)["summary"]
+    assert "this run wrote 1 candidate(s)" in summary
+    assert "0 candidate(s)" not in summary
+    s.close()
+
+
+def test_a_reviewed_fact_does_not_shrink_the_count(tmp_path):
+    """GUARD: the count carries no `status` predicate, and must not grow one.
+
+    `candidate_count` records what the job CREATED. Adding
+    `AND status = 'candidate'` would make a finished job's number fall as a
+    reviewer works through the queue -- the job's own history rewriting itself
+    under the reader, which is the failure mode #482 exists to remove.
+    """
+    s = Store(tmp_path / "kb.sqlite")
+    s.init_schema()
+    job_id = _one_chunk_job(s)
+    process_extraction_job(s, _ThreeFactClient(), job_id=job_id)
+
+    before = s.get_extraction_job(job_id)["candidate_count"]
+    assert before == 3
+
+    fact_id = int(s.facts()[0]["id"])
+    s.toggle_review(fact_id)
+    s.accept_fact(fact_id)
+    assert {f["status"] for f in s.facts()} != {"candidate"}
+
+    s._refresh_extraction_job(job_id)
+    assert s.get_extraction_job(job_id)["candidate_count"] == before
+    s.close()

--- a/tests/test_job_candidate_count_is_derived.py
+++ b/tests/test_job_candidate_count_is_derived.py
@@ -201,4 +201,12 @@ def test_a_reviewed_fact_does_not_shrink_the_count(tmp_path):
 
     s._refresh_extraction_job(job_id)
     assert s.get_extraction_job(job_id)["candidate_count"] == before
+
+    # The same absence, in the other two copies of the predicate: the count-only
+    # refresh `rollback_extraction_job` uses, and the per-run tally. Measured: a
+    # `status` filter added to either was caught by no test before these lines.
+    s._refresh_job_candidate_count(job_id)
+    assert s.get_extraction_job(job_id)["candidate_count"] == before
+    run_id = int(s.facts()[0]["run_id"])
+    assert s.run_candidate_count(job_id=job_id, run_id=run_id) == before
     s.close()

--- a/tests/test_job_candidate_count_is_derived.py
+++ b/tests/test_job_candidate_count_is_derived.py
@@ -22,6 +22,8 @@ meaning; that test is what stops it.
 Fixtures are synthetic throughout (AGENTS.md): `s_alpha`/`s_beta`/`s_gamma`.
 """
 
+import json
+
 import pytest
 
 from verinote.llm.base import ExtractedFact
@@ -148,6 +150,17 @@ def test_a_sidecar_lock_mid_chunk_leaves_the_job_count_true(tmp_path):
     assert job["status"] == "pending"
     assert job["candidate_count"] == 1
     assert job["candidate_count"] == _fact_rows_for_job(s, job_id)
+
+    after_json = json.loads(
+        s._conn.execute(
+            "SELECT after_json FROM fact_events WHERE job_id = ? "
+            "AND event_type = 'extraction_job_rolled_back' ORDER BY id DESC LIMIT 1",
+            (job_id,),
+        ).fetchone()["after_json"]
+    )
+    # the recount runs BEFORE the `after` read, so the history event carries the
+    # corrected count rather than the stale one the row had on entry
+    assert after_json["candidate_count"] == 1
     s.close()
 
 

--- a/tests/test_job_resume.py
+++ b/tests/test_job_resume.py
@@ -926,7 +926,7 @@ def _edge_state_job(tmp_path, *, done: int = 1):
     store.mark_extraction_job_running(job_id)
     for row in store.source_chunks(job_id)[:done]:
         store.mark_chunk_running(int(row["id"]))
-        store.mark_chunk_done(int(row["id"]), candidates=1)
+        store.mark_chunk_done(int(row["id"]))
     _put_job_in_the_edge_state(store, job_id, "analysis failed: RuntimeError: crash")
     assert int(store.get_extraction_job(job_id)["failed_chunks"]) == 0
     return store, source_id, job_id

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -61,7 +61,7 @@ def _done_job(store: Store, source_id: int) -> int:
     )[0]
     store.mark_extraction_job_running(job_id)
     store.mark_chunk_running(chunk_id)
-    store.mark_chunk_done(chunk_id, candidates=1)
+    store.mark_chunk_done(chunk_id)
     store.finish_extraction_job(job_id)
     return job_id
 

--- a/tests/test_sources_running_chunk_display.py
+++ b/tests/test_sources_running_chunk_display.py
@@ -68,7 +68,7 @@ def test_an_in_flight_job_shows_its_claimed_chunk_apart_from_the_waiting_ones(tm
     # A job mid-pass: one chunk finished, one claimed and out at the LLM, two still
     # in the queue.
     store.mark_extraction_job_running(job_id)
-    store.mark_chunk_done(chunk_ids[0], candidates=1)
+    store.mark_chunk_done(chunk_ids[0])
     assert store.mark_chunk_running(chunk_ids[1]) is not None
 
     html = TestClient(app).get("/sources").text

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1675,8 +1675,8 @@ def test_rollback_extraction_job_does_not_revive_a_canceled_job(tmp_path):
     sid = s.add_source("sources/a.txt")
     job_id, _ = _job_with_mixed_chunks(s, sid)
     s._conn.execute(
-        "UPDATE extraction_jobs SET status = 'canceled', message = 'canceled by user' "
-        "WHERE id = ?",
+        "UPDATE extraction_jobs SET status = 'canceled', message = 'canceled by user', "
+        "candidate_count = 99 WHERE id = ?",
         (job_id,),
     )
 
@@ -1685,6 +1685,10 @@ def test_rollback_extraction_job_does_not_revive_a_canceled_job(tmp_path):
     job = s.get_extraction_job(job_id)
     assert job["status"] == "canceled"
     assert job["message"] == "canceled by user"
+    # the recount is placed AFTER the early return, so a canceled job's column is
+    # not rewritten either: the fixture holds 2 real facts, so a recount would
+    # make this 2.
+    assert job["candidate_count"] == 99
     # the in-flight chunk stays `running`: it is not back in the queue
     assert [row["status"] for row in s.source_chunks(job_id)] == ["done", "failed", "running"]
     assert s.next_pending_chunk(job_id) is None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -17,6 +17,26 @@ def _store(tmp_path) -> Store:
     return s
 
 
+def _write_job_facts(s, *, job_id, source_id, n, prefix="F"):
+    """Give a job `n` real candidate facts, so its candidate_count means something.
+
+    Since #482 `candidate_count` is COUNTED from `facts.job_id` rather than
+    accumulated from what `mark_chunk_done` was told, so a fixture that wanted a
+    job to report N candidates has to actually write N of them. Several fixtures
+    here used to pass `candidates=N` to `mark_chunk_done` with no fact behind it
+    and assert the number back; that asserted the arithmetic of a counter rather
+    than any property of the KB, and it is why those assertions survive this
+    change verbatim while their setup grew these rows.
+    """
+    return [
+        s.add_fact(
+            f"{prefix}{i}", "seen_in", "source", status="candidate",
+            source_id=source_id, job_id=job_id,
+        )
+        for i in range(n)
+    ]
+
+
 def _unicode_source_paths() -> tuple[str, str]:
     nfd_name = unicodedata.normalize("NFD", "caf\u00e9.txt")
     nfc_name = unicodedata.normalize("NFC", nfd_name)
@@ -879,7 +899,7 @@ def test_sources_with_counts_includes_latest_analysis_summary(tmp_path):
     old_chunk = s.add_source_chunks(job_id=old_job, source_id=sid, chunks=["old"])[0]
     s.mark_extraction_job_running(old_job)
     s.mark_chunk_running(old_chunk)
-    s.mark_chunk_done(old_chunk, candidates=1)
+    s.mark_chunk_done(old_chunk)
     job_id = s.create_extraction_job(
         source_id=sid,
         artifact_id=artifact_id,
@@ -890,7 +910,8 @@ def test_sources_with_counts_includes_latest_analysis_summary(tmp_path):
     chunks = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b"])
     s.mark_extraction_job_running(job_id)
     s.mark_chunk_running(chunks[0])
-    s.mark_chunk_done(chunks[0], candidates=3)
+    _write_job_facts(s, job_id=job_id, source_id=sid, n=3)
+    s.mark_chunk_done(chunks[0])
     s.mark_chunk_running(chunks[1])
     s.mark_chunk_failed(chunks[1], "provider down")
     s.finish_extraction_job(job_id)  # terminalise to `failed` (#337)
@@ -1087,7 +1108,8 @@ def test_extraction_job_tracks_chunk_progress_and_retry(tmp_path):
 
     s.mark_extraction_job_running(job_id)
     assert s.mark_chunk_running(chunk_ids[0])["attempts"] == 1
-    s.mark_chunk_done(chunk_ids[0], candidates=2)
+    _write_job_facts(s, job_id=job_id, source_id=sid, n=2)
+    s.mark_chunk_done(chunk_ids[0])
     s.mark_chunk_running(chunk_ids[1])
     s.mark_chunk_failed(chunk_ids[1], "provider down")
 
@@ -1469,7 +1491,7 @@ def test_mark_chunk_done_keeps_an_owned_job_running_against_a_second_claim(tmp_p
 
     assert store_a.claim_pending_extraction_job(job_id) is True
     store_a.mark_chunk_running(chunk_ids[0])
-    store_a.mark_chunk_done(chunk_ids[0], candidates=1)
+    store_a.mark_chunk_done(chunk_ids[0])
 
     # Zero chunks `running` now, but the job is still owned: it stays `running`.
     assert store_a.get_extraction_job(job_id)["status"] == "running"
@@ -1534,7 +1556,7 @@ def test_finish_extraction_job_terminalises_a_running_job(tmp_path):
     mixed_chunks = s.add_source_chunks(job_id=mixed, source_id=sid, chunks=["a", "b"])
     s.mark_extraction_job_running(mixed)
     s.mark_chunk_running(mixed_chunks[0])
-    s.mark_chunk_done(mixed_chunks[0], candidates=1)
+    s.mark_chunk_done(mixed_chunks[0])
     s.mark_chunk_running(mixed_chunks[1])
     s.mark_chunk_failed(mixed_chunks[1], "provider down")
     # owned and mid-run, so still `running` even though a chunk has failed
@@ -1549,7 +1571,7 @@ def test_finish_extraction_job_terminalises_a_running_job(tmp_path):
     s.mark_extraction_job_running(clean)
     for cid in clean_chunks:
         s.mark_chunk_running(cid)
-        s.mark_chunk_done(cid, candidates=1)
+        s.mark_chunk_done(cid)
     s.finish_extraction_job(clean)
     assert s.get_extraction_job(clean)["status"] == "done"
 
@@ -1562,7 +1584,10 @@ def _job_with_mixed_chunks(s, sid):
     chunks = s.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b", "c"])
     s.mark_extraction_job_running(job_id)
     s.mark_chunk_running(chunks[0])
-    s.mark_chunk_done(chunks[0], candidates=2)
+    # `rollback_extraction_job`'s docstring says a done chunk's "candidate facts
+    # are real"; this fixture never made them real until #482 required it.
+    _write_job_facts(s, job_id=job_id, source_id=sid, n=2)
+    s.mark_chunk_done(chunks[0])
     s.mark_chunk_running(chunks[1])
     s.mark_chunk_failed(chunks[1], "provider down")
     s.mark_chunk_running(chunks[2])
@@ -1835,7 +1860,7 @@ def test_extraction_job_records_lifecycle_events(tmp_path):
     )[0]
     s.mark_extraction_job_running(done_job)
     s.mark_chunk_running(done_chunk)
-    s.mark_chunk_done(done_chunk, candidates=1)
+    s.mark_chunk_done(done_chunk)
     s.finish_extraction_job(done_job)
 
     events = list(

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -58,7 +58,7 @@ def test_fact_trust_summary_includes_source_run_job_evidence_and_audit(tmp_path)
     )[0]
     s.mark_extraction_job_running(job_id)
     s.mark_chunk_running(chunk_id)
-    s.mark_chunk_done(chunk_id, candidates=1)
+    s.mark_chunk_done(chunk_id)
     run_id = s.add_run(provider="fake", model="sample-model", summary="sample run")
     fact_id = s.add_fact(
         "Sample Company",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -808,11 +808,11 @@ def test_review_shows_accept_recommendation(tmp_path):
     chunk_b = store.add_source_chunks(job_id=job_b, source_id=source_b, chunks=["b"])[0]
     store.mark_extraction_job_running(job_a)
     store.mark_chunk_running(chunk_a)
-    store.mark_chunk_done(chunk_a, candidates=1)
+    store.mark_chunk_done(chunk_a)
     store.finish_extraction_job(job_a)
     store.mark_extraction_job_running(job_b)
     store.mark_chunk_running(chunk_b)
-    store.mark_chunk_done(chunk_b, candidates=1)
+    store.mark_chunk_done(chunk_b)
     store.finish_extraction_job(job_b)
     store.add_fact(
         "Sample Report",
@@ -1061,7 +1061,7 @@ def test_sources_page_lists_sources(tmp_path):
     chunks = store.add_source_chunks(job_id=job_id, source_id=sid, chunks=["a", "b"])
     store.mark_extraction_job_running(job_id)
     store.mark_chunk_running(chunks[0])
-    store.mark_chunk_done(chunks[0], candidates=1)
+    store.mark_chunk_done(chunks[0])
     store.mark_chunk_running(chunks[1])
     store.mark_chunk_failed(chunks[1], "provider down")
 
@@ -1188,7 +1188,7 @@ def test_sources_page_shows_trust_counts_and_evidence_snippets(tmp_path, monkeyp
     )[0]
     store.mark_extraction_job_running(job_id)
     store.mark_chunk_running(chunk_id)
-    store.mark_chunk_done(chunk_id, candidates=1)
+    store.mark_chunk_done(chunk_id)
     fact_id = store.add_fact(
         "Sample Report",
         "published_year",
@@ -1311,7 +1311,7 @@ def test_reanalyze_source_reuses_artifact_and_replaces_extracted_facts(
     )[0]
     store.mark_extraction_job_running(old_job)
     store.mark_chunk_running(old_chunk)
-    store.mark_chunk_done(old_chunk, candidates=1)
+    store.mark_chunk_done(old_chunk)
 
     body = c.get("/sources").text
     assert "Re-analyze" in body
@@ -1764,9 +1764,9 @@ def test_resume_polls_to_done_not_just_to_fact_visibility(tmp_path, monkeypatch,
     )
     real_mark = Store.mark_chunk_done
 
-    def slow_mark(self, chunk_id, *, candidates=0):
+    def slow_mark(self, chunk_id):
         time.sleep(0.3)
-        return real_mark(self, chunk_id, candidates=candidates)
+        return real_mark(self, chunk_id)
 
     monkeypatch.setattr(Store, "mark_chunk_done", slow_mark)
 
@@ -2202,7 +2202,7 @@ def _auto_accept_kb(tmp_path):
         )[0]
         store.mark_extraction_job_running(done_job)
         store.mark_chunk_running(chunk)
-        store.mark_chunk_done(chunk, candidates=1)
+        store.mark_chunk_done(chunk)
         store.finish_extraction_job(done_job)
         store.add_fact(
             "X", "is_a", "Y", status="candidate", source_id=corroborating, job_id=done_job
@@ -3318,7 +3318,7 @@ def test_provenance_renders_trust_dossier_sections(tmp_path):
     )[0]
     store.mark_extraction_job_running(job_id)
     store.mark_chunk_running(chunk_id)
-    store.mark_chunk_done(chunk_id, candidates=1)
+    store.mark_chunk_done(chunk_id)
     run_id = store.add_run(provider="fake", model="sample-model", summary="sample run")
     fact_id = store.add_fact(
         "Sample Report",
@@ -4512,7 +4512,7 @@ def test_worker_demotes_a_stale_fact_and_does_not_re_promote_it_same_request(
         )[0]
         store.mark_extraction_job_running(old_job)
         store.mark_chunk_running(oc)
-        store.mark_chunk_done(oc, candidates=1)
+        store.mark_chunk_done(oc)
         store.finish_extraction_job(old_job)
         london_a = store.add_fact(
             "Ada", "born_in", "London",
@@ -4531,7 +4531,7 @@ def test_worker_demotes_a_stale_fact_and_does_not_re_promote_it_same_request(
             wc = store.add_source_chunks(job_id=wj, source_id=witness, chunks=["x"])[0]
             store.mark_extraction_job_running(wj)
             store.mark_chunk_running(wc)
-            store.mark_chunk_done(wc, candidates=1)
+            store.mark_chunk_done(wc)
             store.finish_extraction_job(wj)
             store.add_fact(
                 "Ada", "born_in", "London",

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -466,9 +466,11 @@ class ChunkedExtractionResult:
     `Store._refresh_extraction_job` runs; `run_candidates` is counted from
     `facts.run_id` at the moment this result is built. Neither can drift from the
     KB the way the old `candidates += inserted` accumulator did when a chunk's
-    insert loop died with facts already written. The scope distinction above is
-    unchanged -- it is now enforced by which column each count is keyed on rather
-    than by remembering to add to the right variable.
+    insert loop died with facts already written. For these two the scope
+    distinction above is no longer kept by remembering to add to the right
+    variable: it follows from which column each one is keyed on. `run_chunks` is
+    the exception and still accumulates, for the reason `process_extraction_job`
+    gives where it is declared.
     """
 
     job_id: int
@@ -538,9 +540,29 @@ def process_extraction_job(
     # `+=` was below the call and never ran, so every number derived from it
     # under-reported the KB. `store.run_candidate_count(job_id=..., run_id=...)`
     # counts the rows this run actually wrote for this job, at the moment each
-    # report needs it. Chunk COUNTS have no such failure: a chunk is `done` or it
-    # is not, and `run_chunks` is incremented on the same line that records the
-    # completion.
+    # report needs it. `run_chunks` has the SAME shape and is not saved by
+    # atomicity: `mark_chunk_done` can raise after the chunk row is already `done`
+    # (`_refresh_extraction_job` failing -- see `_release_claimed_chunk`), and the
+    # `+= 1` below is the NEXT statement, not the same one. What keeps it from
+    # being observably wrong is exception-type ROUTING. Three types are singled
+    # out by the clauses below: `PolicyMissingError` and
+    # `DuckDBFactTermStoreLockedError` reach an outer handler that writes a run
+    # summary carrying this number, and `LLMError` is the one the chunk clause
+    # swallows to keep the loop going. `mark_chunk_done` raises none of the three
+    # -- it is a SQLite read and `UPDATE` plus `_refresh_extraction_job`, with no
+    # policy gate, no sidecar call and no LLM call -- so a raise there leaves
+    # `process_extraction_job` through the chunk clause's own `raise`, before any
+    # summary is written. Measured with `_refresh_extraction_job` forced to raise
+    # `sqlite3.OperationalError` after the first chunk's UPDATE: the chunk is
+    # `done`, `run_chunks` is 0, the error escapes, and `runs.summary` is still
+    # `''`. The success path carries the number out as well
+    # (`ChunkedExtractionResult.run_chunks` -> `cli.py`), but only where nothing
+    # escaped the loop.
+    #
+    # It also cannot be re-derived the way the candidate tally was:
+    # `source_chunks` carries `job_id` and no `run_id` (`store/schema.sql`), so
+    # the KB cannot answer "how many chunks did THIS run finish". That is why only
+    # one of the two accumulators became a count.
     run_chunks = 0
     try:
         while chunk := store.next_pending_chunk(job_id):
@@ -769,7 +791,13 @@ def _halt_extraction_job(
     `run_id` pointing at *this* run, and the provenance page would then tell the
     user that the run which produced the facts in front of them wrote nothing. A
     change that exists to stop the KB lying about its state must not plant a new
-    lie, so every number below is read back from the KB rather than assumed.
+    lie, so the numbers below are read back from the KB rather than assumed:
+    `completed`/`total` from the job row here, `run_candidates` from `facts` via
+    `Store.run_candidate_count` in the caller. `run_chunks` is the one exception,
+    and not by choice -- `source_chunks` carries no `run_id`
+    (`store/schema.sql`), so no table can answer "how many chunks did this run
+    finish" and the caller's accumulator is the only source there (see
+    `process_extraction_job`, where it is declared).
 
     TWO DIFFERENT SCOPES, AND THEY MUST STAY GRAMMATICALLY APART. `completed`/
     `total` are the *job's* progress, cumulative across every resume; `run_chunks`
@@ -844,9 +872,10 @@ def _back_off_from_locked_sidecar(
     intact.
 
     The counts are read back from the KB for the same reason `_halt_extraction_job`
-    reads them back, and the two scopes stay apart in the sentence: `completed`/
-    `total` are the job's progress across every pass, `run_chunks`/`run_candidates`
-    are this run's.
+    reads them back -- and with the same exception, `run_chunks`, which no table
+    can answer because `source_chunks` carries no `run_id`. The two scopes stay
+    apart in the sentence: `completed`/`total` are the job's progress across every
+    pass, `run_chunks`/`run_candidates` are this run's.
     """
     job = store.get_extraction_job(job_id)
     completed = int(job["completed_chunks"]) if job is not None else 0

--- a/verinote/pipeline/extract.py
+++ b/verinote/pipeline/extract.py
@@ -257,8 +257,9 @@ def plan_source_extraction(
     A job rolled back to `pending` (see `_halt_extraction_job`) still holds every
     chunk it finished, and the machinery to carry on already works —
     `next_pending_chunk` skips `done` chunks, `claim_pending_extraction_job`
-    reclaims any in-flight one as it takes ownership, `candidate_count`
-    accumulates. What was missing was anyone
+    reclaims any in-flight one as it takes ownership, `candidate_count` is
+    recounted from the fact rows (#482 -- it accumulated when this was written,
+    which is precisely what made it driftable). What was missing was anyone
     asking for it, so every sync started from chunk zero and paid for the same
     LLM calls twice.
 
@@ -459,6 +460,15 @@ class ChunkedExtractionResult:
     are what *this* call did. Once a job can be resumed the two diverge, and a
     caller that prints the job total as "this run extracted N candidates" is
     reporting work it did not do.
+
+    BOTH CANDIDATE NUMBERS ARE COUNTED FROM THE FACT ROWS, NOT ACCUMULATED (#482).
+    `candidates` is the job column, recomputed from `facts.job_id` whenever
+    `Store._refresh_extraction_job` runs; `run_candidates` is counted from
+    `facts.run_id` at the moment this result is built. Neither can drift from the
+    KB the way the old `candidates += inserted` accumulator did when a chunk's
+    insert loop died with facts already written. The scope distinction above is
+    unchanged -- it is now enforced by which column each count is keyed on rather
+    than by remembering to add to the right variable.
     """
 
     job_id: int
@@ -521,7 +531,16 @@ def process_extraction_job(
         raise ExtractionJobBusyError(job_id)
     run_id = store.add_run(provider=job["provider"], model=job["model"])
 
-    candidates = 0
+    # `run_chunks` still accumulates; the candidate tally deliberately does not.
+    # It used to sit beside this as `candidates = 0` / `candidates += inserted`,
+    # and that accumulator was wrong in exactly the way #482 describes: a chunk
+    # whose insert loop raised part-way had already put facts in the KB, but the
+    # `+=` was below the call and never ran, so every number derived from it
+    # under-reported the KB. `store.run_candidate_count(job_id=..., run_id=...)`
+    # counts the rows this run actually wrote for this job, at the moment each
+    # report needs it. Chunk COUNTS have no such failure: a chunk is `done` or it
+    # is not, and `run_chunks` is incremented on the same line that records the
+    # completion.
     run_chunks = 0
     try:
         while chunk := store.next_pending_chunk(job_id):
@@ -583,7 +602,7 @@ def process_extraction_job(
                 # chunk carries no owner and a job carries no liveness lease
                 # (#242); one statement here shuts in a symptom, not the cause.
                 claimed_attempts = int(running["attempts"])
-                inserted = _extract_chunk(
+                _extract_chunk(
                     store,
                     client,
                     source_id=int(source["id"]),
@@ -596,8 +615,7 @@ def process_extraction_job(
                     chunk_id=chunk_id,
                     schema_hint=schema_hint,
                 )
-                store.mark_chunk_done(chunk_id, candidates=inserted)
-                candidates += inserted
+                store.mark_chunk_done(chunk_id)
                 run_chunks += 1
             except PolicyMissingError:
                 # Not this chunk's failure: the KB went halted. The outer handler
@@ -661,7 +679,7 @@ def process_extraction_job(
             job_id=job_id,
             run_id=run_id,
             source_path=str(source["path"]),
-            run_candidates=candidates,
+            run_candidates=store.run_candidate_count(job_id=job_id, run_id=run_id),
             run_chunks=run_chunks,
         )
         raise
@@ -686,7 +704,7 @@ def process_extraction_job(
             job_id=job_id,
             run_id=run_id,
             source_path=str(source["path"]),
-            run_candidates=candidates,
+            run_candidates=store.run_candidate_count(job_id=job_id, run_id=run_id),
             run_chunks=run_chunks,
         )
         raise
@@ -704,7 +722,7 @@ def process_extraction_job(
         candidates=int(final["candidate_count"]),
         completed_chunks=int(final["completed_chunks"]),
         failed_chunks=int(final["failed_chunks"]),
-        run_candidates=candidates,
+        run_candidates=store.run_candidate_count(job_id=job_id, run_id=run_id),
         run_chunks=run_chunks,
     )
 
@@ -715,9 +733,11 @@ def _release_claimed_chunk(store: Store, chunk_id: int, exc: BaseException) -> N
     ONE judgement point for "a claimed chunk that will not complete becomes
     `failed`". The status re-read is not a second decision: it asks whether the
     claim is still held at all. `mark_chunk_done` writes in several steps and can
-    raise after the chunk is already `done` (its `candidate_count` update or
-    `_refresh_extraction_job` failing), and flipping a completed chunk to `failed`
-    would destroy real work and desync the job counters.
+    raise after the chunk is already `done` (`_refresh_extraction_job` failing --
+    which since #482 is also where the `candidate_count` update lives, the separate
+    increment this used to name having been folded into it), and flipping a
+    completed chunk to `failed` would destroy real work and desync the job
+    counters.
 
     The message is type-qualified for unmodelled exceptions because `str()` of a
     bare `ValueError()` is the empty string, and a chunk whose `error` is empty
@@ -858,7 +878,19 @@ def _extract_chunk(
     artifact_id: int | None = None,
     chunk_id: int | None = None,
     schema_hint: str = "",
-) -> int:
+) -> None:
+    """Write one chunk's candidate facts. Returns nothing, and that is the point.
+
+    It used to return the number it inserted, and `process_extraction_job` carried
+    that number into `mark_chunk_done` and into a per-run accumulator. Both are
+    gone (#482): a return value describes what this call BELIEVES it did, and the
+    two counters that consumed it needed what the KB actually HOLDS. The gap
+    between those is the whole defect -- when this loop raises part-way, the facts
+    it already wrote are real and the count it never returned was zero. Both
+    tallies are now counted from `facts` (`Store._refresh_extraction_job` over
+    `job_id`, `Store.run_candidate_count` over the (job_id, run_id) pair), so
+    there is nothing left for a return value to be right or wrong about.
+    """
     facts = _extract_chunk_facts(
         client,
         source_text=source_text,
@@ -872,7 +904,6 @@ def _extract_chunk(
     assert_writable(store)
     aliases = _relation_aliases_or_error(store)
     rows = _candidate_rows(facts, source_text, relation_aliases=aliases)
-    inserted = 0
     for subject, relation, obj, f in rows:
         result = store.reconcile_fact(
             subject,
@@ -910,8 +941,6 @@ def _extract_chunk(
             locator="chunk",
             snippet=source_text,
         )
-        inserted += 1
-    return inserted
 
 
 def _extract_chunk_facts(

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1822,6 +1822,15 @@ class Store:
             # Count only; recomputing `status` here would drop an owned job out
             # from under its owner (#337). Placed AFTER the `canceled` early
             # return above, which must write nothing at all.
+            #
+            # THAT CARE IS ONE-SIDED. `_refresh_extraction_job` has no `canceled`
+            # branch in its status ladder and no status predicate on its UPDATE
+            # (`WHERE id = ?`), so a canceled job whose chunk is touched has its
+            # `candidate_count` rewritten there regardless -- since #482, a further
+            # column on #526's item 2, which until then was about `status` and
+            # `message` alone. Latent today: nothing under `verinote/` writes
+            # `'canceled'` -- on `grep -rn "canceled" verinote/` every occurrence is
+            # a guard, the CHECK at `store/schema.sql:71`, or prose.
             self._refresh_job_candidate_count(job_id)
             after = self.get_extraction_job(job_id)
             if after is not None:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -3470,6 +3470,17 @@ class Store:
         # table, `COUNT(*) ... WHERE job_id = ?` ran ~200x slower without an index
         # here than with one (single run, 200 calls averaged, one host — enough to
         # settle whether the index is needed, not a portable benchmark figure).
+        #
+        # THE OTHER QUESTION THIS DIFF RAISES is what the derived count costs at
+        # all, since the write it replaced — `candidate_count = candidate_count + ?`
+        # — was constant work. It is no longer constant: with these indexes in place
+        # each recount is an index range scan, linear in the rows THIS job (or this
+        # run) created rather than in `facts` as a whole. `EXPLAIN QUERY PLAN` on
+        # both statements in this tree: `SEARCH facts USING COVERING INDEX
+        # idx_facts_job (job_id=?)` and `... idx_facts_run (run_id=? AND job_id=?)`
+        # — covering, so neither touches the table. It is paid once per chunk
+        # completion, beside that chunk's own provider call, which is why the
+        # affordability of it needs no number here.
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_facts_job ON facts(job_id)")
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_facts_run ON facts(run_id, job_id)"

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1426,7 +1426,28 @@ class Store:
             )
             return cur.rowcount == 1
 
-    def mark_chunk_done(self, chunk_id: int, *, candidates: int = 0) -> None:
+    def mark_chunk_done(self, chunk_id: int) -> None:
+        """Mark one chunk `done`; the job's candidate tally follows from the facts.
+
+        THE `candidates` PARAMETER IS GONE (#482), and its absence is the fix. It
+        used to carry the chunk's insert count into
+        `candidate_count = candidate_count + ?` right here, which made the counter
+        an accumulation of what the pipeline *reported* rather than a statement
+        about what the KB *holds*. Those two diverge the moment
+        `_extract_chunk`'s insert loop raises part-way: the facts it already wrote
+        stay, this method never runs, and nothing counts them. Worse, the
+        divergence was permanent -- on retry `reconcile_fact` dedupes those same
+        facts (`if not result.created`), so the second pass returns a SHORT count
+        and records the short number for good. Measured on the pre-fix code: three
+        facts, a failure on the second, one retry, and the job came to rest `done`
+        holding three fact rows while reporting `candidate_count = 2`.
+
+        Keeping the parameter and ignoring it was the other option and is rejected:
+        an argument a caller can still pass, that silently decides nothing, is the
+        same species of falsehood as the counter it fed. `_refresh_extraction_job`
+        below now recounts the column from `facts.job_id`, so every caller's number
+        was already redundant -- deleting it makes each call site say so.
+        """
         with self._lock:
             chunk = self.get_source_chunk(chunk_id)
             if chunk is None:
@@ -1436,12 +1457,42 @@ class Store:
                 "updated_at = datetime('now') WHERE id = ?",
                 (chunk_id,),
             )
-            self._conn.execute(
-                "UPDATE extraction_jobs SET candidate_count = candidate_count + ?, "
-                "updated_at = datetime('now') WHERE id = ?",
-                (candidates, chunk["job_id"]),
-            )
             self._refresh_extraction_job(int(chunk["job_id"]))
+
+    def run_candidate_count(self, *, job_id: int, run_id: int) -> int:
+        """How many candidate facts THIS run actually put in the KB for THIS job.
+
+        The per-run sibling of the `candidate_count` derivation in
+        `_refresh_extraction_job`, and it exists for the same reason: the pipeline
+        used to accumulate this number as `candidates += inserted` and so lost it
+        whenever an insert loop died part-way. That accumulator fed the run
+        summaries written by `pipeline/extract.py::_halt_extraction_job` and
+        `::_back_off_from_locked_sidecar`, whose docstrings both promise the
+        numbers are "read back from the KB rather than assumed" -- and one of them
+        was not. Measured on the pre-fix code: two facts, the fact-term sidecar
+        locked on the second, and the run summary read "this run wrote 0
+        candidate(s) from 0 chunk(s)" while a fact carrying that very `run_id` sat
+        in the KB. `run_id` is minted once per `process_extraction_job` call, so
+        this count is exactly that invocation's own contribution and never a
+        resumed job's cumulative total.
+
+        KEYED ON BOTH COLUMNS THOUGH `run_id` ALONE WOULD DO TODAY. Verified in
+        this tree: `add_run` is called in exactly one place on this path
+        (`pipeline/extract.py::process_extraction_job`), once per invocation, and
+        that invocation drives exactly one `job_id` -- so every fact carrying this
+        `run_id` already carries this `job_id` and the second predicate selects
+        nothing extra. It is here because the QUESTION this method answers is
+        "what did this run contribute to this job", and a key that states the
+        whole question stays correct if a later change ever lets one run span
+        jobs. The cost is nothing: `idx_facts_run` still drives the lookup.
+
+        Not filtered by status, for the reason `_refresh_extraction_job` gives.
+        """
+        row = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM facts WHERE job_id = ? AND run_id = ?",
+            (job_id, run_id),
+        ).fetchone()
+        return int(row["n"]) if row is not None else 0
 
     def mark_chunk_failed(self, chunk_id: int, error: str) -> None:
         with self._lock:
@@ -1693,12 +1744,49 @@ class Store:
 
         Chunks already `done` stay `done` (their candidate facts are real, and
         re-extracting them would just re-do work), and `failed` chunks keep their
-        error. Only the in-flight `running` chunk is returned to the queue, which is
-        safe: it was rolled back *before* any of its facts were written.
+        error. Only the in-flight `running` chunk is returned to the queue.
 
-        Counters are untouched on purpose — `completed_chunks`/`failed_chunks`/
-        `candidate_count` count `done`/`failed` chunks, and this method changes
-        neither, so they stay true.
+        THAT USED TO BE JUSTIFIED HERE BY THE CLAIM THAT THE CHUNK "was rolled back
+        *before* any of its facts were written", AND THAT CLAIM WAS FALSE (#482).
+        It holds only for `LLMError`, whose three raise sites in `_extract_chunk`
+        all sit ahead of the insert loop. Anything raised INSIDE that loop -- a
+        `ValueError` out of slot validation, a `sqlite3` error, or the fact-term
+        sidecar going locked mid-loop -- leaves the facts written so far in the KB
+        while this method hands the chunk back to the queue. Requeueing is still
+        the right move (`pending` is the only status the documented remedy works
+        from), so what changed is the reasoning, not the behaviour: the requeued
+        chunk may well have facts behind it, and the counters are what must cope.
+
+        THE CHUNK COUNTERS are untouched on purpose --
+        `completed_chunks`/`failed_chunks` count `done`/`failed` chunks and this
+        method changes neither, so they stay true. `candidate_count` IS rewritten
+        here, and that is new in #482. Since a requeued chunk may have facts behind
+        it, this is the one rewind path a partially-inserted chunk reaches without
+        passing `_refresh_extraction_job`; leaving it alone would strand the column
+        until some later chunk completed, and permanently for a job nobody resumes.
+        `_refresh_job_candidate_count` is used rather than the full refresh
+        precisely so that `status` is NOT recomputed: this runs while the job's
+        owner still holds it, and re-deriving status there is the #337 regression.
+
+        The run-scoped number the user is shown on this path
+        (`pipeline/extract.py::_halt_extraction_job` and
+        `::_back_off_from_locked_sidecar`) comes from `Store.run_candidate_count`,
+        which counts at the moment of use and so is true independently of this.
+
+        WHY THE COUNTER IS DERIVED RATHER THAN THE CHUNK MADE TRANSACTIONAL. The
+        other way to make the premise above true again was to wrap the whole insert
+        loop in one transaction, so a mid-loop failure took its facts with it. That
+        was rejected. `add_fact` already opens its own `BEGIN`/`COMMIT` per fact on
+        this autocommit connection, and a nested `BEGIN` raises
+        `sqlite3.OperationalError: cannot start a transaction within a transaction`
+        -- so the chunk-wide transaction would have to hoist transaction ownership
+        out of the one function every fact-writing path shares. Even granting that,
+        `add_fact` writes the DuckDB fact-term sidecar inside that same transaction
+        with a single-fact compensation, and a SQLite `ROLLBACK` cannot reach
+        DuckDB: the chunk-wide version needs a chunk-wide compensation, which is
+        the sidecar write-ordering contract of #169/#170/#173 reopened. Deriving
+        the count touches none of that, and unlike the transaction it also repairs
+        KBs that have ALREADY drifted, since the next refresh recounts them.
 
         A `canceled` job is left alone ENTIRELY — job row, chunks and history. A
         human took it out of the queue, and reviving its in-flight chunk would put
@@ -1725,6 +1813,16 @@ class Store:
                 "updated_at = datetime('now') WHERE id = ?",
                 (message, job_id),
             )
+            # The requeued chunk may have facts behind it (see the docstring): a
+            # non-`LLMError` raised inside `_extract_chunk`'s insert loop leaves
+            # what it already wrote. This is the one rewind a partially-inserted
+            # chunk reaches without passing `_refresh_extraction_job`, so without
+            # this line the column would sit stale until some later chunk
+            # completed -- and for a job that is never resumed, permanently.
+            # Count only; recomputing `status` here would drop an owned job out
+            # from under its owner (#337). Placed AFTER the `canceled` early
+            # return above, which must write nothing at all.
+            self._refresh_job_candidate_count(job_id)
             after = self.get_extraction_job(job_id)
             if after is not None:
                 self._add_fact_event(
@@ -3339,6 +3437,23 @@ class Store:
             "CREATE INDEX IF NOT EXISTS idx_facts_source_term_token "
             "ON facts(source_id, term_token)"
         )
+        # Here for exactly the reason above, and it is not a theoretical one:
+        # putting these in schema.sql raised `sqlite3.OperationalError: no such
+        # column: job_id` on the legacy fixture in
+        # `tests/test_store.py::test_migration_adds_the_stale_column_to_a_legacy_facts_table`,
+        # because that script runs before the `ADD COLUMN job_id` above.
+        #
+        # #482 made `candidate_count` a COUNT over `facts.job_id`, recomputed on
+        # every chunk completion, and the run tally a COUNT over the
+        # (job_id, run_id) pair. Unindexed each is a table scan per chunk. The
+        # gap is about two orders of magnitude: over a synthetic 200k-row `facts`
+        # table, `COUNT(*) ... WHERE job_id = ?` ran ~200x slower without an index
+        # here than with one (single run, 200 calls averaged, one host — enough to
+        # settle whether the index is needed, not a portable benchmark figure).
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_facts_job ON facts(job_id)")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_facts_run ON facts(run_id, job_id)"
+        )
         # #311: superseded is terminal on the content axis too, and for the same
         # reason it is terminal on the status axis. A reject is a judgment about
         # a *specific claim*; rewriting the body afterwards leaves the audit
@@ -3522,7 +3637,68 @@ class Store:
             self._rollback_quietly()
             raise
 
+    def _refresh_job_candidate_count(self, job_id: int) -> None:
+        """Recount `candidate_count` from the fact rows, and touch nothing else.
+
+        The narrow half of `_refresh_extraction_job`, split out so that
+        `rollback_extraction_job` can correct the count WITHOUT recomputing
+        `status`. That distinction is the whole reason this exists: a rollback
+        happens while the job's owner is still holding it, and re-deriving status
+        underneath the owner is the #337 regression that
+        `_refresh_extraction_job`'s `current_status == "running"` branch was
+        written to prevent. Counting facts carries no such hazard -- it reads
+        `facts` and writes one integer.
+
+        Caller holds `self._lock`. `updated_at` is deliberately not stamped here:
+        every caller already stamps it in its own UPDATE, and a second write would
+        only move the clock twice for one logical change.
+        """
+        self._conn.execute(
+            "UPDATE extraction_jobs SET candidate_count = "
+            "(SELECT COUNT(*) FROM facts WHERE job_id = ?) WHERE id = ?",
+            (job_id, job_id),
+        )
+
     def _refresh_extraction_job(self, job_id: int, *, final: bool = False) -> None:
+        """Re-derive the job row from the rows that are actually there.
+
+        `completed_chunks`/`failed_chunks`/`status`/`message` were always computed
+        from `source_chunks` here. `candidate_count` JOINED THEM IN #482; before
+        that it was the one number on this row that was accumulated instead --
+        `mark_chunk_done` added each chunk's reported insert count to it -- and so
+        the one that could drift away from the KB it claims to describe. It did:
+        when `_extract_chunk`'s insert loop raised part-way, its already-written
+        facts were counted by nobody, and a retry made the shortfall permanent
+        because `reconcile_fact` deduped those facts and returned a smaller number
+        the second time. Counting rows cannot drift; an accumulator always can.
+
+        NOT FILTERED BY `status`. The column counts what this job CREATED, and it
+        has never been decremented as a fact moves candidate -> confirmed ->
+        accepted, or is superseded by a reviewer. Adding `AND status = 'candidate'`
+        would look like a tightening and would instead make a finished job's
+        candidate count fall as humans work through the review queue -- a change of
+        meaning wearing a bugfix's clothes. `job_id` alone is the whole predicate.
+
+        Hard deletes cannot desync it either: both paths that delete fact rows
+        (`DELETE FROM facts WHERE source_id = ?` at the source purge, and the
+        status-scoped reset below it) take the source's `extraction_jobs` with
+        them, directly or by `ON DELETE CASCADE` with `PRAGMA foreign_keys = ON`,
+        so no surviving job row is left to under-report.
+
+        WHAT THIS DOES NOT REACH are the paths that rewind a job WITHOUT routing
+        through here, and they are handled rather than ignored.
+        `rollback_extraction_job` is the one a partially-inserted chunk actually
+        arrives at, and it calls `_refresh_job_candidate_count` itself -- the
+        count-only half, deliberately not this method, because recomputing
+        `status` for a job whose owner still holds it is the #337 regression the
+        `current_status == "running"` branch below exists to prevent.
+        `fail_extraction_job` writes the job row directly and
+        `claim_extraction_job_for_retry` uses raw SQL on purpose (#337); neither
+        recounts, so a job failed with a part-written chunk carries a stale column
+        until it is retried and a chunk completes. The run-scoped number the user
+        is shown meanwhile is `Store.run_candidate_count`, counted at the moment of
+        use and therefore true even while this column lags.
+        """
         counts = self._conn.execute(
             "SELECT "
             "COALESCE(SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END), 0) AS done, "
@@ -3582,9 +3758,11 @@ class Store:
 
         self._conn.execute(
             "UPDATE extraction_jobs SET status = ?, completed_chunks = ?, "
-            "failed_chunks = ?, message = ?, updated_at = datetime('now') "
+            "failed_chunks = ?, candidate_count = "
+            "(SELECT COUNT(*) FROM facts WHERE job_id = ?), "
+            "message = ?, updated_at = datetime('now') "
             "WHERE id = ?",
-            (status, done, failed, message, job_id),
+            (status, done, failed, job_id, message, job_id),
         )
 
 

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1481,7 +1481,12 @@ class Store:
         (`pipeline/extract.py::process_extraction_job`), once per invocation, and
         that invocation drives exactly one `job_id` -- so every fact carrying this
         `run_id` already carries this `job_id` and the second predicate selects
-        nothing extra. It is here because the QUESTION this method answers is
+        nothing extra. `grep -n "add_run(" verinote/pipeline/extract.py` finds one
+        sibling off this path, `sync_sources`, and it cannot make this method
+        miscount either: the facts under its run are written by `extract_source`,
+        whose `reconcile_fact` call passes `run_id` and no `job_id`, so they carry a
+        NULL `job_id` and match no `job_id = ?` predicate here. It is here because
+        the QUESTION this method answers is
         "what did this run contribute to this job", and a key that states the
         whole question stays correct if a later change ever lets one run span
         jobs. The cost is nothing: `idx_facts_run` still drives the lookup.

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -1748,8 +1748,14 @@ class Store:
 
         THAT USED TO BE JUSTIFIED HERE BY THE CLAIM THAT THE CHUNK "was rolled back
         *before* any of its facts were written", AND THAT CLAIM WAS FALSE (#482).
-        It holds only for `LLMError`, whose three raise sites in `_extract_chunk`
-        all sit ahead of the insert loop. Anything raised INSIDE that loop -- a
+        It holds for whatever is raised AHEAD of `_extract_chunk`'s insert loop,
+        which is more than `LLMError`. The noun matters too: `_extract_chunk`
+        contains no `raise LLMError` statement at all. What it has is three CALL
+        SITES that can raise one -- `_extract_chunk_facts`,
+        `_relation_aliases_or_error` and `_candidate_rows` -- and all three sit
+        ahead of that loop, as does `assert_writable`, which raises
+        `PolicyMissingError`/`PolicyEmptyError` rather than an `LLMError`.
+        Anything raised INSIDE that loop -- a
         `ValueError` out of slot validation, a `sqlite3` error, or the fact-term
         sidecar going locked mid-loop -- leaves the facts written so far in the KB
         while this method hands the chunk back to the queue. Requeueing is still

--- a/verinote/store/schema.sql
+++ b/verinote/store/schema.sql
@@ -125,6 +125,9 @@ CREATE TABLE IF NOT EXISTS facts (
 CREATE INDEX IF NOT EXISTS idx_facts_status ON facts(status);
 CREATE INDEX IF NOT EXISTS idx_facts_review_status_id ON facts(status, id);
 CREATE INDEX IF NOT EXISTS idx_facts_triple ON facts(subject, relation, object);
+-- idx_facts_job and idx_facts_run (#482) are created in
+-- Store._ensure_schema_migrations for the same reason as the line below: a
+-- legacy facts table has no job_id column when this script runs.
 -- idx_facts_source_term_token is created in Store._ensure_schema_migrations,
 -- not here: on a legacy DB this script runs before term_token is added, so an
 -- index over that column here would fail on the very DBs that most need it.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1848,7 +1848,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
               written over, and `canceled` is one of them. That contradicts what
               the store itself does with such a job:
               `Store.rollback_extraction_job` treats `canceled` as sacred and
-              returns above BOTH of its UPDATEs and its event append rather than
+              returns above every write it would otherwise make rather than
               touch it, while this guard would put `failed` on that row with an
               `extraction_job_failed` event beside it. Unreachable today — no
               production code under `verinote/` writes `'canceled'` at all — which


### PR DESCRIPTION
## What

`candidate_count` was accumulated rather than counted. `mark_chunk_done` added each chunk's
reported insert count, and it runs *after* `_extract_chunk` returns — so when the per-fact
insert loop raised part-way, the facts already written stayed in the KB and nothing counted
them. The shortfall was permanent: a retry re-ran the chunk, `reconcile_fact` deduped those
same facts, the second pass returned a smaller number, and that smaller number was recorded
for good.

Measured on the pre-fix code: three facts, a failure on the second, one retry, and the job
came to rest `done` holding three fact rows while reporting `candidate_count = 2`.

Both candidate tallies are now counted from `facts` instead of accumulated.
`_refresh_extraction_job` recomputes the column from `facts.job_id` alongside the chunk
counters it already re-derived, and `run_candidate_count` counts the `(job_id, run_id)` pair
at the moment each run summary needs it. Counting rows cannot drift from the rows.

`mark_chunk_done` loses its `candidates` parameter outright rather than keeping and ignoring
it: an argument that silently decides nothing is the same species of falsehood as the counter
it fed. Every call site was updated, including the monkeypatched stand-ins in
`tests/test_chunk_claim_release.py` and `tests/test_web.py` whose signatures had to match.

`rollback_extraction_job` gains a count-only refresh, placed after both of its UPDATEs and
therefore after the `canceled` early return, which must write nothing at all.

## Which option, and why the other was rejected

Issue #482 left the fix direction undecided between two branches.

**Chosen — re-derive the counter from the fact rows.** Drift becomes impossible in principle,
and it has an advantage the alternative does not: it heals KBs that already drifted under the
old accumulator, the next time any chunk in that job completes.

**Rejected — wrap the chunk's insert loop in one transaction.** `add_fact` opens its own
`BEGIN`/`COMMIT` per fact on an autocommit connection, so a surrounding `BEGIN` raises
`OperationalError`; and a SQLite `ROLLBACK` cannot unwind the DuckDB sidecar writes. Taking
this branch would have meant settling the sidecar write-ordering contract (#169/#170/#173),
which is still undecided — so it was kept out deliberately, not overlooked.

## The characterisation test flipped, on purpose

`tests/test_chunk_partial_insert_accounting.py` was added by #475 as a characterisation test —
its own file docstring said it described current behaviour and was not a no-regression guard.
This change makes it red, which is the expected and correct outcome, and it is updated rather
than deleted: it now asserts `candidate_count == 1` after a mid-chunk failure, matching the one
fact actually written, and its function is renamed from `..._are_not_counted` to
`..._are_counted`. Its new docstring states that the file fails if the counter ever goes back
to being accumulated instead of counted from what the KB holds.

`tests/test_job_candidate_count_is_derived.py` is new and is the thorough companion, including
`test_a_reviewed_fact_does_not_shrink_the_count` — 3 facts written, one accepted so its status
leaves `candidate`, and `candidate_count` unchanged after `_refresh_extraction_job`. That
guards the deliberate absence of an `AND status = 'candidate'` filter: the column records what
the job *created*, not the live review-queue state, and adding the filter would make the
number shrink as reviewers work through the queue.

## Index

Deriving the count introduces a `COUNT(*) ... WHERE job_id = ?` per chunk completion, so an
index is added in `_ensure_schema_migrations` (not `schema.sql` — the legacy `facts` table
lacks `job_id` when `schema.sql` runs, the same reason `idx_facts_source_term_token` sits
there). The index is part of making the fix non-regressive, not optional cleanup. Its comment
gives the gap as an order of magnitude with its own limits stated inline rather than the
false precision of a millisecond figure a single-host, single-run microbenchmark cannot carry.

## Accepted limitation

`fail_extraction_job` and `claim_extraction_job_for_retry` write raw SQL and do not recount —
the latter by explicit design (#337), because status is already owned by the CAS. On the normal
failure route this costs nothing: the dying chunk's own `mark_chunk_failed` refreshes the count
before `fail_extraction_job` is ever reached, so that call's non-recounting is redundant-safe
rather than a gap. The one genuinely stale route is the pre-existing #524 double-failure case
(the release write itself raising, leaving a chunk `running`) — narrow, already named and
tested before this change, and self-healing on the next chunk completion after retry. A
terminal job that never sees another chunk event keeps a stale column; no backfill migration
ships. The user-facing number on that path (`run_candidate_count`) is computed fresh at time
of use and does not inherit the staleness. This is documented in `_refresh_extraction_job`'s
docstring rather than left implicit.

## Validation

- Full suite, `PYTHONUTF8=1 python -m pytest -q`: **51 failed, 3092 passed, 63 skipped**.
  Compared by name against a baseline captured on untouched `main` @ `ed9332f` (`main` at the time) in the same
  environment (**51 failed, 3087 passed, 63 skipped**): **zero regressions, zero
  newly-passing**. The 51 are pre-existing Windows-host platform failures on the machine this
  ran on — `os.symlink` privilege (`WinError 1314`), POSIX file-mode assertions, and a fake
  `claude` shim that does not shadow the real binary on Windows `PATH`. Passing count rises by
  the 5 new tests.
- Targeted: `tests/test_job_candidate_count_is_derived.py`,
  `tests/test_chunk_partial_insert_accounting.py`, `tests/test_chunk_claim_release.py` — 25
  passed.
- Full suite on a second host — macOS 26.6.2 / arm64, CPython 3.11.15,
  `python -m pytest -q -p no:randomly` at `f9bfae4` (this branch rebased onto `main` @
  `43d745e`), every optional dependency present, `__pycache__` cleared, and `PYTHONPATH` and
  cwd both pinned to a worktree of this branch — the package is editable-installed against
  another checkout, so an unpinned run silently tests that one: **3196 passed, 14 skipped,
  0 failed**. No `PYTHONUTF8` flag was needed there. Over `main` @ `43d745e` this branch adds
  five test functions net: six added, and the characterisation test renamed rather than
  removed. The Windows figures above are kept as measured on that host rather than replaced.
- SQL parameter binding was checked position-by-position for all three recomputing statements.
- `uvx ruff@0.15.18 check .` — the version CI pins at `.github/workflows/ci.yml:22` — run at
  `f9bfae4` on macOS 26.6.2 / arm64: **All checks passed**. An earlier version of this section
  said ruff had not been run, because it is not installed on the Windows host this branch was
  prepared on; it has now been run off that host.

Note for reviewers: the FIRST full-suite line above comes from a Windows host with a `cp949`
locale, run under `PYTHONUTF8=1`. Without that flag this suite additionally produces 25
collection errors that are pure encoding artifacts, unrelated to this change. The macOS line
is a separate host and needed none of that.

Closes #482


