### PR TITLE
test(#517): pin the English attribute patterns' observable quantifier

### DIFF
--- a/tests/test_query_intent.py
+++ b/tests/test_query_intent.py
@@ -419,6 +419,123 @@ def test_generic_attribute_questions_become_lookup_object_intents():
     assert english_of.subject == IntentTarget("entity", "Sample Project")
 
 
+def test_the_of_shape_splits_where_the_greedy_label_stops():
+    """The `of` label is greedy, so it takes the most it can and the entity gets the rest.
+
+    The `of` label and the possessive label are each spelled `{0,40}` on this tree,
+    and the `of` one has never been anything else. Making it lazy is a behaviour
+    change and not a tidy-up: it moves the first row's subject to
+    `Department of Sample Org` and its candidate to `head`, and it reddens nothing
+    else in the suite, which is why this test exists. `head of Department` is a
+    plausible relation name and `Department of Sample Org` a plausible entity, so
+    this records the choice rather than defending it.
+
+    The greed is not bounded by "the last ` of `". The rows below exercise three of
+    its bounds -- the entity's `[A-Z]`, the label group's 41-character ceiling, and
+    the label's character class. This test does not enumerate the bounds.
+
+    The lowercase row is refused by `[A-Z]`, so the split falls back to the first
+    ` of `; it reddens the `[A-Za-z]` mutant, which
+    `tests/test_query.py::test_review_required_question_is_flagged_not_in_draft`
+    already pins. The ceiling rows differ by one letter across 41 characters --
+    `[A-Za-z]` plus `{0,40}` -- and they pin it from both sides: narrowing the cap
+    to `{0,39}` moves the 41-character row, widening it to `{0,41}` moves the
+    42-character row, and nothing else in the suite catches either. The last row's
+    label stops at a `.`, which the character class refuses, with the ceiling
+    nowhere near -- raising the cap does not move it.
+
+    This test is a tripwire for the split point itself. The downstream edits I
+    could build -- widening either head alternation (#433, which #520 argues
+    against) and appending a trailing-predicate tail to the `of` entity (#515) --
+    both leave it green.
+
+    Refs #517. The same pattern is what #521 reads as a proper name, though not the
+    same case: #521's `What is the Bank of America?` has a single ` of `, where
+    greedy and lazy agree.
+    """
+    intent = deterministic_query_intent("What is the head of Department of Sample Org?")
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "Sample Org")                    # row 1
+    assert intent.relation_candidates == ("head of Department",)
+
+    # the entity's `[A-Z]`
+    intent = deterministic_query_intent("What is the head of Department of sample org?")
+    assert intent.subject == IntentTarget("entity", "Department of sample org")      # row 2
+    assert intent.relation_candidates == ("head",)
+
+    # the label group's 41-character ceiling, from both sides
+    intent = deterministic_query_intent(
+        "What is the primary contact email addresses of Region of Sample Org?"
+    )
+    assert intent.subject == IntentTarget("entity", "Sample Org")                    # row 3
+    assert intent.relation_candidates == ("primary contact email addresses of Region",)
+    intent = deterministic_query_intent(
+        "What is the primary contact email addresses of Regions of Sample Org?"
+    )
+    assert intent.subject == IntentTarget("entity", "Regions of Sample Org")         # row 4
+    assert intent.relation_candidates == ("primary contact email addresses",)
+
+    # the label's character class
+    intent = deterministic_query_intent("What is the head of Dept.1 of Sample Org?")
+    assert intent.subject == IntentTarget("entity", "Dept.1 of Sample Org")          # row 5
+    assert intent.relation_candidates == ("head",)
+
+
+def test_the_possessive_shape_splits_at_the_last_possessive():
+    """The possessive label class excludes `'`, so the split lands at the last apostrophe.
+
+    A split at an earlier `'s` would leave an apostrophe inside the label, which
+    `[A-Za-z0-9 _-]` cannot match, so no such split matches.
+
+    Where that fails -- a trailing `'` that is not `'s`, or a remainder past the
+    label's ceiling -- this pattern does not match at some other apostrophe; it does
+    not match at all. What the question then parses as is decided by the branches
+    after this one, and the `of` shape claims some of them:
+    `What is Head of Sample Org's Alice' Ltd?` is read as a lookup on
+    `Sample Org's Alice' Ltd`. Admitting `'` to the class reddens the row below
+    instead: the subject becomes `Sample Project` and the candidate
+    `owner's manager`.
+
+    `tests/test_ask.py` already states this behaviour in prose -- "the regex takes
+    `Sample Project's owner` as the **entity** and leaves a clean `manager` label"
+    -- over this very question, and asserts none of it: its assertions are on the
+    end-to-end result, which is the same by either route. This test is that
+    sentence's warrant, which is why it borrows its witness.
+
+    The exclusion is also what makes the entity's own `{0,100}?` unobservable.
+    That is a derivation, not a sample: lazy walks forward to the last apostrophe
+    and greedy walks back to it, so the two preferences find the same unique match
+    or both fail. Flipping it leaves the suite green. Admit `'` to the label class
+    *and* make the entity greedy, and the answer returns to the row asserted here
+    -- so the quantifier begins deciding the parse exactly when this exclusion is
+    lifted.
+
+    #517 lists four captured-field quantifiers: the possessive label and entity,
+    and the `of` label and entity. The possessive entity's is not the only one of
+    them that cannot be pinned -- the `of` entity's `{0,100}?` and the possessive
+    label's `{0,40}` are unobservable too, for a plainer reason: each is the last
+    group in its pattern, with only an optional `?` and surrounding whitespace
+    after it, and neither class admits `?`, so greed can extend it over trailing
+    whitespace and nothing else, which the caller strips (`.strip()` at
+    `query_intent.py:507`, `_clean_english_attribute_label` at `:1039`). Of those
+    four, only the `of` label's greed is observable, and
+    `test_the_of_shape_splits_where_the_greedy_label_stops` is what pins it -- so
+    #517's "Making the `of` entity greedy instead of lazy likewise changes
+    behaviour" does not hold here.
+
+    This test is a tripwire for the split point itself. The downstream edits I
+    could build -- widening either head alternation (#433, which #520 argues
+    against) and appending a trailing-predicate tail to the `of` entity (#515) --
+    both leave it green.
+
+    Refs #517.
+    """
+    intent = deterministic_query_intent("What is Sample Project's owner's manager?")
+    assert intent.kind == QueryIntentKind.LOOKUP_OBJECT
+    assert intent.subject == IntentTarget("entity", "Sample Project's owner")
+    assert intent.relation_candidates == ("manager",)
+
+
 def test_generic_korean_attribute_requires_question_shape():
     intent = deterministic_query_intent("샘플프로젝트의 목적")
 


