### PR TITLE
fix(web): the remaining 13 endpoints degrade honestly on a broken alias file (#570)

### DIFF
--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -72,14 +72,23 @@ inputs since `ef4b404`, over a POST that 500s whenever
 `auto_accept_recommendations` is on — a default of False is the only reason a
 single-configuration sweep read it as clean.
 
-`/review` and `/workbench` are NOT covered here and are measured to 500 under
-both broken inputs on this commit. `/review` in particular reaches more
-alias-read sites than its traceback names, and for every filter but the default
-the row set itself is alias-derived, since those filters select facts BY trust
-label (#570). That is also why
+`/review` and `/workbench` are covered too, in the Unit E section. `/review`
+degrades TWO different ways and the seam is the filter: on the default filter
+the queue is real (`store.review_queue_page` reads no policy file) and only each
+row's trust signals are withheld, while every other filter — `unsupported`,
+`single-source`, `corroborated`, `conflicted` — selects facts BY the value that
+could not be computed — so the row set, the total and
+the pager are all alias-derived and the route refuses the question instead of
+answering it emptily.
+
+That refusal is why
 `test_dashboard_offers_no_open_button_into_a_not_computed_queue_row` still pins
-the suppressed Open buttons: the `/review?filter=…` and `/workbench` targets it
-names really do still crash under this same file.
+the suppressed Open buttons, on a justification that has changed: those targets
+no longer crash. `/review?filter=unsupported` and `/review?filter=corroborated`
+are two of the filters the route refuses, and `/workbench` withholds
+both its tables — so a button from a "not computed" dashboard row into any of
+them lands on a page that cannot answer the question the row poses. The button
+is still not offered, now for a measured reason rather than an inherited one.
 
 `store_typed_relations` (`policy/typed-relations.md`) is untouched by both
 issues, and its blast radius grew with #570 rather than staying put:
@@ -282,11 +291,23 @@ def test_a_healthy_alias_file_still_shows_the_dashboard_corroboration_table(
 def test_dashboard_offers_no_open_button_into_a_not_computed_queue_row(
     malformed_client,
 ):
-    """MUST-FIX-2 (#555 fix-round gate). Before this, a degraded row still
-    carried a live `Open` button into `/review?filter=…` or `/workbench`, which
-    are measured to 500 under this same broken alias file (#570). The banner
-    explains the degradation; a live button into a crash from that same page is
-    the "looks healthy, isn't" shape criterion 3 exists to prevent."""
+    """MUST-FIX-2 (#555 fix-round gate). Before #555, a degraded row still
+    carried a live `Open` button into `/review?filter=…` or `/workbench`.
+
+    THE REASON HAS CHANGED AND THE TEST HAS NOT. When this was written those two
+    targets 500ed, and a live button into a crash is the "looks healthy, isn't"
+    shape criterion 3 exists to prevent. #570 guarded them, so they are now 200
+    — and the suppression still stands, for a reason that is now measured rather
+    than inherited: `unsupported` and `corroborated` are both filters `/review`
+    REFUSES under a broken alias file, because each selects facts by a
+    trust label that was not computed, and `/workbench` withholds both its
+    tables. A button from a "not computed" row into any of the three would land
+    on a page that cannot answer the question that row poses.
+
+    The two alias-INDEPENDENT rows keep their buttons, and one of them is the
+    check that this is not a blanket suppression: `/review` (unfiltered) is
+    offered here and, since #570, answers at 200 with its real queue.
+    """
     r = malformed_client.get("/")
     for href in ("/review?filter=unsupported", "/review?filter=corroborated", "/workbench"):
         assert f'<a class="btn ghost" href="{href}">Open</a>' not in r.text
@@ -1281,3 +1302,381 @@ def test_a_broken_alias_file_stops_the_auto_accept_pass_rather_than_running_it_o
     r = client.post("/facts/3/accept")
     assert r.status_code == 200
     assert app.state.store.get_fact(2)["status"] == "needs_review"
+
+
+# ---------------------------------------------------------------------------
+# Unit E (#570) -- the review surface: GET /review, on the default filter and
+# on each trust-label filter, and GET /workbench.
+# ---------------------------------------------------------------------------
+
+REVIEW_FILTER_NAV = '<nav class="filters"'
+WORKBENCH_H1 = "<h1>Trust workbench</h1>"
+REVIEW_SHOWING_NONE = "Showing 0 of 0 review facts"
+REVIEW_NO_MATCH = "No facts match this filter."
+REVIEW_PAGINATION = '<nav class="pagination"'
+REVIEW_FILTER_REFUSAL = (
+    "This filter selects facts by trust label, which is not computed"
+)
+WORKBENCH_NO_CORROBORATION = (
+    "No facts are corroborated by multiple distinct sources."
+)
+WORKBENCH_NO_CONFLICTS = "No source-backed single-valued conflicts."
+
+
+def _empty_queue_client(tmp_path: Path, alias_bytes: bytes | None) -> TestClient:
+    """A `/review` whose queue is deliberately empty -- see the test that uses it
+    for why that is an instrument rather than an oversight."""
+    root = _make_kb(tmp_path)
+    cfg = Config(
+        root=root,
+        db_path=root / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    app = create_app(cfg)
+    store = app.state.store
+    source_id = store.add_source("sources/a.txt")
+    store.add_fact(
+        "A", "소속", "B", status="confirmed", confidence=0.9, source_id=source_id
+    )
+    if alias_bytes is not None:
+        path = root / RELATION_ALIASES_RELPATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(alias_bytes)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def corroborated_client(tmp_path: Path) -> TestClient:
+    """A KB whose `/workbench` renders a real corroboration table on a healthy
+    alias file.
+
+    `_open_app`'s KB cannot serve as the workbench anti-vacuity control: it has
+    one source, so nothing is corroborated by two distinct sources and a healthy
+    `/workbench` shows the same empty-state prose a withheld one would have to
+    avoid (measured). Here `A/소속/B` from `a.txt` and `A/member_of/B` from
+    `b.txt` are one canonical triple *because of the user's alias line*, which is
+    what puts a `<table class="counts">` on the healthy page.
+    """
+    root = _make_kb(tmp_path)
+    app = create_app(
+        Config(
+            root=root,
+            db_path=root / "kb.sqlite",
+            provider="anthropic",
+            model="m",
+            api_key=None,
+            base_url=None,
+        )
+    )
+    store = app.state.store
+    source_a = store.add_source("sources/a.txt")
+    source_b = store.add_source("sources/b.txt")
+    store.add_fact(
+        "A", "소속", "B", status="confirmed", confidence=0.9, source_id=source_a
+    )
+    store.add_fact(
+        "A", "member_of", "B", status="confirmed", confidence=0.9, source_id=source_b
+    )
+    store.add_fact(
+        "C", "소속", "D", status="needs_review", confidence=0.5, source_id=source_a
+    )
+    path = root / RELATION_ALIASES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(HEALTHY_BYTES)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# --- GET /review, default filter -------------------------------------------
+
+
+def test_review_survives_a_malformed_alias_file_and_keeps_the_parser_message(
+    malformed_client,
+):
+    r = malformed_client.get("/review")
+    assert r.status_code == 200
+    assert PARSER_MSG in r.text
+    assert NAMED not in r.text
+
+
+def test_review_survives_a_cp949_alias_file_and_names_the_file(cp949_client):
+    r = cp949_client.get("/review")
+    assert r.status_code == 200
+    assert NAMED in r.text
+
+
+def test_review_stays_up_with_an_empty_queue_under_a_broken_alias_file(tmp_path):
+    """The `/review` route guard's own test, and the ONLY fixture in which its
+    failure is observable.
+
+    STATUS-ONLY, PERMANENTLY. Do not add a message or banner assertion here.
+    The banner is a separate guard, and asserting its text would make this test
+    redden when the banner is deleted too — which is exactly the uniqueness this
+    test exists to have. Assert the status and nothing else.
+
+    THIS FIXTURE IS DELIBERATELY EMPTY -- one `confirmed` fact and no
+    `needs_review` fact -- and adding a `needs_review` fact destroys what the
+    test pins, silently, without reddening anything. AC-4 (every `/review`
+    fixture must contain a `needs_review` fact) has been ruled by its own author
+    NOT to govern this test: AC-4 exists to stop a *degradation* assertion
+    passing vacuously on a queue that never reaches `_fact_row_context`, and this
+    test asserts no degradation. It asserts that the route survives at all, and a
+    populated queue provably cannot pin that. The carve-out is this one test
+    wide; AC-4 still governs every other `/review` test in this file.
+
+    The measurement, verbatim, because someone re-deriving this in six months
+    needs the evidence rather than the conclusion:
+
+        A-G1 deleted, B-G1 intact, queue populated=True   -> GET /review = 500
+        A-G1 deleted, B-G1 intact, queue populated=False  -> GET /review = 200
+
+    On a populated queue the fact-row guard's site (`fact_trust_summary`, via
+    `_fact_row_context`) is reached and its deletion 500s the page, so every
+    populated-queue `/review` test is reddened by that guard too. On an empty
+    queue that site is never reached, while this route's own site
+    (`accept_recommendations_for`, which builds its engine off the alias file
+    before it looks at a single id) still is.
+    """
+    client = _empty_queue_client(tmp_path, MALFORMED_BYTES)
+    assert client.get("/review").status_code == 200
+
+
+def test_review_still_lists_the_queue_rows_and_withholds_only_their_trust(
+    malformed_client,
+):
+    """`store.review_queue_page` reads no policy file, so the rows on the default
+    filter are the KB's real ones — only the trust signals on them are withheld.
+    A guard that dropped the queue as well would pass every status assertion and
+    tell the user their review queue was empty."""
+    r = malformed_client.get("/review")
+    assert 'id="fact-2"' in r.text
+    assert ROW_NOT_COMPUTED in r.text
+
+
+def test_the_review_fixture_actually_reaches_a_fact_row(healthy_client):
+    """AC-4's control, paired with the test above: a `/review` whose queue never
+    reaches the row partial would pass the degradation tests against a half-fix.
+    Asserted on the HEALTHY client so it measures the fixture, not the guard."""
+    r = healthy_client.get("/review")
+    assert r.status_code == 200
+    assert 'id="fact-2"' in r.text
+    assert "Showing 1-1 of 1" in r.text
+
+
+# --- GET /review, the trust-label filters ----------------------------------
+
+
+def test_a_trust_label_filter_stays_up_and_keeps_its_filter_nav(malformed_client):
+    """The filter-refusal guard's own test, and the assertion is chosen so that
+    no template deletion can redden it.
+
+    The filter nav sits above the banner, the toolbar, the status line, both
+    pagination calls and the queue block, and is built from static labels — so it
+    renders on every degraded page and survives the deletion of every template
+    guard on it — the banner, the pager block and the queue block. It is also green under the fact-row guard's
+    deletion, because with `queue = None` no row context is ever built. That
+    leaves the route's own refusal as the only deletion that reddens it.
+    """
+    r = malformed_client.get("/review?filter=unsupported")
+    assert r.status_code == 200
+    assert REVIEW_FILTER_NAV in r.text
+
+
+def test_the_filtered_page_reports_no_total_it_did_not_compute(malformed_client):
+    """The pager guard's own test. With `pager = None` and no guard, Jinja
+    renders `{{ pager.start }}` as '' and iterates `pager.pages` as empty without
+    raising, so the page comes back 200 saying it is showing 0 of 0 review facts
+    — a count of a queue nobody built — with a pagination nav offering Previous
+    and Next through it.
+
+    Both strings are asserted because the guard has two halves (the
+    toolbar-and-status block, and the two `review_pages(pager)` calls) and
+    deleting either alone would otherwise be silent.
+    """
+    r = malformed_client.get("/review?filter=unsupported")
+    assert REVIEW_SHOWING_NONE not in r.text
+    assert REVIEW_PAGINATION not in r.text
+
+
+def test_the_filtered_page_does_not_claim_the_filter_matched_nothing(
+    malformed_client,
+):
+    """The queue guard's own test. `{% if queue %}` alone cannot tell `None` from
+    an empty list, so it falls through to "No facts match this filter." — a claim
+    about which facts carry this trust label, made about a label that was never
+    computed.
+
+    The refusal sentence lives in this block and only in this block, so it is
+    asserted here and nowhere else; putting it in the pager block too would leave
+    it on the page when either block alone is deleted.
+    """
+    r = malformed_client.get("/review?filter=unsupported")
+    assert REVIEW_NO_MATCH not in r.text
+    assert REVIEW_FILTER_REFUSAL in r.text
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_the_filtered_page_names_the_alias_failure(
+    tmp_path, alias_bytes, present, absent
+):
+    """The review banner's own test. On this page the banner is the sole carrier
+    of the reason: `review.html`'s only `{% include "partials/fact_row.html" %}`
+    sits inside `{% for row in queue %}`, and with `queue = None` that loop never
+    runs, so the fragment's own reason line renders nowhere."""
+    client = _client(tmp_path, alias_bytes)
+    r = client.get("/review?filter=unsupported")
+    assert r.status_code == 200
+    assert present in r.text
+    assert absent not in r.text
+
+
+def test_a_healthy_alias_file_still_filters_the_review_queue_by_trust_label(
+    healthy_client,
+):
+    """Anti-vacuity control for the filter tests above: a route that refused the
+    filter unconditionally would pass all of them.
+
+    `unsupported` is the only non-vacuous choice on this fixture. `single-source`,
+    `corroborated` and `conflicted` each render `Showing 0 of 0` *and* "No facts
+    match this filter." on a HEALTHY file (measured, each of the four named here),
+    so swapping the
+    filter here would make this control itself vacuous.
+    """
+    r = healthy_client.get("/review?filter=unsupported")
+    assert r.status_code == 200
+    assert 'id="fact-2"' in r.text
+    assert "Showing 1-1 of 1" in r.text
+
+
+def test_a_healthy_review_page_still_carries_its_accept_recommendations(
+    healthy_client,
+):
+    """The review guard's RECOMMENDATION half, on the over-application axis its
+    deletion test cannot reach.
+
+    That guard does two things when the file is broken: it withholds the accept
+    recommendations and it withholds each row's trust. Mutating it to "never
+    compute recommendations at all" is invisible to every other test here — the
+    healthy control above pins the queue and the total, both of which are
+    alias-independent, and the degraded tests pin strings that are absent either
+    way.
+
+    Same conjunction caveat as the fact-row equivalent: the caution chips are
+    rendered inside the trust arm of `fact_row.html`, so this asserts that trust
+    AND recommendations were computed, not recommendations alone.
+    """
+    r = healthy_client.get("/review")
+    assert r.status_code == 200
+    assert RECOMMENDATION_REASON in r.text
+
+
+# --- GET /workbench ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_workbench_stays_up_under_a_broken_alias_file(
+    tmp_path, alias_bytes, present, absent
+):
+    """The workbench route guard's own test, and like the filter nav the
+    assertion is chosen to be above every template guard: the `<h1>` precedes
+    the banner, the corroborated-table branch and the conflicts-table branch, so
+    no template deletion can redden it.
+
+    Parametrized over both inputs deliberately. This is the only place either
+    input's *status* on `/workbench` is asserted — the banner test below asserts
+    the message, and a message assertion only implies a 200 rather than pinning
+    it.
+    """
+    del present, absent
+    client = _client(tmp_path, alias_bytes)
+    r = client.get("/workbench")
+    assert r.status_code == 200
+    assert WORKBENCH_H1 in r.text
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_workbench_names_the_alias_failure(tmp_path, alias_bytes, present, absent):
+    """The workbench banner's own test. `workbench.html` contains no
+    `{% include %}` at all, so unlike the review queue there is no fragment that
+    could carry the reason instead — the banner is its only possible source."""
+    client = _client(tmp_path, alias_bytes)
+    r = client.get("/workbench")
+    assert present in r.text
+    assert absent not in r.text
+
+
+# The two tables below get one test each, not one test asserting both. They are
+# separately deletable `{% if workbench is none %}` branches, and folded into a
+# single test each deletion reddens the same one — which leaves the two
+# indistinguishable in the falsifiability matrix even though either can be got
+# wrong on its own. The occurrence count keeps its own test for the same reason:
+# it reddens under both, so holding it alongside either table's assertion would
+# take that table's uniqueness away again.
+
+
+def test_the_workbench_does_not_deny_corroboration_it_never_computed(
+    malformed_client,
+):
+    """`workbench.corroborated` on a `None` workbench is falsy Undefined rather
+    than a raise, so without its `is none` branch the page renders 200 asserting
+    that no fact is corroborated by multiple distinct sources — over a KB whose
+    corroboration was never computed. One of the exact falsehoods #555 removed
+    from the dashboard."""
+    r = malformed_client.get("/workbench")
+    assert WORKBENCH_NO_CORROBORATION not in r.text
+
+
+def test_the_workbench_does_not_deny_conflicts_it_never_searched_for(
+    malformed_client,
+):
+    """The same shape one table down, and a separate deletion: the conflicts
+    section's `{% else %}` claims there are no source-backed single-valued
+    conflicts, about a search that never ran."""
+    r = malformed_client.get("/workbench")
+    assert WORKBENCH_NO_CONFLICTS not in r.text
+
+
+def test_both_withheld_workbench_tables_say_they_were_not_computed(
+    malformed_client,
+):
+    """The positive half of the corroboration and conflicts tests above: each
+    withheld table must say so
+    rather than silently rendering nothing, which would read as a page with no
+    findings."""
+    r = malformed_client.get("/workbench")
+    assert r.text.count(DOSSIER_NOT_COMPUTED) == 2
+
+
+def test_a_healthy_alias_file_still_shows_the_workbench_tables(corroborated_client):
+    """Anti-vacuity control for the test above: a route that withheld the tables
+    unconditionally would also pass it. Uses the two-source fixture, because on a
+    single-source KB the healthy page shows the same empty-state prose the
+    degraded page must avoid."""
+    r = corroborated_client.get("/workbench")
+    assert r.status_code == 200
+    assert '<table class="counts">' in r.text
+    assert WORKBENCH_NO_CORROBORATION not in r.text
+    assert DOSSIER_NOT_COMPUTED not in r.text
+
+
+# --- AC-3: the control on a guarded page must not lead to a crash -----------
+
+
+def test_the_dashboard_open_button_into_the_review_queue_reaches_a_working_page(
+    malformed_client,
+):
+    """AC-3, asserted as a path rather than as two independent facts.
+
+    #555 guarded `/` and left this Open button live over a `/review` that 500ed:
+    the dashboard rendered honestly at 200 and its own control crashed. Every
+    other test here requests `/review` directly, which cannot see that — a route
+    can be non-500 on a direct request while the page that links to it never
+    offers the link, and it could equally be offered while broken. This walks the
+    one step: read the button off the dashboard, then follow it.
+    """
+    dashboard = malformed_client.get("/")
+    assert dashboard.status_code == 200
+    assert '<a class="btn ghost" href="/review">Open</a>' in dashboard.text
+    assert malformed_client.get("/review").status_code == 200

--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -62,20 +62,44 @@ and the clause is `except Exception`, matching this file's own house form at
 `save_prompt_route`/`reset_prompt_route`, not `except OSError`
 (`test_settings_save_catches_a_non_oserror_write_failure`).
 
-SCOPE. Only the three routes issue #555 names: `/`, `/sources`, `/settings`.
-`/review` and `/workbench` have the same defect (and `/review` has a second,
-independent alias-read site the naive fix misses — see plan555.md M10 and
-critique555.md BLOCK-1, which also found `POST /facts/{id}/{accept,reject,toggle}`
-and `GET /facts/{id}/{row,provenance}` broken the same way) but are deliberately
-NOT touched here; they are registered as a follow-up issue instead of being
-silently dropped. `store_typed_relations` (`policy/typed-relations.md`) is also
-untouched — `_source_trust_rollup` still calls it alongside
-`store_relation_aliases`, so `/sources` can still 500 on a broken
-`typed-relations.md` after this change. The dashboard's degraded queue rows
-still link to `/review` and `/workbench` for their OTHER (non-degraded) rows,
-and those two routes can still 500 under a broken alias file (#570, also out of
-scope) -- `test_dashboard_offers_no_open_button_into_a_not_computed_queue_row`
-pins that the degraded rows themselves do not offer that button.
+SCOPE. Two issues' worth of routes live here, and the seam matters when reading
+a failure. #555 covers `/`, `/sources` and `/settings`. #570 adds the fact-row
+surface, in the Unit D section at the bottom: `GET /facts/{id}/row`,
+`GET /facts/{id}/provenance`, `POST /facts/{id}/{toggle,accept,reject,amend}`
+and `POST /sources/{id}/accept-all`. That last one is the violation #555 itself
+shipped: `/sources` has rendered its `Accept all` form at 200 under both broken
+inputs since `ef4b404`, over a POST that 500s whenever
+`auto_accept_recommendations` is on — a default of False is the only reason a
+single-configuration sweep read it as clean.
+
+`/review` and `/workbench` are NOT covered here and are measured to 500 under
+both broken inputs on this commit. `/review` in particular reaches more
+alias-read sites than its traceback names, and for every filter but the default
+the row set itself is alias-derived, since those filters select facts BY trust
+label (#570). That is also why
+`test_dashboard_offers_no_open_button_into_a_not_computed_queue_row` still pins
+the suppressed Open buttons: the `/review?filter=…` and `/workbench` targets it
+names really do still crash under this same file.
+
+`store_typed_relations` (`policy/typed-relations.md`) is untouched by both
+issues, and its blast radius grew with #570 rather than staying put:
+`_source_trust_rollup` calls it alongside `store_relation_aliases`, and so does
+`fact_trust_summary` on the line after ITS alias read. So `/sources` and every
+fact-row route above can still 500 on a broken `typed-relations.md`. Tracked as
+#585.
+
+Do not read that as "the same endpoints, one file over", and do not reuse this
+file's route list to guard it: the two files' affected sets differ in BOTH
+directions, and #585 forbids copying #570's. Measured here, healthy alias file
+plus a cp949 `typed-relations.md`: `/` and `/sources` — guarded above for the
+ALIAS file since #555 — return 500, while `/settings` stays 200. #585 carries
+the enumeration; this paragraph deliberately carries no count, because the
+number is #585's to keep current.
+
+(#571, which an earlier draft of this paragraph cited for the typed-relations
+hole, is a different defect in a different file: an unusable PATH at
+`policy/relation-aliases.md` — a directory, a symlink loop — read as an absent
+one.)
 """
 
 import stat
@@ -666,3 +690,594 @@ def test_a_missing_alias_file_is_not_treated_as_a_failure(absent_client):
         assert r.status_code == 200
         assert 'class="error"' not in r.text
         assert 'class="warn"' not in r.text
+
+
+# ---------------------------------------------------------------------------
+# Unit D (#570) -- the fact-row surface: GET /facts/{id}/row,
+# GET /facts/{id}/provenance, POST /facts/{id}/{toggle,accept,reject,amend}
+# and POST /sources/{id}/accept-all.
+# ---------------------------------------------------------------------------
+
+# The row's "not computed" marker, and the verdict it must NOT borrow.
+# `trust unavailable` is a MEASURED claim about the fact (it has no trust
+# summary); the marker below means nobody measured. Keeping them distinct is
+# what stops a broken alias file from being reported as a property of the fact.
+ROW_NOT_COMPUTED = '<span class="badge muted">trust not computed</span>'
+ROW_TRUST_UNAVAILABLE = "trust unavailable"
+EVIDENCE_NOT_COMPUTED = '<span class="muted">not computed</span>'
+NO_EVIDENCE_ANCHOR = "No evidence anchor"
+# One of this fixture's `recommendation.reasons` caution chips -- the
+# `{% for reason in recommendation.reasons[:2] %}` loop in `fact_row.html`,
+# named by symbol rather than by line because this same diff moves that file.
+# It is the only string on a fact row that moves when the accept
+# RECOMMENDATION is withheld but the trust summary is not.
+RECOMMENDATION_REASON = "insufficient distinct source support"
+DOSSIER_NOT_COMPUTED = "Not computed — see the alias-file notice above."
+# The lifecycle timeline's own wording. Deliberately not the shared marker:
+# it is the only withheld section with no distinctive sentence, so under the
+# shared one it could be pinned only by counting occurrences.
+TIMELINE_NOT_COMPUTED = (
+    "Extraction and review events not computed — see the alias-file notice above."
+)
+
+# (alias bytes, message that must be present, message that must be absent).
+# The "absent" half is #555's G1 pin, not decoration: deleting the narrow
+# `except CorroborationPolicyError` leaves every status at 200 and only swaps
+# the bare parser message for the "could not be read" wrapper.
+BROKEN_INPUTS = [
+    pytest.param(MALFORMED_BYTES, PARSER_MSG, NAMED, id="malformed"),
+    pytest.param(CP949_BYTES, NAMED, PARSER_MSG, id="cp949"),
+]
+
+AMEND_FORM = {
+    # `*_kind="string"` deliberately: `_fact_input` accepts only "string" and
+    # "term" and rejects anything else at `app.py` before a line of
+    # alias-dependent code runs, so a form sending `kind="entity"` measures a
+    # 400 and proves nothing about this guard. A7 asserts its own healthy
+    # baseline is 200 for the same reason.
+    "subject": "C",
+    "relation": "소속",
+    "object": "D2",
+    "subject_kind": "string",
+    "relation_kind": "string",
+    "object_kind": "string",
+    "note": "",
+}
+
+
+def _done_job(store, source_id: int) -> int:
+    """A completed extraction job, so its source's facts clear the
+    `source_analysis_incomplete` bar in `accept_recommendations`."""
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id, source_id=source_id, chunks=["body"]
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_done(chunk_id)
+    store.finish_extraction_job(job_id)
+    return job_id
+
+
+def _auto_accept_client(tmp_path: Path, alias_bytes: bytes | None):
+    """A KB on which the auto-accept rule really promotes a fact, and promotes it
+    BECAUSE of the user's own alias file.
+
+    `_open_app`'s KB cannot be used here, and not for want of a config flag:
+    `apply_auto_accept_recommendations` promotes only review-tier rows
+    (`accept_recommendations` iterates `store.facts(statuses=review_statuses())`),
+    and that KB's only non-review fact is `confirmed` — engine tier, which the
+    rule never touches. Its one review-tier fact is the one the request decides,
+    which the rule excludes. So "the other fact was not promoted" holds there on
+    a healthy file too, and asserts nothing.
+
+    Here fact 2 (`A 소속 B`, needs_review, `a.txt`) is corroborated by fact 1
+    (`A member_of B`, confirmed, `b.txt`) ONLY because `소속 -> member_of` makes
+    them one canonical triple. Measured: healthy -> fact 2 becomes `accepted`;
+    with no alias file at all -> it stays `needs_review`. Both sources carry a
+    completed job or the recommendation is blocked by
+    `source_analysis_incomplete` before corroboration is even weighed.
+    """
+    root = _make_kb(tmp_path)
+    cfg = Config(
+        root=root,
+        db_path=root / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+        auto_accept_recommendations=True,
+    )
+    app = create_app(cfg)
+    store = app.state.store
+    source_a = store.add_source("sources/a.txt")
+    job_a = _done_job(store, source_a)
+    source_b = store.add_source("sources/b.txt")
+    job_b = _done_job(store, source_b)
+    store.add_fact(
+        "A", "member_of", "B", status="confirmed", confidence=0.9,
+        source_id=source_b, job_id=job_b,
+    )
+    store.add_fact(
+        "A", "소속", "B", status="needs_review", confidence=0.5,
+        source_id=source_a, job_id=job_a,
+    )
+    store.add_fact(
+        "C", "소속", "D", status="needs_review", confidence=0.5,
+        source_id=source_a, job_id=job_a,
+    )
+    if alias_bytes is not None:
+        path = root / RELATION_ALIASES_RELPATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(alias_bytes)
+    return TestClient(app, raise_server_exceptions=False), app
+
+
+# --- GET /facts/{id}/row ---------------------------------------------------
+
+
+def test_a_degraded_fact_row_still_renders_the_fact_and_its_actions(malformed_client):
+    """Withholding trust must not withhold the fact (#570 AC-2).
+
+    This is the route guard's own test: `_fact_row_context`'s deletion 500s the
+    request, which has no body at all, while either TEMPLATE branch's deletion
+    leaves this green — the row is still 200 and still carries every string
+    below. toggle/accept/reject/edit are pure store writes and work fine under a
+    broken alias file, so removing them (the shape #555 used for the dashboard's
+    Open button, where the TARGET was down) would be the wrong fix here.
+    """
+    r = malformed_client.get("/facts/2/row")
+    assert r.status_code == 200
+    assert 'id="fact-2"' in r.text
+    assert '<span class="subj term-string">&#34;C&#34;' in r.text
+    assert '<span class="obj term-string">&#34;D&#34;' in r.text
+    assert '<span class="badge badge-needs_review verdict">needs_review</span>' in r.text
+    for control in (
+        'hx-post="/facts/2/toggle"',
+        'hx-post="/facts/2/accept"',
+        'hx-post="/facts/2/reject"',
+        'hx-get="/facts/2/edit"',
+        'href="/facts/2/provenance"',
+    ):
+        assert control in r.text
+
+
+def test_fact_row_survives_a_malformed_alias_file_and_keeps_the_parser_message(
+    malformed_client,
+):
+    r = malformed_client.get("/facts/2/row")
+    assert r.status_code == 200
+    assert PARSER_MSG in r.text
+    assert NAMED not in r.text
+
+
+def test_fact_row_survives_a_cp949_alias_file_and_names_the_file(cp949_client):
+    r = cp949_client.get("/facts/2/row")
+    assert r.status_code == 200
+    assert NAMED in r.text
+
+
+def test_the_signals_cell_withholds_trust_rather_than_calling_it_unavailable(
+    malformed_client,
+):
+    """The signals-cell branch's own test. Reverting it to `{% if trust %}` sends
+    `trust=None` to the existing `{% else %}`, which prints the
+    `trust unavailable` verdict — a healthy KB's sentence for a fact that has no
+    trust summary — over a fact whose summary was never computed. The evidence
+    cell's branch is not involved either way.
+
+    ASSERTED ON `GET /facts/{id}/row`, AND THAT IS LOAD-BEARING. `review.html`
+    includes this same partial, so the identical branch also sits behind
+    `/review`'s own route guard. Asserting it there would give this test a
+    SECOND outer guard whose deletion reddens it, and the signals cell would
+    stop being independently falsifiable. Do not move it to `/review` for
+    convenience.
+    """
+    r = malformed_client.get("/facts/2/row")
+    assert ROW_NOT_COMPUTED in r.text
+    assert ROW_TRUST_UNAVAILABLE not in r.text
+
+
+def test_the_evidence_cell_claims_no_anchor_it_did_not_look_for(malformed_client):
+    """The evidence-cell branch's own test, and it is a different cell from the
+    one above: the anchor is read off `trust.evidence`, so with no summary the
+    existing `{% else %}` asserts `No evidence anchor` about a fact nobody
+    checked.
+
+    On `GET /facts/{id}/row` for the same reason as the test above: this partial
+    is also included by `review.html`, and asserting there would put a second
+    outer guard behind this one.
+    """
+    r = malformed_client.get("/facts/2/row")
+    assert NO_EVIDENCE_ANCHOR not in r.text
+    assert EVIDENCE_NOT_COMPUTED in r.text
+
+
+def test_a_healthy_alias_file_still_shows_the_fact_row_trust_badges(healthy_client):
+    """Anti-vacuity control for the degraded fact-row tests above: the identity
+    test, both message tests, and the signals- and evidence-cell tests.
+
+    The last assertion is what makes the evidence-cell test non-vacuous:
+    `No evidence anchor` is present on a HEALTHY row for this fixture's
+    anchor-less fact (measured), so its absence under a broken file is a real
+    change and not a string that was never there.
+    """
+    r = healthy_client.get("/facts/2/row")
+    assert r.status_code == 200
+    assert ROW_NOT_COMPUTED not in r.text
+    assert EVIDENCE_NOT_COMPUTED not in r.text
+    assert PARSER_MSG not in r.text
+    assert NAMED not in r.text
+    assert '<span class="badge chip">unsupported</span>' in r.text
+    assert NO_EVIDENCE_ANCHOR in r.text
+
+
+def test_a_healthy_fact_row_still_carries_its_accept_recommendation_reasons(
+    healthy_client,
+):
+    """The fact-row guard's RECOMMENDATION half, on the axis its deletion test
+    cannot reach.
+
+    That guard does two things when the alias file is broken: it withholds
+    `trust` AND it withholds `recommendation`. Over-applying the second —
+    setting `recommendation = None` unconditionally, so recommendations are
+    never computed at all — is invisible to every other test in this file. The
+    healthy control above pins the `unsupported` chip, which comes off
+    `trust.trust_labels`, not off the recommendation; the degraded tests pin
+    strings that are absent either way.
+
+    NOT a duplicate of the equivalent `/review` control. The two pages take
+    their recommendations from DIFFERENT calls — `/review` from
+    `accept_recommendations_for`, this row from the `accept_recommendations`
+    fallback inside `_fact_row_context` — so each mutation is invisible to the
+    other page's test. Measured on this healthy fixture:
+
+        build                              /review  /facts/2/row
+        correct                            present  present
+        accept_recommendations_for -> {}   ABSENT   present
+        accept_recommendations     -> {}   present  ABSENT
+        fact_trust_summary         -> None ABSENT   ABSENT
+
+    Scope of what this string proves, because it is narrower than the test name
+    suggests: the caution chips are rendered inside the `{% elif trust %}` arm
+    of `fact_row.html`, so its presence means trust AND recommendations were
+    computed. That holds on a healthy fixture and is why one assertion can carry
+    both. A refactor that moves those chips out of that arm drops the trust half
+    of the implication without reddening anything — at which point the trust
+    half needs a pin of its own.
+    """
+    r = healthy_client.get("/facts/2/row")
+    assert r.status_code == 200
+    assert RECOMMENDATION_REASON in r.text
+
+
+# --- the decision POSTs ----------------------------------------------------
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_accept_survives_a_broken_alias_file(tmp_path, alias_bytes, present, absent):
+    client = _client(tmp_path, alias_bytes)
+    r = client.post("/facts/2/accept")
+    assert r.status_code == 200
+    assert present in r.text
+    assert absent not in r.text
+
+
+@pytest.mark.parametrize("route", ["toggle", "reject"])
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_toggle_and_reject_survive_a_broken_alias_file(
+    tmp_path, route, alias_bytes, present, absent
+):
+    client = _client(tmp_path, alias_bytes)
+    r = client.post(f"/facts/2/{route}")
+    assert r.status_code == 200
+    assert present in r.text
+    assert absent not in r.text
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_amend_survives_a_broken_alias_file(
+    tmp_path, healthy_client, alias_bytes, present, absent
+):
+    """`POST /facts/{id}/amend` — the endpoint #570's original table omits. It
+    reaches the same `_fact_row_context` -> `fact_trust_summary` stack as
+    accept/reject/toggle, through `_row_after_decision`.
+
+    The healthy baseline is asserted here, not assumed: this form 400s on a
+    rejected kind before any alias-dependent code runs, and a 400 baseline would
+    make the broken-input assertion below measure an early return rather than
+    this guard.
+    """
+    baseline = healthy_client.post("/facts/2/amend", data=AMEND_FORM)
+    assert baseline.status_code == 200
+
+    # `healthy_client` already built a KB under `tmp_path`; the broken one needs
+    # its own root.
+    broken_root = tmp_path / "broken"
+    broken_root.mkdir()
+    client = _client(broken_root, alias_bytes)
+    r = client.post("/facts/2/amend", data=AMEND_FORM)
+    assert r.status_code == 200
+    assert present in r.text
+    assert absent not in r.text
+
+
+def _superseded_amend(tmp_path: Path, monkeypatch, alias_bytes: bytes):
+    """Drive `amend_fact`'s `except TerminalFactError` exit. See the two tests
+    below for what this patch neutralises and what it therefore costs."""
+    client = _client(tmp_path, alias_bytes)
+    assert client.post("/facts/2/reject").status_code == 200
+    monkeypatch.setattr(
+        "verinote.web.app.is_actionable_fact_status", lambda _status: True
+    )
+    return client.post("/facts/2/amend", data=AMEND_FORM)
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_a_superseded_amend_also_survives_a_broken_alias_file(
+    tmp_path, monkeypatch, alias_bytes, present, absent
+):
+    """`amend_fact` has TWO row-rendering exits and this one is not the success
+    path: `except TerminalFactError` re-renders the read-only row directly
+    through `_row`, bypassing `_row_after_decision` entirely. Guarding only the
+    success path leaves this exit 500ing while the test above passes.
+
+    HOW THIS REACHES THAT EXIT, AND WHAT THE PATCH COSTS. In production the exit
+    is reachable only through a TOCTOU window: a reject landing between
+    `amend_fact`'s `_actionable_fact_or_error` pre-check and its
+    `store.amend_fact` call. It is NOT reachable from a stale edit form — the
+    pre-check reads the fact's CURRENT status on this request, so a form left
+    open while someone else rejects the fact just gets a plain 400 (measured:
+    reject-then-amend is 400 on every input, healthy included).
+
+    Simulating that window by monkeypatching the module-level
+    `is_actionable_fact_status` neutralises MORE than the pre-check.
+    `verinote.web.app` binds that name once and TWO callers read it: the
+    pre-check, and `_fact_row_context`'s own `actionable` computation. So the
+    row rendered below carries a `superseded` badge together with live
+    accept/reject/toggle buttons and no `rejected — no further action` text — a
+    combination the real race cannot produce, because there `_fact_row_context`
+    re-reads the row, sees `superseded`, and renders the read-only form. Both
+    sides of that were measured.
+
+    Which is why every assertion here is `actionable`-INDEPENDENT: the status,
+    the alias message, the row id, the withheld-trust marker. Do not add an
+    assertion about the action buttons or the no-further-action text; it would
+    pin a state production cannot reach. Only the `TerminalFactError` is
+    genuine — raised by the real store on a real superseded row, with the
+    handler and the row render running unmodified.
+    """
+    r = _superseded_amend(tmp_path, monkeypatch, alias_bytes)
+    assert r.status_code == 200
+    assert present in r.text
+    assert absent not in r.text
+    assert ROW_NOT_COMPUTED in r.text
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_a_superseded_amend_still_renders_a_row_at_all(
+    tmp_path, monkeypatch, alias_bytes, present, absent
+):
+    """The SEPARATING test for `amend_fact`'s second-exit threading, and the
+    reason it is split off from the message test above.
+
+    Status and row identity are the only observations of this exit that survive
+    a template guard's deletion. Delete the signals-cell branch and this request
+    is still 200 with `id="fact-2"`, losing only the marker and the parser
+    message — so the message test above is reddened by a TEMPLATE guard and
+    cannot be this route-level guard's own evidence. This one can.
+
+    The reddening population, ENUMERATED over every deletable unit in this
+    change rather than quantified over an unnamed set. Exactly three deletions
+    redden this test. Two 500 the amend response itself: this exit's own
+    `alias_error` read, and `_fact_row_context`'s withholding branch, which
+    every fact-row render passes through. The third is `_row_after_decision`'s
+    read, and it fails EARLIER than the exit under test — `_superseded_amend`'s
+    `assert client.post(...reject...).status_code == 200` precondition 500s
+    before the amend is ever sent. Every template guard in this change leaves it
+    green — the fact-row signals and evidence cells, and on `provenance.html`
+    the alias banner and the Trust-summary, Evidence-summary, Conflict, Timeline
+    and Source-evidence branches. Named, not counted: splitting one more dossier
+    section, which is exactly what this change did to the timeline, would make a
+    bare number here wrong without reddening anything. That green-under-all
+    property is the one the split exists for.
+
+    Keep the two assertions below to status and identity. Adding the message or
+    the marker here would merge this test back into the one above and undo the
+    split.
+    """
+    del present, absent
+    r = _superseded_amend(tmp_path, monkeypatch, alias_bytes)
+    assert r.status_code == 200
+    assert 'id="fact-2"' in r.text
+
+
+# --- GET /facts/{id}/provenance -------------------------------------------
+
+
+def test_provenance_survives_a_malformed_alias_file_and_keeps_the_parser_message(
+    malformed_client,
+):
+    r = malformed_client.get("/facts/2/provenance")
+    assert r.status_code == 200
+    assert PARSER_MSG in r.text
+    assert NAMED not in r.text
+
+
+def test_provenance_survives_a_cp949_alias_file_and_names_the_file(cp949_client):
+    r = cp949_client.get("/facts/2/provenance")
+    assert r.status_code == 200
+    assert NAMED in r.text
+
+
+def test_provenance_withholds_the_dossier_but_keeps_the_fact_identity(
+    malformed_client,
+):
+    """`provenance` calls `fact_trust_summary` DIRECTLY, so no `alias_error`
+    threaded through `_fact_row_context` reaches it (#570 trap 1) — and its
+    route guard and template branches are ONE guard, because
+    `{{ trust.support.source_count }}` is a two-deep attribute of `None` and
+    Jinja raises `UndefinedError` on that: withholding `trust` without the
+    template branches swaps one 500 for another.
+
+    The three sentences asserted absent are not `trust.` references — they are
+    `{% else %}` prose that renders happily on `trust=None` and states, in
+    order, that a conflict search found nothing, that no evidence anchors are
+    recorded, and that the fact was seeded or hand-entered. None of the three
+    was measured on this KB.
+    """
+    r = malformed_client.get("/facts/2/provenance")
+    assert "canonical relation" not in r.text
+    assert '<span class="badge chip">unsupported</span>' not in r.text
+    # One marker per withheld section that shares the standard wording: trust
+    # summary, evidence summary, conflict summary, source evidence. The
+    # timeline's withheld middle has its own sentence and its own test.
+    assert r.text.count(DOSSIER_NOT_COMPUTED) == 4
+    # The identity is not withheld with the dossier.
+    assert "Trust dossier — fact #2" in r.text
+    assert '<span class="subj term-string">&#34;C&#34;' in r.text
+    assert '<span class="obj term-string">&#34;D&#34;' in r.text
+    assert '<span class="badge badge-needs_review">needs_review</span>' in r.text
+
+
+# The sections below are asserted one test each, not folded into the test
+# above. Each is a separately deletable `{% if %}` in `provenance.html`, and
+# with all of them asserted in one test every one of those deletions reddens
+# the same single test — which makes them indistinguishable in the
+# falsifiability matrix even though each is a place the code can get this wrong
+# on its own. No count here on purpose: `provenance.html` carries guards beyond
+# these sections (the alias banner, the Trust-summary wrapper), so a bare number
+# would be both wrong now and staler after the next split.
+
+
+def test_the_dossier_does_not_deny_a_conflict_it_never_searched_for(
+    malformed_client,
+):
+    """`{% if trust.conflict %}`'s `{% else %}` renders happily on `trust=None`
+    (Jinja: `None.conflict` is falsy Undefined, it does not raise) and states
+    that this fact has no single-valued conflict — over a search that never
+    ran."""
+    r = malformed_client.get("/facts/2/provenance")
+    assert "No deterministic single-valued conflict for this fact." not in r.text
+
+
+def test_the_dossier_does_not_deny_evidence_anchors_it_never_looked_for(
+    malformed_client,
+):
+    """Same shape, Source-evidence section: the `{% else %}` claims no anchors
+    are recorded for a fact whose anchors were never read."""
+    r = malformed_client.get("/facts/2/provenance")
+    assert "No source evidence anchors recorded for this fact." not in r.text
+
+
+def test_the_dossier_does_not_call_an_uncomputed_origin_hand_entered(
+    malformed_client,
+):
+    """Evidence-summary section. Its run row falls through to
+    `— (seeded or hand-entered)`, which is a positive claim about where the
+    fact came from, asserted about an origin nobody looked up."""
+    r = malformed_client.get("/facts/2/provenance")
+    assert "(seeded or hand-entered)" not in r.text
+
+
+def test_the_degraded_timeline_says_its_middle_is_missing(malformed_client):
+    """The Lifecycle timeline keeps `created` and `updated` (both off `f`) and
+    loses everything between them, which is read out of the trust summary. With
+    no row of its own it would close silently and read as a fact nothing ever
+    happened to.
+
+    This section is why the marker here has its own wording: it is the only
+    withheld section with no distinctive sentence, so under the shared marker it
+    was pinned by an occurrence COUNT alone — and a count reddens for whichever
+    section went missing, naming none of them.
+    """
+    r = malformed_client.get("/facts/2/provenance")
+    assert TIMELINE_NOT_COMPUTED in r.text
+
+
+def test_a_healthy_alias_file_still_shows_the_trust_dossier(healthy_client):
+    """Anti-vacuity control for the degraded-dossier tests: each string they
+    assert ABSENT under a broken alias file is asserted present here, so every
+    one of those absences is a real change rather than a string this page never
+    had. Paired by name, since a positional reference does not survive a split:
+
+      `canonical relation`                 <- ..._withholds_the_dossier_but_keeps_the_fact_identity
+      `No deterministic single-valued ...` <- ..._does_not_deny_a_conflict_it_never_searched_for
+      `No source evidence anchors ...`     <- ..._does_not_deny_evidence_anchors_it_never_looked_for
+      `(seeded or hand-entered)`           <- ..._does_not_call_an_uncomputed_origin_hand_entered
+
+    The two not-computed markers go the other way: they must not appear on a
+    healthy page at all, and `..._degraded_timeline_says_its_middle_is_missing`
+    asserts the timeline one present when the file is broken.
+
+    (An earlier version of this docstring said "the test above". Splitting the
+    degraded assertions into one test per section silently invalidated that,
+    without reddening anything — hence the names.)
+    """
+    r = healthy_client.get("/facts/2/provenance")
+    assert r.status_code == 200
+    assert DOSSIER_NOT_COMPUTED not in r.text
+    assert TIMELINE_NOT_COMPUTED not in r.text
+    assert "canonical relation" in r.text
+    assert "No deterministic single-valued conflict for this fact." in r.text
+    assert "No source evidence anchors recorded for this fact." in r.text
+    assert "(seeded or hand-entered)" in r.text
+
+
+# --- the auto-accept write path -------------------------------------------
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_accept_all_source_facts_survives_a_broken_alias_file_when_auto_accept_is_on(
+    tmp_path, alias_bytes, present, absent
+):
+    """#555 shipped this one broken: `/sources` has rendered
+    `action="/sources/1/accept-all"` at 200 under both broken inputs since
+    `ef4b404`, over a POST that 500s whenever `auto_accept_recommendations` is
+    on. `auto_accept_recommendations` defaults to False, which is why a
+    single-configuration sweep reads this endpoint as clean.
+
+    This route never enters `_fact_row_context`, so the fact-row guard's
+    deletion leaves it at 303 — it is the auto-accept guard's own test.
+    """
+    del present, absent  # a 303 carries no body to assert a message on
+    client, _app = _auto_accept_client(tmp_path, alias_bytes)
+    r = client.post("/sources/1/accept-all", follow_redirects=False)
+    assert r.status_code == 303
+
+
+@pytest.mark.parametrize("alias_bytes, present, absent", BROKEN_INPUTS)
+def test_a_broken_alias_file_stops_the_auto_accept_pass_rather_than_running_it_on_defaults(
+    tmp_path, alias_bytes, present, absent
+):
+    """The strongest form of #570 AC-2, because this one is a WRITE.
+    `apply_auto_accept_recommendations` promotes facts to `accepted` and retracts
+    lapsed ones, and it decides which by reading the alias file. A badge computed
+    on the wrong rules is re-rendered next request; a status transition is
+    committed and audited.
+
+    Fact 2 is promoted here only because the user's `소속 -> member_of` line
+    makes it corroborated by two distinct sources — the healthy half below is
+    what proves this fixture can see a promotion at all.
+
+    Stated limit: "fact 2 is still needs_review" is also what a pass run under
+    bare defaults produces (measured with no alias file present). That mode is
+    not reachable at this site, because `store_relation_aliases` RAISES on both
+    of these inputs rather than returning defaults, so there is no third build
+    to tell apart. This test's falsifying build is the guard's deletion, which
+    500s the request.
+    """
+    del present, absent
+
+    (tmp_path / "healthy").mkdir()
+    (tmp_path / "broken").mkdir()
+    healthy, healthy_app = _auto_accept_client(tmp_path / "healthy", HEALTHY_BYTES)
+    assert healthy.post("/facts/3/accept").status_code == 200
+    assert healthy_app.state.store.get_fact(2)["status"] == "accepted"
+
+    client, app = _auto_accept_client(tmp_path / "broken", alias_bytes)
+    r = client.post("/facts/3/accept")
+    assert r.status_code == 200
+    assert app.state.store.get_fact(2)["status"] == "needs_review"

--- a/tests/test_superseded_terminal.py
+++ b/tests/test_superseded_terminal.py
@@ -414,8 +414,11 @@ def test_edit_route_still_serves_a_form_for_a_live_fact(tmp_path):
 
 def test_amend_route_rejects_a_superseded_fact_without_mutating_it(tmp_path):
     # The store raises TerminalFactError, which is a ValueError; unhandled it
-    # would be a 500. Reachable from a form that was already open when someone
-    # else rejected the fact, so it has to answer cleanly.
+    # would be a 500. Reachable through a TOCTOU window -- a reject landing
+    # between the route's `_actionable_fact_or_error` pre-check and
+    # `store.amend_fact` -- and not from a stale edit form, which that pre-check
+    # answers with a plain 400 (measured). Either way the route owes a clean
+    # answer rather than a 500.
     #
     client, store = _client(tmp_path)
     fact_id = _rejected_fact(store)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1524,17 +1524,40 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             view[f"{field}_kind"] = term_input_kind(term)
         return view
 
-    def _fact_row_context(fact, recommendations=None):
+    def _fact_row_context(fact, recommendations=None, *, alias_error: str | None):
+        """Row context. `alias_error` withholds every alias-derived signal (#570).
+
+        `alias_error` is REQUIRED and keyword-only on purpose. The recurring
+        defect here is a caller that reaches an alias read without guarding it
+        (#570 trap 1): a defaulted parameter turns the next such caller into a
+        silent 500 in production, a required one turns it into a `TypeError` at
+        the call site.
+
+        When it is set, `trust` and `recommendation` are `None` rather than
+        computed anyway. `store_relation_aliases` returns
+        `merge_default_relation_aliases(user_aliases)`, so the delta between the
+        user's file and the defaults is exactly their custom entries — i.e. the
+        only reason the file exists. A badge computed without them is a number
+        about a KB nobody has, rendered in the same badges a healthy KB uses.
+        `None` is also what lets `fact_row.html` say "not computed" instead of
+        borrowing the `trust unavailable` verdict below it, which means
+        something else and something measured: this fact has no trust summary.
+        """
         view = _fact_view(fact)
-        trust = fact_trust_summary(_active_store(), int(fact["id"])) if fact else None
-        if fact and recommendations is None:
-            recommendations = accept_recommendations(_active_store())
-        recommendation = recommendations.get(int(fact["id"])) if fact else None
+        if alias_error is None:
+            trust = fact_trust_summary(_active_store(), int(fact["id"])) if fact else None
+            if fact and recommendations is None:
+                recommendations = accept_recommendations(_active_store())
+            recommendation = recommendations.get(int(fact["id"])) if fact else None
+        else:
+            trust = None
+            recommendation = None
         return {
             "f": view,
             "trust": trust,
             "recommendation": recommendation,
             "actionable": bool(fact and is_actionable_fact_status(fact["status"])),
+            "alias_error": alias_error,
         }
 
     def _actionable_fact_or_error(fact_id: int):
@@ -1545,17 +1568,36 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             raise HTTPException(status_code=400, detail="fact is not actionable")
         return fact
 
-    def _maybe_apply_auto_accept(exclude_fact_ids: tuple[int, ...] = ()) -> list:
+    def _maybe_apply_auto_accept(
+        exclude_fact_ids: tuple[int, ...] = (), *, alias_error: str | None
+    ) -> list:
+        """Run the auto-accept pass, unless the alias file cannot be read (#570).
+
+        The only guard in this change that stops a WRITE.
+        `apply_auto_accept_recommendations` promotes facts to `accepted` and
+        retracts lapsed ones, and it decides which by reading the alias file. A
+        pass run while that file is unreadable would rewrite the KB's review
+        state under `merge_default_relation_aliases(...)` — rules the user did
+        not configure. A badge computed on the wrong rules is re-rendered on the
+        next request; a status transition is committed and audited.
+
+        `alias_error` is required and keyword-only for the same reason as on
+        `_fact_row_context`.
+        """
+        if alias_error is not None:
+            return []
         if _active_cfg().auto_accept_recommendations:
             return apply_auto_accept_recommendations(
                 _active_store(), exclude_fact_ids=exclude_fact_ids
             )
         return []
 
-    def _row(request: Request, fact):
+    def _row(request: Request, fact, *, alias_error: str | None):
         # Starlette's current API is TemplateResponse(request, name, context).
         return templates.TemplateResponse(
-            request, "partials/fact_row.html", _fact_row_context(fact)
+            request,
+            "partials/fact_row.html",
+            _fact_row_context(fact, alias_error=alias_error),
         )
 
     def _row_after_decision(
@@ -1588,13 +1630,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         letting it promote everything else — for the one decision that parks a
         fact back in the tier auto-accept harvests from (see `toggle`).
         """
+        # One alias read per decision POST, threaded into both the auto-accept
+        # pass and the row render, rather than one per consumer (#570).
+        alias_error = _relation_alias_failure(_active_store())
         excluded = () if rule_may_act or acted_fact_id is None else (acted_fact_id,)
-        applied = _maybe_apply_auto_accept(excluded) if decided else []
+        applied = (
+            _maybe_apply_auto_accept(excluded, alias_error=alias_error) if decided else []
+        )
         if acted_fact_id is not None:
             refreshed = _active_store().get_fact(acted_fact_id)
             if refreshed is not None:
                 fact = refreshed
-        response = _row(request, fact)
+        response = _row(request, fact, alias_error=alias_error)
         if any(rec.fact_id != acted_fact_id for rec in applied):
             response.headers["HX-Refresh"] = "true"
         return response
@@ -2672,14 +2719,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.post("/sources/{source_id}/accept-all", response_class=HTMLResponse)
     def accept_all_source_facts(request: Request, source_id: int):
-        accepted = _active_store().accept_review_facts_for_source(source_id)
+        store = _active_store()
+        accepted = store.accept_review_facts_for_source(source_id)
         # Bulk-confirming a source can corroborate facts elsewhere; the redirect
         # reloads the page so no HX-Refresh header is needed here. `accepted` is
         # the same transition test the single-fact routes apply: a source with
         # nothing left in the review tier confirms nothing, so the POST decided
         # nothing and the rule stays out of it.
         if accepted:
-            _maybe_apply_auto_accept()
+            # The alias file is read here rather than at the top of the route:
+            # a source with nothing left in the review tier never runs the pass,
+            # so it owes no read (#570).
+            _maybe_apply_auto_accept(alias_error=_relation_alias_failure(store))
         return RedirectResponse("/sources", status_code=303)
 
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
@@ -2720,7 +2771,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         recommendations = accept_recommendations_for(
             store, [int(f["id"]) for f in page_data.rows]
         )
-        rows = [_fact_row_context(f, recommendations) for f in page_data.rows]
+        # `/review` itself is NOT guarded here: `_review_page` and
+        # `accept_recommendations_for` above both read the alias file and both
+        # still raise, so a broken file 500s this route before it reaches this
+        # line. What this call must not do is assert `alias_error=None` — a
+        # claim about a file nothing on this path has read.
+        alias_error = _relation_alias_failure(store)
+        rows = [
+            _fact_row_context(f, recommendations, alias_error=alias_error)
+            for f in page_data.rows
+        ]
         return templates.TemplateResponse(
             request,
             "review.html",
@@ -2797,7 +2857,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     @app.get("/facts/{fact_id}/row", response_class=HTMLResponse)
     def fact_row(request: Request, fact_id: int):
         # Re-render the read-only row (used to cancel an inline edit).
-        return _row(request, _active_store().get_fact(fact_id))
+        store = _active_store()
+        return _row(
+            request,
+            store.get_fact(fact_id),
+            alias_error=_relation_alias_failure(store),
+        )
 
     @app.post("/facts/{fact_id}/amend", response_class=HTMLResponse)
     def amend_fact(
@@ -2833,7 +2898,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             )
         except TerminalFactError:
             # #311: the fact was rejected, so its content is frozen. Reachable
-            # from a form that was already open when someone else rejected it.
+            # through a TOCTOU window -- a reject landing between this route's
+            # `_actionable_fact_or_error` pre-check and the `store.amend_fact`
+            # call above -- and NOT from a stale edit form: that pre-check reads
+            # the fact's status on THIS request, so a form left open while
+            # someone else rejects it gets a plain 400 (measured). The sentence
+            # this replaces predates `_actionable_fact_or_error` and was true
+            # until it landed.
             # Re-render the read-only row at 200 rather than an error at 4xx:
             # htmx's default responseHandling does not swap 4xx, so an error
             # status would leave the stale edit form on screen still offering a
@@ -2844,7 +2915,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # re-renders the edit form at 400, does not swap either and so shows
             # the user nothing. That predates this change and is left alone here
             # rather than fixed in passing, but it is the same bug.
-            return _row(request, _active_store().get_fact(fact_id))
+            #
+            # This is `amend_fact`'s SECOND row-rendering exit; the success path
+            # below renders through `_row_after_decision`, which reads the alias
+            # file itself. Guarding only that one leaves this path 500ing on a
+            # broken alias file while a naive amend test passes (#570).
+            store = _active_store()
+            return _row(
+                request,
+                store.get_fact(fact_id),
+                alias_error=_relation_alias_failure(store),
+            )
         # The rule may act on the amended fact itself, unlike a toggle demotion.
         # An amend decides the fact's content, not its tier: correcting a term so
         # it finally matches a second source's wording *is* corroboration
@@ -2857,7 +2938,16 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def provenance(request: Request, fact_id: int):
         store = _active_store()
         fact = store.get_fact(fact_id)
-        trust = fact_trust_summary(store, fact_id) if fact else None
+        # This route calls `fact_trust_summary` DIRECTLY — it does not go
+        # through `_fact_row_context`, so the `alias_error` threaded through
+        # that helper never reaches here and this route computes its own (#570
+        # trap 1). Withholding `trust` here is inseparable from the
+        # `{% if trust %}` blocks in `provenance.html`: that template writes
+        # `trust.support.source_count`, and Jinja raises `UndefinedError` on a
+        # two-deep attribute of `None`, so guarding this line alone turns one
+        # 500 into a different 500. Route and template are one guard.
+        alias_error = _relation_alias_failure(store)
+        trust = fact_trust_summary(store, fact_id) if fact and alias_error is None else None
         run = store.get_run(fact["run_id"]) if fact and fact["run_id"] else None
         job = (
             store.get_extraction_job_detail(fact["job_id"])
@@ -2870,6 +2960,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             {
                 "f": _fact_view(fact),
                 "trust": trust,
+                "alias_error": alias_error,
                 "run": run,
                 "job": job,
                 "log": store.fact_log(fact_id) if fact else [],

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -2814,10 +2814,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # `acceptance._engine`, `trust.fact_trust_summary` and
         # `corroboration.store_single_valued_conflicts`, and from nowhere else.
         # The readers are named rather than counted on purpose: the count moves
-        # whenever a guard is added — the guard above is itself the fourth — and
-        # what this comment needs to say is that the QUEUE QUERY is not among
-        # them. So the queue is the KB's own and only its trust signals are
-        # withheld.
+        # whenever a guard is added, and what this comment needs to say is that
+        # the QUEUE QUERY is not among them. So the queue is the KB's own and
+        # only its trust signals are withheld.
         # `accept_recommendations_for` is the opposite: it builds its engine off
         # the alias file before it looks at a single id, so it raises even for an
         # empty id list. Skipping it and passing `{}` is what keeps this route up.

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -2767,16 +2767,67 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     ):
         store = _active_store()
         active_filter = _active_review_filter(filter)
-        page_data = _review_page(store, active_filter, page, page_size, sort)
-        recommendations = accept_recommendations_for(
-            store, [int(f["id"]) for f in page_data.rows]
-        )
-        # `/review` itself is NOT guarded here: `_review_page` and
-        # `accept_recommendations_for` above both read the alias file and both
-        # still raise, so a broken file 500s this route before it reaches this
-        # line. What this call must not do is assert `alias_error=None` — a
-        # claim about a file nothing on this path has read.
         alias_error = _relation_alias_failure(store)
+        if alias_error is not None and active_filter != "needs-human-decision":
+            # #570. Every filter but `needs-human-decision` — `unsupported`,
+            # `single-source`, `corroborated`, `conflicted` — selects facts BY the value that
+            # could not be computed: `_review_page` runs `fact_trust_summary`
+            # over the whole queue and keeps the ids whose labels match. So the
+            # row set, the total and the pager are themselves alias-derived, not
+            # just the badges. There is no degraded list to show. Falling back
+            # to the default filter would answer a question the user did not
+            # ask; rendering an empty one would be a false statement about which
+            # facts carry this label.
+            #
+            # This RETURNS rather than setting a flag the code below reads. With
+            # `page_data = None` the `[int(f["id"]) for f in page_data.rows]`
+            # argument to `accept_recommendations_for` raises `AttributeError` —
+            # a 500 with nothing to do with the alias file.
+            #
+            # The filter nav is how the user gets back to a page that works, so
+            # it survives — and its hrefs must carry the sort and page size the
+            # user already chose, normalized exactly as a healthy render
+            # normalizes them. `ReviewQueuePage.from_rows` is that normalizer and
+            # it is pure arithmetic over the query string; re-deriving the two
+            # values here would let this nav drift from the healthy one.
+            nav = ReviewQueuePage.from_rows(
+                rows=[], total=0, page=page, page_size=page_size, sort=sort
+            )
+            return templates.TemplateResponse(
+                request,
+                "review.html",
+                {
+                    "queue": None,
+                    "active_filter": active_filter,
+                    "filters": _review_filter_links(
+                        active_filter, nav.sort, nav.page_size
+                    ),
+                    "pager": None,
+                    "alias_error": alias_error,
+                },
+            )
+        page_data = _review_page(store, active_filter, page, page_size, sort)
+        # #570. On the default filter the ROWS are real: `store.review_queue_page`
+        # reads no policy file. Measured by spying every module that binds
+        # `store_relation_aliases` — a healthy `/review` reads it from
+        # `_relation_alias_failure` (this route's own guard, above),
+        # `acceptance._engine`, `trust.fact_trust_summary` and
+        # `corroboration.store_single_valued_conflicts`, and from nowhere else.
+        # The readers are named rather than counted on purpose: the count moves
+        # whenever a guard is added — the guard above is itself the fourth — and
+        # what this comment needs to say is that the QUEUE QUERY is not among
+        # them. So the queue is the KB's own and only its trust signals are
+        # withheld.
+        # `accept_recommendations_for` is the opposite: it builds its engine off
+        # the alias file before it looks at a single id, so it raises even for an
+        # empty id list. Skipping it and passing `{}` is what keeps this route up.
+        recommendations = (
+            {}
+            if alias_error is not None
+            else accept_recommendations_for(
+                store, [int(f["id"]) for f in page_data.rows]
+            )
+        )
         rows = [
             _fact_row_context(f, recommendations, alias_error=alias_error)
             for f in page_data.rows
@@ -2791,15 +2842,28 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     active_filter, page_data.sort, page_data.page_size
                 ),
                 "pager": _review_pager(active_filter, page_data),
+                "alias_error": alias_error,
             },
         )
 
     @app.get("/workbench", response_class=HTMLResponse)
     def workbench(request: Request):
+        # #570. `trust_workbench` reads the alias file in its first statement,
+        # and its whole return value is the page. `None` rather than an empty
+        # workbench: `{% if workbench.corroborated %}` is falsy either way, so an
+        # empty value renders "No facts are corroborated by multiple distinct
+        # sources." and "No source-backed single-valued conflicts." — two claims
+        # about a KB nothing analysed. Only `None` lets the template tell "not
+        # computed" from "computed, and empty".
+        store = _active_store()
+        alias_error = _relation_alias_failure(store)
         return templates.TemplateResponse(
             request,
             "workbench.html",
-            {"workbench": trust_workbench(_active_store())},
+            {
+                "workbench": None if alias_error is not None else trust_workbench(store),
+                "alias_error": alias_error,
+            },
         )
 
     @app.post("/facts/{fact_id}/toggle", response_class=HTMLResponse)

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -42,9 +42,25 @@
        (_trust_labels derives the label from that very summary), so they collapse
        into this one verdict rather than two badges.
 
-       Every branch below stays inside `{% if trust %}` and reads only `f`, `trust`
-       and `recommendation` -- the whole context a lone HTMX row swap gets. #}
-    {% if trust %}
+       Every branch of that ladder stays inside the `{% elif trust %}` arm below and
+       reads only `f`, `trust` and `recommendation` -- the whole context a lone HTMX
+       row swap gets, plus the `alias_error` the arm above it adds (#570). #}
+    {# `alias_error` comes FIRST, ahead of the ladder and ahead of the
+       `trust unavailable` fallback (#570). Those two say different things and
+       must keep saying different things: `trust unavailable` is a measured
+       verdict on the fact (it has no trust summary), while this branch means
+       nobody measured -- the KB's alias file could not be read, and computing
+       the ladder on `merge_default_relation_aliases(...)` would put a number
+       about a KB nobody has into the same badges a healthy KB uses.
+
+       The reason line lives INSIDE the fragment rather than only in a page
+       banner because an HTMX decision swaps this one <tr> and the user may
+       never see a banner. That is the difference between a row that degrades
+       honestly and one that just goes grey. #}
+    {% if alias_error %}
+      <span class="badge muted">trust not computed</span>
+      <div class="src">{{ alias_error }} Trust signals and accept recommendations are withheld until this file can be read. Fix it on <a href="/settings">Settings</a>.</div>
+    {% elif trust %}
       {% if trust.conflict or 'conflicted' in trust.trust_labels %}
         {% set verdict_label, verdict_class, verdict_text, verdict_risk = 'conflicted', 'trust-conflicted', 'conflicted', true %}
       {% elif 'evidence_missing' in trust.trust_labels %}
@@ -108,7 +124,14 @@
     {% endif %}
   </td>
   <td class="evidence-cell">
-    {% if trust and trust.evidence %}
+    {# Same rule as the signals cell, one cell over (#570). The anchor comes off
+       `trust.evidence`, so with no trust summary the `{% else %}` below would
+       assert `No evidence anchor` -- a claim about the fact that nobody
+       measured, and one a healthy row makes too, which would leave the degraded
+       row and the healthy row indistinguishable on that string. #}
+    {% if alias_error %}
+      <span class="muted">not computed</span>
+    {% elif trust and trust.evidence %}
       {% set e = trust.evidence[0] %}
       <div><span class="badge chip">{{ e.evidence_kind }}</span> <code>{{ e.source_path }}</code></div>
       <div class="src">

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -6,8 +6,23 @@
 {% else %}
 <h1>Trust dossier — fact #{{ f["id"] }}</h1>
 
+{# #570. Every section below whose contents come off `trust` is withheld when
+   this KB's alias file cannot be read, because `store_relation_aliases` merges
+   the user's entries over the defaults -- so a dossier computed without their
+   file is a dossier about a different KB, printed in the same tables a healthy
+   one uses. The route and this template are ONE guard: withholding `trust`
+   without these branches replaces the 500 with a different 500, because
+   `{{ trust.support.source_count }}` is a two-deep attribute of `None` and
+   Jinja raises `UndefinedError` on that (measured). #}
+{% if alias_error %}
+<p class="error" role="alert">{{ alias_error }} The trust dossier below is withheld, because it
+  would have been computed under different alias rules than this KB's file specifies. Fix it on
+  <a href="/settings">Settings</a>.</p>
+{% endif %}
+
 <section class="trust-block">
   <h2>Trust summary</h2>
+  {% if trust %}
   {# role=list, not a bare div: a div is role=generic, which is name-prohibited, so
      the aria-label below would have been free to go unannounced (#294). list does
      permit an author name -- and it owns listitems, hence the role on each badge. #}
@@ -46,6 +61,9 @@
       {% endif %}
     </tbody>
   </table>
+  {% else %}
+  <p class="muted">Not computed — see the alias-file notice above.</p>
+  {% endif %}
 </section>
 
 <section class="trust-block">
@@ -59,7 +77,10 @@
     <span class="obj term-{{ f['object_kind'] }}">{{ f["object_display"] }}<span class="visually-hidden">&nbsp;({{ f['object_kind'] }})</span></span>
     <span class="badge badge-{{ f['status'] }}">{{ f["status"] }}</span>
   </p>
-  {% if trust.canonical_terms %}
+  {# The triple, its term kinds and the status badge above come off `f` and stay:
+     withholding the trust dossier must not withhold the fact's own identity. Only
+     the CANONICAL rendering of it is alias-derived (#570). #}
+  {% if trust and trust.canonical_terms %}
   <table class="counts">
     <tbody>
       <tr><td>canonical subject</td><td><code>{{ trust.canonical_terms.subject }}</code></td></tr>
@@ -72,6 +93,11 @@
 
 <section class="trust-block">
   <h2>Evidence summary</h2>
+  {# Every row here reads `trust`, not the route's own `run`/`job`, so the whole
+     table is withheld rather than left to render its "—" and
+     "— (seeded or hand-entered)" fallbacks, which would be claims about an
+     origin nobody looked up (#570). #}
+  {% if trust %}
   <table class="counts">
     <tbody>
       <tr><td>source</td><td>{% if trust.source %}<code>{{ trust.source.path }}</code> <span class="badge">{{ trust.source.kind }}</span>{% else %}—{% endif %}</td></tr>
@@ -89,11 +115,19 @@
       </td></tr>
     </tbody>
   </table>
+  {% else %}
+  <p class="muted">Not computed — see the alias-file notice above.</p>
+  {% endif %}
 </section>
 
 <section class="trust-block">
   <h2>Conflict summary</h2>
-  {% if trust.conflict %}
+  {# `trust is none` first: falling through to the `{% else %}` below would print
+     "No deterministic single-valued conflict for this fact." over a conflict
+     search that never ran (#570). #}
+  {% if trust is none %}
+  <p class="muted">Not computed — see the alias-file notice above.</p>
+  {% elif trust.conflict %}
   <table class="counts">
     <thead><tr><th>value</th><th>sources</th></tr></thead>
     <tbody>
@@ -115,6 +149,20 @@
   <table class="counts">
     <tbody>
       <tr><td class="src">{{ f["created_at"] }}</td><td><span class="badge">created</span></td></tr>
+      {# `created_at`/`updated_at` come off `f` and stay. Everything between them
+         is read out of the trust summary, so when that is withheld the timeline
+         says so rather than closing the gap silently and reading as a fact
+         nothing ever happened to (#570).
+
+         Its own wording, not the shared "Not computed" marker the other
+         sections use: this row is the only withheld section with no distinctive
+         sentence of its own, so a shared marker leaves it pinnable only by
+         counting occurrences — and a count cannot say WHICH section went
+         missing. The words also carry more here, since what is withheld is
+         specifically the extraction job and the audit events. #}
+      {% if trust is none %}
+      <tr><td class="src">—</td><td><span class="muted">Extraction and review events not computed — see the alias-file notice above.</span></td></tr>
+      {% endif %}
       {% if trust.job %}
       <tr><td class="src">—</td><td><span class="badge">extracted</span> job #{{ trust.job.id }} · {{ trust.job.status }}</td></tr>
       {% endif %}
@@ -134,7 +182,12 @@
 
 <section class="trust-block">
   <h2>Source evidence</h2>
-  {% if trust.evidence %}
+  {# Same shape as Conflict summary: the `{% else %}` prose below would claim
+     "No source evidence anchors recorded for this fact." about anchors nobody
+     looked for (#570). #}
+  {% if trust is none %}
+  <p class="muted">Not computed — see the alias-file notice above.</p>
+  {% elif trust.evidence %}
     {% for e in trust.evidence %}
     <div class="evidence">
       <div>

--- a/verinote/web/templates/review.html
+++ b/verinote/web/templates/review.html
@@ -5,6 +5,21 @@
 <p class="muted">Facts awaiting the human gate (<code>candidate</code> / <code>needs_review</code>).
   Toggle promotes to <code>confirmed</code>; accept/reject decide directly.</p>
 
+{# #570. A GUARD, not decoration. On the trust-label-filter pages the queue is
+   `None`, so the `{% include %}` below never runs and the fact-row fragment's own
+   reason line renders nowhere -- this banner is the only thing on the page that
+   says why. Deleting it leaves a 200 that explains nothing. #}
+{% if alias_error %}
+<p class="error" role="alert">{{ alias_error }} Trust signals and accept recommendations on this
+  page are withheld, because they would have been computed under different alias rules than this
+  KB's file specifies. Fix it on <a href="/settings">Settings</a>.</p>
+{% endif %}
+
+{# The filter nav stays on every degraded render: it is built from static labels,
+   reads nothing alias-derived, and is how the user gets back to a queue that
+   works. It also sits above every guard below, which is what lets a test assert
+   the route survived without that assertion being reddened by a template
+   deletion. #}
 <nav class="filters" aria-label="review filters">
   {% for item in filters %}
     <a class="badge {% if item.active %}active{% endif %}"
@@ -13,6 +28,26 @@
   {% endfor %}
 </nav>
 
+{# #570. Everything in this block reads `pager`, which is `None` when the queue
+   could not be built. Jinja does NOT raise on that: `{{ pager.start }}` renders
+   '' and `{% for item in pager.pages %}` renders nothing, so without this guard
+   the page comes back 200 saying "Showing 0 of 0 review facts" over empty
+   Sort/Page-size selects and greyed Previous/Next -- three statements about a
+   queue nobody counted, none of them visible to a status assertion.
+
+   The block renders nothing of its own when suppressed. The sentence explaining
+   why belongs to the queue block below, which is what it is about; saying it
+   here too would print it twice and, worse, would leave it present when either
+   block alone is deleted.
+
+   ONE GUARD SPANNING TWO SITES -- this block, and the two
+   `{% if pager %}{{ review_pages(pager) }}{% endif %}` calls further down. They
+   cannot be one contiguous `{% if %}` because the `review_pages` macro
+   definition sits between them. Both halves are load-bearing and the test
+   asserts a string from each, so neither deletion is silent; but no test tells
+   them apart, and they are recorded as one guard rather than two the matrix
+   would show as indistinguishable. #}
+{% if pager %}
 <form class="review-toolbar" action="/review" method="get">
   <input type="hidden" name="filter" value="{{ active_filter }}">
   <input type="hidden" name="page" value="1">
@@ -42,6 +77,7 @@
     Showing 0 of 0 review facts
   {% endif %}
 </div>
+{% endif %}
 
 {% macro review_pages(pager) -%}
 <nav class="pagination" aria-label="Review pages">
@@ -67,9 +103,20 @@
 </nav>
 {%- endmacro %}
 
-{{ review_pages(pager) }}
+{# Part of the same guard as the toolbar above: `review_pages(None)` renders a
+   pagination nav with greyed Previous/Next and no page items -- controls for a
+   queue that was never built. #}
+{% if pager %}{{ review_pages(pager) }}{% endif %}
 
-{% if queue %}
+{% if queue is none %}
+{# #570, and this sentence belongs to THIS block and to nothing else. It is a
+   statement about the queue, so it lives where the queue would be. Putting it in
+   the pager block as well would print it twice and would leave it on the page
+   when either block alone is deleted -- at which point neither block could be
+   told from the other. #}
+<p class="muted">This filter selects facts by trust label, which is not computed — see the
+  notice above. <a href="/review">Show the facts awaiting a decision</a> instead.</p>
+{% elif queue %}
 <table class="facts">
   <thead>
     <tr><th>Fact</th><th>Trust signals</th><th>Evidence</th><th>Decision</th></tr>
@@ -96,5 +143,5 @@
   {% endif %}
 </div>
 {% endif %}
-{{ review_pages(pager) }}
+{% if pager %}{{ review_pages(pager) }}{% endif %}
 {% endblock %}

--- a/verinote/web/templates/workbench.html
+++ b/verinote/web/templates/workbench.html
@@ -4,8 +4,24 @@
 <h1>Trust workbench</h1>
 <p class="muted">Source-backed corroboration and single-valued conflicts for reviewed engine-input facts.</p>
 
+{# #570. A GUARD, and this template's ONLY possible carrier of the reason: it
+   contains no `{% include %}` at all, so unlike the review queue there is no
+   fragment that could say it instead. Deleting this leaves a page that withholds
+   both tables and never says why. #}
+{% if alias_error %}
+<p class="error" role="alert">{{ alias_error }} Both tables below are withheld, because they
+  would have been computed under different alias rules than this KB's file specifies. Fix it on
+  <a href="/settings">Settings</a>.</p>
+{% endif %}
+
 <h2>Corroborated facts <span class="muted">- grouped by normalized SPO</span></h2>
-{% if workbench.corroborated %}
+{# `is none` first, and it is not the same test as the `{% else %}` below.
+   `workbench.corroborated` on a `None` workbench is falsy Undefined rather than a
+   raise, so without this branch the page renders the empty-state prose -- a
+   measured claim about corroboration over a KB nothing analysed. #}
+{% if workbench is none %}
+<p class="muted">Not computed — see the alias-file notice above.</p>
+{% elif workbench.corroborated %}
 <table class="counts">
   <thead><tr><th>Normalized fact</th><th>Source support</th><th>Facts</th></tr></thead>
   <tbody>
@@ -52,7 +68,11 @@
 {% endif %}
 
 <h2>Single-valued conflicts <span class="muted">- engine-input facts only</span></h2>
-{% if workbench.conflicts %}
+{# Same shape, second table: its `{% else %}` claims there are no source-backed
+   single-valued conflicts, over a search that never ran. #}
+{% if workbench is none %}
+<p class="muted">Not computed — see the alias-file notice above.</p>
+{% elif workbench.conflicts %}
 <table class="counts">
   <thead><tr><th>Subject / relation</th><th>Competing values</th><th>Related candidates</th></tr></thead>
   <tbody>


### PR DESCRIPTION
Closes #570.

A `policy/relation-aliases.md` that could not be read or parsed made **13 endpoints** answer 500. `docs/operations.md` tells users to edit that file by hand, so one typo took out most of the site. #555 fixed `/`, `/sources` and `/settings`; this is the rest of the web layer.

## The issue undercounted itself, three times

Every number in #570's original text was low, and the corrections are recorded in its `## 정정` section:

| | issue said | measured |
|---|---|---|
| defective endpoints | 9 | **13** — found by sweeping all 46 route/method pairs, not by following tracebacks |
| `/review`'s alias-read sites | "at least three" | **4**, enumerated by spying `store_relation_aliases` in all 11 modules that bind the name |
| narrow `except` clauses to widen | 2 | **4**, in 3 modules |
| the CLI-shared fix site | `verify.py`, via `verinote check` | **there is no `verinote check`.** The real shared site is `translate_questions`, called by `cli.py`'s `query` subcommand |

A 4xx at baseline turned out to be an *unmeasured* cell rather than a clean one — `POST /facts/{id}/amend` first read 400/400/400 because the probe sent a `subject_kind` the input validator rejects before the handler runs. All 46 pairs are now measured or proven not to read the alias file.

## What ships here

**Unit A (`4d35a91`)** — the fact-row family: `GET /facts/{id}/{row,provenance}`, `POST /facts/{id}/{toggle,accept,reject,amend}`, `POST /sources/{id}/accept-all`.

**Unit B (`6278aa2`)** — `/review` and `/workbench`.

The order is load-bearing, not cosmetic. `/review` renders rows carrying Accept, Reject, Toggle and Inspect controls; before Unit A every one of those POSTs answered 500. Guarding `/review` first would have produced exactly the shape #570's third criterion exists to prevent — a page that looks healthy and explodes on its primary action. Rebase-merge puts each commit on `main` alone.

## Withheld, not approximated

`store_relation_aliases` returns `merge_default_relation_aliases(user_aliases)`, so the delta between a user's file and the defaults **is** their custom entries. Rendering trust computed under defaults in the badges a healthy KB uses would be a false statement about the system's own state. So trust is withheld, and every place that would otherwise assert an absence it never checked for now says so instead — four `{% else %}` branches in `provenance.html` were claiming no conflict was found, no evidence anchors were recorded, and a run was seeded or hand-entered, about searches that never ran.

`/review` degrades two ways because it has two problems: the default filter's row set is the KB's own, but the four trust-label filters select facts **by** the value that could not be computed, so the queue cannot be built at all and that view refuses. `/workbench` cannot render partially — its whole context is one object, and an empty value renders "No facts are corroborated by multiple distinct sources." about a KB never checked.

## AC-3, walked rather than inferred

Every `href`, `hx-get`, `hx-post` and form action rendered by every degraded page was parsed out and followed. **Zero controls into a 5xx.** That includes the dashboard's Open button into `/review`, which #555 left live over a page that answered 500 — a direct request for `/review` cannot see a button offered over a crash, so one test reads the button off the dashboard and follows it.

## Falsifiability

Each guard has a mutation reddening a test no other guard's deletion reddens, measured rather than predicted. Where a template guard sits behind a route guard, three builds are compared — inner alone, outer alone, and the pair — because a 500 has no body to assert on, and the pair build is what attributes the inner build's red.

**Literal AC-5 is not met and is not meetable** for a stacked guard, so the achievable formulation is stated instead: *each route guard has a test that no template guard's deletion reddens, and each template guard has a test that no other template guard's deletion reddens.*

One test is a ruled exception to the issue's fourth criterion. An empty `/review` queue reaches `accept_recommendations_for` and never `fact_trust_summary`, which is the only state where the default-filter guard's failure is observable — a populated queue is masked by the fact-row guard. Its docstring carries that measurement and says outright that adding a `needs_review` fact would destroy what it pins, silently.

## Still broken, and visible from here

`/questions` and `/report` answer 500 on a cp949-encoded alias file, and both sit in the global nav of every page including the two guarded here. They fail in `verify.py` and `report_trace.py`, not the web layer, and `report_trace.py` already substitutes a default silently. That is #570's remaining half and it will be the visible remainder after this lands, exactly as `/review` was after #555.

Filed from this work: **#585** (a broken `typed-relations.md` 500s 23 endpoints, including `/` and `/sources`, which #555 guarded for the *alias* file only) and **#586** (the terminal-amend handler is pinned by no test at all).

## Verification

**3352 passed, 12 skipped, 0 failed** in a real checkout of the head commit; `uvx ruff@0.15.18 check .` clean at the version CI pins; CI green on py3.11/3.12/3.13.

A correction worth recording, because it ran through every review of this branch. All six gate reports and an earlier draft of this section said *"3349 passed, 3 failed — the three are `tests/test_gitignore.py`, environmental."* Each gate worked from a `git archive` extract, which is a plain directory with no `.git`, so those three git-dependent tests could not pass there. The number was true of the measurement and misleading about the code: three failures set aside, not a clean suite.

The three gates agreeing exactly was not independent corroboration — it is what you get when three parties share an instrument. Re-measured with `git worktree add --detach`, which is isolated **and** a genuine repo, the suite is clean, and CI (a real clone) runs those same three tests green. Zero line-number citations in the touched files — they are cited by symbol, because a line number is true of the tree it was written against and false of the tree it is read in.
