### PR TITLE
ci(#566): bound both jobs with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   ruff:
     name: ruff
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v4.0.0
@@ -25,6 +26,9 @@ jobs:
   test:
     name: pytest (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Job-level, so it is evaluated once per matrix leg; the legs run
+    # concurrently, so a hang costs this bound once per leg, not once.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Closes #566.

## What was unbounded

Neither job in `.github/workflows/ci.yml` declared `timeout-minutes`, so GitHub's default of **360 minutes** applied. The `test` job is a three-entry matrix whose legs run concurrently, so a source-level hang hangs all three at once — 360 minutes per leg, on every push to `main` and every pull request.

Nothing hangs today. #567 is one concrete way to get there.

## Sizing

Measured over the **full paginated population** — 706 completed runs, 2118 pytest legs, 2026-06-23 → 2026-08-24:

| | min | mean | p95 | p99 | max |
|---|---|---|---|---|---|
| pytest legs | 0.22 | 2.11 | 4.80 | 7.92 | **18.28** |
| ruff | 0.07 | 0.10 | 0.12 | — | 0.27 |

- legs over 15 min: **2 / 2118** (0.09%), both `success`
- legs over 20 min: **0 / 2118**
- worst non-success job in 63 days: 7.83 min — nothing has ever hung

The slowest green leg ever recorded is **18.28 min** (run `32125541826`, py3.12, `success`), so **30 is 1.64×** it. `ruff`'s bound is far looser in ratio and inconsequential in cost: one non-matrix job whose slowest run was 16 seconds.

Note the issue's own sizing used **run** wall-clock rather than per-**job** duration, and an early per-job estimate sampled one API page of a 706-run population. Both understated the maximum. The figures above name their population so they can be re-derived.

## Not matching `provider-contract.yml`'s 20

Deliberate, on measured grounds: that same 18.28-minute green leg would have finished with **1.7 minutes of margin** under a 20-minute bound — 91.5% consumed — and a day 10% worse on the same mechanism would have turned a healthy commit red. This says nothing about why that workflow chose its number; it is untouched.

## The comment carries no number and no count

By design. A count of legs goes stale when a fourth Python version is added, and any arithmetic about the default becomes false the moment a bound exists. Both clauses stay true after this change and after a leg is added; the arithmetic lives in the commit message, which is a historical record.

## Verification

`timeout-minutes` is enforced by the Actions runner, so **nothing short of an induced hang demonstrates the bound firing**, and that is not worth a deliberately wedged run. What is checkable:

- indentation is job-level (4-space, sibling of `runs-on`) — not step-level, not under `strategy`
- `grep -rn timeout .github/` returns exactly 3 lines; all three jobs across both workflow files are now bounded
- **this PR's own run** executes under the new bounds, which establishes that the workflow still parses and dispatches (a misplaced key makes GitHub reject the workflow) and that 30/10 do not clip a normal green run

A YAML-parse assertion was rejected — PyYAML is not a repo dependency — and a lint step cannot fail on an optional key's absence.

## Follow-up

**#577** — the margin is against a maximum that is still growing: weekly mean has risen every week since W28 (0.76 → 5.43 min) and weekly max went 10.08 → 18.28 over W30–W34, against 11.7 minutes of remaining headroom. No date is projected from four weekly points; #577 carries a re-review trigger keyed on the **median** green leg rather than the max, because the median is measured on every run, has low variance, and crosses its threshold well before the maximum approaches the bound.