### PR DESCRIPTION
## Why

Five open issues edit the two English attribute patterns in `verinote/pipeline/query_intent.py` — **#433, #511, #515, #520, #521** — and they disagree with each other (#520 measures #433's proposed change and concludes it "should not be made"; #521 shows the same widening extends an `of`-in-a-proper-name misparse). Nothing pinned what those patterns already do, so each of those edits would land blind.

## What is pinnable, and what is not

#517 names four captured-field quantifiers. **Only one is observable.**

| quantifier | observable? | why |
|---|---|---|
| `of` label `{0,40}` | **yes** | decides where a multi-` of ` question splits |
| `of` entity `{0,100}?` | no | followed only by `\s*\??\s*$`, class excludes `?`, so greed extends over trailing whitespace only — removed by `.strip()` at `:507` |
| possessive label `{0,40}` | no | same shape; removed by `_clean_english_attribute_label` at `:1039` |
| possessive entity `{0,100}?` | no | the label class refuses `'`, so no split at a non-final apostrophe matches at all |

That is a derivation, not a sample: at a given match the two preferences differ only over whitespace the caller then strips. Differential sweeps agree (0 observable differences), but the derivation is what carries it.

## The tests

Two characterisation tests. **No production line moves.**

1. **the `of` shape splits where the greedy label stops** — three bounds on that split each get a row and a mutant: the entity's `[A-Z]`, the label's 41-character ceiling, and the label's character class. The rows do not enumerate the bounds and say so.
2. **the possessive shape splits at the last possessive** — pins the apostrophe exclusion.

The ceiling is pinned **from both sides**: `{0,39}` reddens one row, `{0,41}` reddens the other, so `{0,40}` is the unique cap the pair admits.

Measured, both tests are **inert** under everything the five issues propose. They are a record for whoever edits next, and a tripwire only for a change to the split point itself.

## #517's premise does not hold on `main`

The issue describes a lazy possessive label. **Both labels are spelled `{0,40}` here**, and `git log -S'A-Za-z0-9 _-]{0,40}?'` finds nothing — the lazy form has never existed on `main`. It was measured against PR #527's head `2a21e4e`, where the possessive label is `{0,40}?`; that PR is closed and not an ancestor of `main`.

Its `of`-entity finding ("making it greedy likewise changes behaviour") was not accurate on that tree either: the `of` pattern at `2a21e4e` is byte-identical to this one, so the derivation above applies unchanged. Measured at `2a21e4e`: `482 passed` with the `of` entity made greedy.

A correction comment goes on the issue at merge. `Refs #517` rather than `Closes` — the surviving half is pinned here, and the head-set question it opens is filed separately.

## Validation

macOS 26.6.2 (arm64), CPython 3.11.15. `pytest-randomly` is not installed, so collection order is deterministic and every mutant result is attributable.

| run | result |
|---|---|
| parent `27be843` | `3200 passed, 14 skipped, 0 failed` |
| this branch | `3202 passed, 14 skipped, 0 failed` |
| `uvx ruff@0.15.18 check .` (CI pins that version at `ci.yml:22`) | All checks passed |

Every mutant was applied by rebinding the compiled patterns at import time, not by patching source, so no result can be a stale-`__pycache__` artifact.

Refs #517.
