### PR TITLE
fix(#555): keep /, /sources and /settings up when the alias file cannot be read

### DIFF
--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -1,0 +1,668 @@
+# SPDX-License-Identifier: MPL-2.0
+r"""A broken `policy/relation-aliases.md` degrades `/`, `/sources`, `/settings`
+instead of 500ing them (#555).
+
+WHY THE MALFORMED TESTS ASSERT THE MESSAGE, NOT THE STATUS. Deleting the narrow
+`except CorroborationPolicyError` clause (G1) inside `_relation_alias_failure`
+does NOT turn any route back into a 500: the malformed case falls through to the
+broad `except Exception` clause (G2) underneath, which also returns a string, so
+every affected route still renders 200 (measured — see plan555.md §2.2/M9,
+critique555.md's independent reproduction). What changes is the MESSAGE: the
+banner goes from `relation-aliases.md:1: expected \`raw\` -> \`canonical\`` to
+`policy/relation-aliases.md could not be read: relation-aliases.md:1: expected …`
+— the file's own name, prefixed onto a message that already carries the file's
+own name, claiming a file that WAS read and DID parse "could not be read" at
+all. That is a false statement about the system's own state on a user-facing
+page, not a cosmetic duplication, and this repo gates on state-honesty. A test
+written as `assert response.status_code == 200` does not detect it. So every
+malformed-input test below asserts the body contains the bare parser message
+(`PARSER_MSG`) and does NOT contain the "could not be read" wrapper (`NAMED`).
+Do not shorten these to a status-code check — that silently un-pins G1.
+
+WHY THE EMPTY-SAVE REFUSAL KEYS ON A HIDDEN FIELD, NOT A RE-READ AT SUBMIT TIME.
+`/settings/relation-aliases` refuses an empty submit while the box was rendered
+empty because the on-disk file could not be read (BLOCKER-2/BLOCKER-3 in the
+#555 fix-round gate) — otherwise `relation_aliases("")` parses cleanly and the
+submit reaches `path.unlink()`, deleting the user's only copy. An earlier
+version of this refusal re-derived "is the file unreadable?" at submit time,
+which raced: a stale tab that rendered while the file was broken could submit
+its empty box *after* someone repaired the file on disk, the re-derived check
+would see a now-readable file, not refuse, and delete the just-repaired file.
+The fix carries a hidden `relation_aliases_rendered_unreadable` field that the
+template only emits when THAT render's box was empty for that reason, and the
+route refuses on the hidden field rather than re-reading. Two tests pin both
+directions: `test_settings_refuses_a_stale_empty_submit_even_after_the_file_is_repaired`
+(the race) and `test_settings_lets_a_genuine_empty_submit_delete_a_healthy_file`
+(the feature the refusal must not break).
+
+WHY THE SAVE WRITES THROUGH A TEMP FILE (`_write_relation_aliases_atomic`),
+NOT `Path.write_text` (#555 gate REV-3). `write_text` truncates on open, so a
+write that fails partway (a full disk, a killed process, ...) can leave the
+alias file empty or half-written while the page still says "Nothing was
+saved" -- measured end-to-end on a real full filesystem: the file was left
+`b""` and the claim was false. `_write_relation_aliases_atomic` writes a
+sibling temp file and `os.replace`s it in, so any failure leaves the original
+file untouched; `test_settings_save_leaves_the_file_untouched_when_the_write_fails`
+pins that with a monkeypatched `fsync` failure (a POST cannot deliver a body
+that fails to write for an encoding reason, so this is how the real trigger --
+ENOSPC -- actually reaches the code). A second, non-obvious consequence of
+`os.replace`-based writes is that they succeed against a file this process
+cannot itself read or write (`chmod 000`), because replacing a directory
+entry needs write access to the DIRECTORY, not to the file being replaced --
+`test_settings_can_repair_a_permission_denied_alias_file` pins that the
+remedy this page prescribes for an unreadable file actually works, and that
+the new file's mode does not simply repeat the broken one it replaced.
+
+The write/delete guard clause itself carries three more pins (#555 gate
+rev-2): the failure message names the operation that actually ran ("written"
+vs "removed" -- `test_settings_save_names_removed_not_written_when_the_delete_fails`),
+the empty-submit refusal arms on ANY non-empty hidden-field value rather than
+one exact string (`test_settings_refusal_arms_on_any_non_empty_hidden_field_value`),
+and the clause is `except Exception`, matching this file's own house form at
+`save_prompt_route`/`reset_prompt_route`, not `except OSError`
+(`test_settings_save_catches_a_non_oserror_write_failure`).
+
+SCOPE. Only the three routes issue #555 names: `/`, `/sources`, `/settings`.
+`/review` and `/workbench` have the same defect (and `/review` has a second,
+independent alias-read site the naive fix misses — see plan555.md M10 and
+critique555.md BLOCK-1, which also found `POST /facts/{id}/{accept,reject,toggle}`
+and `GET /facts/{id}/{row,provenance}` broken the same way) but are deliberately
+NOT touched here; they are registered as a follow-up issue instead of being
+silently dropped. `store_typed_relations` (`policy/typed-relations.md`) is also
+untouched — `_source_trust_rollup` still calls it alongside
+`store_relation_aliases`, so `/sources` can still 500 on a broken
+`typed-relations.md` after this change. The dashboard's degraded queue rows
+still link to `/review` and `/workbench` for their OTHER (non-degraded) rows,
+and those two routes can still 500 under a broken alias file (#570, also out of
+scope) -- `test_dashboard_offers_no_open_button_into_a_not_computed_queue_row`
+pins that the degraded rows themselves do not offer that button.
+"""
+
+import stat
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from verinote.config import Config
+from verinote.policy_defaults import RELATION_ALIASES_RELPATH
+from verinote.web import create_app
+
+PARSER_MSG = "relation-aliases.md:1:"
+NAMED = f"{RELATION_ALIASES_RELPATH} could not be read"
+
+MALFORMED_BYTES = "- 소속 member_of\n".encode()  # valid UTF-8, arrow missing
+CP949_BYTES = "- 소속 -> member_of\n".encode("cp949")
+HEALTHY_BYTES = "- 소속 -> member_of\n".encode()
+
+RENDERED_UNREADABLE_FIELD = (
+    '<input type="hidden" name="relation_aliases_rendered_unreadable" value="1">'
+)
+
+
+def _make_kb(tmp_path: Path) -> Path:
+    root = tmp_path / "kb"
+    root.mkdir()
+    return root
+
+
+def _open_app(root: Path):
+    cfg = Config(
+        root=root,
+        db_path=root / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    app = create_app(cfg)
+    store = app.state.store
+    source_id = store.add_source("sources/a.txt")
+    store.add_fact(
+        "A", "소속", "B", status="confirmed", confidence=0.9, source_id=source_id
+    )
+    store.add_fact(
+        "C", "소속", "D", status="needs_review", confidence=0.5, source_id=source_id
+    )
+    return app
+
+
+def _client(tmp_path: Path, alias_bytes: bytes | None) -> TestClient:
+    """A KB with one confirmed, source-backed `소속` fact and one `needs_review`
+    fact, so the alias-dependent numbers (corroboration, review-queue trust
+    labels) are non-trivial rather than vacuously empty on a healthy alias file.
+    """
+    root = _make_kb(tmp_path)
+    app = _open_app(root)
+    if alias_bytes is not None:
+        path = root / RELATION_ALIASES_RELPATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(alias_bytes)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def malformed_client(tmp_path: Path) -> TestClient:
+    return _client(tmp_path, MALFORMED_BYTES)
+
+
+@pytest.fixture
+def cp949_client(tmp_path: Path) -> TestClient:
+    return _client(tmp_path, CP949_BYTES)
+
+
+@pytest.fixture
+def healthy_client(tmp_path: Path) -> TestClient:
+    return _client(tmp_path, HEALTHY_BYTES)
+
+
+@pytest.fixture
+def absent_client(tmp_path: Path) -> TestClient:
+    return _client(tmp_path, None)
+
+
+# ---------------------------------------------------------------------------
+# Unit A -- /sources
+# ---------------------------------------------------------------------------
+
+
+def test_sources_survives_a_malformed_alias_file_and_keeps_the_parser_message(
+    malformed_client,
+):
+    r = malformed_client.get("/sources")
+    assert r.status_code == 200
+    assert PARSER_MSG in r.text
+    assert NAMED not in r.text
+
+
+def test_sources_survives_a_cp949_alias_file_and_names_the_file(cp949_client):
+    r = cp949_client.get("/sources")
+    assert r.status_code == 200
+    assert NAMED in r.text
+
+
+def test_sources_shows_no_trust_counts_it_could_not_compute(malformed_client):
+    """Refuses to fall back to defaults/`{}` -- see plan555.md Q3.
+
+    Asserted on the trust block and the exact label, not the bare words
+    unsupported/conflicted/corroborated: `sources.html` also renders
+    `<span class="badge trust-conflicted">chunk N</span>` for a failed
+    extraction chunk, which is unrelated to trust COUNTS (critique555.md N-3).
+    """
+    r = malformed_client.get("/sources")
+    assert '<span class="badge muted">trust not computed</span>' in r.text
+    assert 'unsupported</span>' not in r.text
+    assert 'conflicted</span>' not in r.text
+    assert 'corroborated</span>' not in r.text
+
+
+def test_a_healthy_alias_file_still_shows_the_sources_trust_counts(healthy_client):
+    """Anti-vacuity control for the three tests above: a guard that fires
+    unconditionally would also pass them."""
+    r = healthy_client.get("/sources")
+    assert r.status_code == 200
+    assert "trust not computed" not in r.text
+    assert PARSER_MSG not in r.text
+    assert NAMED not in r.text
+    assert 'unsupported</span>' in r.text
+
+
+# ---------------------------------------------------------------------------
+# Unit B -- /
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_survives_a_malformed_alias_file_and_keeps_the_parser_message(
+    malformed_client,
+):
+    r = malformed_client.get("/")
+    assert r.status_code == 200
+    assert PARSER_MSG in r.text
+    assert NAMED not in r.text
+
+
+def test_dashboard_survives_a_cp949_alias_file_and_names_the_file(cp949_client):
+    r = cp949_client.get("/")
+    assert r.status_code == 200
+    assert NAMED in r.text
+
+
+def test_dashboard_does_not_claim_there_are_no_corroborated_facts(malformed_client):
+    """`[]` and `None` both render falsy in `{% if %}`, but only `None` lets the
+    template tell "not computed" apart from "computed, and empty" -- passing `[]`
+    would print the exact same "No source-backed …" prose a healthy, empty KB
+    gets, which is a false statement about a KB that was never analysed."""
+    r = malformed_client.get("/")
+    assert "No source-backed engine-input facts yet." not in r.text
+    assert "No source-backed single-valued conflicts." not in r.text
+    assert r.text.count("Not computed — see the alias-file notice above.") == 2
+    # The four alias-dependent queue rows show the not-computed marker, not a
+    # digit -- plus one more occurrence inside the banner's own sentence, which
+    # names the marker it is pointing at (MUST-FIX-3, #555 fix-round gate).
+    assert r.text.count('<span class="badge muted">not computed</span>') == 5
+
+
+def test_a_healthy_alias_file_still_shows_the_dashboard_corroboration_table(
+    healthy_client,
+):
+    r = healthy_client.get("/")
+    assert r.status_code == 200
+    assert "Not computed — see the alias-file notice above." not in r.text
+    assert '<span class="badge muted">not computed</span>' not in r.text
+    # The healthy KB's one confirmed, source-backed fact appears in the table.
+    assert "<code>A</code>" in r.text
+
+
+def test_dashboard_offers_no_open_button_into_a_not_computed_queue_row(
+    malformed_client,
+):
+    """MUST-FIX-2 (#555 fix-round gate). Before this, a degraded row still
+    carried a live `Open` button into `/review?filter=…` or `/workbench`, which
+    are measured to 500 under this same broken alias file (#570). The banner
+    explains the degradation; a live button into a crash from that same page is
+    the "looks healthy, isn't" shape criterion 3 exists to prevent."""
+    r = malformed_client.get("/")
+    for href in ("/review?filter=unsupported", "/review?filter=corroborated", "/workbench"):
+        assert f'<a class="btn ghost" href="{href}">Open</a>' not in r.text
+    # The two alias-INDEPENDENT rows ("Failed source analyses" -> /sources,
+    # "Recent lifecycle changes" -> /review) show real counts and keep their
+    # buttons -- this is not a blanket "hide every Open button" change.
+    assert '<a class="btn ghost" href="/sources">Open</a>' in r.text
+    assert '<a class="btn ghost" href="/review">Open</a>' in r.text
+
+
+def test_a_healthy_alias_file_still_offers_every_open_button(healthy_client):
+    """Anti-vacuity control: a template that hid Open buttons unconditionally
+    would also pass the test above."""
+    r = healthy_client.get("/")
+    assert r.text.count("Open</a>") == 6
+
+
+# ---------------------------------------------------------------------------
+# Unit C -- /settings
+# ---------------------------------------------------------------------------
+
+
+def test_settings_names_the_parse_error_in_a_malformed_alias_file(malformed_client):
+    """Red on the parent commit too: today `/settings` is 200 and silent on this
+    same input (plan555.md M3) -- that silence is what this test is closing."""
+    r = malformed_client.get("/settings")
+    assert r.status_code == 200
+    assert PARSER_MSG in r.text
+
+
+def test_settings_survives_a_cp949_alias_file_and_names_the_file(cp949_client):
+    """Red on the parent commit: `/settings` 500s on cp949 today (M1/M2)."""
+    r = cp949_client.get("/settings")
+    assert r.status_code == 200
+    assert NAMED in r.text
+
+
+def test_settings_says_the_empty_alias_box_is_not_the_file_on_disk(cp949_client):
+    r = cp949_client.get("/settings")
+    assert r.status_code == 200
+    # The textarea is empty -- nothing decoded from the file was put into it.
+    assert '<textarea name="relation_aliases_text" rows="8"\n              placeholder="- `역할` -> `role`"></textarea>' in r.text
+    # BLOCKER-3: the broad clause behind this banner also catches non-decode
+    # failures (permission errors, …), so the copy says "read", never "decoded"
+    # -- "decoded" was only ever true for this one mode among several.
+    assert "could not be read" in r.text
+    assert "decoded" not in r.text
+    # The refusal exists, and the page says so, rather than only predicting a
+    # deletion that a later POST in fact refuses (BLOCKER-1).
+    assert "refused" in r.text.lower()
+    # The render carries the hidden marker the POST refusal keys on.
+    assert RENDERED_UNREADABLE_FIELD in r.text
+
+
+def test_settings_refuses_a_stale_empty_submit_even_after_the_file_is_repaired(
+    cp949_client, tmp_path
+):
+    """MUST-FIX-1 (#555 fix-round gate). The refusal must be attributable to
+    what THIS render showed, not re-derived from the file's state at submit
+    time. Measured end-to-end against the earlier (re-deriving) shape: render
+    while the file is unreadable (empty box, hidden field set) -> repair the
+    file on disk, as the page's own advice says to -> submit the STALE empty
+    box -> the re-deriving shape saw a now-readable file, did not refuse, and
+    deleted the just-repaired file. This test pins that the repaired file
+    survives a submit carrying the render-time hidden marker regardless of the
+    file's state when the submit arrives."""
+    root = tmp_path / "kb"
+    alias_path = root / RELATION_ALIASES_RELPATH
+
+    r = cp949_client.get("/settings")
+    assert RENDERED_UNREADABLE_FIELD in r.text  # this render's box was empty
+
+    repaired = "- 소속 -> member_of\n".encode()  # valid UTF-8, healthy
+    alias_path.write_bytes(repaired)
+
+    r2 = cp949_client.post(
+        "/settings/relation-aliases",
+        data={
+            "relation_aliases_text": "",
+            "relation_aliases_rendered_unreadable": "1",
+        },
+    )
+    assert r2.status_code == 400
+    assert "nothing was saved" in r2.text.lower()
+    assert alias_path.read_bytes() == repaired
+
+
+def test_settings_lets_a_genuine_empty_submit_delete_a_healthy_file(
+    healthy_client, tmp_path
+):
+    """BLOCKER-2 (#555 fix-round gate): the narrow side of the refusal. Without
+    a test posting an empty body against a HEALTHY file, a mutant that refuses
+    every empty submit unconditionally (destroying the deliberate-clear
+    feature) survives the whole suite. A render of a readable, non-empty file
+    never emits the hidden marker (see `test_settings_says_the_empty_alias_box…`
+    for the case that does), so a genuine empty submit from that render carries
+    no `relation_aliases_rendered_unreadable` field and must still delete the
+    file -- this mirrors the ORIGINAL, pre-#555 behaviour for that state."""
+    root = tmp_path / "kb"
+    alias_path = root / RELATION_ALIASES_RELPATH
+    assert alias_path.exists()
+
+    r = healthy_client.get("/settings")
+    assert RENDERED_UNREADABLE_FIELD not in r.text  # this render's box was NOT empty
+
+    r2 = healthy_client.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": ""},
+        follow_redirects=False,
+    )
+    assert r2.status_code == 303
+    assert not alias_path.exists()
+
+
+def test_settings_names_a_permission_failure_as_unreadable_not_undecoded(tmp_path):
+    """BLOCKER-3 half 1 (#555 fix-round gate). `relation_aliases_unreadable`
+    comes from a BROAD `except Exception` around `read_text`, so it is also
+    true for `PermissionError` -- a `chmod 000` file, not a decode failure.
+    The banner and warning must say "could not be read", never "decoded",
+    for both halves of what that broad clause catches."""
+    root = _make_kb(tmp_path)
+    app = _open_app(root)
+    client = TestClient(app, raise_server_exceptions=False)
+    path = root / RELATION_ALIASES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("- 소속 -> member_of\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "could not be read" in r.text
+        assert "decoded" not in r.text
+    finally:
+        path.chmod(0o600)
+        path.unlink(missing_ok=True)
+
+
+def test_settings_can_repair_a_permission_denied_alias_file(tmp_path):
+    """The remedy for a `chmod 000` alias file actually works, and leaves the
+    result readable. Measured (#555 REV-3, mode-preservation follow-up): the
+    FIRST atomic-write shape tried here derived the new file's mode from the
+    file it was replacing, so "repairing" a `chmod 000` file wrote valid
+    content into a NEW file that was ALSO `chmod 000` -- the POST 303'd as
+    though it worked, but the very next `GET /settings` showed "could not be
+    read" again, unreadable by the same mode it had before. The fix is to use
+    a fixed `0o644` rather than deriving one from the existing file (see
+    `_write_relation_aliases_atomic`'s docstring for why fixed, and what it
+    costs -- `write_text` PRESERVES an existing file's mode, so this is a
+    deliberate difference from it, not a match).
+
+    This also confirms `os.replace` genuinely repairs a `chmod 000` file:
+    replacing a directory entry needs write access to the DIRECTORY, not to
+    the file being replaced, so `_write_relation_aliases_atomic` can succeed
+    here even though a direct `open(path, 'w')` (the prior `write_text`
+    implementation) could not have.
+    """
+    root = _make_kb(tmp_path)
+    app = _open_app(root)
+    client = TestClient(app, raise_server_exceptions=False)
+    path = root / RELATION_ALIASES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("- 소속 -> member_of\n", encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        try:
+            path.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user reads straight through mode 0o000")
+
+        r2 = client.post(
+            "/settings/relation-aliases",
+            data={"relation_aliases_text": "- 소속 -> role"},
+            follow_redirects=False,
+        )
+        assert r2.status_code == 303
+
+        r3 = client.get("/settings")
+        assert r3.status_code == 200
+        assert "could not be read" not in r3.text
+        assert "role" in r3.text
+    finally:
+        path.chmod(0o600)
+        path.unlink(missing_ok=True)
+
+
+def test_settings_save_leaves_the_file_untouched_when_the_write_fails(
+    healthy_client, tmp_path, monkeypatch
+):
+    """BLOCKER-3 part 2 (#555 fix-round gate, REV-3). `write_text` truncates
+    in place on open, so a write that fails partway through -- a full disk,
+    a killed process, two processes saving at once -- could leave the file
+    empty or half-written while the page claimed "Nothing was saved", which
+    was then false. Measured end-to-end on a real full filesystem by the
+    gate. The fix (`_write_relation_aliases_atomic`) writes a sibling temp
+    file and `os.replace`s it in, so a failure anywhere in that sequence must
+    leave the ORIGINAL file byte-for-byte untouched, with no temp file left
+    behind.
+
+    A POST cannot deliver text that fails to write for a form-encoding
+    reason -- by the time this route sees it, it is already decoded text --
+    so this drives the failure the way ENOSPC actually would reach the code:
+    an `OSError` out of the `fsync` call, via monkeypatch, rather than
+    through form input.
+
+    NOT a durability test (#555 gate rev-2, Critic N11): patching `fsync` is a
+    convenient injection POINT for a mid-sequence failure, not a claim that
+    this test verifies data reaches disk. Whether `fsync` itself actually
+    makes the write durable against a real power loss is not something a unit
+    test can observe; what this test verifies is the code's reaction to A
+    failure at that point in the sequence -- that the ORIGINAL file survives
+    untouched -- which holds regardless of which step in the sequence raises.
+    """
+    root = tmp_path / "kb"
+    alias_path = root / RELATION_ALIASES_RELPATH
+    before = alias_path.read_bytes()
+
+    def boom(*args, **kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("verinote.web.app.os.fsync", boom)
+
+    r = healthy_client.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": "- 소속 -> role"},
+    )
+    # 500, not 400 (#555 gate rev-7): `relation_aliases(text)` already
+    # succeeded before this failure, so the request was valid -- the disk is
+    # what said no. Matches `tests/test_web.py`'s pin for the identical
+    # failure class on `save_prompt_route`/`reset_prompt_route`.
+    assert r.status_code == 500
+    assert "could not be written" in r.text
+    assert "nothing was saved" in r.text.lower()
+    assert alias_path.read_bytes() == before
+    leftovers = [p for p in alias_path.parent.iterdir() if p != alias_path]
+    assert leftovers == []
+
+
+def test_settings_save_always_writes_mode_0o644(healthy_client, tmp_path):
+    """#555 REV-4. Nothing pinned the resulting file's mode before this test
+    -- three mutations (`mode = 0o600`, `mode = 0o666`, deleting the
+    `fchmod`/`chmod` step entirely) all left the whole suite green.
+
+    `write_text` PRESERVES an existing file's mode (measured independently: a
+    `chmod 0o600` file stays `0o600` after `write_text` rewrites it), so a
+    hand-written alias file under a tight umask would otherwise keep that
+    mode forever, unaffected by any UI save. `_write_relation_aliases_atomic`
+    deliberately applies a FIXED `0o644` instead (see its docstring) -- on
+    existing files too, which is a real widening a security-conscious user
+    would not expect from a "save" button.
+
+    Start the file at `0o600` -- the documented hand-edit workflow under
+    `umask 077` (`docs/operations.md:21` says the file is written "by hand or
+    via the Settings UI") -- and confirm the save widens it to `0o644` rather
+    than leaving `0o600` unpinned and silently correct only by accident.
+    """
+    root = tmp_path / "kb"
+    alias_path = root / RELATION_ALIASES_RELPATH
+    alias_path.chmod(0o600)
+
+    r = healthy_client.post(
+        "/settings/relation-aliases",
+        data={"relation_aliases_text": "- 소속 -> role"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    assert stat.S_IMODE(alias_path.stat().st_mode) == 0o644
+
+
+def test_settings_save_names_removed_not_written_when_the_delete_fails(tmp_path):
+    """#555 gate rev-2 (Critic). The `elif path.exists(): path.unlink()` branch
+    is the DELETE path -- reached on an empty, non-refused submit -- and its
+    failure message must name the operation that actually ran. Measured before
+    this fix: a directory sitting at the alias path made `unlink()` raise
+    `PermissionError`/`IsADirectoryError` (platform-dependent), and the shared
+    error message said "could not be WRITTEN", naming an operation (writing)
+    that never happened -- the same class of defect as the "decoded" vs "read"
+    mismatch fixed earlier in this file."""
+    root = _make_kb(tmp_path)
+    app = _open_app(root)
+    client = TestClient(app, raise_server_exceptions=False)
+    path = root / RELATION_ALIASES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.mkdir()  # a directory, not a file, sits where the alias file goes
+
+    r = client.post("/settings/relation-aliases", data={"relation_aliases_text": ""})
+    # 500, not 400 (#555 gate rev-7): the empty submit itself was not refused
+    # (the file is unreadable-as-a-directory, not "unreadable" in the sense
+    # the hidden-field refusal above guards) -- it is the disk saying no to a
+    # valid request, the same class `tests/test_web.py` pins at 500 on the
+    # sibling prompt routes.
+    assert r.status_code == 500
+    assert "could not be removed" in r.text
+    assert "could not be written" not in r.text
+    assert "nothing was saved" in r.text.lower()
+
+
+def test_settings_refusal_arms_on_any_non_empty_hidden_field_value(
+    cp949_client, tmp_path
+):
+    """#555 gate rev-2 (Critic). The refusal keyed on
+    `relation_aliases_rendered_unreadable == "1"` -- an exact string match on
+    client-controlled input. Measured: a forged `"0"` or `"true"` value
+    bypassed the guard entirely (303, file deleted), because only the
+    template's literal `value="1"` armed it; every other non-empty value
+    disarmed a destructive-path guard. The template is the only real submitter
+    of this field (so this was not live), but a guard on a delete should not
+    rely on matching one exact string forever -- the fix is a truthy check:
+    ANY non-empty value means the same thing (this render's box was empty
+    because the file was unreadable), and only an ABSENT field means the other
+    thing (a genuine clear). This test drives a value the template never
+    sends, to pin that the guard still arms on it rather than silently
+    treating it as absent."""
+    root = tmp_path / "kb"
+    alias_path = root / RELATION_ALIASES_RELPATH
+    before = alias_path.read_bytes()
+
+    r = cp949_client.post(
+        "/settings/relation-aliases",
+        data={
+            "relation_aliases_text": "",
+            "relation_aliases_rendered_unreadable": "0",
+        },
+    )
+    assert r.status_code == 400
+    assert alias_path.exists()
+    assert alias_path.read_bytes() == before
+
+
+def test_settings_save_catches_a_non_oserror_write_failure(
+    healthy_client, tmp_path, monkeypatch
+):
+    """#555 gate rev-2 (Critic N7), strengthened per gate rev-6 (Reviewer nit
+    4). The write/delete guard is `except Exception`, not `except OSError` --
+    matching the house form already used by `save_prompt_route`/
+    `reset_prompt_route` for the same reason: this route has no narrower a
+    claim to make about how its own filesystem calls can fail than those
+    routes make about theirs.
+
+    Injected at `os.replace` -- the LAST step in `_write_relation_aliases_atomic`,
+    not the first. An earlier version of this test patched `tempfile.mkstemp`
+    instead, where "nothing was saved" is trivially true because no temp file
+    was ever created there. `os.replace` runs only after `mkstemp`, `fchmod`,
+    `fdopen`, `write`, `flush` and `fsync` have all already succeeded, so a
+    real temp file exists on disk at the moment this failure fires -- the
+    interesting case, where the ORIGINAL file must still survive untouched and
+    the now-orphaned temp file must be cleaned up rather than left behind, not
+    just where nothing had happened yet to undo."""
+
+    def boom(*args, **kwargs):
+        raise ValueError("not an OSError")
+
+    monkeypatch.setattr("verinote.web.app.os.replace", boom)
+
+    root = tmp_path / "kb"
+    alias_path = root / RELATION_ALIASES_RELPATH
+    before = alias_path.read_bytes()
+
+    r = healthy_client.post(
+        "/settings/relation-aliases", data={"relation_aliases_text": "- 소속 -> role"}
+    )
+    # 500, not 400 (#555 gate rev-7): a server-side write failure, not a
+    # client-request error -- see the guard's own comment for the argument.
+    assert r.status_code == 500
+    assert "could not be written" in r.text
+    assert "nothing was saved" in r.text.lower()
+    assert alias_path.read_bytes() == before
+    leftovers = [p for p in alias_path.parent.iterdir() if p != alias_path]
+    assert leftovers == []
+
+
+def test_a_healthy_alias_file_still_fills_the_settings_textarea(healthy_client):
+    r = healthy_client.get("/settings")
+    assert r.status_code == 200
+    assert PARSER_MSG not in r.text
+    assert NAMED not in r.text
+    assert "member_of" in r.text
+    assert RENDERED_UNREADABLE_FIELD not in r.text
+
+
+# ---------------------------------------------------------------------------
+# R1 -- regression control: an absent alias file is not treated as a failure
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_alias_file_is_not_treated_as_a_failure(absent_client):
+    """`store_relation_aliases` returns the parsed packaged defaults, and raises
+    nothing, when the file does not exist (corroboration.py `not path.is_file()`
+    branch). A guard that mistook "absent" for "broken" would put a banner on
+    every healthy KB that never wrote this optional file."""
+    for route in ("/", "/sources", "/settings"):
+        r = absent_client.get(route)
+        assert r.status_code == 200
+        assert 'class="error"' not in r.text
+        assert 'class="warn"' not in r.text

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -14,6 +14,7 @@ import logging
 import os
 from pathlib import Path
 import sqlite3
+import tempfile
 import threading
 from threading import Lock
 import unicodedata
@@ -1046,15 +1047,100 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _relation_aliases_path() -> Path:
         return _active_cfg().root / RELATION_ALIASES_RELPATH
 
-    def _relation_aliases_text() -> str:
+    def _relation_alias_failure(store: Store) -> str | None:
+        """Why this KB's alias file cannot be applied, or None when it can.
+
+        Calls `store_relation_aliases` — the function the routes' own failures
+        come out of — rather than re-reading the file here. `store_relation_aliases`
+        resolves `store.db_path.parent / RELATION_ALIASES_RELPATH`, which agrees
+        with `_relation_aliases_path()` (`_active_cfg().root / …`) for every
+        `Config.for_root`, but the two are independent `Config` fields, so a guard
+        that re-derived the path could clear one file while the route read the
+        other and still 500 (#555).
+
+        This call's own read happens chronologically FIRST (measured: it runs
+        before any pipeline function does, since the route calls it before
+        computing anything alias-dependent) — but it is not the ONLY read. When
+        the file is healthy, the route's own pipeline functions
+        (`store_corroboration`, `trust_workbench`, `fact_trust_summary`, …) each
+        call `store_relation_aliases` again themselves; this call does not
+        replace those reads or cache the result for them, and it is not a fix
+        for the check-then-use gap that leaves: a rewrite between this call and
+        the route's own reads still 500s. Freezing one read and threading it
+        through every alias-dependent pipeline function would change signatures
+        shared with the CLI, and is a separate refactor.
+
+        The broad clause below wraps EXACTLY ONE CALL, not a route body, and that
+        call touches no database: `store_relation_aliases` reads `store.db_path` as
+        an attribute, stats the file, and parses it. So the only thing this can
+        swallow is a failure to read or parse that one file.
+        """
+        try:
+            store_relation_aliases(store)
+        except CorroborationPolicyError as exc:
+            # G1. Already normalised, and its message already begins with the
+            # file name (`relation-aliases.md:1: expected …`). Prefixing it below
+            # would say the file twice, AND would misstate what happened — the
+            # file WAS read; it parsed and failed. That is a false claim about the
+            # system's own state on a user-facing page. Must stay ABOVE G2.
+            return str(exc)
+        except Exception as exc:  # noqa: BLE001 - normalise every alias-read failure
+            # G2. BROAD, NOT A TYPE LIST. `UnicodeDecodeError` (a file saved as
+            # cp949) descends from `ValueError` as `CorroborationPolicyError`
+            # does but is no subclass of it; `PermissionError` is not a
+            # `ValueError` at all. Same reasoning, and the same shape, as
+            # `extract.py::_relation_aliases_or_error` (#553).
+            #
+            # NAME THE FILE: `str(UnicodeDecodeError)` is a byte offset and no
+            # path, so an unprefixed message put a bare codec complaint about
+            # nothing in particular on the page.
+            return f"{RELATION_ALIASES_RELPATH} could not be read: {exc}"
+        return None
+
+    def _relation_aliases_context() -> dict[str, object]:
+        """The Settings page's own read of the alias file, plus its own guard.
+
+        Deliberately NOT `_relation_alias_failure` + `store_relation_aliases`:
+        this route never calls `store_relation_aliases` (it reads the file
+        straight from `_relation_aliases_path()`, which resolves from
+        `cfg.root` rather than `store.db_path.parent` — see
+        `_relation_alias_failure`'s docstring), so it needs its own read and its
+        own broad `except Exception` around that one `read_text` call (same G2
+        rationale: no database access, only a stat and a read of this file).
+        """
         path = _relation_aliases_path()
         if not path.is_file():
-            return DEFAULT_RELATION_ALIASES
-        text = path.read_text(encoding="utf-8")
+            return {
+                "relation_aliases": DEFAULT_RELATION_ALIASES,
+                "relation_aliases_error": None,
+                "relation_aliases_unreadable": False,
+            }
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001 - normalise every alias-read failure
+            # BROAD, not just `UnicodeDecodeError`: `PermissionError`,
+            # `IsADirectoryError`, and other `OSError`s reach this too (measured,
+            # #555 BLOCKER-3), so the flag and the message say "read", never
+            # "decoded" — "decoded" was true only for the one mode among several
+            # this clause actually catches, and was a false claim about the
+            # system's own state for the others (e.g. a `chmod 000` file).
+            return {
+                "relation_aliases": "",
+                "relation_aliases_error": f"{RELATION_ALIASES_RELPATH} could not be read: {exc}",
+                "relation_aliases_unreadable": True,
+            }
         try:
             existing = relation_aliases(text)
-        except CorroborationPolicyError:
-            return text
+        except CorroborationPolicyError as exc:
+            # The file WAS read; it parsed and failed. Keep the parser's own
+            # message (already file-and-line-prefixed) rather than wrapping it —
+            # wrapping would say the file twice and misstate that it could not be
+            # read at all (same reasoning as G1 above).
+            return {
+                "relation_aliases": text,
+                "relation_aliases_error": str(exc),
+                "relation_aliases_unreadable": False,
+            }
         merged = merge_default_relation_aliases(existing)
         missing_defaults = {
             alias: canonical
@@ -1062,12 +1148,135 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             if alias not in existing
         }
         if not missing_defaults:
-            return text
+            return {
+                "relation_aliases": text,
+                "relation_aliases_error": None,
+                "relation_aliases_unreadable": False,
+            }
         missing_text = "\n".join(
             f"- `{alias}` -> `{canonical}`"
             for alias, canonical in sorted(missing_defaults.items())
         )
-        return f"{text.rstrip()}\n\n# Default aliases not yet saved in this KB\n{missing_text}\n"
+        return {
+            "relation_aliases": (
+                f"{text.rstrip()}\n\n# Default aliases not yet saved in this KB\n{missing_text}\n"
+            ),
+            "relation_aliases_error": None,
+            "relation_aliases_unreadable": False,
+        }
+
+    def _write_relation_aliases_atomic(path: Path, text: str) -> None:
+        """Replace `path` with `text`, or leave it exactly as it was.
+
+        Follows `config.py::_write_json_atomic`'s shape — mkstemp beside the
+        target, `fsync` before `os.replace` — rather than
+        `query.py::write_query_file`'s fuller one (which also fsyncs the
+        parent directory and threads a `BaseException` handler around an
+        `os.fdopen`-wrapped fd). These are two INDEPENDENT differences, not one
+        choice: the parent-directory fsync is decided below, on durability
+        grounds. The fd-ownership handling is not a separate decision here —
+        this function inherits `_write_json_atomic`'s exact shape for it,
+        `fd`/`tmp` included, so it has the same gap `query.py` closes and
+        `config.py` does not: if `os.fchmod` or `os.fdopen` itself raises
+        (before the `with` block owns the fd), the raw `fd` from `mkstemp` is
+        never explicitly closed — `tmp` is still unlinked below regardless,
+        and the process still reclaims the fd at exit, but it is a real,
+        measured leak in the interim (#555 gate rev-6), not a durability
+        question at all.
+
+        PARENT-DIRECTORY FSYNC, deliberately skipped. Not explaining WHY
+        `write_query_file` fsyncs its parent and this one doesn't —
+        `query.py` never says why it needs that stronger guarantee, and two
+        earlier rounds of this docstring each guessed a different reason and
+        were each wrong ("paired with a database commit"; "a snapshot it must
+        not outlive" — neither is stated anywhere in `query.py`). The fact
+        both guesses were reaching for does hold, checked directly rather
+        than reasoned from either: that transaction commits no database
+        write, on any path reachable in the tree today, including through its
+        one caller-supplied guard — and that enumeration is CLOSED, not just
+        long: `Store.immediate_transaction` has exactly one definition and no
+        subclass overrides it anywhere in the tree. The derivation is not
+        repeated here — three rounds running, it has been the part that goes
+        stale, not the one-line result. What IS checkable: this route
+        publishes one file and returns a redirect, so the guarantee bought by
+        `fsync`-before-`replace` alone ("never torn", not
+        "committed before we return" — `_write_json_atomic`'s own phrase) is
+        complete for what it does. `write_query_file` makes a strictly
+        stronger guarantee than that; this docstring does not claim to know
+        why.
+
+        `write_text` (the prior implementation) truncates in place, so a write
+        that fails partway through — full disk, a killed process, two
+        processes saving at once — can leave the file empty or half-written.
+        Measured end-to-end on a full filesystem (#555, gate REV-3): the alias
+        file was left truncated to `b""` while the page reported "Nothing was
+        saved", which was then false. `mkstemp` + `os.replace` means a failed
+        write leaves `path` untouched — the reader (`_relation_aliases_path()`
+        callers) always sees either the whole old file or the whole new one.
+
+        MODE. Uses a FIXED `0o644`, like `_write_json_atomic` uses a fixed
+        mode, rather than deriving one from the existing file the way
+        `write_query_file` does — deliberately NOT reused here even though
+        this route replaces an existing file more often than `write_query_file`
+        does. `write_query_file` derives its mode to preserve a KB's chosen
+        permissions across regenerations of a machine-written file. This
+        route's very reason to write is often "the existing file was unusable"
+        (`relation_aliases_unreadable`, e.g. a `chmod 000` file) — deriving the
+        new file's mode from that SAME file would carry the broken permissions
+        onto its own replacement. Measured: with the derive-from-existing
+        shape, a POST that successfully rewrote a `chmod 000` alias file with
+        valid content still 303'd, but the new file was ALSO mode 0o000, so
+        the very next `GET /settings` showed "could not be read" again — a
+        "successful" save the user could not then read back.
+
+        `0o644` is NOT equivalent to what `write_text` produced. `write_text`
+        PRESERVES an existing file's mode (measured: a `chmod 0o600` file
+        stays `0o600` after `write_text` rewrites it) and only applies the
+        umask-derived default when CREATING a new file. This writer always
+        applies `0o644`, on existing files too — mirroring the exact hazard
+        `_write_json_atomic`'s own docstring names for `app.json` ("switching
+        to this writer silently tightened `app.json` … on existing files
+        too"), except in the opposite direction: a hand-written `0o600` alias
+        file (e.g. under `umask 077` — `docs/operations.md`'s
+        `policy/relation-aliases.md` row says it is "written by hand or by
+        the Settings UI") becomes world-readable `0o644` after one
+        Settings-UI save. That widening is accepted, not fixed here
+        — the alternative (reading the current umask to replicate
+        `write_text`'s create-time behaviour) needs a racy
+        `os.umask(0); os.umask(old)` get-and-set in a threaded web process,
+        and this route does not have a KB-scoped permissions policy worth
+        deriving from the file it is about to replace (the paragraph above).
+        The mode is also set via `fchmod` on the temp file's descriptor, which
+        ignores the process umask entirely — under `umask 077`, this writer
+        still produces `0o644` where a fresh `write_text` would have produced
+        `0o600`.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        mode = 0o644
+        fd, tmp_name = tempfile.mkstemp(
+            dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+        )
+        tmp = Path(tmp_name)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, mode)
+            else:
+                os.chmod(tmp, mode)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+            # `os.replace` MUST be the LAST statement in this `try` (#555 gate
+            # rev-8). `save_relation_aliases`'s "Nothing was saved" on any
+            # exception out of this function is true only because nothing
+            # after a successful rename can still raise — a statement added
+            # here, after the rename, would raise into the SAME broad
+            # `except Exception` over a file that HAD already changed, and
+            # the caller's message would then be false.
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
 
     def _override_is_unreadable(path: Path) -> bool:
         """Is the KB's override for this prompt the file that could not be read?
@@ -1551,20 +1760,36 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             sort=page_data.sort,
         )
 
-    def _source_inspector_rows(store: Store) -> list[dict[str, object]]:
+    def _source_inspector_rows(
+        store: Store, *, alias_error: str | None
+    ) -> list[dict[str, object]]:
         facts = store.facts()
-        trust_rollup = _source_trust_rollup(store, facts)
+        # Compute the rollup only when the alias file is usable — an alias_error
+        # means `_source_trust_rollup` would 500 the same way this route used to
+        # (#555). One `store.facts()` scan either way: passing `alias_error` in and
+        # branching here, rather than a caller-side `None if alias_error else
+        # _source_trust_rollup(store, store.facts())`, avoids a second full scan on
+        # every healthy request.
+        trust_rollup = None if alias_error else _source_trust_rollup(store, facts)
         rows = []
         for source in store.sources_with_counts():
             row = dict(source)
             source_id = int(source["id"])
-            counts = trust_rollup.get(
-                source_id,
-                {"unsupported": 0, "conflicted": 0, "corroborated": 0},
-            )
-            row["unsupported_count"] = counts["unsupported"]
-            row["conflicted_count"] = counts["conflicted"]
-            row["corroborated_count"] = counts["corroborated"]
+            if trust_rollup is None:
+                # Leave the count keys unset rather than zeroing them: a template
+                # that forgot this branch renders a blank badge (Jinja's default
+                # `Undefined` renders '', it does not raise), which is still
+                # honest — a false "0 unsupported" on a KB that was never checked
+                # is not.
+                row["trust_unavailable"] = True
+            else:
+                counts = trust_rollup.get(
+                    source_id,
+                    {"unsupported": 0, "conflicted": 0, "corroborated": 0},
+                )
+                row["unsupported_count"] = counts["unsupported"]
+                row["conflicted_count"] = counts["conflicted"]
+                row["corroborated_count"] = counts["corroborated"]
             row["evidence_snippets"] = store.source_evidence_snippets(source_id)
             row["artifacts"] = [dict(artifact) for artifact in store.source_artifacts(source_id)]
             row["failed_chunk_details"] = []
@@ -1649,31 +1874,53 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 return ("scalar", scalar)
         return ("raw", obj)
 
-    def _dashboard_queues(store: Store) -> list[dict[str, object]]:
-        review_summaries = [
-            fact_trust_summary(store, int(fact["id"])) for fact in store.review_queue()
-        ]
-        review_summaries = [summary for summary in review_summaries if summary is not None]
+    def _dashboard_queues(
+        store: Store, *, alias_error: str | None
+    ) -> list[dict[str, object]]:
+        # `jobs` and `recent_lifecycle` are alias-independent (measured, #555 M5) and
+        # keep their real counts either way. The other four rows depend on
+        # `fact_trust_summary`, `trust_workbench`, or `store_corroboration` — all
+        # alias-dependent — so when the file cannot be applied they show `None`
+        # (rendered as "not computed" by the template) rather than a count computed
+        # under rules the user did not configure, or a false `0`.
         jobs = store.source_extraction_jobs()
-        workbench = trust_workbench(store)
-        corroboration = store_corroboration(store)
         recent_lifecycle = store.count_facts_with_events(("amended", "reanalyzed"))
+        if alias_error is None:
+            review_summaries = [
+                fact_trust_summary(store, int(fact["id"])) for fact in store.review_queue()
+            ]
+            review_summaries = [summary for summary in review_summaries if summary is not None]
+            workbench = trust_workbench(store)
+            corroboration = store_corroboration(store)
+            unsupported_count = sum(
+                1 for summary in review_summaries if "unsupported" in summary.trust_labels
+            )
+            corroborated_review_count = sum(
+                1 for summary in review_summaries if "corroborated" in summary.trust_labels
+            )
+            conflicts_count = len(workbench.conflicts)
+            engine_facts_count = len(corroboration)
+        else:
+            unsupported_count = None
+            corroborated_review_count = None
+            conflicts_count = None
+            engine_facts_count = None
         return [
             {
                 "label": "Unsupported review items",
-                "count": sum(1 for summary in review_summaries if "unsupported" in summary.trust_labels),
+                "count": unsupported_count,
                 "href": "/review?filter=unsupported",
                 "detail": "candidate facts without deterministic source support",
             },
             {
                 "label": "Corroborated review targets",
-                "count": sum(1 for summary in review_summaries if "corroborated" in summary.trust_labels),
+                "count": corroborated_review_count,
                 "href": "/review?filter=corroborated",
                 "detail": "review items backed by repeated source support",
             },
             {
                 "label": "Single-valued conflicts",
-                "count": len(workbench.conflicts),
+                "count": conflicts_count,
                 "href": "/workbench",
                 "detail": "accepted/confirmed values competing under functional rules",
             },
@@ -1691,7 +1938,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             },
             {
                 "label": "Source-backed engine facts",
-                "count": len(corroboration),
+                "count": engine_facts_count,
                 "href": "/workbench",
                 "detail": "accepted/confirmed facts with source support",
             },
@@ -1704,7 +1951,22 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
         cfg = _active_cfg()
+        alias_error = _relation_alias_failure(store)
         counts = store.status_counts()
+        # `counts`, `total`, `engine_input`, `sources`, `coverage` are all
+        # alias-independent (measured, #555 M5) and keep their real values even
+        # when the alias file is broken. `corroboration` and
+        # `single_valued_conflicts` are alias-dependent; `None` (not `[]`) so the
+        # template can tell "not computed" apart from "computed, and empty" —
+        # `[]` would render the same "No source-backed …" prose a healthy KB with
+        # nothing to show gets, which is a false statement about a KB that was
+        # never analysed.
+        if alias_error is None:
+            corroboration = store_corroboration(store)
+            single_valued_conflicts = store_single_valued_conflicts(store)
+        else:
+            corroboration = None
+            single_valued_conflicts = None
         return templates.TemplateResponse(
             request,
             "dashboard.html",
@@ -1718,9 +1980,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "all_fact_statuses": fact_status_order(),
                 "sources": store.sources(),
                 "coverage": coverage(store, root=cfg.root),
-                "corroboration": store_corroboration(store),
-                "single_valued_conflicts": store_single_valued_conflicts(store),
-                "queues": _dashboard_queues(store),
+                "corroboration": corroboration,
+                "single_valued_conflicts": single_valued_conflicts,
+                "queues": _dashboard_queues(store, alias_error=alias_error),
+                "alias_error": alias_error,
                 "provider": app.state.cfg.provider,
                 "provider_label": PROVIDER_LABELS.get(
                     app.state.cfg.provider, app.state.cfg.provider
@@ -1736,6 +1999,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if app.state.store is None:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
+        alias_error = _relation_alias_failure(store)
         jobs = store.source_extraction_jobs()
         latest_job_ids = latest_source_job_ids(jobs)
         # A superseded `pending` row is dead work, and counting it here is what
@@ -1746,10 +2010,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             request,
             "sources.html",
             {
-                "sources": _source_inspector_rows(store),
+                "sources": _source_inspector_rows(store, alias_error=alias_error),
                 "suffixes": ", ".join(sorted(supported_suffixes())),
                 "accept": ",".join(sorted(supported_suffixes())),
                 "error": error,
+                "alias_error": alias_error,
                 "jobs": jobs,
                 "has_running_jobs": has_running_jobs,
                 "chunk_chars": app.state.cfg.extraction_chunk_chars,
@@ -2882,7 +3147,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 **_credentials_context(c.provider),
                 "credentials_editable": credentials_editable,
                 "connection_test_enabled": c.provider in TESTABLE_PROVIDERS,
-                "relation_aliases": _relation_aliases_text(),
+                **_relation_aliases_context(),
                 # The Model field starts as the plain text input and, for a
                 # model-enumerable provider, lazily swaps itself for the picker
                 # (`hx-trigger="load"`). Enumerating eagerly here would put a
@@ -3184,18 +3449,139 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return RedirectResponse("/settings", status_code=303)
 
     @app.post("/settings/relation-aliases", response_class=HTMLResponse)
-    def save_relation_aliases(request: Request, relation_aliases_text: str = Form("")):
+    def save_relation_aliases(
+        request: Request,
+        relation_aliases_text: str = Form(""),
+        relation_aliases_rendered_unreadable: str | None = Form(None),
+    ):
         text = relation_aliases_text.strip()
+        if not text and relation_aliases_rendered_unreadable:
+            # #555 BLOCKER-2/MUST-FIX-1: `relation_aliases("")` parses cleanly
+            # (returns {}), so nothing below would otherwise refuse this submit,
+            # and it would reach the `path.exists(): path.unlink()` branch further
+            # down. That branch exists for "the user deliberately cleared their
+            # aliases" — a real choice when the box started full and readable.
+            # But `_relation_aliases_context` (unit C) puts an EMPTY box on the
+            # page when the on-disk file could not be read at all (cp949,
+            # permission-denied, …) — there the empty box is not a choice, it is
+            # the only thing the page could show, and the same submit would
+            # delete the user's only copy of their aliases.
+            #
+            # `relation_aliases_rendered_unreadable` is a hidden field the
+            # template only emits when THIS render's box was empty for that
+            # reason (settings.html), and the refusal below keys on it rather
+            # than re-deriving `_relation_aliases_context()` here. Re-deriving
+            # was the original (broken) shape: measured end-to-end, it let a
+            # STALE tab that rendered while the file was unreadable send its
+            # empty box after someone repaired the file on disk in the
+            # meantime — the re-derived check then saw a readable file, did not
+            # refuse, and deleted the just-repaired file. Binding the refusal to
+            # what THIS render actually showed, instead of to the file's state
+            # at submit time, closes that race in the destructive direction; the
+            # genuine-clear path (rendered from a readable file, so no hidden
+            # field) is unaffected either way.
+            #
+            # Truthy, not `== "1"` (#555 gate rev-2): the template only ever
+            # sends `"1"`, but a destructive-path guard should not silently
+            # disarm on a value that merely drifted from that literal — any
+            # non-empty value here means the same thing (this render's box was
+            # empty because the file was unreadable). Falsiness, not `is None`:
+            # an ABSENT field (`None`, the default) and a PRESENT-but-empty one
+            # (`""`, e.g. a forged submit with the field but no value) both take
+            # the non-refusal path below, and both are correct there — the
+            # template itself only ever omits the field or sends `"1"`, never an
+            # empty string, so this is generous rather than load-bearing.
+            return _settings(
+                request,
+                error=(
+                    f"Nothing was saved. This box was empty because "
+                    f"{RELATION_ALIASES_RELPATH} could not be read when this page "
+                    "was loaded, and saving it as submitted would have deleted the "
+                    "file instead of fixing it. Paste corrected contents here before "
+                    "saving."
+                ),
+                status_code=400,
+            )
         try:
             relation_aliases(text)
         except CorroborationPolicyError as e:
             return _settings(request, error=str(e), status_code=400)
         path = _relation_aliases_path()
-        if text:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(text + "\n", encoding="utf-8")
-        elif path.exists():
-            path.unlink()
+        try:
+            if text:
+                _write_relation_aliases_atomic(path, text + "\n")
+            elif path.exists():
+                # No truncate-before-fail risk here: `unlink` either removes the
+                # whole file or, on failure, leaves it exactly as it was — unlike
+                # `write_text`'s open(mode='w'), there is no partial-content state
+                # for this branch to land in, so it needs no atomic treatment.
+                path.unlink()
+        except Exception as exc:  # noqa: BLE001 - same house form as save_prompt_route/reset_prompt_route above
+            # #555 BLOCKER-3: previously unguarded, so a write against a file this
+            # process cannot write to (e.g. permission-denied) 500'd instead of
+            # reporting the failure. Newly reachable now that this page no longer
+            # 500s on GET for that same file — before this PR the form was
+            # unreachable for a KB in that state.
+            #
+            # `_write_relation_aliases_atomic` leaves `path` byte-identical to
+            # before on any failure (mkstemp + os.replace, never `write_text`'s
+            # in-place truncate — #555 gate REV-3), so "Nothing was saved" below
+            # is true of a write failure now, not just of the unlink branch.
+            #
+            # BROAD, matching `save_prompt_route`/`reset_prompt_route`'s stated
+            # reasoning rather than the narrower `except OSError` an earlier
+            # round of this fix used (#555 gate rev-2, Critic N7): both routes
+            # do plain filesystem calls (`mkdir`/`write_text`/`unlink` there,
+            # `mkstemp`/`fchmod`/`write`/`fsync`/`os.replace` here) that raise
+            # `OSError` in every case anyone has produced, but this file's own
+            # precedent (`save_prompt_route`'s comment) declines to trust that
+            # as a closed set — "the ways a directory the user can chmod fails
+            # are not a set this route can enumerate" — and this route has no
+            # narrower a claim to make about its own filesystem calls than that
+            # one does about its. One rule, not two.
+            #
+            # STATUS IS 500, MATCHING `save_prompt_route`/`reset_prompt_route`,
+            # NOT 400 (#555 gate rev-7 — an earlier round of this comment kept
+            # 400 here and argued the retry consideration was neutral because
+            # this route, like those two, is a plain `<form method="post">`
+            # with no `hx-post` (checked — `prompts.html` has zero `hx-post`
+            # occurrences too). That premise is true but was applied wrong:
+            # it is equally true of the routes this one is being compared
+            # AGAINST, so it cannot be the reason to diverge from them. It
+            # shows only that no CLIENT BEHAVIOUR keys on the split here —
+            # not that the argument for 500 does not apply. `save_prompt_route`'s
+            # own reasoning ("the user's text was accepted and the disk said
+            # no, so repeating the identical request once the mode bits are
+            # fixed is exactly the right thing to do — which is what 4xx
+            # denies") is a claim about MEANING, not about what a browser
+            # does next, and it applies here word for word. `tests/test_web.py`
+            # pins 500 for exactly this failure class on the sibling routes,
+            # six times: "the write did not happen" (×4), "the delete did not
+            # happen" (×2).
+            #
+            # The decisive reason, independent of any of that: a status code is
+            # not only a retry hint, it is a machine-readable claim about WHO
+            # was at fault. `relation_aliases(text)` has already succeeded by
+            # the time this `try` is entered, so the request itself was valid
+            # — the failure below is the server's filesystem, not the client's
+            # submission. A 4xx here would be a false attribution of fault, in
+            # the one part of the response a machine reads, the same class of
+            # defect as a docstring that misstates what the code does. The
+            # empty-submit refusal and the parse-error branch above stay at
+            # 400 — both are refusals the client can correct by what it sends
+            # next (paste valid aliases; paste the file's actual contents
+            # rather than the empty box the server itself rendered).
+            #
+            # The verb names the operation that actually ran, not always
+            # "written" (measured, #555 gate rev-2: a directory sitting at the
+            # alias path made the `unlink()` branch raise, and "could not be
+            # written" named an operation — writing — that never happened).
+            action = "written" if text else "removed"
+            return _settings(
+                request,
+                error=f"Nothing was saved. {RELATION_ALIASES_RELPATH} could not be {action}: {exc}",
+                status_code=500,
+            )
         return RedirectResponse("/settings", status_code=303)
 
     @app.post("/settings/root", response_class=HTMLResponse)

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -4,6 +4,13 @@
 <h1>Knowledge base</h1>
 <p class="muted">KB <code>{{ root }}</code> · provider <strong>{{ provider_label }}</strong> · model <code>{{ model }}</code></p>
 
+{% if alias_error %}
+<p class="error" role="alert">{{ alias_error }} Every count on this page marked
+  <span class="badge muted">not computed</span> is withheld for that reason — it would
+  have been computed under different alias rules than this KB's file specifies. Fix it
+  on <a href="/settings">Settings</a>.</p>
+{% endif %}
+
 <section class="cards">
   <div class="card"><div class="num">{{ sources|length }}</div><div class="lbl">sources</div></div>
   <div class="card"><div class="num">{{ total }}</div><div class="lbl">facts</div></div>
@@ -21,8 +28,14 @@
         <strong>{{ queue.label }}</strong>
         <div class="src">{{ queue.detail }}</div>
       </td>
-      <td class="conf">{{ queue.count }}</td>
-      <td><a class="btn ghost" href="{{ queue.href }}">Open</a></td>
+      <td class="conf">{% if queue.count is none %}<span class="badge muted">not computed</span>{% else %}{{ queue.count }}{% endif %}</td>
+      <td>
+        {% if queue.count is none %}
+        <span class="muted" title="Not offered while its count is not computed — see the alias-file notice above.">—</span>
+        {% else %}
+        <a class="btn ghost" href="{{ queue.href }}">Open</a>
+        {% endif %}
+      </td>
     </tr>
     {% endfor %}
   </tbody>
@@ -62,7 +75,9 @@
 {% endif %}
 
 <h2>Source corroboration <span class="muted">- engine-input facts only</span></h2>
-{% if corroboration %}
+{% if corroboration is none %}
+<p class="muted">Not computed — see the alias-file notice above.</p>
+{% elif corroboration %}
 <table class="counts">
   <thead><tr><th>Fact</th><th>Sources</th></tr></thead>
   <tbody>
@@ -82,7 +97,9 @@
 {% endif %}
 
 <h2>Single-valued conflicts <span class="muted">- source support by value</span></h2>
-{% if single_valued_conflicts %}
+{% if single_valued_conflicts is none %}
+<p class="muted">Not computed — see the alias-file notice above.</p>
+{% elif single_valued_conflicts %}
 <table class="counts">
   <thead><tr><th>Subject / relation</th><th>Competing values</th></tr></thead>
   <tbody>

--- a/verinote/web/templates/settings.html
+++ b/verinote/web/templates/settings.html
@@ -172,7 +172,25 @@
 <p><a class="btn ghost" href="/prompts">Manage prompts</a></p>
 
 <h2>Relation aliases</h2>
+{% if relation_aliases_error %}<p class="error" role="alert">{{ relation_aliases_error }}</p>{% endif %}
+{% if relation_aliases_unreadable %}
+{# Two remedies, because they cover different failures: pasting corrected
+   content here succeeds even against a file this process cannot itself read or
+   write (`os.replace` only needs write access to the containing DIRECTORY, not
+   to the file it replaces -- measured, #555 REV-3/4), so a `chmod 000` file is
+   NOT the case that needs the second remedy. A read-only DIRECTORY is: there
+   the save itself fails (400, "could not be written", file untouched) and only
+   an outside fix -- permissions on the directory, or a genuine encoding repair
+   -- helps. #}
+<p class="warn" role="alert">The box below is empty because the file above could not be
+  read. Submitting it empty is refused here, so it will not delete the file — paste
+  corrected contents here before saving, or repair the file outside the app
+  (permissions, encoding) and reload this page.</p>
+{% endif %}
 <form class="settings" action="/settings/relation-aliases" method="post">
+  {% if relation_aliases_unreadable %}
+  <input type="hidden" name="relation_aliases_rendered_unreadable" value="1">
+  {% endif %}
   <label>Aliases
     <textarea name="relation_aliases_text" rows="8"
               placeholder="- `역할` -> `role`">{{ relation_aliases }}</textarea>

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -5,6 +5,11 @@
 <p class="muted">Review uploaded sources, analysis progress, fact counts, and next actions.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
+{% if alias_error %}
+<p class="error" role="alert">{{ alias_error }} Per-source trust counts below are not
+  shown, because they would be computed under different alias rules than this KB's
+  file specifies. Fix it on <a href="/settings">Settings</a>.</p>
+{% endif %}
 
 <form class="upload" action="/sources" method="post" enctype="multipart/form-data">
   <label>Add a source
@@ -241,11 +246,17 @@
         {# Derived from ENGINE_STATUSES, which already includes `accepted`:
            label it by what it means (the engine reads it), not by one status. #}
         {% if s["engine_count"] %}<br>{{ s["engine_count"] }} engine input{% endif %}
+        {% if s.get("trust_unavailable") %}
+        <div class="source-trust">
+          <span class="badge muted">trust not computed</span>
+        </div>
+        {% else %}
         <div class="source-trust">
           <span class="badge trust-unsupported">{{ s["unsupported_count"] }} unsupported</span>
           <span class="badge trust-conflicted">{{ s["conflicted_count"] }} conflicted</span>
           <span class="badge trust-corroborated">{{ s["corroborated_count"] }} corroborated</span>
         </div>
+        {% endif %}
       </td>
       <td class="evidence-cell" id="evidence-{{ s["id"] }}">
         {% if s["evidence_snippets"] %}


### PR DESCRIPTION
Closes #555.

## What was broken

A typo in the hand-edited `policy/relation-aliases.md` returned **500** from `/` and `/sources`; saving the file as cp949 took `/settings` down too, so the entire web UI was unreachable. `docs/operations.md`'s `policy/relation-aliases.md` row says the file is "written by hand or by the Settings UI", so ordinary use reaches both states.

Measured on `5cb0bd8` vs this branch, malformed = `- 소속 member_of` (valid UTF-8, arrow missing), cp949 = the same line encoded cp949:

| input | route | before | after |
|---|---|---|---|
| malformed | `/` · `/sources` · `/settings` | 500 · 500 · 200 | **200 · 200 · 200** |
| cp949 | `/` · `/sources` · `/settings` | 500 · 500 · 500 | **200 · 200 · 200** |

`/settings` returned 200 on the malformed input before this change but **surfaced nothing** — it swallowed the parse error and rendered the broken text back — so acceptance criterion 1 was unmet there too.

## The degradation is honest, not a fallback

The pages do not fall back to the packaged defaults. `store_relation_aliases` returns `merge_default_relation_aliases(...)`, so the delta between the user's file and the defaults is *exactly their custom entries* — computing under defaults would print corroborated/conflicted/unsupported counts the user never configured, in the same badges a healthy KB uses.

So the four alias-dependent queue rows, both dashboard tables and the per-source trust badges are **withheld and marked**, and the empty-state prose ("No source-backed engine-input facts yet.") is suppressed rather than shown over a KB that could not be analysed. Rows whose count is withheld no longer offer an `Open` button, because those targets are still down (#570).

Everything alias-*independent* still renders: status counts, coverage, the sources list, job state, and the two queue rows that do not depend on aliases.

## `/settings` no longer destroys the file it exists to repair

Saving an empty box reached `path.exists() → path.unlink()`, and `relation_aliases("")` parses cleanly so nothing refused it. Before this change `/settings` 500'd on cp949, so that path was unreachable; making the page render would have made it reachable.

An empty submit is now refused whenever *the render that produced it* showed an empty box for an unreadable file — keyed on a hidden field emitted by that render rather than re-derived at submit time. Re-deriving was measured to let a stale tab delete a file the user had just repaired on disk, which is the page's own advice. A deliberate clear on a readable file still deletes, unchanged.

The write is atomic (`mkstemp` → `fsync` → `os.replace`), following `config.py::_write_json_atomic`. `write_text` truncates on open, so a failure partway through left the file empty *while the page said "Nothing was saved"* — measured on a real full filesystem. A failed save now leaves the file byte-identical, which is what makes that sentence true. Verified at six injection points and under 80 concurrent saves (zero torn reads, no temp files left).

## Status split

A disk failure returns **500**, matching `save_prompt_route`/`reset_prompt_route`; the two refusals above it stay **400**. Both refusals are correctable by what the client sends next (paste valid aliases; paste the file's contents); a disk failure is not — the remedy is outside the request entirely. `tests/test_web.py` already pins 500 for this class on the sibling routes six times.

## Tests

24 tests in `tests/test_relation_aliases_web_guard.py`. Every guard is falsifiable on its own: each mutation reddens a test that no other guard's deletion reddens, verified independently by three reviewers (32, 42 and 41-mutant matrices, zero survivors, no pin lost across revisions).

Note the malformed-input tests assert the **message**, not the status: deleting the narrow `except CorroborationPolicyError` leaves every route at 200 and only changes the text — a status-only assertion would pin nothing there.

Full suite: 3281 passed, 12 skipped, 0 failed. `ruff check` clean, no new findings.

## Out of scope, registered

- **#570** — `/review`, `/workbench` and the five `/facts/{id}/*` endpoints have the same defect. Cut deliberately: guarding `/review` alone would ship a 200 page whose Accept/Reject/Toggle buttons and provenance link all still 500.
- **#571** — `store_typed_relations` treats an unusable path as absent. **`/sources` can still 500 on a broken `policy/typed-relations.md`** after this change; the test module docstring says so.
