### PR TITLE
feat(#494): scan the NULs already stored in artifacts and chunks

### DIFF
--- a/tests/test_ingest_unreadable_chars.py
+++ b/tests/test_ingest_unreadable_chars.py
@@ -483,8 +483,10 @@ def test_sources_page_separates_measured_loss_from_never_measured(tmp_path, nulx
 
 
 _UNMEASURED_NOTE = (
-    '<span class="badge src">not checked for unreadable characters — some may '
-    "remain; re-upload to fix, or delete the source and upload it again if "
+    '<span class="badge src">not checked for unreadable characters — this '
+    "records that the extraction never measured, not what the file holds, so "
+    "it stays after a scan; run verinote sources scan-unreadable to see what "
+    "is stored. Re-upload to fix, or delete the source and upload it again if "
     "this note stays</span>"
 )
 
@@ -494,6 +496,15 @@ _UNMEASURED_NOTE = (
 # new note opens with that clause. The closing tag is what pins the old one.
 _DESTRUCTIVE_FIRST_NOTE = "; delete the source and upload it again to fix</span>"
 _RE_UPLOAD_ONLY_NOTE = "; re-upload to fix</span>"
+
+# The wording #494 replaced, which told the reader the note might mean the file
+# still holds unreadable characters and offered no way to find out. The rule
+# above cannot anchor this one: the new note ends in the same
+# `...if this note stays</span>` the old one did, so the closing tag does not
+# discriminate. The clause that vanished does, so it is the guard -- and it is
+# quoted here whole rather than trimmed to a prefix, because a prefix of it is
+# also a prefix of the current note.
+_NO_SCAN_POINTER_NOTE = "unreadable characters — some may remain; re-upload to fix,"
 
 
 def _block_the_extraction_worker(monkeypatch) -> list[int]:
@@ -596,6 +607,7 @@ def test_the_sources_page_names_an_action_that_actually_clears_the_unmeasured_no
     # of a note rather than a prefix of one.
     assert _RE_UPLOAD_ONLY_NOTE not in html
     assert _DESTRUCTIVE_FIRST_NOTE not in html
+    assert _NO_SCAN_POINTER_NOTE not in html
     assert html.count("not checked for unreadable characters") == 1
 
     # Leg 2: do what the note says first -- upload the same bytes again -- and

--- a/tests/test_unreadable_scan.py
+++ b/tests/test_unreadable_scan.py
@@ -1,0 +1,1200 @@
+# SPDX-License-Identifier: MPL-2.0
+"""#494: NULs already stored before #473's sanitizer must be findable.
+
+#473 stopped new NULs entering the KB. It reached nothing already written, so a
+KB ingested before it still holds them in its extraction-text artifact files and
+in `source_chunks.text`. The scan here reports them and repairs nothing.
+
+The population that matters is the *unmigrated* KB — one whose
+`source_artifacts` table has no `unreadable_chars` column, because that column
+arrived with #473. `_unmigrated_kb` builds that; `_legacy_source` builds the
+easier state, a migrated KB still carrying pre-#473 rows and files.
+"""
+
+import sqlite3
+
+import pytest
+
+import verinote.cli as cli
+from verinote.pipeline.extract import create_chunked_extraction_job
+from verinote.pipeline.ingest import store_source
+from verinote.pipeline.policy_state import POLICY_RELPATH
+from verinote.store import Store
+
+# #473's reported shape, where deleting the NUL rather than replacing it would
+# manufacture the identifier `A01`.
+_DIRTY = "A\x0001 and \x00"
+_DIRTY_NULS = 2
+
+
+def _env(monkeypatch, tmp_path):
+    monkeypatch.setenv("VERINOTE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VERINOTE_PROVIDER", "anthropic")
+
+
+def _store(tmp_path) -> Store:
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    return store
+
+
+def _write_artifact(root, source_id: int, name: str, text: str) -> str:
+    rel = f"artifacts/sources/{source_id}/{name}.txt"
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return rel
+
+
+def _legacy_source(store, root, *, name, text, kind="extracted_text"):
+    """A migrated KB whose artifact file and chunks still hold their NULs.
+
+    `store_source` is not used on purpose: it sanitizes, which is the whole
+    thing this data predates. The artifact file is written directly and the
+    chunks come from `create_chunked_extraction_job`, the real pre-#473
+    re-analysis path — it chunks whatever text it is handed and sanitizes
+    nothing (`normalize_for_extraction` does not touch NULs).
+
+    This is NOT what a KB written before #473 looks like on disk: that KB has no
+    `unreadable_chars` column at all. `_unmigrated_kb` is that one.
+    """
+    source_id = store.add_source(f"sources/{name}", kind="binary")
+    rel = _write_artifact(root, source_id, name, text)
+    artifact_id = store.add_source_artifact(
+        source_id=source_id, kind=kind, path=rel, checksum=name,
+    )  # unreadable_chars omitted -> NULL, the "never measured" state
+    job_id = create_chunked_extraction_job(
+        store, source_id=source_id, artifact_id=artifact_id,
+        source_text=text, provider=None, model=None,
+    )
+    # Preconditions, not decoration: if anything ever starts sanitizing on this
+    # path the fixture stops planting what the tests claim to find.
+    assert (root / rel).read_text(encoding="utf-8").count("\x00") == text.count("\x00")
+    assert sum(r["text"].count("\x00") for r in store.source_chunks(job_id)) > 0
+    return source_id, artifact_id, job_id
+
+
+def _repaired_source(store, root, *, name):
+    """`_legacy_source`, then the clean rows a re-upload and a re-sync leave.
+
+    The post-remediation shape: a dirty superseded artifact under a clean newer
+    one, and a superseded job's dirty chunks under a clean newer job. Both are
+    reachable — a re-upload INSERTs a second artifact rather than filling the
+    first one in, and `verinote sync` builds a fresh job without clearing the
+    old one's chunks.
+    """
+    source_id, old_artifact_id, old_job_id = _legacy_source(
+        store, root, name=name, text=_DIRTY
+    )
+    clean = _DIRTY.replace("\x00", "�")
+    rel = _write_artifact(root, source_id, f"{name}-clean", clean)
+    new_artifact_id = store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel,
+        checksum=f"{name}-clean", unreadable_chars=_DIRTY_NULS,
+    )
+    new_job_id = create_chunked_extraction_job(
+        store, source_id=source_id, artifact_id=new_artifact_id,
+        source_text=clean, provider=None, model=None,
+    )
+    assert new_artifact_id > old_artifact_id and new_job_id > old_job_id
+    return source_id, old_artifact_id, new_artifact_id, old_job_id, new_job_id
+
+
+_UNMIGRATED_SCHEMA = """
+CREATE TABLE sources (id INTEGER PRIMARY KEY, path TEXT NOT NULL, kind TEXT NOT NULL);
+CREATE TABLE facts (
+    id INTEGER PRIMARY KEY,
+    subject TEXT NOT NULL,
+    relation TEXT NOT NULL,
+    object TEXT NOT NULL,
+    status TEXT NOT NULL
+);
+CREATE TABLE review_log (id INTEGER PRIMARY KEY);
+CREATE TABLE runs (id INTEGER PRIMARY KEY);
+CREATE TABLE source_artifacts (
+    id INTEGER PRIMARY KEY,
+    source_id INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    path TEXT NOT NULL,
+    content_type TEXT NOT NULL DEFAULT 'text/plain',
+    checksum TEXT NOT NULL DEFAULT ''
+);
+"""
+
+
+def _unmigrated_kb(tmp_path, *, text=_DIRTY):
+    """A KB as it stood before #473: no `unreadable_chars`, no `source_chunks`.
+
+    Hand-rolled the way `tests/test_cli.py`'s legacy-KB test hand-rolls its own,
+    and for the same reason: every fixture built through `init_schema()` is a
+    *migrated* KB, so none of them can stand in for this one. The four tables
+    above are what `_KB_CORE_TABLES` demands, so this file passes
+    `_require_existing_kb` — that is what makes it a reachable state and not a
+    straw fixture, and it is asserted in the test that uses it.
+
+    `source_artifacts` here has no `unreadable_chars` column and there is no
+    `source_chunks` table, because both arrived by migration.
+    """
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.executescript(_UNMIGRATED_SCHEMA)
+    conn.execute("INSERT INTO sources(path, kind) VALUES('sources/legacy.pdf', 'binary')")
+    source_id = int(conn.execute("SELECT id FROM sources").fetchone()[0])
+    rel = _write_artifact(tmp_path, source_id, "legacy", text)
+    conn.execute(
+        "INSERT INTO source_artifacts(source_id, kind, path, checksum) "
+        "VALUES(?, 'extracted_text', ?, 'legacy')",
+        (source_id, rel),
+    )
+    conn.commit()
+    conn.close()
+    return source_id, rel
+
+
+def _only_source(scan):
+    assert len(scan.sources) == 1
+    return scan.sources[0]
+
+
+def _source_line(out: str, path: str) -> str:
+    """The one report line for `path`.
+
+    Assertions about a source's verdict have to be made against its own line:
+    the summary line names every category, so `"in superseded rows only" not in
+    out` is satisfied by nothing and fails on the summary's own "0 in
+    superseded rows only".
+    """
+    lines = [line for line in out.splitlines() if line.startswith(f"{path}: ")]
+    assert len(lines) == 1, f"expected one report line for {path}, got {lines}"
+    return lines[0]
+
+
+# --- what the scan finds ---------------------------------------------------
+
+
+def test_scan_finds_nuls_in_artifact_file(tmp_path):
+    store = _store(tmp_path)
+    _legacy_source(store, tmp_path, name="legacy", text=_DIRTY)
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert len(source.artifacts) == 1
+    artifact = source.artifacts[0]
+    assert artifact.status == "found"
+    assert artifact.nuls == _DIRTY_NULS
+    assert artifact.recorded is None
+    assert artifact.is_latest is True
+    assert scan.artifacts_scanned == 1
+
+
+def test_scan_finds_nuls_in_chunk_text(tmp_path):
+    store = _store(tmp_path)
+    _, _, job_id = _legacy_source(store, tmp_path, name="legacy", text=_DIRTY)
+    rows = store.source_chunks(job_id)
+    planted = {
+        int(row["chunk_index"]): row["text"].count("\x00")
+        for row in rows
+        if row["text"].count("\x00")
+    }
+    assert planted, "the fixture planted no dirty chunk"
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    # Exactly the planted indices with their exact counts, and no others: a
+    # scan that reported every chunk, or one extra, fails here.
+    assert {c.chunk_index: c.nuls for c in source.chunks} == planted
+    assert source.chunks_scanned == len(rows)
+    assert scan.chunks_scanned == len(rows)
+
+
+def test_scan_counts_every_nul_in_a_chunk(tmp_path):
+    """Three NULs, counted as three.
+
+    `length()` truncates at the first NUL and `instr()` returns a position, so
+    SQL-side counting reports 0 and 1 respectively for this text. Only a real
+    count gives 3.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/three.txt")
+    job_id = store.create_extraction_job(
+        source_id=source_id, artifact_id=None, provider=None, model=None,
+        total_chunks=1, message="",
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=["\x00a\x00b\x00"])
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert [c.nuls for c in source.chunks] == [3]
+
+
+def test_artifact_and_chunk_counts_are_not_summed(tmp_path, monkeypatch, capsys):
+    """One NUL in the artifact becomes two in the chunk store, and neither total
+    is the other's business.
+
+    `chunk_text` prepends the previous chunk's last 40 characters to each later
+    chunk, so a NUL inside that window is stored twice. This fixture puts one
+    there. The report therefore has no headline over both stores — there is no
+    number a headline could honestly carry.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    _legacy_source(store, tmp_path, name="overlap", text="A" * 290 + "\x00" + "B" * 300)
+
+    scan = store.scan_unreadable_text()
+    store.close()
+    source = _only_source(scan)
+
+    assert sum(a.nuls for a in source.artifacts) == 1
+    assert sum(c.nuls for c in source.chunks) == 2
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    # No aggregate sits between the source and its two segments; each count is
+    # printed inside the segment that owns it.
+    assert "sources/overlap: unreadable characters still stored — artifacts: " in out
+    assert "artifacts: 1 in the latest of 1 artifact row(s)" in out
+    assert "chunks: 2 in 2 chunk(s) of the latest job" in out
+
+
+def test_replacement_char_is_not_a_finding(tmp_path):
+    """U+FFFD is what #473 wrote *instead* of a NUL. Counting it would report
+    every repaired source as still broken."""
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/repaired.txt")
+    rel = _write_artifact(tmp_path, source_id, "repaired", "a�b")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel, checksum="repaired",
+    )
+    job_id = store.create_extraction_job(
+        source_id=source_id, artifact_id=None, provider=None, model=None,
+        total_chunks=1, message="",
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=["a�b"])
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert [(a.status, a.nuls) for a in source.artifacts] == [("clean", 0)]
+    assert source.chunks == ()
+
+
+def test_legacy_original_text_artifact_is_scanned(tmp_path):
+    """`original_text` rows are still read by `latest_source_text_artifact` and
+    `source_text_inputs`, so narrowing the scan to `extracted_text` would skip
+    artifacts re-analysis will happily re-read."""
+    store = _store(tmp_path)
+    _legacy_source(store, tmp_path, name="orig", text=_DIRTY, kind="original_text")
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert [(a.status, a.nuls) for a in source.artifacts] == [("found", _DIRTY_NULS)]
+
+
+# --- what the scan could not read is never called clean --------------------
+
+
+def test_missing_artifact_file_is_not_clean(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/pruned.pdf", kind="binary")
+    rel = _write_artifact(tmp_path, source_id, "pruned", _DIRTY)
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel, checksum="pruned",
+    )
+    (tmp_path / rel).unlink()
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    assert [(a.status, a.nuls) for a in _only_source(scan).artifacts] == [
+        ("file_missing", 0)
+    ]
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "could not scan 1 artifact(s)" in out
+    assert f"file_missing: {rel}" in out
+
+
+def test_undecodable_artifact_file_is_not_clean(tmp_path):
+    """Bytes that are not UTF-8 mean "we could not look", not "nothing here".
+
+    The file below holds two NULs a decoding read would have found. Reporting
+    it as `found` with a partial count would turn a failed read into a
+    measurement; reporting it as `clean` would turn it into an all-clear.
+    """
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/broken.pdf", kind="binary")
+    rel = f"artifacts/sources/{source_id}/broken.txt"
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"ok\x00text \xff\xfe tail\x00")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel, checksum="broken",
+    )
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    assert [(a.status, a.nuls) for a in _only_source(scan).artifacts] == [
+        ("file_undecodable", 0)
+    ]
+
+
+# --- clean sources are still listed, and still say what ingest recorded ----
+
+
+def test_clean_kb_reports_no_findings(tmp_path):
+    store = _store(tmp_path)
+    result = store_source(store, tmp_path, "doc.txt", b"body", "body", "text")
+    create_chunked_extraction_job(
+        store, source_id=result["source_id"], artifact_id=result["artifact_id"],
+        source_text=result["text"], provider=None, model=None,
+    )
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert [a.status for a in source.artifacts] == ["clean"]
+    assert source.chunks == ()
+    assert scan.artifacts_scanned == 1
+    assert scan.chunks_scanned > 0
+
+
+def test_clean_source_is_reported_as_scanned(tmp_path, monkeypatch, capsys):
+    """"Scanned and clean" and "not looked at" are different answers.
+
+    Dropping clean sources from the report would leave a reader unable to tell
+    which of the two a missing line meant.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    store_source(store, tmp_path, "doc.txt", b"body", "body", "text")
+    store.close()
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "sources/doc.txt: no unreadable characters still stored" in out
+    assert "across 1 source(s)" in out
+
+
+def test_clean_source_names_what_ingest_recorded(tmp_path, monkeypatch, capsys):
+    """The commonest post-#473 source: 71 replaced at ingest, none still stored.
+
+    A bare "no unreadable characters still stored" is true and unreadable-proof
+    to over-read as "this document lost nothing". The line has to keep ingest's
+    number visible beside its own.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/measured.pdf", kind="binary")
+    rel = _write_artifact(tmp_path, source_id, "measured", "clean text")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel,
+        checksum="measured", unreadable_chars=71,
+    )
+    store.close()
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert (
+        "sources/measured.pdf: no unreadable characters still stored — "
+        "extraction recorded 71 replaced at ingest" in out
+    )
+
+
+def test_report_keeps_recorded_and_found_apart(tmp_path, monkeypatch, capsys):
+    """An artifact that measured 0 and whose file holds 2.
+
+    Reachable: `unreadable_chars` is the count of what the *extraction*
+    replaced, so a row written by a clean extraction and a file that later
+    diverged from it disagree. Printing one number for both would make the
+    report unable to say which it meant.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/mixed.pdf", kind="binary")
+    rel = _write_artifact(tmp_path, source_id, "mixed", _DIRTY)
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel,
+        checksum="mixed", unreadable_chars=0,
+    )
+
+    scan = store.scan_unreadable_text()
+    store.close()
+    artifact = _only_source(scan).artifacts[0]
+    assert (artifact.nuls, artifact.recorded) == (_DIRTY_NULS, 0)
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "artifacts: 2 in the latest of 1 artifact row(s)" in out
+    assert "extraction recorded 0 replaced at ingest" in out
+
+
+def test_source_with_no_stored_text_is_named(tmp_path, monkeypatch, capsys):
+    """`extract.py`'s loose-file path registers a source with no artifact row.
+
+    Omitting it would be the strongest form of "not looked at, and not said so",
+    and would make the summary's source count a denominator missing its own rows.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    store.add_source("sources/loose.txt")
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert source.status == "no_stored_text"
+    assert (source.artifacts, source.chunks) == ((), ())
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "sources/loose.txt: no stored extraction text — not scanned" in out
+    assert "1 with no stored text" in out
+
+
+# --- superseded rows are not the ones a finding should be reported on -------
+
+
+def test_superseded_artifact_is_named_as_superseded(tmp_path, monkeypatch, capsys):
+    """A user who already re-uploaded must not read a finding about dead rows.
+
+    This command recommends nothing; `sources.html` is what names
+    delete-and-re-upload, and `store.delete_source` drops every fact from the
+    source including `confirmed` and `accepted` ones. So the harm here is not a
+    line telling anyone to delete anything -- it is a report that presents a
+    superseded row the same way as a live one, leaving a user whose KB is
+    already fixed to act on it through the surface that does recommend.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    _, old_id, new_id, _, _ = _repaired_source(store, tmp_path, name="repaired")
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    by_id = {a.artifact_id: a for a in _only_source(scan).artifacts}
+    assert by_id[old_id].status == "found" and by_id[old_id].is_latest is False
+    assert by_id[new_id].status == "clean" and by_id[new_id].is_latest is True
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "sources/repaired: unreadable characters in superseded rows only" in out
+    assert "no re-upload is called for" in out
+    assert "artifacts: 2 in 1 superseded of 2 artifact row(s)" in out
+
+
+def test_superseded_chunk_is_named_as_superseded(tmp_path):
+    store = _store(tmp_path)
+    _, _, _, old_job_id, new_job_id = _repaired_source(store, tmp_path, name="repaired")
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    chunks = _only_source(scan).chunks
+    assert chunks, "the fixture planted no dirty chunk"
+    assert {c.job_id for c in chunks} == {old_job_id}
+    assert all(c.is_latest_job is False for c in chunks)
+
+
+def test_a_newest_job_with_no_chunks_does_not_promote_a_superseded_one(tmp_path):
+    """Job recency comes from `extraction_jobs`, not from the chunk rows.
+
+    `create_chunked_extraction_job` finishes a job immediately when its text
+    chunks to nothing, so a source's newest job can own no `source_chunks` rows
+    at all. `MAX(job_id)` over `source_chunks` then names the *superseded* job
+    as the newest, and every dirty chunk under it reads as a live finding —
+    which is the report telling a user whose current job is clean to delete the
+    source and re-upload it.
+    """
+    store = _store(tmp_path)
+    source_id, _, old_job_id = _legacy_source(store, tmp_path, name="legacy", text=_DIRTY)
+    new_job_id = create_chunked_extraction_job(
+        store, source_id=source_id, artifact_id=None,
+        source_text="   ", provider=None, model=None,
+    )
+    assert new_job_id > old_job_id
+    assert store.source_chunks(new_job_id) == [], (
+        "the newer job owns chunk rows, so this fixture cannot separate the two "
+        "readings of 'the newest job'"
+    )
+    probe = sqlite3.connect(tmp_path / "kb.sqlite")
+    highest_job_id_in_chunks = probe.execute(
+        "SELECT MAX(job_id) FROM source_chunks WHERE source_id = ?", (source_id,)
+    ).fetchone()[0]
+    probe.close()
+    assert highest_job_id_in_chunks == old_job_id
+
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    chunks = _only_source(scan).chunks
+    assert chunks, "the fixture planted no dirty chunk"
+    assert all(c.is_latest_job is False for c in chunks)
+
+
+def _kb_with_chunks_but_no_jobs(tmp_path):
+    """A KB holding dirty chunks whose `extraction_jobs` table is absent.
+
+    Hand-rolled: `extraction_jobs` and `source_chunks` are both plain
+    `CREATE TABLE IF NOT EXISTS` in `schema.sql` with no ALTER, so a real KB has
+    both or neither and I could not construct this state through any migration
+    path. What the two tests below pin is the contract, at the two levels it has
+    to hold at — the `Store` method must not call an underivable recency
+    `False`, and the CLI line must not turn that into reassurance.
+    """
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.executescript(_UNMIGRATED_SCHEMA)
+    conn.executescript(
+        """
+        CREATE TABLE source_chunks (
+            id INTEGER PRIMARY KEY,
+            source_id INTEGER NOT NULL,
+            job_id INTEGER NOT NULL,
+            chunk_index INTEGER NOT NULL,
+            text TEXT NOT NULL
+        );
+        """
+    )
+    conn.execute("INSERT INTO sources(path, kind) VALUES('sources/legacy.pdf', 'binary')")
+    conn.execute(
+        "INSERT INTO source_chunks(source_id, job_id, chunk_index, text) VALUES(1, 1, 0, ?)",
+        (_DIRTY,),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_chunk_recency_is_unknown_without_an_extraction_jobs_table(tmp_path):
+    """No `extraction_jobs` table means recency cannot be derived — not that
+    every finding is superseded."""
+    _kb_with_chunks_but_no_jobs(tmp_path)
+
+    store = Store(tmp_path / "kb.sqlite")
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    assert scan.jobs_table_present is False
+    chunks = _only_source(scan).chunks
+    assert [c.is_latest_job for c in chunks] == [None]
+    assert [c.nuls for c in chunks] == [_DIRTY_NULS]
+
+
+def test_unknown_chunk_recency_is_not_reported_as_reassurance(tmp_path, monkeypatch, capsys):
+    """The `Store` contract's CLI consequence, which is where the harm lands.
+
+    `_source_scan_verdict`'s docstring says an underivable recency counts as
+    current because not knowing must not read as reassurance. The sibling above
+    stops at the method and never reaches that function, so without this the
+    clause is a declared choice with nothing behind it: treating `None` as "not
+    the latest job" leaves the whole suite green and prints "unreadable
+    characters in superseded rows only — nothing re-analysis will read again, so
+    no re-upload is called for" about a chunk whose job it never identified.
+    """
+    _env(monkeypatch, tmp_path)
+    _kb_with_chunks_but_no_jobs(tmp_path)
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    line = _source_line(capsys.readouterr().out, "sources/legacy.pdf")
+    assert line.startswith("sources/legacy.pdf: unreadable characters still stored — ")
+    assert "no re-upload is called for" not in line
+    assert "in superseded rows only" not in line
+
+
+def test_an_unread_latest_artifact_is_not_reported_as_an_absence(
+    tmp_path, monkeypatch, capsys
+):
+    """"We could not look" must not round down to "there is nothing there".
+
+    Two shapes, because they round down to two different false sentences. The
+    first source's only artifact file is gone, so a `clean` headline would say
+    "no unreadable characters still stored" about a file nobody read. The
+    second's latest artifact is gone above a dirty superseded one, so a
+    `superseded` headline would say "nothing re-analysis will read again" about
+    the row re-analysis is precisely the one that would read. Neither may claim
+    an absence — and neither may take the `superseded` headline's reassurance,
+    which is the one remedy word this command prints and is the assertion these
+    lines have not earned.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+
+    sole = store.add_source("sources/sole.pdf", kind="binary")
+    rel = _write_artifact(tmp_path, sole, "sole", "")
+    store.add_source_artifact(
+        source_id=sole, kind="extracted_text", path=rel, checksum="sole",
+    )
+    (tmp_path / rel).unlink()
+
+    half = store.add_source("sources/half.pdf", kind="binary")
+    old_rel = _write_artifact(tmp_path, half, "old", _DIRTY)
+    store.add_source_artifact(
+        source_id=half, kind="extracted_text", path=old_rel, checksum="half-old",
+    )
+    new_rel = _write_artifact(tmp_path, half, "new", "")
+    newer = store.add_source_artifact(
+        source_id=half, kind="extracted_text", path=new_rel, checksum="half-new",
+    )
+    (tmp_path / new_rel).unlink()
+
+    scan = store.scan_unreadable_text()
+    store.close()
+    by_path = {s.path: s for s in scan.sources}
+    latest = [a for a in by_path["sources/half.pdf"].artifacts if a.is_latest]
+    assert [(a.artifact_id, a.status) for a in latest] == [(newer, "file_missing")], (
+        "the fixture's unread artifact is not the latest row, so it cannot "
+        "undermine the verdict and this test would prove nothing"
+    )
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    for path in ("sources/sole.pdf", "sources/half.pdf"):
+        line = _source_line(out, path)
+        assert line.startswith(
+            f"{path}: could not tell whether unreadable characters are still stored — "
+        )
+        assert "no unreadable characters still stored" not in line
+        assert "no re-upload is called for" not in line
+        assert "in superseded rows only" not in line
+        # The caveat still names the row that could not be read.
+        assert "could not scan 1 artifact(s)" in line
+
+
+def test_an_unreadable_superseded_artifact_does_not_cloud_a_clean_latest_one(
+    tmp_path, monkeypatch, capsys
+):
+    """The `unknown` verdict is scoped to the LATEST artifact, and that matters.
+
+    Superseded artifact files going missing is the ordinary state of a KB that
+    has been re-uploaded, so a verdict that fired on any unreadable artifact
+    would make "could not tell" the common answer and the command noise. The
+    latest row is the one re-analysis reads (`latest_source_text_artifact` takes
+    MAX(id)), and the scan read it, so this source's absence of findings is one
+    the scan actually established.
+
+    `test_an_unread_latest_artifact_is_not_reported_as_an_absence` covers the
+    other direction. Neither can stand in for this one: both of its fixtures
+    make the unreadable artifact the latest row, so dropping the `is_latest`
+    qualifier leaves them green.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/reuploaded.pdf", kind="binary")
+    gone_rel = _write_artifact(tmp_path, source_id, "old", "stale")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=gone_rel, checksum="old",
+    )
+    (tmp_path / gone_rel).unlink()
+    latest_rel = _write_artifact(tmp_path, source_id, "new", "clean text")
+    latest = store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=latest_rel, checksum="new",
+    )
+
+    scan = store.scan_unreadable_text()
+    store.close()
+    by_id = {a.artifact_id: a for a in _only_source(scan).artifacts}
+    assert by_id[latest].is_latest is True and by_id[latest].status == "clean", (
+        "the readable artifact is not the latest row, so this fixture cannot "
+        "separate the scoped clause from the broad one"
+    )
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    line = _source_line(capsys.readouterr().out, "sources/reuploaded.pdf")
+    assert line.startswith(
+        "sources/reuploaded.pdf: no unreadable characters still stored — "
+    )
+    assert "could not tell" not in line
+
+
+def test_a_live_finding_outranks_an_unread_latest_artifact(
+    tmp_path, monkeypatch, capsys
+):
+    """Not knowing about one store must not withhold what the other store said.
+
+    `_source_scan_verdict` puts the live-chunk clause above the unknown-artifact
+    clause deliberately. Reversed, this source — whose latest artifact could not
+    be read AND whose newest job holds a chunk with NULs the scan did read —
+    would report "could not tell" and drop a finding it is certain of.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/both.pdf", kind="binary")
+    gone_rel = _write_artifact(tmp_path, source_id, "gone", "stale")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=gone_rel, checksum="gone",
+    )
+    (tmp_path / gone_rel).unlink()
+    job_id = store.create_extraction_job(
+        source_id=source_id, artifact_id=None, provider=None, model=None,
+        total_chunks=1, message="",
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=[_DIRTY])
+
+    scan = store.scan_unreadable_text()
+    store.close()
+    source = _only_source(scan)
+    assert [a.status for a in source.artifacts] == ["file_missing"]
+    assert [c.is_latest_job for c in source.chunks] == [True], (
+        "the chunk is not on the latest job, so this fixture cannot separate "
+        "the two clauses' order"
+    )
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    line = _source_line(capsys.readouterr().out, "sources/both.pdf")
+    assert line.startswith("sources/both.pdf: unreadable characters still stored — ")
+    assert f"chunks: {_DIRTY_NULS} in 1 chunk(s) of the latest job" in line
+    assert "could not tell" not in line
+
+
+def test_recorded_prints_beside_a_finding_under_the_unknown_headline(
+    tmp_path, monkeypatch, capsys
+):
+    """"measured 0" stays distinguishable from "never measured" on every line
+    that reports a finding — not only on the ones whose headline is `current`.
+
+    Keying the suppression on the verdict name instead of on finding-ness
+    silently dropped this clause when the fourth verdict arrived. The source
+    below carries a real finding (a dirty superseded artifact) under the
+    `unknown` headline, and both of its rows recorded 0, so without the number
+    the line is byte-identical to the same source with `unreadable_chars` NULL.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/measured.pdf", kind="binary")
+    dirty_rel = _write_artifact(tmp_path, source_id, "dirty", _DIRTY)
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=dirty_rel,
+        checksum="dirty", unreadable_chars=0,
+    )
+    gone_rel = _write_artifact(tmp_path, source_id, "gone", "stale")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=gone_rel,
+        checksum="gone", unreadable_chars=0,
+    )
+    (tmp_path / gone_rel).unlink()
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    line = _source_line(capsys.readouterr().out, "sources/measured.pdf")
+    assert line.startswith(
+        "sources/measured.pdf: could not tell whether unreadable characters are "
+        "still stored — "
+    )
+    assert f"artifacts: {_DIRTY_NULS} in 1 superseded of 2 artifact row(s)" in line
+    assert "extraction recorded 0 replaced at ingest" in line
+
+
+def test_a_line_with_no_finding_stays_quiet_about_a_measured_zero(
+    tmp_path, monkeypatch, capsys
+):
+    """A measured, lossless source has nothing to report, and reports nothing.
+
+    Asserted as whole lines. A substring assertion cannot see this property at
+    all: `"...no unreadable characters still stored" in out` is satisfied just as
+    well by a line that goes on to say "— extraction recorded 0 replaced at
+    ingest", so it leaves "stays quiet" untested.
+
+    Both findingless headlines are here, because the suppression covers both and
+    a rule keyed on one of them would leave the other chattering.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+
+    clean_id = store.add_source("sources/clean.pdf", kind="binary")
+    clean_rel = _write_artifact(tmp_path, clean_id, "clean", "clean text")
+    store.add_source_artifact(
+        source_id=clean_id, kind="extracted_text", path=clean_rel,
+        checksum="clean", unreadable_chars=0,
+    )
+
+    unread_id = store.add_source("sources/unread.pdf", kind="binary")
+    unread_rel = _write_artifact(tmp_path, unread_id, "unread", "stale")
+    store.add_source_artifact(
+        source_id=unread_id, kind="extracted_text", path=unread_rel,
+        checksum="unread", unreadable_chars=0,
+    )
+    (tmp_path / unread_rel).unlink()
+    store.close()
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert (
+        _source_line(out, "sources/clean.pdf")
+        == "sources/clean.pdf: no unreadable characters still stored"
+    )
+    assert _source_line(out, "sources/unread.pdf") == (
+        "sources/unread.pdf: could not tell whether unreadable characters are "
+        f"still stored — could not scan 1 artifact(s) — file_missing: {unread_rel}"
+    )
+
+
+def test_the_summary_counts_the_sources_the_scan_could_not_answer_for(
+    tmp_path, monkeypatch, capsys
+):
+    """Every verdict gets a bucket, so `unknown` sources can be counted.
+
+    Without one, an `unknown` source shows up only under "have an artifact that
+    could not be read" — a different and broader question, which the `current`
+    source below also answers yes to because of its own missing superseded row.
+    One bucket standing for two verdicts cannot be read either way round.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+
+    live = store.add_source("sources/live.pdf", kind="binary")
+    stale_rel = _write_artifact(tmp_path, live, "stale", "stale")
+    store.add_source_artifact(
+        source_id=live, kind="extracted_text", path=stale_rel, checksum="stale",
+    )
+    (tmp_path / stale_rel).unlink()
+    dirty_rel = _write_artifact(tmp_path, live, "dirty", _DIRTY)
+    store.add_source_artifact(
+        source_id=live, kind="extracted_text", path=dirty_rel, checksum="dirty",
+    )
+
+    unread = store.add_source("sources/unread.pdf", kind="binary")
+    gone_rel = _write_artifact(tmp_path, unread, "gone", "stale")
+    store.add_source_artifact(
+        source_id=unread, kind="extracted_text", path=gone_rel, checksum="gone",
+    )
+    (tmp_path / gone_rel).unlink()
+    store.close()
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert _source_line(out, "sources/live.pdf").startswith(
+        "sources/live.pdf: unreadable characters still stored — "
+    )
+    assert _source_line(out, "sources/unread.pdf").startswith(
+        "sources/unread.pdf: could not tell "
+    )
+    assert "1 with unreadable characters in current rows" in out
+    assert "1 whose latest stored text could not be read" in out
+    # The broader question still has its own count, still names both sources,
+    # and is still marked off from the verdict buckets. Asserted as the whole
+    # clause: `"2 source(s) had ..."` alone survives deleting `separately,`,
+    # which is the word saying this number is not part of the list before it.
+    assert "; separately, 2 source(s) had an artifact that could not be read" in out
+
+
+def test_a_kb_with_no_source_artifacts_table_is_named_not_called_clean(
+    tmp_path, monkeypatch, capsys
+):
+    """A KB predating `source_artifacts` scans zero artifacts and says so.
+
+    `_KB_CORE_TABLES`' comment records that `source_artifacts` arrived by
+    migration, so this KB passes `_require_existing_kb` — asserted below. The
+    probe is what keeps `SELECT ... FROM source_artifacts` from raising, and
+    nothing else in this file drops that table, so without this test the probe
+    can be replaced by `True` and stay green.
+    """
+    _env(monkeypatch, tmp_path)
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.executescript(
+        _UNMIGRATED_SCHEMA[: _UNMIGRATED_SCHEMA.index("CREATE TABLE source_artifacts")]
+    )
+    conn.execute("INSERT INTO sources(path, kind) VALUES('sources/old.txt', 'text')")
+    conn.commit()
+    conn.close()
+    assert cli._kb_schema_problem(tmp_path / "kb.sqlite") is None
+
+    store = Store(tmp_path / "kb.sqlite")
+    scan = store.scan_unreadable_text()
+    store.close()
+    assert scan.artifacts_table_present is False
+    assert scan.artifacts_scanned == 0
+    assert _only_source(scan).status == "no_stored_text"
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "no source_artifacts table" in out
+    assert "scanned 0 extraction-text artifact(s)" in out
+
+
+def test_recorded_prints_beside_a_chunk_only_finding(tmp_path, monkeypatch, capsys):
+    """A finding in the chunk store keeps the recorded number on the line too.
+
+    `_recorded_clause` asks whether the LINE reports a finding, and a line can
+    report one from either store. This source's artifact is clean and measured
+    0, and its finding is a dirty chunk in the latest job — so with only the
+    artifact half of that question the clause disappears and the line stops
+    distinguishing "measured 0" from "never measured", which is the property
+    the docstring names.
+
+    `test_recorded_prints_beside_a_finding_under_the_unknown_headline` covers
+    the artifact half; neither can stand in for the other, because each is the
+    other's deleted disjunct.
+    """
+    _env(monkeypatch, tmp_path)
+    store = _store(tmp_path)
+    source_id = store.add_source("sources/chunky.pdf", kind="binary")
+    rel = _write_artifact(tmp_path, source_id, "clean", "clean text")
+    store.add_source_artifact(
+        source_id=source_id, kind="extracted_text", path=rel,
+        checksum="clean", unreadable_chars=0,
+    )
+    job_id = store.create_extraction_job(
+        source_id=source_id, artifact_id=None, provider=None, model=None,
+        total_chunks=1, message="",
+    )
+    store.add_source_chunks(job_id=job_id, source_id=source_id, chunks=[_DIRTY])
+
+    scan = store.scan_unreadable_text()
+    store.close()
+    source = _only_source(scan)
+    assert [a.status for a in source.artifacts] == ["clean"], (
+        "an artifact finding would let the artifact disjunct carry this test "
+        "on its own, and the chunk disjunct would go unpinned again"
+    )
+    assert [c.nuls for c in source.chunks] == [_DIRTY_NULS]
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    line = _source_line(capsys.readouterr().out, "sources/chunky.pdf")
+    assert "extraction recorded 0 replaced at ingest" in line
+
+
+def test_only_extraction_text_artifacts_are_scanned(tmp_path, monkeypatch, capsys):
+    """The scan reads extraction text, not every row in `source_artifacts`.
+
+    `latest_source_text_artifact` and `source_text_inputs` both filter to
+    `original_text`/`extracted_text`, so the scan filtering the same way is what
+    keeps `is_latest` naming the row those two would actually return. The report
+    also calls what it counted "extraction-text artifact(s)". The filter is
+    forward cover: if the CHECK is ever widened, a new kind must not silently
+    start being opened as text.
+
+    NO REAL KB CAN HOLD A THIRD KIND, so what this test rests on is a divergence
+    between `_UNMIGRATED_SCHEMA` and any KB verinote has ever written: the
+    missing CHECK on `kind`, an artefact of hand-rolling. The missing
+    `unreadable_chars` column is NOT one of those — a real pre-#473 KB lacks it
+    too, which is exactly what that fixture exists to reproduce.
+
+    Do not read the fixture as faithful apart from that. It is a hand-rolled
+    minimum shaped to satisfy `_require_existing_kb`, and it diverges from the
+    real schema in tables, columns and constraints this test never touches.
+    `init_schema()` neither leaves it alone nor cleanly refuses it: measured on
+    this fixture, it creates tables and adds `unreadable_chars`, and only then
+    raises, on an index over a column the hand-rolled `facts` lacks.
+
+    `test_scan_writes_nothing[True]` does catch an accidental `init_schema()`
+    here, but by the RAISE rather than by its snapshot -- the raise escapes, or
+    the command's floor turns it into a non-zero return code, and either way
+    `assert cli.main(...) == 0` trips one line before the snapshot is compared.
+    Measured both ways round: suppress the raise and the snapshot does catch the
+    landed migration; raise the same error before any write and the test still
+    fails. So the ordering above is described, not pinned -- were
+    `init_schema()` ever to become inert on this fixture, that mutant would
+    return 0 with an identical snapshot and the test would go quietly green.
+
+    Both creation paths have always carried the constraint: `schema.sql` since
+    `source_artifacts` was introduced in `2bb1aa4` ("Add source text
+    artifacts"), and `_ensure_schema_migrations`' own CREATE — the path an
+    existing KB goes through — in every form it has had. `schema.sql` is
+    `CREATE TABLE IF NOT EXISTS`, so no migration could have left an older KB a
+    CHECK-free copy either, and `add_source_artifact(kind="sidecar")` on a real
+    KB raises `CHECK constraint failed`.
+
+    So this pins a contract, not a reachable state, the way
+    `test_chunk_recency_is_unknown_without_an_extraction_jobs_table` does.
+
+    `test_legacy_original_text_artifact_is_scanned` pins the filter's other
+    edge, that it must not narrow to `extracted_text` alone.
+    """
+    _env(monkeypatch, tmp_path)
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.executescript(_UNMIGRATED_SCHEMA)
+    conn.execute("INSERT INTO sources(path, kind) VALUES('sources/mixed.pdf', 'binary')")
+    source_id = int(conn.execute("SELECT id FROM sources").fetchone()[0])
+    text_rel = _write_artifact(tmp_path, source_id, "text", _DIRTY)
+    other_rel = _write_artifact(tmp_path, source_id, "other", _DIRTY)
+    conn.executemany(
+        "INSERT INTO source_artifacts(source_id, kind, path, checksum) VALUES(?,?,?,?)",
+        [(source_id, "extracted_text", text_rel, "t"), (source_id, "sidecar", other_rel, "o")],
+    )
+    conn.commit()
+    conn.close()
+
+    store = Store(tmp_path / "kb.sqlite")
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    source = _only_source(scan)
+    assert [a.path for a in source.artifacts] == [text_rel], (
+        "the non-extraction-text row was scanned, so the scan is reading rows "
+        "no extraction path would ever read as text"
+    )
+    assert scan.artifacts_scanned == 1
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    # No assertion that the sidecar PATH is absent: paths reach stdout from one
+    # place, the `could not scan` detail, and only for a row that failed to be
+    # read. This sidecar file is readable, so under the mutation this test
+    # guards it is scanned as `found` and its path is never printed either way.
+    assert "scanned 1 extraction-text artifact(s)" in out
+
+
+# --- the unmigrated KB, which is the population #494 exists for ------------
+
+
+def test_scan_finds_nuls_on_unmigrated_kb(tmp_path, monkeypatch, capsys):
+    """The acceptance property: a KB written before #473 is found and reported.
+
+    Such a KB has no `unreadable_chars` column and no `source_chunks` table, and
+    it passes `_require_existing_kb` — asserted below, because a fixture that
+    could not get past the refusal would prove nothing. Selecting the column
+    unconditionally raises `no such column`; querying the table raises `no such
+    table`. Either way the one command written for these users would answer with
+    a traceback.
+    """
+    _env(monkeypatch, tmp_path)
+    _unmigrated_kb(tmp_path)
+    assert cli._kb_schema_problem(tmp_path / "kb.sqlite") is None, (
+        "this fixture does not pass _require_existing_kb, so it is not the "
+        "reachable state the test claims to cover"
+    )
+
+    store = Store(tmp_path / "kb.sqlite")
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    assert scan.artifacts_table_present is True
+    assert scan.chunks_table_present is False
+    assert scan.unreadable_chars_column_present is False
+    artifact = _only_source(scan).artifacts[0]
+    assert (artifact.status, artifact.nuls, artifact.recorded) == (
+        "found", _DIRTY_NULS, None,
+    )
+    assert scan.chunks_scanned == 0
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    out = capsys.readouterr().out
+    assert "no source_chunks table" in out
+    assert "predates the unreadable_chars column" in out
+    assert "artifacts: 2 in the latest of 1 artifact row(s)" in out
+
+
+@pytest.mark.parametrize("unmigrated", [False, True])
+def test_scan_writes_nothing(tmp_path, monkeypatch, unmigrated):
+    """Nothing on disk or in the KB differs after a scan, on either schema.
+
+    Both fixtures, because each pins a half the other cannot. On the unmigrated
+    KB an accidental `init_schema()` shows up in `sqlite_master` and in
+    `table_info`, and a write-back of the count cannot even be attempted
+    because the column does not exist. On the migrated KB `init_schema()` is a
+    no-op over both snapshots (it only ever adds what is already there), but a
+    write-back succeeds silently and the data snapshot is the only thing that
+    catches it. Measured on this tree: an accidental `init_schema()` in the
+    command leaves the migrated parameter green and reddens the unmigrated one;
+    a write-back reddens both, and only the migrated one by the snapshot.
+
+    Driven through `cli.main` and not only through the method, because the two
+    ways this command could write are in different files: the method's SQL, and
+    an `init_schema()` on the Store the command opens.
+    """
+    _env(monkeypatch, tmp_path)
+    if unmigrated:
+        _unmigrated_kb(tmp_path)
+    else:
+        store = _store(tmp_path)
+        _legacy_source(store, tmp_path, name="legacy", text=_DIRTY)
+        store.close()
+
+    def snapshot():
+        conn = sqlite3.connect(tmp_path / "kb.sqlite")
+        conn.row_factory = sqlite3.Row
+        state = {
+            "master": [tuple(r) for r in conn.execute(
+                "SELECT type, name, sql FROM sqlite_master ORDER BY type, name"
+            )],
+            "artifact_columns": [
+                r["name"] for r in conn.execute("PRAGMA table_info(source_artifacts)")
+            ],
+        }
+        if "unreadable_chars" in state["artifact_columns"]:
+            state["recorded"] = [tuple(r) for r in conn.execute(
+                "SELECT id, unreadable_chars FROM source_artifacts ORDER BY id"
+            )]
+        if conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='source_chunks'"
+        ).fetchone():
+            state["chunks"] = [tuple(r) for r in conn.execute(
+                "SELECT id, text FROM source_chunks ORDER BY id"
+            )]
+        conn.close()
+        state["files"] = sorted(
+            (str(p.relative_to(tmp_path)), p.read_bytes())
+            for p in (tmp_path / "artifacts").rglob("*") if p.is_file()
+        )
+        return state
+
+    before = snapshot()
+    store = Store(tmp_path / "kb.sqlite")
+    scan = store.scan_unreadable_text()
+    store.close()
+
+    assert any(a.status == "found" for s in scan.sources for a in s.artifacts), (
+        "the scan found nothing, so a write-back mutant would have nothing to write"
+    )
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    assert snapshot() == before
+
+
+# --- the command's floors --------------------------------------------------
+
+
+def test_scan_unreadable_runs_on_halted_kb(tmp_path, monkeypatch, capsys):
+    """A halt the user cannot diagnose is a bricked KB.
+
+    `_refuse_on_halted_kb` opens a Store and calls `init_schema()` on it, so a
+    non-`halt_safe` spelling would migrate the KB before this read-only scan of
+    it ran.
+    """
+    _env(monkeypatch, tmp_path)
+    assert cli.main(["init"]) == 0
+    (tmp_path / POLICY_RELPATH).unlink()
+    capsys.readouterr()
+
+    assert cli.main(["sources", "scan-unreadable"]) == 0
+    assert "extraction-text artifact(s)" in capsys.readouterr().out
+
+
+def test_scan_unreadable_refuses_missing_kb(tmp_path, monkeypatch, capsys):
+    """A mistyped root must not be scaffolded into a KB that then reports clean."""
+    _env(monkeypatch, tmp_path)
+
+    assert cli.main(["sources", "scan-unreadable"]) == 1
+    assert "no KB at" in capsys.readouterr().err
+    assert not (tmp_path / "kb.sqlite").exists()
+
+
+def test_unreadable_scan_reports_an_unreadable_kb(tmp_path, monkeypatch, capsys):
+    """A KB that gets past `_require_existing_kb` and fails deeper in.
+
+    `source_artifacts` here has no `kind` column — a shape the probes do not
+    cover, standing in for the next column someone forgets. The floor is what
+    turns it into a diagnosis instead of a traceback.
+    """
+    _env(monkeypatch, tmp_path)
+    conn = sqlite3.connect(tmp_path / "kb.sqlite")
+    conn.executescript(_UNMIGRATED_SCHEMA.replace("kind TEXT NOT NULL,\n", "", 1))
+    conn.commit()
+    conn.close()
+    assert cli._kb_schema_problem(tmp_path / "kb.sqlite") is None
+    assert "kind" not in {
+        row[1]
+        for row in sqlite3.connect(tmp_path / "kb.sqlite").execute(
+            "PRAGMA table_info(source_artifacts)"
+        )
+    }
+
+    assert cli.main(["sources", "scan-unreadable"]) == 1
+    assert "cannot read the KB at" in capsys.readouterr().err

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1280,6 +1280,292 @@ def cmd_sources_repair_identities(cfg: Config, args: argparse.Namespace) -> int:
         store.close()
 
 
+def cmd_sources_scan_unreadable(cfg: Config, args: argparse.Namespace) -> int:
+    """Report the NULs still stored in extraction artifacts and chunks (#494).
+
+    Reports; it does not repair. Nothing is rewritten, re-chunked or recorded --
+    the KBs this is for predate #473's sanitizer, and telling their owner what
+    is there is the whole job.
+    """
+    refusal = _require_existing_kb(cfg)
+    if refusal is not None:
+        return refusal
+    # `Store(...)` without `init_schema()`, like `cmd_sources_repair_identities`
+    # in its dry-run mode. Migrating here would ALTER in the very
+    # `unreadable_chars` column `scan_unreadable_text` is built to work without,
+    # so the command written for unmigrated KBs would be the one that migrates
+    # them.
+    store = Store(cfg.db_path)
+    try:
+        return _scan_unreadable(store)
+    except (sqlite3.DatabaseError, TypeError, ValueError) as exc:
+        # `cmd_coverage`'s floor. `scan_unreadable_text`'s probes answer the
+        # schema drift we know about; this answers the next column someone
+        # forgets, because per `_unusable_kb` a command whose whole job is to
+        # report on a KB must not answer with a traceback.
+        return _unusable_kb(cfg, exc)
+    finally:
+        store.close()
+
+
+def _scan_unreadable(store: Store) -> int:
+    scan = store.scan_unreadable_text()
+    for note in _scan_schema_notes(scan):
+        print(note)
+
+    current = superseded = unknown = unscannable = unscanned = 0
+    for source in scan.sources:
+        if source.status == "no_stored_text":
+            unscanned += 1
+            print(f"{source.path}: no stored extraction text — not scanned")
+            continue
+        verdict = _source_scan_verdict(source)
+        if verdict == "current":
+            current += 1
+        elif verdict == "superseded":
+            superseded += 1
+        elif verdict == "unknown":
+            unknown += 1
+        if _unscannable_artifacts(source):
+            unscannable += 1
+        print(_source_scan_line(source, verdict))
+
+    # `unknown` has a bucket of its own so a reader can count the sources the
+    # scan could not answer for instead of inferring them. `clean` has none: it
+    # is the residue, and a bucket for it would imply these add up.
+    #
+    # THEY ARE NOT BUILT AS A PARTITION, deliberately, and need not add up to
+    # the source count. `current`, `superseded` and `unknown` are verdicts from
+    # `_source_scan_verdict`;
+    # `unscanned` is not a verdict at all, but the `no_stored_text` branch
+    # above, which `continue`s before a verdict is asked for; and `unscannable`
+    # answers a different question -- did ANY artifact of this source fail to be
+    # read -- so a `current` source with one bad superseded row is counted under
+    # it as well. No clause claims a total, and making them partition would mean
+    # dropping either a verdict or the caveat.
+    #
+    # The artifact and chunk totals stay apart for the reason
+    # `scan_unreadable_text` refuses to add them: a NUL inside a chunk overlap
+    # window is stored twice, so their sum counts a set with no meaning.
+    #
+    # `fact_evidence.snippet` is out of scope and can hold NULs copied from a
+    # chunk, so the first clause names what was looked at rather than letting a
+    # clean result read as "this KB holds no NULs anywhere".
+    print(
+        f"scanned {scan.artifacts_scanned} extraction-text artifact(s) and "
+        f"{scan.chunks_scanned} analysis chunk(s) across {len(scan.sources)} "
+        f"source(s): {current} with unreadable characters in current rows, "
+        f"{superseded} in superseded rows only, {unknown} whose latest stored "
+        f"text could not be read, {unscanned} with no stored text; "
+        f"separately, {unscannable} source(s) had an artifact that could not be read"
+    )
+    return 0
+
+
+def _scan_schema_notes(scan) -> list[str]:
+    """KB-level facts about what was there to scan. Said once, about the KB."""
+    notes = []
+    if not scan.artifacts_table_present:
+        notes.append(
+            "this KB has no source_artifacts table, so no extraction-text "
+            "artifact was scanned"
+        )
+    if not scan.chunks_table_present:
+        notes.append(
+            "this KB has no source_chunks table, so no analysis chunk was scanned"
+        )
+    if scan.artifacts_table_present and not scan.unreadable_chars_column_present:
+        notes.append(
+            "this KB predates the unreadable_chars column, so no extraction "
+            "here ever measured what it could not read"
+        )
+    if scan.chunks_table_present and not scan.jobs_table_present:
+        notes.append(
+            "this KB has no extraction_jobs table, so a chunk finding cannot be "
+            "told apart from one in a superseded job"
+        )
+    return notes
+
+
+def _unscannable_artifacts(source) -> list:
+    return [a for a in source.artifacts if a.status not in {"clean", "found"}]
+
+
+def _source_scan_verdict(source) -> str:
+    """`current`, `unknown`, `superseded` or `clean` for one scanned source.
+
+    A verdict picks a headline in `_source_scan_line` and increments a summary
+    bucket in `_scan_unreadable`. A fifth verdict has to be given both, and the
+    two go wrong differently. Miss the bucket and it prints uncounted -- the trap
+    `clean` sits in on purpose, for the reason the comment beside those buckets
+    gives. Miss the HEADLINE and it falls to that function's `else`, which is
+    the clean one, so the line denies the findings printed beside it on the same
+    line.
+
+    That second one is caught only where some headline assertion tells the new
+    verdict's headline apart from `clean`'s. Measured: a fifth verdict for the
+    underivable-job-recency case, bucket wired and headline forgotten, reddens
+    `test_unknown_chunk_recency_is_not_reported_as_reassurance` and prints the
+    offending line in the failure.
+
+    A carve-out from `clean` escapes that however well tested `clean` is,
+    because the `else` prints `clean`'s own headline -- the new verdict and
+    `clean` are then indistinguishable by construction, not by coverage.
+    Measured too: `return "clean"` -> `return "pristine"` leaves the suite
+    unchanged. `clean` is the residue, which makes it the likeliest donor for a
+    fifth verdict and the one to be most careful with. A carve-out from a state
+    no test exercises escapes it as well. Write the headline with the branch.
+
+    Neither consumer asks the user to do anything: these lines report what the
+    scan found, and even the `superseded` headline's mention of re-upload is
+    there to say it is not called for. So what a verdict is chosen for is
+    whether its headline would be TRUE of the source -- not what it would tell
+    anyone to do.
+
+    `current` means at least one finding sits where something will read it
+    again -- the latest text artifact, or a chunk of the newest job. Its
+    headline asserts that unreadable characters are still stored, so it is
+    reached only from a finding the scan actually made; reached any other way it
+    would report one that does not exist.
+
+    Two different things can be unknown, and they do not get the same answer.
+    When a chunk's job recency could not be derived, the NULs are still stored
+    -- the scan read them -- and only their liveness is in doubt, so the verdict
+    is `current`: its headline is true either way, and what the source must not
+    get is the superseded headline's reassurance about a job nothing identified.
+    When the LATEST artifact's file could not be read, it is the finding itself
+    that is unknown, and then an absence and a presence would both be asserting
+    something about a file nobody opened. `unknown` asserts neither.
+    `_scan_artifact_file` names the first half of that rule -- "we could not
+    look" must never round down to "there is nothing there" -- and `current` is
+    what it must not round up to.
+
+    `superseded` therefore needs a finding the scan DID read, on a row nothing
+    will read again, and `clean` needs a scan that read everything it needed to.
+    """
+    if any(a.status == "found" and a.is_latest for a in source.artifacts):
+        return "current"
+    if any(c.is_latest_job is not False for c in source.chunks):
+        return "current"
+    if any(a.is_latest and a.status not in {"clean", "found"} for a in source.artifacts):
+        return "unknown"
+    if any(a.status == "found" for a in source.artifacts):
+        return "superseded"
+    if source.chunks:
+        return "superseded"
+    return "clean"
+
+
+def _source_scan_line(source, verdict: str) -> str:
+    segments = []
+    artifact_segment = _artifact_scan_segment(source)
+    if artifact_segment:
+        segments.append(artifact_segment)
+    chunk_segment = _chunk_scan_segment(source)
+    if chunk_segment:
+        segments.append(chunk_segment)
+    unscannable = _unscannable_artifacts(source)
+    if unscannable:
+        detail = ", ".join(f"{a.status}: {a.path}" for a in unscannable)
+        segments.append(f"could not scan {len(unscannable)} artifact(s) — {detail}")
+    recorded = _recorded_clause(source)
+    if recorded:
+        segments.append(recorded)
+
+    if verdict == "current":
+        headline = "unreadable characters still stored"
+    elif verdict == "unknown":
+        headline = "could not tell whether unreadable characters are still stored"
+    elif verdict == "superseded":
+        headline = (
+            "unreadable characters in superseded rows only — nothing re-analysis "
+            "will read again, so no re-upload is called for"
+        )
+    else:
+        headline = "no unreadable characters still stored"
+    if not segments:
+        return f"{source.path}: {headline}"
+    return f"{source.path}: {headline} — " + "; ".join(segments)
+
+
+def _artifact_scan_segment(source) -> str | None:
+    found = [a for a in source.artifacts if a.status == "found"]
+    if not found:
+        return None
+    latest = [a for a in found if a.is_latest]
+    superseded = [a for a in found if not a.is_latest]
+    bits = []
+    if latest:
+        bits.append(
+            f"{sum(a.nuls for a in latest)} in the latest of "
+            f"{len(source.artifacts)} artifact row(s)"
+        )
+    if superseded:
+        bits.append(
+            f"{sum(a.nuls for a in superseded)} in {len(superseded)} superseded "
+            f"of {len(source.artifacts)} artifact row(s)"
+        )
+    return "artifacts: " + "; ".join(bits)
+
+
+def _chunk_scan_segment(source) -> str | None:
+    if not source.chunks:
+        return None
+    live = [c for c in source.chunks if c.is_latest_job is True]
+    superseded = [c for c in source.chunks if c.is_latest_job is False]
+    unknown = [c for c in source.chunks if c.is_latest_job is None]
+    bits = []
+    if live:
+        bits.append(
+            f"{sum(c.nuls for c in live)} in {len(live)} chunk(s) of the latest job"
+        )
+    if superseded:
+        bits.append(
+            f"{sum(c.nuls for c in superseded)} in {len(superseded)} chunk(s) of "
+            "a superseded job"
+        )
+    if unknown:
+        bits.append(
+            f"{sum(c.nuls for c in unknown)} in {len(unknown)} chunk(s) whose job "
+            "recency is unknown"
+        )
+    return (
+        "chunks: " + "; ".join(bits) + f" (of {source.chunks_scanned} chunk(s) scanned)"
+    )
+
+
+def _recorded_clause(source) -> str | None:
+    """What ingest said it replaced, kept apart from what the scan found.
+
+    Two different sentences share the word "unreadable": ingest's
+    `unreadable_chars` counts characters it REPLACED with U+FFFD, and this scan
+    counts NULs STILL STORED. A source whose extraction replaced 71 and stores
+    none reads as a bare "no unreadable characters still stored", which the
+    reader cannot help but over-read as "this PDF lost nothing".
+
+    Whether the clause prints turns on whether the LINE reports a finding, not
+    on which headline the line got. Beside a finding the row's number always
+    prints, 0 included, so "measured 0" stays distinguishable from "never
+    measured". Keying this on the verdict name instead is a bug that hides until
+    someone adds a verdict, because the new one inherits silence it was never
+    considered for -- which is what happened when `unknown` was added and a line
+    reporting superseded NULs quietly lost its recorded number.
+
+    With no finding to sit beside, the clause prints only when the extraction
+    actually replaced something. A measured, lossless source stays quiet: it has
+    nothing to report.
+    """
+    values = [a.recorded for a in source.artifacts if a.recorded is not None]
+    if not values:
+        return None
+    reports_a_finding = any(a.status == "found" for a in source.artifacts) or bool(
+        source.chunks
+    )
+    if not reports_a_finding and not any(values):
+        return None
+    return f"extraction recorded {sum(values)} replaced at ingest"
+
+
 def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     from verinote.llm import LLMError, get_client
     from verinote.pipeline import translate_questions, write_query_file
@@ -1792,6 +2078,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="confirm repair of groups whose paths are samefile-verified",
     )
     repair_identities.set_defaults(func=cmd_sources_repair_identities, halt_safe=False)
+
+    scan_unreadable = sources_sub.add_parser(
+        "scan-unreadable",
+        parents=[root_option],
+        help="report NUL characters still stored in extraction artifacts and analysis chunks",
+    )
+    # Static, not the dynamic clause `repair-identities` needs in `main`: that
+    # clause exists because one parser hosts both a dry run and a write, and this
+    # command has no write mode to condition on. The reason the flag matters at
+    # all is `_refuse_on_halted_kb`, which opens a Store and calls
+    # `init_schema()` on it -- so `halt_safe=False` would migrate the KB before
+    # a read-only scan of it ran, and the unmigrated KB is exactly the one this
+    # command exists for. The flag also skips `_refuse_on_corrupt_config`, which
+    # `main` runs first: harmless here, since the scan resolves no provider and
+    # reads no credentials, so #269's "a corrupt config must not silently
+    # resolve to the cloud default" has nothing to bite on.
+    scan_unreadable.set_defaults(func=cmd_sources_scan_unreadable, halt_safe=True)
 
     query = sub.add_parser(
         "query", parents=[root_option], help="translate pending NL questions to Datalog queries"

--- a/verinote/pipeline/ingest.py
+++ b/verinote/pipeline/ingest.py
@@ -94,6 +94,25 @@ class SanitizedText:
     unreadable_chars: int
 
 
+def count_nuls(text: str) -> int:
+    """How many NULs `text` holds -- the one definition of "unreadable character".
+
+    Only NUL. Not the other control characters -- `\\x0c` in particular is
+    pdftotext's ordinary page separator, and widening this would delete
+    structure nobody reported as broken. That paragraph used to sit on
+    `sanitize_extracted_text`; it decides *what counts*, so it belongs wherever
+    the counting is done.
+
+    Callers with opposite jobs share it: `sanitize_extracted_text` replaces what
+    it counts as text enters the KB, while the #494 scan
+    (`Store.scan_unreadable_text` and its `_scan_artifact_file` helper) only
+    counts what is already stored. Sharing the definition is the point -- a scan
+    that disagreed with the sanitizer about what an unreadable character is
+    would report a problem no re-ingest could clear, or miss one it could.
+    """
+    return text.count("\x00")
+
+
 def sanitize_extracted_text(text: str) -> SanitizedText:
     """Replace NULs the extractor could not map with U+FFFD, and count them.
 
@@ -101,15 +120,15 @@ def sanitize_extracted_text(text: str) -> SanitizedText:
     already contain a legitimate replacement character, and only the NULs are
     this extraction's loss.
 
-    Only NUL. Not the other control characters -- `\\x0c` in particular is
-    pdftotext's ordinary page separator, and widening this would delete
-    structure nobody reported as broken.
+    What counts as unreadable is `count_nuls`'s decision, not this function's.
 
     Called from exactly one place, `store_source`. Sanitizing in two places
     would make two decision points about what may enter the KB, and two such
-    points drift apart quietly -- which is how the NULs got in (#473).
+    points drift apart quietly -- which is how the NULs got in (#473). Counting
+    is not sanitizing: `count_nuls` has a second caller and replaces nothing,
+    so that sentence stays true.
     """
-    return SanitizedText(text.replace("\x00", UNREADABLE_CHAR), text.count("\x00"))
+    return SanitizedText(text.replace("\x00", UNREADABLE_CHAR), count_nuls(text))
 
 
 def ingest_bytes(raw: bytes, filename: str) -> tuple[str, str]:

--- a/verinote/store/db.py
+++ b/verinote/store/db.py
@@ -199,6 +199,69 @@ class SourceIdentityRepairResult:
     groups: tuple[SourceIdentityRepairGroup, ...]
 
 
+@dataclass(frozen=True)
+class UnreadableArtifactScan:
+    """What one stored extraction-text artifact file holds, right now (#494)."""
+
+    artifact_id: int
+    path: str  # as stored, relative to the KB root
+    # clean | found | file_missing | file_unreadable | file_undecodable
+    status: str
+    nuls: int  # 0 unless status == "found"
+    # `source_artifacts.unreadable_chars` verbatim. None means nobody measured,
+    # which covers a NULL value AND a KB whose schema has no such column.
+    recorded: int | None
+    is_latest: bool  # what `latest_source_text_artifact` would return
+
+
+@dataclass(frozen=True)
+class UnreadableChunkScan:
+    """One stored analysis chunk that still holds NULs (#494).
+
+    Clean chunks are not listed; `UnreadableSourceScan.chunks_scanned` is how
+    many rows were read.
+    """
+
+    chunk_id: int
+    job_id: int
+    chunk_index: int
+    nuls: int  # always > 0
+    # Is `job_id` this source's newest job, per `latest_source_job_ids` over the
+    # `extraction_jobs` rows. None when that table is absent, so recency could
+    # not be derived at all -- which is not the same as "superseded".
+    is_latest_job: bool | None
+
+
+@dataclass(frozen=True)
+class UnreadableSourceScan:
+    """One source's findings, or the fact that it had nothing to scan (#494)."""
+
+    source_id: int
+    path: str
+    status: str  # scanned | no_stored_text
+    artifacts: tuple[UnreadableArtifactScan, ...]
+    chunks: tuple[UnreadableChunkScan, ...]
+    chunks_scanned: int  # this source's chunk rows, clean ones included
+
+
+@dataclass(frozen=True)
+class UnreadableTextScan:
+    """A whole KB's stored-NUL scan, plus what of its schema was there to scan.
+
+    The three `*_present` flags are not diagnostics about verinote: a KB written
+    before the table or column existed is the population #494 is about, and the
+    report has to be able to say "not scanned" rather than imply "clean".
+    """
+
+    sources: tuple[UnreadableSourceScan, ...]
+    artifacts_scanned: int
+    chunks_scanned: int
+    artifacts_table_present: bool
+    jobs_table_present: bool
+    chunks_table_present: bool
+    unreadable_chars_column_present: bool
+
+
 REVIEW_PAGE_SIZES = (25, 50, 100)
 DEFAULT_REVIEW_PAGE_SIZE = 50
 DEFAULT_REVIEW_SORT = "newest"
@@ -677,6 +740,209 @@ class Store:
         return self._conn.execute(
             "SELECT * FROM sources WHERE path = ?", (path,)
         ).fetchone()
+
+    def scan_unreadable_text(self) -> UnreadableTextScan:
+        """Report the NULs still stored in artifacts and analysis chunks (#494).
+
+        Read-only in the strong sense: SELECTs and PRAGMAs only, no UPDATE, and
+        no `init_schema()`. That last one is the point rather than tidiness. A
+        KB written before #473 has no `unreadable_chars` column, and
+        `init_schema()` is what ALTERs it in -- so a scan that opened the KB the
+        ordinary way would migrate the very KBs it exists to diagnose, and then
+        report `recorded = 0` rows it had just created. Nothing here records
+        what it finds, either: `unreadable_chars` means "how many characters
+        this extraction replaced", and in a row this scan finds NULs in nothing
+        was replaced.
+
+        Every table is probed through `sqlite_master` first --
+        `source_artifacts`, `extraction_jobs`, `source_chunks` -- and
+        `unreadable_chars` through `PRAGMA table_info`. `cli.py`'s
+        `_KB_CORE_TABLES` comment records that all three tables arrived by
+        migration, so a file can pass `_require_existing_kb` and still lack
+        them. A missing table contributes zero scanned rows and a flag the
+        caller can name in its report, not an `OperationalError`.
+
+        `recorded is None` says nobody measured. It covers a NULL value and a
+        KB with no such column, because those are the same sentence about the
+        row: `schema.sql` gives the column no default precisely so the older
+        rows do not read as clean.
+
+        THE TWO COUNTS ARE NOT SUMMABLE, and this method never adds them.
+        `chunk_text` prepends the previous chunk's tail to each later chunk, so
+        one NUL inside that overlap window is stored twice; `_base_chunks` also
+        re-splits on paragraphs and strips, so chunk text is not a partition of
+        artifact text. Neither total can be derived from the other in either
+        direction, and a headline over both would be a number with no referent.
+
+        `UnicodeDecodeError` is caught per artifact, here, and reported as that
+        one file's `file_undecodable`. It is a `ValueError` and not an
+        `OSError`, so a caller wrapping this in `cmd_coverage`'s
+        `(sqlite3.DatabaseError, TypeError, ValueError)` floor would otherwise
+        turn one unreadable file into a verdict about the whole KB.
+        """
+        # Local because the dependency runs the other way: `verinote.pipeline`
+        # imports `verinote.store` at module level (`extract.py:27`,
+        # `ingest.py:28`), so a module-level import here would be circular.
+        from verinote.pipeline.extract import latest_source_job_ids
+        from verinote.pipeline.ingest import count_nuls
+
+        artifacts_table_present = self._has_table("source_artifacts")
+        jobs_table_present = self._has_table("extraction_jobs")
+        chunks_table_present = self._has_table("source_chunks")
+        column_present = artifacts_table_present and any(
+            str(row["name"]) == "unreadable_chars"
+            for row in self._conn.execute("PRAGMA table_info(source_artifacts)")
+        )
+
+        artifact_rows: dict[int, list[sqlite3.Row]] = {}
+        if artifacts_table_present:
+            columns = "id, source_id, path"
+            if column_present:
+                columns += ", unreadable_chars"
+            for row in self._conn.execute(
+                f"SELECT {columns} FROM source_artifacts "
+                "WHERE kind IN ('original_text','extracted_text') "
+                "ORDER BY source_id, id"
+            ):
+                artifact_rows.setdefault(int(row["source_id"]), []).append(row)
+
+        # Derived from the `extraction_jobs` rows, NOT from MAX(job_id) over the
+        # chunk rows the loop below is already streaming. A job can own no chunk
+        # rows at all -- `create_chunked_extraction_job` finishes one straight
+        # away when the text chunks to nothing -- and then the newest job is
+        # invisible in `source_chunks` while a superseded job's dirty chunks
+        # carry the highest job_id present. The chunk-row reading would call
+        # those chunks live, and the report's remedy is delete-and-re-upload,
+        # which drops confirmed facts. So the shortcut's cost is telling a user
+        # whose current job is clean to destroy human decisions.
+        latest_job_by_source: dict[int, int] = {}
+        if jobs_table_present:
+            latest_job_by_source = latest_source_job_ids(
+                self._conn.execute("SELECT id, source_id FROM extraction_jobs")
+            )
+
+        chunk_findings: dict[int, list[UnreadableChunkScan]] = {}
+        chunks_per_source: dict[int, int] = {}
+        chunks_scanned = 0
+        if chunks_table_present:
+            # Streamed row by row, never fetchall(): a chunk row is atomic, so
+            # there is no partial-count question, and memory stays bounded by
+            # the widest single chunk rather than by the KB.
+            for row in self._conn.execute(
+                "SELECT id, source_id, job_id, chunk_index, text FROM source_chunks "
+                "ORDER BY source_id, job_id, chunk_index"
+            ):
+                chunks_scanned += 1
+                source_id = int(row["source_id"])
+                chunks_per_source[source_id] = chunks_per_source.get(source_id, 0) + 1
+                nuls = count_nuls(str(row["text"]))
+                if not nuls:
+                    continue
+                job_id = int(row["job_id"])
+                chunk_findings.setdefault(source_id, []).append(
+                    UnreadableChunkScan(
+                        chunk_id=int(row["id"]),
+                        job_id=job_id,
+                        chunk_index=int(row["chunk_index"]),
+                        nuls=nuls,
+                        is_latest_job=(
+                            latest_job_by_source.get(source_id) == job_id
+                            if jobs_table_present
+                            else None
+                        ),
+                    )
+                )
+
+        sources: list[UnreadableSourceScan] = []
+        artifacts_scanned = 0
+        for source_row in self._conn.execute("SELECT id, path FROM sources ORDER BY path"):
+            source_id = int(source_row["id"])
+            rows = artifact_rows.get(source_id, [])
+            # MAX(id) over the same two kinds, which is what
+            # `latest_source_text_artifact` and `source_text_inputs` both read.
+            latest_artifact_id = max((int(row["id"]) for row in rows), default=None)
+            artifacts: list[UnreadableArtifactScan] = []
+            for row in rows:
+                artifacts_scanned += 1
+                status, nuls = self._scan_artifact_file(str(row["path"]))
+                recorded = None
+                if column_present and row["unreadable_chars"] is not None:
+                    recorded = int(row["unreadable_chars"])
+                artifacts.append(
+                    UnreadableArtifactScan(
+                        artifact_id=int(row["id"]),
+                        path=str(row["path"]),
+                        status=status,
+                        nuls=nuls,
+                        recorded=recorded,
+                        is_latest=int(row["id"]) == latest_artifact_id,
+                    )
+                )
+            chunks = chunk_findings.get(source_id, [])
+            scanned_here = chunks_per_source.get(source_id, 0)
+            sources.append(
+                UnreadableSourceScan(
+                    source_id=source_id,
+                    path=str(source_row["path"]),
+                    # "no stored text" and "scanned, clean" are different
+                    # answers and the report must not merge them.
+                    status="scanned" if rows or scanned_here else "no_stored_text",
+                    artifacts=tuple(artifacts),
+                    chunks=tuple(chunks),
+                    chunks_scanned=scanned_here,
+                )
+            )
+
+        return UnreadableTextScan(
+            sources=tuple(sources),
+            artifacts_scanned=artifacts_scanned,
+            chunks_scanned=chunks_scanned,
+            artifacts_table_present=artifacts_table_present,
+            jobs_table_present=jobs_table_present,
+            chunks_table_present=chunks_table_present,
+            unreadable_chars_column_present=column_present,
+        )
+
+    def _has_table(self, name: str) -> bool:
+        """Is `name` a table in this KB, per `sqlite_master`.
+
+        The `_source_identity_has_active_job` probe (below) in general form. A
+        read-only diagnosis has to ask before it queries, because the tables it
+        reads all arrived by migration and it must not run the migration.
+        """
+        return (
+            self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (name,),
+            ).fetchone()
+            is not None
+        )
+
+    def _scan_artifact_file(self, path: str) -> tuple[str, int]:
+        """`(status, nuls)` for one stored artifact file. Never raises.
+
+        Read whole, with `Path.read_text`, which is how production already
+        reads these same artifact files, so the scan inherits a memory ceiling
+        the product accepts rather than inventing a new one -- and there is then
+        no partially-read count that could be mistaken for a total.
+
+        Three failure statuses, and `nuls` is 0 in all three. NONE of them may
+        be reported as `clean`: "we could not look" is the one answer a
+        diagnosis must never round down to "there is nothing there".
+        """
+        from verinote.pipeline.ingest import count_nuls
+
+        resolved = self.db_path.parent / path
+        try:
+            text = resolved.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return "file_missing", 0
+        except UnicodeDecodeError:
+            return "file_undecodable", 0
+        except OSError:
+            return "file_unreadable", 0
+        nuls = count_nuls(text)
+        return ("found" if nuls else "clean"), nuls
 
     def plan_source_identity_repairs(self) -> SourceIdentityRepairPlan:
         """Read-only plan for merging same-file NFC/NFD duplicate sources.

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -137,10 +137,22 @@
                  is meant to stay plain text rather than become a chip. The
                  unmeasured note keeps `.badge src`: a chip is right for
                  information, and `.artifact-row .badge` already lays one out.
-                 No new CSS either way. #}
+                 No new CSS either way.
+
+                 #494's scan (`verinote sources scan-unreadable`) reads the
+                 stored artifact files and chunk rows and records nothing, so
+                 this row's state is genuinely unchanged by running it and this
+                 note is genuinely still true afterwards. The copy says so
+                 rather than leaving the page to send a user who scanned and
+                 got a clean answer back to run the scan again. Re-upload is
+                 stated unconditionally for the same reason it is stated first
+                 above: a pre-#473 artifact that held no NUL still needs it to
+                 clear this note, and that is the majority. Plain text, no
+                 nested `<code>` -- `policy_halted.html` names a CLI command in
+                 a `<p>`, not inside a `.badge`. #}
               {% set unreadable = artifact["unreadable_chars"] %}
               {% if unreadable is none %}
-                <span class="badge src">not checked for unreadable characters — some may remain; re-upload to fix, or delete the source and upload it again if this note stays</span>
+                <span class="badge src">not checked for unreadable characters — this records that the extraction never measured, not what the file holds, so it stays after a scan; run verinote sources scan-unreadable to see what is stored. Re-upload to fix, or delete the source and upload it again if this note stays</span>
               {% elif unreadable %}
                 <span class="warn-inline">{{ unreadable }} unreadable character(s)</span>
               {% endif %}


### PR DESCRIPTION
Closes #494.

## What

`verinote sources scan-unreadable` — a read-only scan that reads existing extraction artifacts and `source_chunks.text` and reports, per source, what NULs are still stored.

#473 replaced NULs with `U+FFFD` at ingest, but only for **new** ingest. Re-analysis does not go through `store_source` again; it reads the artifact already on disk. So a KB written before #473 still holds raw NULs and still fails the way #473 fixed, until the source is re-uploaded.

## What it deliberately does not do

**It repairs nothing.** Cleaning would mean rewriting artifacts or rebuilding chunks, which adds a second adjudication point beside `store_source` — exactly what #473 avoided — and cleaning without an artifact context to record in is the silent removal #473 rejected. The scan tells you; you fix it by deleting and re-uploading.

## The four verdicts

They answer one question: *are unreadable characters still stored where re-analysis will read them?*

| verdict | line |
|---|---|
| `current` | `unreadable characters still stored` |
| `superseded` | `unreadable characters in superseded rows only — … so no re-upload is called for` |
| `unknown` | `could not tell whether unreadable characters are still stored` |
| `clean` | `no unreadable characters still stored` |

`unknown` exists because a latest artifact whose file could not be read must round **neither** down to an absence **nor** up to a finding. `_scan_artifact_file` states that rule; the fourth verdict is what answers to it.

## Verification

- **Writes nothing** — every file under the KB root hashed before and after a scan with live findings, on a migrated KB **and** one whose `unreadable_chars` column was actually `DROP COLUMN`-ed. Byte- and mtime-identical, no WAL or journal created. Reproduced independently by three reviewers on separate extractions.
- **Acceptance property** — a genuine pre-#473 KB is found and reported, `rc 0`, `sqlite_master` unchanged.
- **No over-warning path** — a 75-shape sweep (15 artifact × 5 chunk states) found no reassuring headline asserting an absence over something unread, except the one documented case where the caveat sits on the same line.
- **Memory** — reads whole with `Path.read_text`, matching how production already reads these files (`cli.py`, `web/app.py`, `ask.py`); measured at 437 MB peak RSS on a 200 MB artifact.
- Suite `3252 passed, 14 skipped`; `ruff@0.15.18` clean.

## Known limits, stated in the tree

- A `superseded`-only finding under a clean latest artifact prints the clean headline with the caveat on the same line. It under-warns; it steers nobody toward the destructive remedy.
- The `current` line reports a finding without naming a remedy. Filed separately.
- The scan does not cover the unsanitized original under `sources/<name>`, which `ask` reads into grounding — see #561.