### PR TITLE
fix(prompts): answer a write failure with the page, not a crash (#545)

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -6731,9 +6731,11 @@ def test_the_prompts_page_survives_the_override_it_exists_to_repair(tmp_path, mo
     page. The selector and reset assertions are what that distinction turns on,
     so they are pinned here rather than left implied by the status: the selector
     still routes to the other prompts, and the broken prompt itself still
-    carries a control that repairs it. What the page does not carry is that
+    carries a control that repairs it. What this GET does not carry is that
     prompt's text or its Save form — see
-    `test_a_broken_override_page_offers_no_editor_to_overwrite_it_with`.
+    `test_a_broken_override_page_offers_no_editor_to_overwrite_it_with`. A
+    refused save POST does get a textarea, holding the bytes that request
+    submitted and nothing else (#545).
     """
     from verinote.prompts.library import prompt_override_path
 
@@ -6868,9 +6870,15 @@ def test_a_broken_override_page_offers_no_editor_to_overwrite_it_with(tmp_path, 
 
     A Save form pre-filled with default text turns one careless click into a
     silent overwrite of a file this process could not read — the user's own
-    customisation, gone, with nothing having displayed it. So the broken
-    prompt's page carries the reset control and no editor, and the opening line
-    of the default text is not in the response.
+    customisation, gone, with nothing having displayed it. So on a GET the
+    broken prompt's page carries the reset control and no editor, and the
+    opening line of the default text is not in the response.
+
+    Unchanged by the echo-back editor #545 added, and this row is what pins that
+    it is unchanged: that block is gated on `prompt_text is not none`, which a
+    GET never sets, and what it can show is the bytes of the request being
+    answered, never a default. Mutate the gate to `not prompt` and this test
+    reddens.
     """
     from verinote.prompts.library import prompt_override_path
 
@@ -6993,9 +7001,12 @@ def test_an_unreadable_prompts_directory_still_renders_the_page(tmp_path):
     in this file, nothing else catches that mutation, which is why this test is
     here.
 
-    The POST is a different matter and is not asserted: `delete_prompt_override`
-    calls `path.exists()`, which raises the same way. What is pinned here is the
-    GET, and 200 is what it answers today.
+    The POST from this same state is driven by
+    `test_a_reset_that_cannot_unlink_is_a_page_not_a_crash[dir_0o000_no_override]`
+    (#545): `delete_prompt_override` calls `path.exists()`, which raises the same
+    way, and that POST now renders a page naming the file it could not delete
+    instead of escaping the handler. What is pinned HERE is the GET, and 200 is
+    what it answers today.
     """
     from verinote.prompts.library import prompt_override_path
 
@@ -7018,3 +7029,525 @@ def test_an_unreadable_prompts_directory_still_renders_the_page(tmp_path):
         assert 'value="query-translation"' in r.text  # the selector still routes away
     finally:
         prompts_dir.chmod(0o700)
+
+
+def test_a_refusal_over_an_invalid_stored_override_keeps_both_reasons(tmp_path):
+    """A refused save has two things to say when the page cannot load either.
+
+    Reachable with no write failure at all: a stored override that is READABLE
+    and fails validation — someone hand-edited `query-translation.md` and lost
+    `{qid}`. `_prompts_page` then takes its `except PromptError` branch, which
+    used to REPLACE the caller's `error` with its own. The page told the user
+    their submitted text must include `{qid}` while the complaint was about the
+    file on disk, and the reason their save was actually refused was gone.
+
+    Mutation: put `str(exc)` back in that branch and `prompt text is required`
+    leaves the page.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "query-translation")
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("Translate the question into Datalog.\n", encoding="utf-8")
+
+    r = c.post(
+        "/prompts",
+        data={"prompt_id": "query-translation", "prompt_text": "   "},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert "prompt text is required" in r.text  # the route's own refusal
+    assert "{qid}" in r.text  # and why the page could not be loaded either
+
+
+@pytest.mark.parametrize("route", ["/prompts", "/prompts/reset"])
+def test_an_unknown_prompt_id_is_reported_once_not_twice(tmp_path, route):
+    """Composing the two diagnoses must not concatenate a string with itself.
+
+    An unknown `prompt_id` raises the same `PromptError` in the route's own
+    library call and again in `_prompts_page`'s `get_prompt`, out of the same
+    `prompt_definition` lookup. Composing them unconditionally printed
+    `unknown prompt: nope; unknown prompt: nope` on the most ordinary error page
+    these routes have.
+
+    Equality on the banner text, not a substring: `unknown prompt: nope` is a
+    substring of the duplicate, so every other assertion in this file — and
+    `test_prompt_routes_reject_unknown_key`, which drives this exact request —
+    passes on it. Mutation: drop `error == load_error` from that branch.
+    """
+    c = _prompts_client(tmp_path)
+
+    r = c.post(
+        route,
+        data={"prompt_id": "nope", "prompt_text": "No."},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    banner = re.search(r'<p class="error" role="alert">(.*?)</p>', r.text, re.S)
+    assert banner is not None
+    assert unescape(banner.group(1)).strip() == "unknown prompt: nope"
+
+
+@pytest.mark.parametrize("mode", ["non_utf8", "chmod"])
+def test_a_refused_save_keeps_the_typed_text_when_the_prompt_cannot_load(tmp_path, mode):
+    """A refusal must hand the user's own paragraph back, not eat it.
+
+    `{% if prompt %}` collapses the editor whenever `get_prompt` fails, so a
+    save refused over a broken override took the submitted text down with the
+    textarea — retype it or lose it. The loss is not caused by the write: it
+    lands on any refused POST whose page cannot load, which is why this row is
+    red on its own.
+
+    `query-translation` because its required `{qid}` makes a NON-EMPTY text
+    refusable; an empty-text refusal preserves nothing observable.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    submitted = "Return a query for the supplied question."
+
+    with _broken_override(prompt_override_path(tmp_path, "query-translation"), mode):
+        r = c.post(
+            "/prompts",
+            data={"prompt_id": "query-translation", "prompt_text": submitted},
+            follow_redirects=False,
+        )
+
+    assert r.status_code == 400
+    assert submitted in r.text  # the paragraph they typed
+    assert 'name="prompt_text"' in r.text  # in a field they can resubmit
+    assert "{qid}" in r.text  # still told why it was refused
+    assert "prompt query-translation could not be loaded" in r.text
+
+
+def test_a_save_into_an_unwritable_prompts_dir_is_a_page_not_a_crash(tmp_path):
+    """The bare 500 #545 opens with: `mkdir`/`write_text` raise outside `PromptError`.
+
+    `policy/prompts` at `0o500` with NO override file yet — the state the issue
+    measured. With one present the save succeeds, because `write_text` truncates
+    an existing inode and needs write permission on the FILE, not on the
+    directory (measured; `..._reset_that_cannot_unlink...[dir_0o500_readable_override]`
+    pins that it still does).
+
+    Here `get_prompt` succeeds — `is_file()` answers False through a `0o500`
+    directory — so the page is the ordinary editor and the text comes back in
+    it. What is new is the banner and the status.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.parent.chmod(0o500)
+    sentinel = "Extract every fact you are sure of, and nothing else."
+    try:
+        probe = override.parent / ".write-probe"
+        try:
+            probe.write_text("x", encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            probe.unlink()
+            pytest.skip("this user writes straight through mode 0o500")
+
+        r = c.post(
+            "/prompts",
+            data={"prompt_id": "extraction", "prompt_text": sentinel},
+            follow_redirects=False,
+        )
+    finally:
+        override.parent.chmod(0o700)
+
+    assert r.status_code == 500  # plan §3.1: the write did not happen
+    assert f"prompt extraction could not be saved to {override}:" in r.text
+    assert sentinel in r.text
+    assert 'name="prompt_text"' in r.text
+    assert not override.exists()  # outside the restricted directory: `stat()` needs it
+
+
+def test_a_save_over_an_unwritable_override_keeps_the_typed_text(tmp_path):
+    """A failed write over an unreadable override: banner AND textarea.
+
+    `chmod` only and never `non_utf8`: a non-UTF-8 override is fully writable,
+    so that save succeeds with 303 and the row would prove nothing.
+
+    Here `get_prompt` fails as well as the write, so `prompt` is None and the
+    pre-existing editor is gone — the submitted text can only come back through
+    the block #545 added to `prompts.html`.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+    sentinel = "at most {max_facts} facts, and this sentence."
+
+    with _broken_override(override, "chmod"):
+        r = c.post(
+            "/prompts",
+            data={"prompt_id": "extraction", "prompt_text": sentinel},
+            follow_redirects=False,
+        )
+
+    assert r.status_code == 500  # plan §3.1: the write did not happen
+    assert f"prompt extraction could not be saved to {override}:" in r.text
+    assert sentinel in r.text
+    assert 'name="prompt_text"' in r.text
+    assert "prompt extraction could not be loaded" in r.text  # both reasons
+
+
+def test_a_save_that_cannot_be_written_over_an_invalid_override_still_names_the_file(
+    tmp_path,
+):
+    """The state where the diagnosis used to be thrown away entirely.
+
+    A READABLE override that fails validation, and a write that fails: the
+    `except PromptError` branch of `_prompts_page` renders this page, and that
+    branch used to replace the caller's `error` and hardcode its status. So the
+    page said the user's text was missing `{qid}` — text that contains `{qid}` —
+    at 400, naming no file, while the actual failure was the disk.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "query-translation")
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("Translate the question into Datalog.\n", encoding="utf-8")
+    override.chmod(0o444)
+    sentinel = "Translate the question {qid} into Datalog."
+    try:
+        try:
+            with override.open("a", encoding="utf-8"):
+                pass
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user writes straight through mode 0o444")
+
+        r = c.post(
+            "/prompts",
+            data={"prompt_id": "query-translation", "prompt_text": sentinel},
+            follow_redirects=False,
+        )
+    finally:
+        override.chmod(0o600)
+
+    assert r.status_code == 500  # plan §3.1: the write did not happen
+    assert f"prompt query-translation could not be saved to {override}:" in r.text
+    assert sentinel in r.text
+    assert 'name="prompt_text"' in r.text
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["dir_0o500_readable_override", "dir_0o000_override", "dir_0o000_no_override"],
+)
+def test_a_reset_that_cannot_unlink_is_a_page_not_a_crash(tmp_path, mode):
+    """Reset is not the working half: `exists()` and `unlink()` fail too.
+
+    The issue measured only an unreadable FILE, where reset legitimately
+    redirects. Restrict the DIRECTORY and both calls raise — `unlink()` under
+    `0o500`, `Path.exists()` under `0o000`, which propagates `EACCES` instead of
+    answering False.
+
+    The usability assertion is the reset form, not `name="prompt_text"`: under
+    `0o500` a textarea is present but it belongs to the pre-existing editor and
+    says nothing about the reset, and under `0o000` the page is the reset-only
+    shape and has none. What the user needs in every one of the three states is
+    the control that retries the reset.
+
+    `override.exists()` runs after the `finally` restores the mode, because
+    under `0o000` it WOULD raise `PermissionError` from the test itself — the
+    same `pathlib` fact the production code is here for. Where it stands it does
+    not raise, and the row passes.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+    override.parent.mkdir(parents=True, exist_ok=True)
+    if mode != "dir_0o000_no_override":
+        override.write_text("at most {max_facts} facts\n", encoding="utf-8")
+    override.parent.chmod(0o500 if mode == "dir_0o500_readable_override" else 0o000)
+    try:
+        probe = override.parent / ".write-probe"
+        try:
+            probe.write_text("x", encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            probe.unlink()
+            pytest.skip("this user writes straight through a restricted directory")
+
+        if mode == "dir_0o500_readable_override":
+            # Pinned as a positive because it is the trap in the issue body: a
+            # save into a `0o500` directory SUCCEEDS while an override exists,
+            # since `write_text` truncates the existing inode. A future
+            # `save_prompt_override` switching to temp-file + `os.replace` would
+            # need directory write permission and start failing here.
+            saved = c.post(
+                "/prompts",
+                data={
+                    "prompt_id": "extraction",
+                    "prompt_text": "at most {max_facts} facts, rewritten in place",
+                },
+                follow_redirects=False,
+            )
+            assert saved.status_code == 303
+            assert "rewritten in place" in override.read_text(encoding="utf-8")
+
+        r = c.post(
+            "/prompts/reset",
+            data={"prompt_id": "extraction"},
+            follow_redirects=False,
+        )
+    finally:
+        override.parent.chmod(0o700)
+
+    assert r.status_code == 500  # plan §3.1: the delete did not happen
+    assert f"prompt extraction override could not be deleted from {override}:" in r.text
+    assert 'action="/prompts/reset"' in r.text  # the retry the user needs
+    if mode != "dir_0o000_no_override":
+        assert override.exists()  # nothing was destroyed on the way to the failure
+    # WHICH section carried that control is the other half of the sentence in
+    # `reset_prompt_route`'s clause, so it is pinned here rather than implied: an
+    # override that loads gets the full editor, one that cannot be READ gets the
+    # reset-only section. The third shape that sentence names — an override that
+    # reads and fails validation — has no control at all and is pinned by
+    # `test_a_failed_reset_over_an_invalid_override_offers_no_control`.
+    if mode == "dir_0o500_readable_override":
+        assert 'name="prompt_text"' in r.text  # the full editor
+        assert "Could not load" not in r.text
+    else:
+        assert 'name="prompt_text"' not in r.text  # the reset-only shape
+        assert "Could not load" in r.text
+
+
+class _Unlisted(Exception):
+    """A failure in neither the `ValueError` nor the `OSError` hierarchy."""
+
+
+@pytest.mark.parametrize("route", ["save", "reset"])
+def test_a_prompt_write_failure_of_a_kind_nobody_enumerated_is_still_a_page(
+    tmp_path, monkeypatch, route
+):
+    """The breadth tripwire: narrow either clause to a type list and this dies.
+
+    `except OSError` would carry every filesystem row in this file, so nothing
+    else notices the narrowing. `_Unlisted` is outside both hierarchies the
+    clause could plausibly be narrowed to.
+
+    Patched on `webapp`, not on `verinote.prompts.library`: both names are
+    module-level imports in `verinote/web/app.py` and the routes resolve them
+    from module globals at call time.
+    """
+
+    def raiser(*args, **kwargs):
+        raise _Unlisted("nobody enumerated this")
+
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+
+    if route == "save":
+        monkeypatch.setattr(webapp, "save_prompt_override", raiser)
+        r = c.post(
+            "/prompts",
+            data={"prompt_id": "extraction", "prompt_text": "Extract the facts."},
+            follow_redirects=False,
+        )
+        expected = f"prompt extraction could not be saved to {override}:"
+    else:
+        monkeypatch.setattr(webapp, "delete_prompt_override", raiser)
+        r = c.post(
+            "/prompts/reset",
+            data={"prompt_id": "extraction"},
+            follow_redirects=False,
+        )
+        expected = f"prompt extraction override could not be deleted from {override}:"
+
+    assert r.status_code == 500  # plan §3.1: the write did not happen
+    assert expected in r.text
+    assert "nobody enumerated this" in r.text
+
+
+def test_an_unpatched_prompt_write_still_redirects(tmp_path):
+    """The negative control for the tripwire above: the patch is what fails.
+
+    Every assertion in the tripwire sits downstream of a monkeypatch, so a
+    clause that answered 500 to a save that WORKED would satisfy it. This row
+    drives the same two routes with nothing patched.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "extraction")
+
+    saved = c.post(
+        "/prompts",
+        data={"prompt_id": "extraction", "prompt_text": "Extract the facts."},
+        follow_redirects=False,
+    )
+
+    assert saved.status_code == 303
+    assert override.is_file()
+
+    reset = c.post(
+        "/prompts/reset",
+        data={"prompt_id": "extraction"},
+        follow_redirects=False,
+    )
+
+    assert reset.status_code == 303
+    assert not override.exists()
+
+
+def test_a_failed_reset_over_an_invalid_override_offers_no_control(tmp_path):
+    """The third shape a failed reset renders, and the one with nothing to click.
+
+    An override that READS and fails validation makes `get_prompt` raise
+    `PromptError`, so `_prompts_page` takes that branch: `prompt` is None, so no
+    editor, and that branch passes `reset_only=False` outright, so no reset-only
+    section. `_override_is_unreadable` is the `except Exception` branch's gate
+    and is never consulted here — forcing it to return True leaves this response
+    byte-identical, which is how that was checked rather than read off. What
+    comes back is the banner and the prompt selector.
+
+    Short of a repair affordance, deliberately: offering one for a
+    readable-but-invalid override is #546, and the line it has to change is that
+    hardcoded `reset_only=False`. It cannot simply become True, because
+    `get_prompt` raises the same `PromptError` when the PACKAGED default is what
+    fails validation — where a reset would delete the user's file and fix
+    nothing.
+
+    What #545 does deliver here is the diagnosis, and the contrast is measured,
+    not assumed: on `2c96317` this same request answers a bare 500 with no page
+    at all — no banner, no selector, nothing naming the file. Delete the broad
+    clause in `reset_prompt_route` and this row returns to that.
+
+    When #546 lands, the two `not in` assertions below are what tell you this
+    docstring and `reset_prompt_route`'s comment need rewriting.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "query-translation")
+    override.parent.mkdir(parents=True, exist_ok=True)
+    # Valid UTF-8 and readable, so this is not the unreadable-override state; it
+    # is missing the required `{qid}`, so `get_prompt` refuses it.
+    override.write_text("Translate the question into Datalog.\n", encoding="utf-8")
+    override.parent.chmod(0o500)
+    try:
+        probe = override.parent / ".write-probe"
+        try:
+            probe.write_text("x", encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            probe.unlink()
+            pytest.skip("this user writes straight through mode 0o500")
+
+        r = c.post(
+            "/prompts/reset",
+            data={"prompt_id": "query-translation"},
+            follow_redirects=False,
+        )
+    finally:
+        override.parent.chmod(0o700)
+
+    assert r.status_code == 500  # plan §3.1: the delete did not happen
+    assert (
+        f"prompt query-translation override could not be deleted from {override}:"
+        in r.text
+    )
+    assert "{qid}" in r.text  # and why the page could not be loaded either
+    assert 'value="ask-fallback"' in r.text  # the selector still routes away
+    assert 'action="/prompts/reset"' not in r.text  # the #546 gap, pinned
+    assert 'name="prompt_text"' not in r.text  # neither section rendered
+
+
+def test_a_save_for_an_unknown_prompt_id_is_offered_no_save_form(tmp_path):
+    """A control for an id `prompt_definition` rejected is a control that lies.
+
+    The echo-back section renders for a save POST whose page could not load the
+    prompt, and an unknown `prompt_id` is one of the ways a page fails to load —
+    so without the membership test in its gate the section comes back with a
+    Save button whose hidden `prompt_id` is the rejected id, and every click on
+    it reproduces the same 400.
+    `test_a_broken_override_does_not_blank_the_other_prompts` states that rule
+    for the sibling reset control; this is the same rule for Save.
+
+    The positive is in this row deliberately: an assertion that a section is
+    absent proves nothing unless that section can render at all here, so a known
+    id in the same could-not-load state is driven through the same client.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    submitted = "T44 is the text I typed."
+
+    unknown = c.post(
+        "/prompts",
+        data={"prompt_id": "nope", "prompt_text": submitted},
+        follow_redirects=False,
+    )
+
+    assert unknown.status_code == 400
+    assert "unknown prompt: nope" in unknown.text  # still told why
+    assert "Not saved" not in unknown.text
+    assert 'name="prompt_text"' not in unknown.text
+    assert submitted not in unknown.text
+    assert 'value="nope"' not in unknown.text  # no hidden id either
+
+    with _broken_override(prompt_override_path(tmp_path, "query-translation"), "chmod"):
+        known = c.post(
+            "/prompts",
+            data={"prompt_id": "query-translation", "prompt_text": submitted},
+            follow_redirects=False,
+        )
+
+    assert known.status_code == 400
+    assert "Not saved" in known.text  # the section does render for a real id
+    assert submitted in known.text
+
+
+def test_a_save_that_cleared_the_textarea_gets_the_empty_textarea_back(tmp_path):
+    """`is not none` and not truthiness, and the empty string is what buys it.
+
+    Clearing the field and pressing Save sends `prompt_text=""`, and the save is
+    refused for exactly that. On a truthy gate the echo-back section would not
+    render, so over an override that cannot load the page would come back with
+    no editor, no Save button, and — the override being readable, so
+    `reset_only` is False — no reset control either: a 400 with nothing on the
+    page to act on. `is not none` hands the empty field back, and the user can
+    type into it and resubmit.
+
+    `""` and not `"   "`: whitespace is truthy, so a whitespace submission
+    survives that mutation and would pin nothing. The assertion the mutation
+    kills is the textarea one; the status and both banner reasons are already
+    covered by `test_a_refusal_over_an_invalid_stored_override_keeps_both_reasons`.
+    """
+    from verinote.prompts.library import prompt_override_path
+
+    c = _prompts_client(tmp_path)
+    override = prompt_override_path(tmp_path, "query-translation")
+    override.parent.mkdir(parents=True, exist_ok=True)
+    # Readable, so this is the validation-failure state, not the unreadable one.
+    override.write_text("Translate the question into Datalog.\n", encoding="utf-8")
+
+    r = c.post(
+        "/prompts",
+        data={"prompt_id": "query-translation", "prompt_text": ""},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert "prompt text is required" in r.text  # why the save was refused
+    assert "{qid}" in r.text  # and why the page could not be loaded
+    assert 'name="prompt_text"' in r.text  # the field comes back, empty
+    # And it is the only control on this page: `reset_only` is False here, so
+    # without that field the 400 would be a dead end.
+    assert 'action="/prompts/reset"' not in r.text

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1125,6 +1125,27 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         try:
             prompt = get_prompt(cfg.root, prompt_id)
         except PromptError as exc:
+            # Compose the caller's `error` with the load complaint, and honour
+            # the caller's status, in the shape of the branch below — with the
+            # two departures the paragraphs beneath explain: the
+            # `error == load_error` guard, and promoting a caller's 200 to 400
+            # rather than passing it through.
+            # Replacing them threw away the diagnosis a POST had composed: over
+            # a readable-but-invalid override (someone hand-edited the file and
+            # dropped a required placeholder), a save that failed to WRITE was
+            # reported as "your text must include {qid}" when the user's text
+            # did include it, and the caller's status went with it.
+            #
+            # `error == load_error` and not a bare `error is None`: an unknown
+            # `prompt_id` raises the SAME `PromptError` here that the route
+            # already caught from its own library call, and composing a string
+            # with itself printed `unknown prompt: nope; unknown prompt: nope`.
+            #
+            # `400 if status_code == 200 else status_code` and not a bare
+            # `status_code`: a GET of `/prompts?prompt=nope` passes the default
+            # 200 and must still answer 400
+            # (`test_a_broken_override_does_not_blank_the_other_prompts`).
+            load_error = str(exc)
             return templates.TemplateResponse(
                 request,
                 "prompts.html",
@@ -1134,11 +1155,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     "selected_prompt": prompt_id,
                     "prompt_text": prompt_text,
                     "message": message,
-                    "error": str(exc),
+                    "error": (
+                        load_error
+                        if error is None or error == load_error
+                        else f"{error}; {load_error}"
+                    ),
                     "reset_only": False,
                     "override_path": None,
                 },
-                status_code=400,
+                status_code=400 if status_code == 200 else status_code,
             )
         except Exception as exc:  # noqa: BLE001 - the page that repairs a broken override
             # `get_prompt` reads the override off disk, so a file the user saved
@@ -1156,9 +1181,14 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # `unlink()`s, so that repair survives a file this process could not
             # read (measured: 303, the override gone, the page healthy again, in
             # both modes the tests cover). What the page does NOT carry is the
-            # broken prompt's own text or its Save form: `prompt=None` collapses
-            # the editor, and seeding the textarea with the default would invite
-            # overwriting a file this process could not read. So it is a
+            # broken prompt's SAVED text or an editor seeded from the default:
+            # `prompt=None` collapses the editor, and seeding the textarea with
+            # the default would invite overwriting a file this process could not
+            # read. A refused save POST is the exception, and it seeds
+            # nothing: `prompts.html` echoes back the bytes that very request
+            # carried, so such a save keeps the user's own typing (#545). Both
+            # of the other callers — a GET, and a reset POST — pass no
+            # `prompt_text`, so neither is offered an editor at all. So it is a
             # delivered page, not a refused one, and #539's non-regression
             # condition asks for 200 in as many words.
             #
@@ -2944,6 +2974,56 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 error=str(exc),
                 status_code=400,
             )
+        except Exception as exc:  # noqa: BLE001 - a KB tree the user can chmod fails in ways PromptError does not name
+            # `save_prompt_override` does filesystem work — `mkdir` then
+            # `write_text` — and the `OSError` family that raises is outside
+            # `PromptError`'s hierarchy, so a write the operator's own mode bits
+            # refused left this handler as an unhandled exception: a bare error
+            # response, no page, and nothing saying which file or why (#545).
+            #
+            # Broad rather than a type list, per the house form of
+            # `_prompts_page` above and of
+            # `verinote/pipeline/extract.py::_relation_aliases_or_error`: the
+            # ways a directory the user can chmod fails are not a set this route
+            # can enumerate, and every member of it is better answered with a
+            # page that names the file than with a traceback. `Exception` and
+            # never `BaseException`, so `KeyboardInterrupt`, `SystemExit` and
+            # `CancelledError` still travel.
+            #
+            # BELOW the narrow `except PromptError`, which keeps its 400: empty
+            # text, a missing required placeholder and an unknown `prompt_id`
+            # are refusals of the request, not failures of the disk, and folding
+            # them in here would relabel all three. Read
+            # `verinote/prompts/library.py`: in `save_prompt_override`,
+            # `prompt_definition`, the empty check and `_validate_prompt_text`
+            # all run BEFORE `mkdir`, and nothing after it raises `PromptError`
+            # — so the narrow clause above cannot today take a write failure and
+            # report it as a validation refusal. That is a property of the
+            # current library, not a guarantee: add a `PromptError` after the
+            # write and this ordering needs revisiting.
+            #
+            # 500 rather than 400: the user's text was accepted and the disk
+            # said no, so repeating the identical request once the mode bits are
+            # fixed is exactly the right thing to do — which is what 4xx denies.
+            #
+            # `cfg = _active_cfg()` stays ABOVE the `try`, and the body stays
+            # the single library call. Its `RuntimeError("no active KB")` is an
+            # application-state bug; caught here it would render as "could not
+            # be saved to …: no active KB", blaming the filesystem for it.
+            #
+            # The path is named here rather than left to `str(exc)`: a failing
+            # `mkdir` names only the directory, and an exception outside
+            # `OSError` names nothing at all.
+            return _prompts_page(
+                request,
+                prompt_id=prompt_id,
+                prompt_text=prompt_text,
+                error=(
+                    f"prompt {prompt_id} could not be saved to "
+                    f"{prompt_override_path(cfg.root, prompt_id)}: {exc}"
+                ),
+                status_code=500,
+            )
         return RedirectResponse(f"/prompts?{urlencode({'prompt': prompt_id})}", status_code=303)
 
     @app.post("/prompts/reset", response_class=HTMLResponse)
@@ -2957,6 +3037,52 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 prompt_id=prompt_id,
                 error=str(exc),
                 status_code=400,
+            )
+        except Exception as exc:  # noqa: BLE001 - `exists()`/`unlink()` fail the ways a save does
+            # The same clause and the same reasoning as `save_prompt_route`'s
+            # above: why it is broad, why it sits below the narrow one, why the
+            # status is what it is, why `_active_cfg()` stays outside the `try`,
+            # and why the path is named rather than left to `str(exc)`.
+            #
+            # Reset is not the working half of this pair. `delete_prompt_override`
+            # calls `path.exists()` before `path.unlink()`, and under a directory
+            # the operator restricted BOTH raise — `Path.exists()` propagates
+            # `EACCES` rather than answering False, which is what took the reset
+            # POST down from a `0o000` prompts directory.
+            #
+            # No `prompt_text`: this route carries none, so what its failure
+            # page can carry is decided by what `get_prompt` makes of the
+            # override, and that has three outcomes, not two. Loads: the full
+            # editor, banner above it. Cannot be READ: `reset_only` renders the
+            # section that deletes it, banner above it. Reads but fails
+            # VALIDATION: `_prompts_page` takes its `except PromptError` branch,
+            # where `prompt` is None and that branch passes `reset_only=False`
+            # outright — `_override_is_unreadable` is the `except Exception`
+            # branch's gate and is never consulted here — so the page is the
+            # banner and the prompt selector and no control at all.
+            # `test_a_reset_that_cannot_unlink_is_a_page_not_a_crash` pins the
+            # first two shapes, one per param;
+            # `test_a_failed_reset_over_an_invalid_override_offers_no_control`
+            # pins the third.
+            #
+            # That third page is deliberately left short of a repair control.
+            # Offering one for a readable-but-invalid override is #546's whole
+            # subject, and the line it has to change is that hardcoded
+            # `reset_only=False` — not this clause, and not the predicate. What
+            # it cannot do is flip that literal to True, because `get_prompt`
+            # raises the same `PromptError` when the PACKAGED default is what
+            # fails validation, where a reset would delete the user's file and
+            # fix nothing. What this change does deliver there is the diagnosis:
+            # measured against `2c96317`, the same request answered a bare 500
+            # carrying no page, no banner and not even the selector.
+            return _prompts_page(
+                request,
+                prompt_id=prompt_id,
+                error=(
+                    f"prompt {prompt_id} override could not be deleted from "
+                    f"{prompt_override_path(cfg.root, prompt_id)}: {exc}"
+                ),
+                status_code=500,
             )
         return RedirectResponse(f"/prompts?{urlencode({'prompt': prompt_id})}", status_code=303)
 

--- a/verinote/web/templates/prompts.html
+++ b/verinote/web/templates/prompts.html
@@ -49,6 +49,43 @@
 </section>
 {% endif %}
 
+{# Gated on `prompt_text is not none`, NOT on truthiness and NOT on `not prompt`
+   alone: `save_prompt_route` declares `prompt_text: str = Form("")`, so a save
+   always passes a string, `reset_prompt_route` passes none, and a GET passes
+   none. So this renders only for a save POST that came back as a page with the
+   prompt unloadable — the state where `{% if prompt %}` above collapses the
+   editor and takes the user's typing with it (#545). It seeds nothing: the only
+   text it can show is the text that very request carried, which is why it does
+   not re-open the overwrite hazard a default-seeded editor would.
+
+   The membership test is what keeps the Save button off an id
+   `prompt_definition` has already rejected: an unknown `prompt_id` also reaches
+   this page with `prompt` None and a `prompt_text`, and without it the form
+   comes back carrying `nope` in its hidden field, so every click on it
+   reproduces the same 400. That is the rule
+   `test_a_broken_override_does_not_blank_the_other_prompts` states for the
+   sibling reset control — an id with no definition has nothing for a control to
+   act on. The banner still says `unknown prompt: nope`. #}
+{% if not prompt and prompt_text is not none and selected_prompt in prompts|map(attribute="id")|list %}
+<section class="prompt-editor">
+  <div class="prompt-meta">
+    <span class="badge">Not saved</span>
+    <span><code>{{ selected_prompt }}</code></span>
+  </div>
+  <p class="muted">This is the text you submitted. It was not written to disk — the banner above says why.</p>
+  <form class="settings prompt-form" action="/prompts" method="post">
+    <input type="hidden" name="prompt_id" value="{{ selected_prompt }}">
+    <label>Prompt text
+      <textarea name="prompt_text" rows="24" spellcheck="false">{{ prompt_text }}</textarea>
+    </label>
+    <div class="prompt-actions">
+      <button class="btn" type="submit">Save prompt</button>
+      <a class="btn ghost" href="/settings">Back to settings</a>
+    </div>
+  </form>
+</section>
+{% endif %}
+
 {% if reset_only %}
 <section class="prompt-editor">
   <div class="prompt-meta">
@@ -56,7 +93,7 @@
     <span><code>{{ selected_prompt }}</code></span>
     <span>{{ override_path }}</span>
   </div>
-  <p class="muted">This prompt's text is not shown and cannot be edited here. Reset to default deletes the override file named above; this prompt then falls back to the built-in default.</p>
+  <p class="muted">This prompt's saved text could not be read and is not shown. Reset to default deletes the override file named above; this prompt then falls back to the built-in default.</p>
   <form class="prompt-reset" action="/prompts/reset" method="post">
     <input type="hidden" name="prompt_id" value="{{ selected_prompt }}">
     <button class="btn ghost" type="submit">Reset to default</button>


### PR DESCRIPTION
## What was broken

`save_prompt_override` does `mkdir` then `write_text`; `delete_prompt_override` does `unlink`. Both routes caught only `PromptError`, which is a `ValueError` and shares no ancestor with `OSError`. An unwritable prompts directory therefore answered **21 bytes of `Internal Server Error`** — no banner, no filename, no selector, no way back to any other prompt.

The second half: `_prompts_page` rendered `prompt: None` on its error branch and the template gated the whole editor on it, so a save that came back 400 came back **empty** — the user's typed text was gone.

## The shape

Both routes take a broad clause **below** the narrow one, the form #539 and #553 settled on: the narrow type keeps its own branch, the broad one names the path and the errno, and a test raises a type in neither hierarchy so the breadth is pinned rather than assumed.

The editor now renders from the submitted text when the prompt itself will not load, gated on `prompt_text is not none` — **not truthiness**, because clearing the textarea and saving is how a user asks for an empty prompt and they get the empty editor back to retype in; and **not on `not prompt` alone**, because an id `prompt_definition` rejected must not be offered a Save button carrying that id. All three clauses have a row that reddens on them.

`_prompts_page`'s `PromptError` branch composes the caller's error with the load error and honours a non-200 status, so a page that is both unwritable and unloadable says both things — **once**: the same `PromptError` reaches it twice for an unknown id, and `or error == load_error` is what stops the banner repeating itself.

## Three shapes a failed reset can render

| override | editor | reset-only section |
|---|---|---|
| loads | **yes** | no |
| cannot be read | no | **yes** |
| reads, fails validation | no | no |

The third is **#546's**. That branch passes `reset_only=False` outright — `_override_is_unreadable` gates the *other* branch and is never consulted here (checked by mutation: forcing it True leaves the response byte-identical). It cannot simply become `True`, because `get_prompt` raises the same `PromptError` when the **packaged default** is what fails validation, where a reset would delete the user's file and fix nothing. Pinned as a gap so #546 cannot land silently.

## On the status code

**This ships 500 for a write failure**, while the issue's first bullet reads "500 이 아니고". A 500 is what the condition is: the server could not do what it was asked, and no correction to the request fixes an unwritable directory. What the issue was actually asking for — and what was missing — is that the response be a *page*: banner, filename, errno, the editor with your text still in it, and the selector. That is what changed. Validation failures remain **400**, which is where the request really is at fault.

## Validation

macOS 26.6.2 (arm64), CPython 3.11.15. `pytest-randomly` is not installed, so collection order is deterministic and every mutant result is attributable.

| run | result |
|---|---|
| parent `2c96317` | `3202 passed, 14 skipped, 0 failed` |
| this branch | `3219 passed, 14 skipped, 0 failed` |
| `uvx ruff@0.15.18 check .` (CI pins that version at `ci.yml:22`) | All checks passed |

Every mechanism clause in the new comments has a mutant that reddens a row: the breadth tripwire, the `or error == load_error` guard and its equality assertion, each of the three gate conjuncts, and the `#546 gap, pinned` assertion.

Closes #545.
