### PR TITLE
fix(web): a blank exception no longer leaves a job message ending at the colon (#551)

### DIFF
--- a/tests/test_chunk_claim_release.py
+++ b/tests/test_chunk_claim_release.py
@@ -347,7 +347,13 @@ def test_the_recorded_cause_reaches_the_sources_page(tmp_path):
         process_extraction_job(
             store, _ChunkClient(fail_on=2, exc=ValueError()), job_id=job_id
         )
-    _caller_marks_job_failed(store, job_id, "analysis failed: ")  # caller stand-in
+    # Caller stand-in: `_start_source_extraction`'s generic clause (`web/app.py`)
+    # would write this for the injected bare `ValueError()` post-#551 —
+    # `_error_cause` names the type when `str(exc)` is blank, so the stand-in is
+    # "analysis failed: ValueError", not a bare "analysis failed: ". The
+    # assertion below is about the CHUNK message, not this job-level string;
+    # kept accurate anyway so the stand-in still stands in for a real caller.
+    _caller_marks_job_failed(store, job_id, "analysis failed: ValueError")
 
     html = TestClient(app).get("/sources").text
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -28,6 +28,7 @@ import verinote.web.app as webapp  # noqa: E402
 from verinote.config import (  # noqa: E402
     Config,
     ConfigCorruptError,
+    CredentialsCorruptError,
     app_config_path,
     read_app_config,
     save_settings,
@@ -1836,7 +1837,92 @@ def test_worker_still_fails_the_job_on_an_ordinary_error(tmp_path, monkeypatch, 
         assert _job_row(cfg, job_id)["status"] == "failed"
 
     _wait_for(failed)
-    assert "boom" in _job_row(cfg, job_id)["message"]
+    # Exact equality, not `"boom" in message`: the weaker form does not pin the
+    # no-op property of `_error_cause` (#551) — that a message-bearing exception
+    # passes through unchanged rather than being type-qualified.
+    assert _job_row(cfg, job_id)["message"] == "analysis failed: boom"
+
+
+def test_worker_names_the_type_when_the_generic_error_has_no_message(
+    tmp_path, monkeypatch, fake_client
+):
+    """#551: a bare `ValueError()` must not leave the job row reading "analysis
+    failed: " with nothing after the colon. `_error_cause` names the exception's
+    type when `str(exc)` is blank."""
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+
+    def boom(*args, **kwargs):
+        raise ValueError()
+
+    monkeypatch.setattr(webapp, "process_extraction_job", boom)
+
+    create_app(cfg)
+
+    def failed():
+        assert _job_row(cfg, job_id)["status"] == "failed"
+
+    _wait_for(failed)
+    assert _job_row(cfg, job_id)["message"] == "analysis failed: ValueError"
+
+
+def test_worker_names_the_type_when_the_llm_error_has_no_message(
+    tmp_path, monkeypatch, fake_client
+):
+    """#551: the `except LLMError` clause has the same blank-cause symptom as the
+    generic one — a bare `LLMError("")` must not leave "extraction failed: "."""
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+
+    def raise_blank_llm_error(cfg):
+        raise LLMError("")
+
+    monkeypatch.setattr(webapp, "get_client", raise_blank_llm_error)
+
+    create_app(cfg)
+
+    def failed():
+        assert _job_row(cfg, job_id)["status"] == "failed"
+
+    _wait_for(failed)
+    assert _job_row(cfg, job_id)["message"] == "extraction failed: LLMError"
+
+
+def test_worker_leaves_a_message_bearing_error_unbounded_on_the_job_row(
+    tmp_path, monkeypatch, fake_client
+):
+    """Truncation stays out of `_error_cause`. #551's own scope declaration
+    ("범위 밖" / out of scope in the issue) names message-length bounding as
+    something neither of the two job-level clauses it discusses — the CLI's
+    `fail_extraction_job` call and the web worker's generic clause — has,
+    and something this issue does not add: it covers cause notation only.
+    The extraction worker's two direct sites (S1/S2) are unbounded for that
+    reason, unlike `_short_error` and S6's own inline normalisation, which
+    both bound their reason to 240 characters. A 300-character message must
+    survive on the job row whole."""
+    cfg, job_id, _ = _job_kb(tmp_path, with_policy=True)
+    monkeypatch.setattr(
+        webapp,
+        "get_client",
+        lambda cfg: fake_client([ExtractedFact("X", "is_a", "Y", 0.9)]),
+    )
+    long_message = "x" * 300
+
+    def boom(*args, **kwargs):
+        raise RuntimeError(long_message)
+
+    monkeypatch.setattr(webapp, "process_extraction_job", boom)
+
+    create_app(cfg)
+
+    def failed():
+        assert _job_row(cfg, job_id)["status"] == "failed"
+
+    _wait_for(failed)
+    assert _job_row(cfg, job_id)["message"] == f"analysis failed: {long_message}"
 
 
 def test_worker_busy_does_not_mark_the_job_failed(tmp_path, monkeypatch, fake_client):
@@ -1966,9 +2052,10 @@ def test_worker_leaves_a_done_job_done_when_finishing_it_raises(
     # log, a real sqlite/WAL-class failure would leave no trace anywhere at all.
     assert "not recording on the job row" in caplog.text
     assert "post-done store error" in caplog.text
-    # `exc_info` specifically, not just the message: the web message is NOT
-    # type-qualified, so for a bare `ValueError()` it degrades to "analysis failed: "
-    # and the traceback is the only thing left naming what was raised. Asserting the
+    # `exc_info` specifically, not just the message: the row would be type-qualified
+    # only when the message is blank (`_error_cause`, #551), so a bare `ValueError()`
+    # here would read "analysis failed: ValueError" and the traceback would still
+    # be the only thing naming anything more specific than that. Asserting the
     # message text alone does not pin it — that string is in the message too.
     assert "RuntimeError" in caplog.text
     declined = next(
@@ -3736,6 +3823,72 @@ def test_translate_persists_get_client_failure_reason(tmp_path, monkeypatch):
     assert "missing provider credentials" in page
 
 
+def test_translate_leaves_the_reason_blank_when_the_llm_error_has_no_message(
+    tmp_path, monkeypatch
+):
+    """`_fail_pending_translations` (S6) is deliberately OUT of #551's scope: its
+    `reason` is a standalone column, not interpolated after a separator, and
+    `question_outcome_view` already renders a per-status default sentence when it
+    is blank — there is no dangling colon here to fix. Naming the exception's type
+    at this site would REPLACE that sentence ("The provider output could not be
+    used.") with a bare class name, which is a regression, not an improvement.
+    This pins the unchanged behavior so nothing re-routes this site through
+    `_error_cause` later."""
+
+    def raise_blank_llm_error(cfg):
+        raise LLMError("")
+
+    monkeypatch.setattr(webapp, "get_client", raise_blank_llm_error)
+    c = _client(tmp_path)
+    c.app.state.store.add_question("What is the sample answer?")
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    assert r.status_code == 303
+    q = c.app.state.store.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == ""
+    page = c.get("/questions").text
+    assert "The provider output could not be used." in page
+
+
+def test_translate_collapses_whitespace_and_bounds_the_reason_to_240_chars(
+    tmp_path, monkeypatch
+):
+    """S6's inline normalisation (`" ".join(str(exc).split())[:240]`) is a bare
+    expression, not a named helper, since #551 cut this site off from
+    `_short_error` — easier to lose a piece of by accident than a helper call
+    would be. `questions.reason` is unbounded `TEXT`, written for every pending
+    question at once, so both halves need a test: the internal-whitespace
+    collapse, and the 240-character bound.
+
+    Message built so the expected result can be computed by direct slicing,
+    not by re-deriving the production logic: 100 `a`s, an irregular whitespace
+    run that must collapse to one space, then 200 `b`s. Collapsed that is 301
+    characters (100 + 1 + 200); truncated to 240 it is 100 `a`s, one space, and
+    139 `b`s — one message that exercises both the collapse and the
+    truncation boundary.
+    """
+    message = "a" * 100 + "  \n\t  " + "b" * 200
+    collapsed = "a" * 100 + " " + "b" * 200
+    assert len(collapsed) == 301
+    expected_reason = collapsed[:240]
+    assert expected_reason == "a" * 100 + " " + "b" * 139
+
+    def raise_long_llm_error(cfg):
+        raise LLMError(message)
+
+    monkeypatch.setattr(webapp, "get_client", raise_long_llm_error)
+    c = _client(tmp_path)
+    c.app.state.store.add_question("What is the sample answer?")
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    assert r.status_code == 303
+    q = c.app.state.store.questions()[0]
+    assert q["status"] == "translation_failed"
+    assert q["reason"] == expected_reason
+    assert len(q["reason"]) == 240
+
+
 def test_translate_shows_invalid_model_output_reason_in_question_row(
     tmp_path, monkeypatch
 ):
@@ -3905,6 +4058,119 @@ def test_repair_post_enqueues_without_constructing_a_client(tmp_path, monkeypatc
     assert response.status_code == 303
     assert recorder.started == ["verinote-question-repair-1"]
     assert store.latest_repair_job()["status"] == "pending"
+
+
+def _repair_kb(tmp_path) -> tuple[TestClient, "Store"]:
+    """A KB with one `review_required` question, ready to be repaired."""
+    c = _client(tmp_path)
+    store = c.app.state.store
+    qid = store.add_question("What is synthetic?")
+    store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    return c, store
+
+
+def test_repair_worker_names_the_type_when_the_config_error_has_no_message(
+    tmp_path, monkeypatch
+):
+    """#551, site S3: `except (ConfigCorruptError, CredentialsCorruptError)` in the
+    repair worker's `run()` must not leave "repair failed: " with nothing after
+    the colon for a blank exception.
+
+    `assert_writable` is called on the worker's OWN `Store`, while every request
+    (including this test's own POST) calls it only on `app.state.store` — so the
+    patch is keyed on store identity, not on call order, to reach the worker
+    without disturbing the route.
+    """
+    c, store = _repair_kb(tmp_path)
+    real_assert_writable = webapp.assert_writable
+
+    def boom(store_arg):
+        if store_arg is not c.app.state.store:
+            raise CredentialsCorruptError("")
+        return real_assert_writable(store_arg)
+
+    monkeypatch.setattr(webapp, "assert_writable", boom)
+
+    response = c.post("/questions/repair", follow_redirects=False)
+    assert response.status_code == 303
+
+    def failed():
+        job = store.latest_repair_job()
+        assert job is not None and job["status"] == "failed"
+
+    _wait_for(failed)
+    assert store.latest_repair_job()["message"] == "repair failed: CredentialsCorruptError"
+
+
+def test_repair_worker_names_the_type_when_the_llm_error_has_no_message(
+    tmp_path, monkeypatch
+):
+    """#551, site S4: `except LLMError` in the repair worker has the same
+    blank-cause symptom as the config/credentials clause beside it."""
+    c, store = _repair_kb(tmp_path)
+
+    def raise_blank_llm_error(cfg):
+        raise LLMError("")
+
+    monkeypatch.setattr(webapp, "get_client", raise_blank_llm_error)
+
+    response = c.post("/questions/repair", follow_redirects=False)
+    assert response.status_code == 303
+
+    def failed():
+        job = store.latest_repair_job()
+        assert job is not None and job["status"] == "failed"
+
+    _wait_for(failed)
+    assert store.latest_repair_job()["message"] == "repair failed: LLMError"
+
+
+def test_repair_worker_names_the_type_when_the_generic_error_has_no_message(
+    tmp_path, monkeypatch
+):
+    """#551, site S5: the repair worker's broad `except Exception` clause already
+    composes `_short_error`, which now routes through `_error_cause` — a bare
+    `ValueError()` must not leave "repair failed: "."""
+    c, store = _repair_kb(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise ValueError()
+
+    monkeypatch.setattr(webapp, "process_repair_job", boom)
+
+    response = c.post("/questions/repair", follow_redirects=False)
+    assert response.status_code == 303
+
+    def failed():
+        job = store.latest_repair_job()
+        assert job is not None and job["status"] == "failed"
+
+    _wait_for(failed)
+    assert store.latest_repair_job()["message"] == "repair failed: ValueError"
+
+
+def test_repair_worker_names_the_type_when_the_generic_error_has_only_whitespace(
+    tmp_path, monkeypatch
+):
+    """`.strip()`, not truthiness. `ValueError("   ")` has a truthy `str()`, so
+    without `.strip()` in `_error_cause` this still degrades to
+    "repair failed: " with a trailing space and no cause."""
+    c, store = _repair_kb(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise ValueError("   ")
+
+    monkeypatch.setattr(webapp, "process_repair_job", boom)
+
+    response = c.post("/questions/repair", follow_redirects=False)
+    assert response.status_code == 303
+
+    def failed():
+        job = store.latest_repair_job()
+        assert job is not None and job["status"] == "failed"
+
+    _wait_for(failed)
+    assert store.latest_repair_job()["message"] == "repair failed: ValueError"
 
 
 def test_questions_page_shows_live_repair_progress_and_terminal_failure(tmp_path):

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -988,15 +988,20 @@ def cmd_sync(cfg: Config, args: argparse.Namespace) -> int:
                     # (`store/db.py`). Usually that pair is the whole difference in
                     # what gets WRITTEN from before this handler existed; on the
                     # path where the store write itself raises, what the user sees
-                    # differs too. (2) The message is type-qualified
-                    # here and is not in `web/app.py`, whose `f"analysis failed:
-                    # {e}"` renders a bare `ValueError()` as "analysis failed: "
-                    # with no cause — the same empty-cause symptom
-                    # `_release_claimed_chunk` type-qualifies against, open there as
-                    # #551 and outside the scope of the #525 re-read that clause
-                    # has since grown. So this clause is the web clause's counterpart,
-                    # not its mirror. Neither bounds the message length; the store
-                    # takes `str(exc)` whole, exactly as the web one does.
+                    # differs too. (2) This clause type-qualifies unconditionally:
+                    # `f"analysis failed: {type(exc).__name__}: {exc}"`. The web
+                    # extraction worker's own generic clause now reads
+                    # `f"analysis failed: {_error_cause(e)}"` — #551 landed a fix
+                    # there that names the type only when `str(exc)` is blank, so a
+                    # message-bearing `OSError` still differs between the two
+                    # ("analysis failed: OSError: no space" here, "analysis failed:
+                    # no space" there). The same empty-cause symptom
+                    # `_release_claimed_chunk` type-qualifies against is outside the
+                    # scope of the #525 re-read that clause has since grown. So this
+                    # clause is the web clause's counterpart, not its mirror.
+                    # Neither bounds the message length; the store takes `str(exc)`
+                    # whole here, and `_error_cause(exc)` whole there — equal to
+                    # `str(exc)` except when it is blank.
                     # (3) What this clause hands planning is a `failed` job whose
                     # `failed_chunks` COUNTER is whatever `mark_chunk_done` or
                     # `mark_chunk_failed` last computed — the counter, because

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1020,11 +1020,20 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             raise RuntimeError("no active KB")
         return cfg
 
+    def _error_cause(exc: BaseException) -> str:
+        """The exception's own message, or its type name when that message is blank."""
+        text = str(exc)
+        return text if text.strip() else type(exc).__name__
+
     def _short_error(exc: BaseException) -> str:
-        return " ".join(str(exc).split())[:240]
+        return " ".join(_error_cause(exc).split())[:240]
 
     def _fail_pending_translations(store: Store, cfg: Config, exc: LLMError) -> None:
-        reason = _short_error(exc)
+        # Not `_short_error`: this reason is a standalone column, not interpolated
+        # into a separator, and `question_outcome_view` renders a per-status
+        # sentence when it is blank. Substituting a type name here replaces that
+        # sentence, it does not rescue a dangling colon.
+        reason = " ".join(str(exc).split())[:240]
         for q in store.questions(pending_only=True):
             store.set_question_query(q["id"], None, "translation_failed", reason)
         write_query_file(store, cfg.root)
@@ -2188,10 +2197,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     # it is the second place the predicate would otherwise be
                     # encoded in prose, and a widened refusal set would silently
                     # make a hardcoded reason lie. `exc_info` is not decoration —
-                    # the web message is deliberately not type-qualified, so for a
-                    # bare `ValueError()` the formatted text degrades to
-                    # "analysis failed: " and the traceback is the only surviving
-                    # record of what was raised.
+                    # the row would gain only the exception's TYPE when its message
+                    # is blank (`_error_cause`, #551), never the traceback, so for a
+                    # bare `ValueError()` the formatted text would read "analysis
+                    # failed: ValueError" and the traceback here is still the only
+                    # surviving record of anything more specific than that.
                     logger.warning(
                         "extraction job %s is %s; not recording on the job row: %s",
                         job_id,
@@ -2390,11 +2400,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 # answers, and these two clauses are one decision in two halves —
                 # `LLMError` is a `RuntimeError` subclass, so they are adjacent,
                 # not alternatives.
-                _fail_job_unless_done(f"extraction failed: {e}")
+                _fail_job_unless_done(f"extraction failed: {_error_cause(e)}")
             # Keep background failures visible: on the job row when this call still
             # owns the job, in the log when it does not.
             except Exception as e:  # noqa: BLE001
-                _fail_job_unless_done(f"analysis failed: {e}")
+                _fail_job_unless_done(f"analysis failed: {_error_cause(e)}")
 
         threading.Thread(
             target=run,
@@ -2500,11 +2510,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             except (ConfigCorruptError, CredentialsCorruptError) as exc:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
-                    worker_store.fail_pending_repair_job(job_id, f"repair failed: {exc}")
+                    worker_store.fail_pending_repair_job(
+                        job_id, f"repair failed: {_error_cause(exc)}"
+                    )
             except LLMError as exc:
                 with Store(cfg.db_path) as worker_store:
                     worker_store.init_schema()
-                    worker_store.fail_pending_repair_job(job_id, f"repair failed: {exc}")
+                    worker_store.fail_pending_repair_job(
+                        job_id, f"repair failed: {_error_cause(exc)}"
+                    )
             except Exception as exc:  # noqa: BLE001 - durable UI-visible worker error
                 logger.exception("repair job %s failed", job_id)
                 with Store(cfg.db_path) as worker_store:


### PR DESCRIPTION
Closes #551.

## What

`str()` of a bare `ValueError()` is the empty string, so a web worker failure raised by such an exception wrote `"analysis failed: "` — a durable, user-facing row whose only account of the cause was a dangling separator. The chunk level already type-qualifies against exactly this (`_release_claimed_chunk`, `pipeline/extract.py`); the job level did not.

`_error_cause` returns the exception's own message, or its type name when that message is blank. It is `text.strip()`, not truthiness: `ValueError("   ")` has a truthy `str()` and would otherwise still produce a bare separator.

Five sites route through it — the extraction worker's two direct clauses (`app.py:2403`, `:2407`) and the repair worker's three (`:2514`, `:2520`, and `:2526` via `_short_error`). For any exception carrying a message the helper is the identity, so nothing changes on the paths that already read well.

Measured on the merge candidate, real worker thread, bare `ValueError()`: job row `'analysis failed: ValueError'`.

## The one site deliberately excluded

`_fail_pending_translations` is **not** routed through `_error_cause`, and is decoupled from `_short_error` to keep it that way. Its `reason` is a standalone column rather than text interpolated after a separator, and `question_outcome_view` renders a per-status sentence when it is blank. Naming a type there would replace that sentence ("The provider output could not be used.") with a bare class name — a regression, not a rescue, since there is no dangling colon at that site to fix.

This was mutation-proved rather than argued: applying the substitution the comment forbids destroys the rendered sentence and reddens exactly one test.

| tree | stored reason | per-status sentence rendered |
|---|---|---|
| candidate | `''` | yes |
| mutated to use `_short_error` | `'LLMError'` | **no** |

## Duplication: one more copy, deliberately

That decoupling leaves an inline `" ".join(str(exc).split())[:240]` at the site, so the collapse-then-truncate idiom now appears at **eight** places in non-test `.py` files rather than seven:

```
git grep -nE "join\(.*\.split\(\)\)\[:[0-9]+\]" -- '*.py' | grep -v ':tests/'
```

(six bound to 240, two in `repair.py` to 200.) That is one more copy, not fewer. The trade is deliberate: sharing the helper is precisely what would have carried type substitution into a site that must not have it. Both halves of the inline expression — the whitespace collapse and the 240 bound — are pinned independently by their own test.

## Out of scope

No message-length bound is added anywhere. #551 puts that out of scope (`## 범위 밖`), and neither job-level clause bounded its message before this change or does now — measured, a 300-character message survives whole on both surfaces.

`verinote/cli.py` is comment-only (verified: zero non-comment changed lines). Its clause type-qualifies unconditionally and still differs from the web one for a message-bearing exception, so the comment contrasting the two needed updating once the web side changed.

## Tests

Nine tests in `tests/test_web.py` cover the five routed sites, the whitespace-only case, the unbounded-message property, and the excluded site in both directions. All nine were confirmed to execute rather than skip.

Full suite `3300 passed, 12 skipped, 0 failed`; `uvx ruff@0.15.18 check .` clean at the version CI pins.

## Follow-ups filed, not fixed here

- **#579** — `repair.py` shadows this PR's S5 site in the real flow. Its "Not included" section has been corrected: it claimed `_short_reason` had two call sites; it has 16, and two of them build `f"llm error: {exc}"`, which renders as `'llm error:'` for a blank exception.
- `web/app.py::_short_error`'s own `[:240]` is pinned by no test — confirmed unpinned **and** pre-existing (the same mutation leaves pass counts identical on this branch and on `bbbda33`). Follow-up issue pending.
