### PR TITLE
fix(web): the web layer degrades on an unreadable typed-relations.md (#585)

### DIFF
--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -3,7 +3,7 @@ r"""A broken `policy/relation-aliases.md` degrades `/`, `/sources`, `/settings`
 instead of 500ing them (#555).
 
 WHY THE MALFORMED TESTS ASSERT THE MESSAGE, NOT THE STATUS. Deleting the narrow
-`except CorroborationPolicyError` clause (G1) inside `_relation_alias_failure`
+`except CorroborationPolicyError` clause (G1) inside `_trust_policy_failure`
 does NOT turn any route back into a 500: the malformed case falls through to the
 broad `except Exception` clause (G2) underneath, which also returns a string, so
 every affected route still renders 200 (measured — see plan555.md §2.2/M9,
@@ -90,20 +90,24 @@ both its tables — so a button from a "not computed" dashboard row into any of
 them lands on a page that cannot answer the question the row poses. The button
 is still not offered, now for a measured reason rather than an inherited one.
 
-`store_typed_relations` (`policy/typed-relations.md`) is untouched by both
-issues, and its blast radius grew with #570 rather than staying put:
-`_source_trust_rollup` calls it alongside `store_relation_aliases`, and so does
-`fact_trust_summary` on the line after ITS alias read. So `/sources` and every
-fact-row route above can still 500 on a broken `typed-relations.md`. Tracked as
-#585.
+`store_typed_relations` (`policy/typed-relations.md`) was untouched by both
+issues and is now covered by #585, in
+`tests/test_typed_relations_web_guard.py`. The guard is SHARED rather than
+duplicated: `_relation_alias_failure` became `_trust_policy_failure`, which
+checks the alias file first and the typed file second and returns the first
+failure, and every `alias_error` in this file's routes and templates became
+`policy_error`. That rename is why the assertions here read "policy-file
+notice" rather than "alias-file notice" and why no banner ends "Fix it on
+Settings" any more — `settings.html` has an editor for the alias file and none
+for the typed one.
 
-Do not read that as "the same endpoints, one file over", and do not reuse this
-file's route list to guard it: the two files' affected sets differ in BOTH
-directions, and #585 forbids copying #570's. Measured here, healthy alias file
-plus a cp949 `typed-relations.md`: `/` and `/sources` — guarded above for the
-ALIAS file since #555 — return 500, while `/settings` stays 200. #585 carries
-the enumeration; this paragraph deliberately carries no count, because the
-number is #585's to keep current.
+Do not read the two files as parametrizations of each other. Their affected
+route sets differ in BOTH directions, their malformed INPUT classes differ (a
+line `typed_relations` cannot parse is silently skipped, not raised), and an
+absent typed file degrades to `{}` — the same value a healthy KB with no typed
+declarations produces — so #585's guard cannot pin itself on the rendered value
+the way this file's can. The sibling file's docstring carries all three
+measurements.
 
 (#571, which an earlier draft of this paragraph cited for the typed-relations
 hole, is a different defect in a different file: an unusable PATH at
@@ -270,7 +274,7 @@ def test_dashboard_does_not_claim_there_are_no_corroborated_facts(malformed_clie
     r = malformed_client.get("/")
     assert "No source-backed engine-input facts yet." not in r.text
     assert "No source-backed single-valued conflicts." not in r.text
-    assert r.text.count("Not computed — see the alias-file notice above.") == 2
+    assert r.text.count("Not computed — see the policy-file notice above.") == 2
     # The four alias-dependent queue rows show the not-computed marker, not a
     # digit -- plus one more occurrence inside the banner's own sentence, which
     # names the marker it is pointing at (MUST-FIX-3, #555 fix-round gate).
@@ -282,7 +286,7 @@ def test_a_healthy_alias_file_still_shows_the_dashboard_corroboration_table(
 ):
     r = healthy_client.get("/")
     assert r.status_code == 200
-    assert "Not computed — see the alias-file notice above." not in r.text
+    assert "Not computed — see the policy-file notice above." not in r.text
     assert '<span class="badge muted">not computed</span>' not in r.text
     # The healthy KB's one confirmed, source-backed fact appears in the table.
     assert "<code>A</code>" in r.text
@@ -733,12 +737,12 @@ NO_EVIDENCE_ANCHOR = "No evidence anchor"
 # It is the only string on a fact row that moves when the accept
 # RECOMMENDATION is withheld but the trust summary is not.
 RECOMMENDATION_REASON = "insufficient distinct source support"
-DOSSIER_NOT_COMPUTED = "Not computed — see the alias-file notice above."
+DOSSIER_NOT_COMPUTED = "Not computed — see the policy-file notice above."
 # The lifecycle timeline's own wording. Deliberately not the shared marker:
 # it is the only withheld section with no distinctive sentence, so under the
 # shared one it could be pinned only by counting occurrences.
 TIMELINE_NOT_COMPUTED = (
-    "Extraction and review events not computed — see the alias-file notice above."
+    "Extraction and review events not computed — see the policy-file notice above."
 )
 
 # (alias bytes, message that must be present, message that must be absent).
@@ -1093,7 +1097,7 @@ def test_a_superseded_amend_still_renders_a_row_at_all(
     The reddening population, ENUMERATED over every deletable unit in this
     change rather than quantified over an unnamed set. Exactly three deletions
     redden this test. Two 500 the amend response itself: this exit's own
-    `alias_error` read, and `_fact_row_context`'s withholding branch, which
+    `policy_error` read, and `_fact_row_context`'s withholding branch, which
     every fact-row render passes through. The third is `_row_after_decision`'s
     read, and it fails EARLIER than the exit under test — `_superseded_amend`'s
     `assert client.post(...reject...).status_code == 200` precondition 500s
@@ -1136,7 +1140,7 @@ def test_provenance_survives_a_cp949_alias_file_and_names_the_file(cp949_client)
 def test_provenance_withholds_the_dossier_but_keeps_the_fact_identity(
     malformed_client,
 ):
-    """`provenance` calls `fact_trust_summary` DIRECTLY, so no `alias_error`
+    """`provenance` calls `fact_trust_summary` DIRECTLY, so no `policy_error`
     threaded through `_fact_row_context` reaches it (#570 trap 1) — and its
     route guard and template branches are ONE guard, because
     `{{ trust.support.source_count }}` is a two-deep attribute of `None` and

--- a/tests/test_typed_relations_web_guard.py
+++ b/tests/test_typed_relations_web_guard.py
@@ -1,0 +1,813 @@
+# SPDX-License-Identifier: MPL-2.0
+r"""A broken `policy/typed-relations.md` degrades the web surface instead of
+500ing it (#585).
+
+This is the sibling of `test_relation_aliases_web_guard.py`, and the two files
+are deliberately NOT parametrizations of each other. Read the four paragraphs
+below before adding to either: three of them are measurements that make an
+"obvious" simplification of this file silently stop proving anything.
+
+WHY THE MALFORMED INPUT IS A DUPLICATE ALIAS AND NOT A SYNTAX ERROR.
+`relation_aliases` raises on the first line it cannot parse. `typed_relations`
+does the opposite: a line that does not match `_TYPED_REL_RE`, or whose type tag
+is outside `_TYPED_TYPES = {date, number, ordinal, amount}`, hits `continue` --
+no error, no 500, the declaration is just dropped. Measured on this tree by
+calling the parser directly:
+
+    "- 소속 member_of"            (the alias file's MALFORMED_BYTES)  -> {}
+    "- 설립일: colour as founded" (unknown type tag)                  -> {}
+    "- 자본금: amount as capital
+     - 자산: amount as capital"   (duplicate alias)                   -> RAISES
+
+Exactly four SEMANTIC conditions raise: a duplicate alias, units on a non-amount
+type, a unit pair with no `=`, and a non-numeric unit value. So a test that
+plants the alias file's malformed bytes here sees 200, passes, and pins
+NOTHING -- the file parsed cleanly to `{}`. `TYPED_DUP_ALIAS` below is a
+duplicate alias for that reason, and
+`test_a_typo_in_typed_relations_is_silently_ignored_rather_than_reported`
+pins the distinction so a later edit cannot quietly promote the typo case into
+the malformed slot and make this whole file vacuous.
+
+WHY THE FIXTURE IS AN `amount` DECLARATION ON AN UNALIASED RELATION NAME.
+Two separate constraints, and the second one is the trap.
+
+The TYPE has to be `amount` because it is the only one of the four that makes
+this fixture's two objects one value: `normalize_typed_value` maps both `1억`
+and `100000000원` to `100000000`, while `date`, `number` and `ordinal` each
+return `None` for BOTH of them, leaving two unrelated raw keys. Every
+corroboration control below rests on that merge.
+
+The declared NAME has to be one the alias table leaves alone, and this part is
+type-independent. `typed_relations()` keys its dict on the RAW name written in
+the file, but `fact_trust_summary` canonicalizes before looking it up --
+`relation = canonical_relation(display.relation, aliases)`, then
+`_typed_spec(typed, relation)`. A declaration whose name appears in the alias
+table is therefore stored under a key it is never read back by, and is dropped
+without a word. Each row below fixes a type AND an object and varies only the
+declared name, so the two results in a row differ in exactly one thing. The
+object is named in every row because the result depends on it as much as on the
+type and the name; a row giving only a type and a name is not a controlled
+comparison, which is the defect an earlier draft of this table carried. The
+objects differ between rows because each row's object is one its own type
+normalizes: `'2020.03.01'` as a date, `'1억'` as an amount, `'3'` as a number,
+`'3위'` as an ordinal. Every `None` in the aliased column is the same `None`:
+`fact_trust_summary` found no declaration under `established_on`, so there is
+no typed summary at all, rather than a summary carrying a null value. A
+declaration on `설립일` is stored under key `설립일` and looked up under
+`established_on`; one on `자본금` is stored and looked up under `자본금`:
+
+    type     object         on '설립일' (aliased)  on '자본금' (unaliased)
+    date     '2020.03.01'   None                  20200301
+    amount   '1억'           None                  100000000
+    number   '3'            None                  3000
+    ordinal  '3위'           None                  3
+
+Declaring `date` on the canonical `established_on`, with the fact's relation
+still `설립일` and the object still `'2020.03.01'`, yields 20200301 -- the
+mechanism, not merely the absence.
+
+`설립일` is `DEFAULT_RELATION_ALIASES`' own mapping to `established_on`, so this
+bites a KB with NO alias file too: an absent file yields the packaged defaults,
+not an empty table. The declaration under test below is on `자본금`, which is
+absent from those 36 entries, and that absence is the only reason it observes
+anything at all -- a declaration on any label the table does name would be
+dropped instead, whatever its type.
+
+An earlier draft of this paragraph said `date` never surfaces a `typed_value`
+and blamed the type. It had measured only `설립일` declarations, so it read the
+alias mismatch as a property of `date`; `date` in fact normalizes every
+well-formed input that draft listed -- `2020.03.01`, `2020-03-01`, `2020/3/1`,
+`date(2020,3,1)` and `2020.03`, each to 20200301. So do not "simplify" the fixture
+to a relation name `DEFAULT_RELATION_ALIASES` canonicalizes -- of ANY type --
+or every healthy control and every AC-2 control here silently stops proving
+anything. The silent drop is itself a state-honesty defect with no 500 attached,
+out of #585's scope and tracked as #589, which treats it and the unparseable-line
+drop above as one defect.
+
+WHY THE GUARD HAS TO CARRY ITS OWN MARKER, AND CANNOT PIN ITSELF ON THE VALUE.
+`policy_defaults.py` defines `DEFAULT_RELATION_ALIASES` and no
+`DEFAULT_TYPED_RELATIONS`. When `policy/typed-relations.md` is absent,
+`store_typed_relations` returns `{}` -- the normal state of most KBs. So a
+typed-relations failure degraded to `{}` renders BYTE-IDENTICALLY to a healthy
+KB that declares no typed relations, and no assertion on a rendered number could
+tell the two apart. #570's AC-2 argument ("the value itself is wrong, because
+the defaults are not the user's rules") does not transfer. What this file
+asserts instead is that the degraded page carries a not-computed marker AND the
+message naming the file, and every such assertion is paired with a healthy
+control that shows the same page carrying the real value.
+
+WHY EVERY FIXTURE HERE PLANTS A HEALTHY `policy/relation-aliases.md`.
+#570's guards return before `fact_trust_summary` is ever called, so on a broken
+ALIAS file the typed file is never read at all -- measured: alias-ok/typed-broken
+is 500 on this tree's parent, alias-broken/typed-broken is 200. A fixture that
+left the alias file broken would exercise #570's guard and never reach this one.
+`test_both_policy_files_broken_names_one_and_claims_nothing_about_the_other`
+covers that interaction on purpose.
+
+SCOPE. Eleven route/method pairs, re-derived rather than copied from #570
+(AC-3). All 46 route/method pairs registered on `create_app` outside the
+`/static` mount were driven, each with a fresh app and a fresh KB, under five
+configurations: both files healthy, typed cp949, typed duplicate alias, alias
+malformed, alias cp949. Thirty-nine went through the route sweep; the remaining
+seven -- the three `*-unavailable` pages and FastAPI's four built-in doc routes
+-- were measured separately, and the `*-unavailable` three answer 409 under
+every input, which is their DESIGNED status, so their bodies did run and they
+are clean rather than unmeasured. Two cells are named rather than counted clean,
+because their handler bodies never ran under any payload I could build:
+`POST /settings/root/persist` (control 400) and `POST /settings/test` (control
+502). The eleven:
+`GET /`, `GET /sources`, `GET /review`, `GET /workbench`, `GET /facts/{id}/row`,
+`GET /facts/{id}/provenance`, `POST /facts/{id}/{toggle,accept,reject,amend}`
+and `POST /sources/{id}/accept-all`. Four more POSTs under `/sources` are 303s
+that only ever landed on 500 by redirecting into `GET /sources`; they are fixed
+by guarding that page and have no guard of their own
+(`test_the_sources_post_redirects_land_on_a_page_that_survives`).
+
+`POST /ask` and `POST /questions/translate` are NOT fixed here. Both files fail
+for them at the same statement in `query_schema.build_query_schema_snapshot`,
+which `verinote/cli.py` reaches too, and the ALIAS half of that same statement
+is already owed to #570's follow-up. `POST /ask` is also the one route in the
+population with no upstream guard of any kind, which is why the ordering rule in
+`_trust_policy_failure` has nothing above it there.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from verinote.config import Config
+from verinote.pipeline.corroboration import typed_relations
+from verinote.policy_defaults import RELATION_ALIASES_RELPATH, TYPED_RELATIONS_RELPATH
+from verinote.web import create_app
+
+# The bare parser message (G1: it already names its own file, so the guard must
+# not wrap it) and the named-file wrapper (G2: `str(UnicodeDecodeError)` is a
+# byte offset and no path).
+# Quote-free on purpose: Jinja escapes the message's own `'capital'` to
+# `&#39;capital&#39;`, so the readable form of this string never appears in a
+# rendered page. Mirrors `PARSER_MSG` in the alias guard file.
+TYPED_PARSER_MSG = "typed-relations.md: alias"
+TYPED_NAMED = f"{TYPED_RELATIONS_RELPATH} could not be read"
+
+TYPED_HEALTHY = "- 자본금: amount as capital\n".encode()
+# Raises `CorroborationPolicyError`. See the module docstring: the alias file's
+# malformed input parses to `{}` here and would prove nothing.
+TYPED_DUP_ALIAS = "- 자본금: amount as capital\n- 자산: amount as capital\n".encode()
+TYPED_CP949 = "- 자본금: amount as capital\n".encode("cp949")
+# Parses to `{}` -- used ONLY by the silent-skip test, never as a broken input.
+TYPED_TYPO = "- 소속 member_of\n".encode()
+ALIAS_HEALTHY = "- 소속 -> member_of\n".encode()
+
+# (typed bytes, message that must be present, message that must be absent).
+# The "absent" half is the G1/G2 pin #555 measured: deleting the narrow
+# `except CorroborationPolicyError` leaves every status unchanged and only swaps
+# the bare parser message for the "could not be read" wrapper, so a test written
+# as `assert status == 200` does not detect it.
+BROKEN_INPUTS = [
+    pytest.param(TYPED_DUP_ALIAS, TYPED_PARSER_MSG, TYPED_NAMED, id="duplicate-alias"),
+    pytest.param(TYPED_CP949, TYPED_NAMED, TYPED_PARSER_MSG, id="cp949"),
+]
+
+# Fact ids in the fixture KB below.
+CONFIRMED_AMOUNT = 1  # A / 자본금 / 1억        confirmed, sources/a.txt
+REVIEW_AMOUNT = 3  # A / 자본금 / 1억        needs_review, sources/b.txt
+REVIEW_PLAIN = 4  # C / 소속   / D          needs_review, sources/a.txt
+
+AMEND_FORM = {
+    "subject": "A",
+    "relation": "자본금",
+    "object": "2억",
+    # `_fact_input` accepts only "string" and "term" and rejects anything else
+    # before a line of policy-dependent code runs, so a form sending
+    # `kind="entity"` measures a 400 and proves nothing about this guard.
+    "subject_kind": "string",
+    "relation_kind": "string",
+    "object_kind": "string",
+    "note": "",
+}
+
+# Every endpoint that renders a body. `POST /sources/{id}/accept-all` is the
+# twelfth member of the population and is absent here on purpose: it answers 303
+# with no body, so it gets its own tests below.
+BODY_ENDPOINTS = [
+    pytest.param("GET", "/", {}, id="dashboard"),
+    pytest.param("GET", "/sources", {}, id="sources"),
+    pytest.param("GET", "/review", {}, id="review"),
+    pytest.param("GET", "/review?filter=corroborated", {}, id="review-filtered"),
+    pytest.param("GET", "/workbench", {}, id="workbench"),
+    pytest.param("GET", f"/facts/{CONFIRMED_AMOUNT}/row", {}, id="fact-row"),
+    pytest.param("GET", f"/facts/{CONFIRMED_AMOUNT}/provenance", {}, id="provenance"),
+    pytest.param("POST", f"/facts/{REVIEW_AMOUNT}/toggle", {}, id="toggle"),
+    pytest.param("POST", f"/facts/{REVIEW_AMOUNT}/accept", {}, id="accept"),
+    pytest.param("POST", f"/facts/{REVIEW_AMOUNT}/reject", {}, id="reject"),
+    pytest.param("POST", f"/facts/{REVIEW_AMOUNT}/amend", {"data": AMEND_FORM}, id="amend"),
+]
+
+
+def _done_job(store, source_id: int) -> int:
+    """A completed extraction job, so this source's facts clear the
+    `source_analysis_incomplete` bar in `accept_recommendations`."""
+    job_id = store.create_extraction_job(
+        source_id=source_id, provider="fake", model="m", total_chunks=1
+    )
+    chunk_id = store.add_source_chunks(
+        job_id=job_id, source_id=source_id, chunks=["body"]
+    )[0]
+    store.mark_extraction_job_running(job_id)
+    store.mark_chunk_running(chunk_id)
+    store.mark_chunk_done(chunk_id)
+    store.finish_extraction_job(job_id)
+    return job_id
+
+
+def _build(
+    tmp_path: Path,
+    typed_bytes: bytes | None,
+    *,
+    alias_bytes: bytes | None = ALIAS_HEALTHY,
+    auto_accept: bool = False,
+):
+    """A KB whose trust signals really move when `policy/typed-relations.md` is
+    applied, so that "the value is withheld" is distinguishable from "there was
+    never a value".
+
+    `1억` and `100000000원` are the SAME amount and two DIFFERENT strings. With
+    the typed declaration `자본금: amount as capital` both normalize to
+    `100000000` and the three facts below become one corroborated group backed by
+    two distinct sources; without it they are three unrelated raw triples.
+    Measured end to end -- with the file vs without it, everything else equal:
+
+        GET /                      "Corroborated review targets" count 1 vs 0
+        GET /sources               "1 corroborated" / "2 corroborated" vs "0"
+        GET /review                fact 3's chip "corroborated" vs "single source"
+        GET /workbench             a corroborated table vs "No facts are ..."
+        GET /facts/1/provenance    "corroborated", "2 sources" vs "single source"
+        GET /facts/1/row           chip "corroborated" vs "single source"
+
+    That list is what makes every healthy control in this file non-vacuous: a
+    guard that fired unconditionally would fail all six.
+    """
+    root = tmp_path / "kb"
+    root.mkdir()
+    cfg = Config(
+        root=root,
+        db_path=root / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+        auto_accept_recommendations=auto_accept,
+    )
+    app = create_app(cfg)
+    store = app.state.store
+    # Real files on disk: `POST /sources/{id}/reanalyze` answers 400 for a source
+    # whose bytes are missing, which would make the redirect-landing test measure
+    # a validation error instead of the redirect it is about.
+    (root / "sources").mkdir(parents=True, exist_ok=True)
+    for name in ("a.txt", "b.txt"):
+        (root / "sources" / name).write_text("A는 1억이다.\n", encoding="utf-8")
+    source_a = store.add_source("sources/a.txt")
+    job_a = _done_job(store, source_a)
+    source_b = store.add_source("sources/b.txt")
+    job_b = _done_job(store, source_b)
+    for source_id, name in ((source_a, "a.txt"), (source_b, "b.txt")):
+        # `reanalyze` answers 400 without an extracted-text artifact, for the
+        # same reason as the files above.
+        store.add_source_artifact(
+            source_id=source_id, kind="extracted_text", path=f"sources/{name}"
+        )
+    store.add_fact(
+        "A", "자본금", "1억", status="confirmed", confidence=0.9,
+        source_id=source_a, job_id=job_a,
+    )
+    store.add_fact(
+        "A", "자본금", "100000000원", status="confirmed", confidence=0.9,
+        source_id=source_b, job_id=job_b,
+    )
+    store.add_fact(
+        "A", "자본금", "1억", status="needs_review", confidence=0.5,
+        source_id=source_b, job_id=job_b,
+    )
+    store.add_fact(
+        "C", "소속", "D", status="needs_review", confidence=0.5,
+        source_id=source_a, job_id=job_a,
+    )
+    for relpath, data in (
+        (RELATION_ALIASES_RELPATH, alias_bytes),
+        (TYPED_RELATIONS_RELPATH, typed_bytes),
+    ):
+        if data is not None:
+            path = root / relpath
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+    return TestClient(app, raise_server_exceptions=False), app
+
+
+def _client(tmp_path: Path, typed_bytes: bytes | None) -> TestClient:
+    return _build(tmp_path, typed_bytes)[0]
+
+
+@pytest.fixture
+def healthy_client(tmp_path: Path) -> TestClient:
+    return _client(tmp_path, TYPED_HEALTHY)
+
+
+@pytest.fixture
+def absent_client(tmp_path: Path) -> TestClient:
+    return _client(tmp_path, None)
+
+
+def _request(client: TestClient, method: str, path: str, kwargs: dict):
+    return client.request(method, path, follow_redirects=False, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-5 -- every endpoint in the population survives, and says why
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method, path, kwargs", BODY_ENDPOINTS)
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_every_endpoint_survives_a_broken_typed_relations_file_and_says_why(
+    tmp_path, method, path, kwargs, typed_bytes, present, absent
+):
+    """AC-1 and AC-5 together. Each of these answered 500 on the parent commit.
+
+    The assertion is the MESSAGE, not the status: the narrow
+    `except CorroborationPolicyError` (G1) sits above a broad `except Exception`
+    (G2) that also returns a string, so deleting G1 leaves every status
+    unchanged and only swaps the bare parser message for a "could not be read"
+    wrapper -- a claim that a file which WAS read and DID parse could not be
+    read at all.
+    """
+    r = _request(_client(tmp_path, typed_bytes), method, path, kwargs)
+    assert r.status_code == 200
+    assert present in r.text
+    assert absent not in r.text
+
+
+@pytest.mark.parametrize("method, path, kwargs", BODY_ENDPOINTS)
+def test_every_endpoint_is_unchanged_by_a_healthy_typed_relations_file(
+    tmp_path, method, path, kwargs
+):
+    """Anti-vacuity control for the test above: a guard that fired
+    unconditionally would put the banner on every healthy KB too."""
+    r = _request(_client(tmp_path, TYPED_HEALTHY), method, path, kwargs)
+    assert r.status_code == 200
+    assert TYPED_PARSER_MSG not in r.text
+    assert TYPED_NAMED not in r.text
+    assert 'class="error"' not in r.text
+
+
+@pytest.mark.parametrize("method, path, kwargs", BODY_ENDPOINTS)
+def test_an_absent_typed_relations_file_is_not_treated_as_a_failure(
+    tmp_path, method, path, kwargs
+):
+    """`store_typed_relations` returns `{}` and raises nothing when the file does
+    not exist, which is the normal state of most KBs. A guard that mistook
+    "absent" for "broken" would put a banner on every one of them."""
+    r = _request(_client(tmp_path, None), method, path, kwargs)
+    assert r.status_code == 200
+    assert TYPED_RELATIONS_RELPATH not in r.text
+    assert 'class="error"' not in r.text
+
+
+def test_a_typo_in_typed_relations_is_silently_ignored_rather_than_reported():
+    """C-1, at the parser, so the reason this file's malformed input is a
+    duplicate alias is recorded next to the evidence for it.
+
+    A later edit that "simplifies" `TYPED_DUP_ALIAS` to the alias file's
+    malformed bytes would leave every test above green and pinning nothing.
+    This test fails the moment those two inputs stop being different classes.
+    """
+    assert typed_relations(TYPED_TYPO.decode()) == {}
+    assert typed_relations("- 설립일: colour as founded_on\n") == {}
+    with pytest.raises(Exception) as excinfo:
+        typed_relations(TYPED_DUP_ALIAS.decode())
+    assert "used for both" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("method, path, kwargs", BODY_ENDPOINTS)
+def test_a_typod_declaration_renders_no_banner_because_nothing_failed(
+    tmp_path, method, path, kwargs
+):
+    """The page half of the test above. A dropped declaration is a real
+    state-honesty defect -- trust is computed under rules the user believes they
+    configured -- but it is not this issue's, and reporting it through THIS
+    guard would mean claiming a file that was read and parsed could not be. It
+    is one of the two silent-drop paths #589 tracks."""
+    r = _request(_client(tmp_path, TYPED_TYPO), method, path, kwargs)
+    assert r.status_code == 200
+    assert TYPED_RELATIONS_RELPATH not in r.text
+    assert 'class="error"' not in r.text
+
+
+# ---------------------------------------------------------------------------
+# AC-2 -- withheld, never substituted. Each page's own typed-derived value.
+# ---------------------------------------------------------------------------
+
+DASHBOARD_CORROBORATED_ROW = re.compile(
+    r"Corroborated review targets.*?<td class=\"conf\">(.*?)</td>", re.S
+)
+NOT_COMPUTED = '<span class="badge muted">not computed</span>'
+ROW_NOT_COMPUTED = '<span class="badge muted">trust not computed</span>'
+DOSSIER_NOT_COMPUTED = "Not computed — see the policy-file notice above."
+WORKBENCH_NO_CORROBORATION = "No facts are corroborated by multiple distinct sources."
+
+
+def _dashboard_corroborated(body: str) -> str:
+    match = DASHBOARD_CORROBORATED_ROW.search(body)
+    assert match is not None, "the queue row this test is about is not on the page"
+    return match.group(1).strip()
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_the_dashboard_withholds_the_count_the_typed_file_would_have_changed(
+    tmp_path, typed_bytes, present, absent
+):
+    """`Corroborated review targets` is 1 under this KB's typed file and 0
+    without it, so a page that printed either number would be making a claim it
+    could not compute -- and `0` is the one a naive `{}` fallback produces."""
+    del present, absent
+    body = _client(tmp_path, typed_bytes).get("/").text
+    assert _dashboard_corroborated(body) == NOT_COMPUTED
+
+
+def test_a_healthy_typed_file_gives_the_dashboard_its_real_count(healthy_client):
+    assert _dashboard_corroborated(healthy_client.get("/").text) == "1"
+
+
+def test_the_absent_file_build_gives_a_different_count_than_the_healthy_one(
+    absent_client,
+):
+    """The measurement the two tests above rest on: the withheld value is a
+    value that really does depend on this file. Without it this page's AC-2
+    assertion would be pinning a constant."""
+    assert _dashboard_corroborated(absent_client.get("/").text) == "0"
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_sources_withholds_the_trust_counts_the_typed_file_would_have_changed(
+    tmp_path, typed_bytes, present, absent
+):
+    del present, absent
+    body = _client(tmp_path, typed_bytes).get("/sources").text
+    assert body.count(ROW_NOT_COMPUTED) == 2
+    assert "corroborated</span>" not in body
+
+
+def test_a_healthy_typed_file_gives_sources_its_real_trust_counts(healthy_client):
+    body = healthy_client.get("/sources").text
+    assert ROW_NOT_COMPUTED not in body
+    assert '<span class="badge trust-corroborated">1 corroborated</span>' in body
+    assert '<span class="badge trust-corroborated">2 corroborated</span>' in body
+
+
+def test_sources_counts_differ_without_the_typed_file(absent_client):
+    """`0 corroborated` is what a `{}` fallback would render, and it is a
+    legitimate rendering for a KB with no typed declarations -- which is exactly
+    why the degraded page must not render a number at all."""
+    body = absent_client.get("/sources").text
+    assert body.count('<span class="badge trust-corroborated">0 corroborated</span>') == 2
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_the_review_queue_withholds_each_row_s_typed_derived_signals(
+    tmp_path, typed_bytes, present, absent
+):
+    del present, absent
+    body = _client(tmp_path, typed_bytes).get("/review").text
+    assert body.count(ROW_NOT_COMPUTED) == 2
+    assert '<span class="badge chip">corroborated</span>' not in body
+    assert '<span class="badge chip">single source</span>' not in body
+
+
+def test_a_healthy_typed_file_gives_the_review_queue_its_real_chips(healthy_client):
+    body = healthy_client.get("/review").text
+    assert ROW_NOT_COMPUTED not in body
+    assert '<span class="badge chip">corroborated</span>' in body
+
+
+def test_the_review_queue_chip_differs_without_the_typed_file(absent_client):
+    body = absent_client.get("/review").text
+    assert '<span class="badge chip">corroborated</span>' not in body
+    assert '<span class="badge chip">single source</span>' in body
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_the_workbench_withholds_both_tables(tmp_path, typed_bytes, present, absent):
+    del present, absent
+    body = _client(tmp_path, typed_bytes).get("/workbench").text
+    assert body.count(DOSSIER_NOT_COMPUTED) == 2
+    assert WORKBENCH_NO_CORROBORATION not in body
+
+
+def test_a_healthy_typed_file_gives_the_workbench_its_corroborated_group(
+    healthy_client,
+):
+    body = healthy_client.get("/workbench").text
+    assert DOSSIER_NOT_COMPUTED not in body
+    assert WORKBENCH_NO_CORROBORATION not in body
+    assert "<code>자본금</code>" in body
+
+
+def test_the_workbench_has_no_corroborated_group_without_the_typed_file(
+    absent_client,
+):
+    assert WORKBENCH_NO_CORROBORATION in absent_client.get("/workbench").text
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_the_dossier_withholds_the_typed_value_row(
+    tmp_path, typed_bytes, present, absent
+):
+    del present, absent
+    body = _client(tmp_path, typed_bytes).get(f"/facts/{CONFIRMED_AMOUNT}/provenance").text
+    assert DOSSIER_NOT_COMPUTED in body
+    assert "as <code>capital</code>" not in body
+    # The fact's own identity is not withheld with its trust dossier.
+    assert '<span class="rel term-string">&#34;자본금&#34;' in body
+
+
+def test_a_healthy_typed_file_gives_the_dossier_its_typed_value_row(healthy_client):
+    body = healthy_client.get(f"/facts/{CONFIRMED_AMOUNT}/provenance").text
+    assert DOSSIER_NOT_COMPUTED not in body
+    assert "as <code>capital</code>" in body
+    assert "2 sources" in body
+
+
+def test_the_dossier_has_no_typed_value_row_without_the_typed_file(absent_client):
+    body = absent_client.get(f"/facts/{CONFIRMED_AMOUNT}/provenance").text
+    assert "as <code>capital</code>" not in body
+    assert "1 source" in body
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_the_fact_row_withholds_its_typed_chip(tmp_path, typed_bytes, present, absent):
+    del present, absent
+    body = _client(tmp_path, typed_bytes).get(f"/facts/{CONFIRMED_AMOUNT}/row").text
+    assert ROW_NOT_COMPUTED in body
+    # The chip markup, not the bare word: the duplicate-alias message
+    # legitimately contains "capital", so `"capital" not in body` would be
+    # reddened by the very message this guard is supposed to render.
+    assert '<span class="badge chip">amount <code>capital</code></span>' not in body
+    # Withholding trust must not withhold the fact or its controls.
+    assert f'id="fact-{CONFIRMED_AMOUNT}"' in body
+    assert f'hx-post="/facts/{CONFIRMED_AMOUNT}/toggle"' in body
+
+
+TYPED_CHIP = '<span class="badge chip">amount <code>capital</code></span>'
+
+
+def test_a_healthy_typed_file_gives_the_fact_row_its_typed_chip(healthy_client):
+    body = healthy_client.get(f"/facts/{CONFIRMED_AMOUNT}/row").text
+    assert ROW_NOT_COMPUTED not in body
+    assert TYPED_CHIP in body
+
+
+def test_the_fact_row_has_no_typed_chip_without_the_typed_file(absent_client):
+    assert TYPED_CHIP not in absent_client.get(f"/facts/{CONFIRMED_AMOUNT}/row").text
+
+
+# ---------------------------------------------------------------------------
+# The write path: POST /sources/{id}/accept-all, and the auto-accept pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_accept_all_survives_a_broken_typed_file_when_auto_accept_is_on(
+    tmp_path, typed_bytes, present, absent
+):
+    """The one endpoint in the population invisible to a sweep that leaves
+    `auto_accept_recommendations` at its `False` default: it answers 303 either
+    way with the flag off, and 500 with the flag on. It never enters
+    `_fact_row_context`, so no template guard's deletion touches it.
+
+    The assertion is a status and not a message, for the only reason this file
+    accepts one: a 303 carries no body to put a message in (measured).
+    """
+    del present, absent
+    client = _build(tmp_path, typed_bytes, auto_accept=True)[0]
+    r = client.post("/sources/1/accept-all", follow_redirects=False)
+    assert r.status_code == 303
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_a_broken_typed_file_stops_the_auto_accept_pass_rather_than_running_it_empty(
+    tmp_path, typed_bytes, present, absent
+):
+    """The strongest form of AC-2, because this one is a WRITE.
+    `apply_auto_accept_recommendations` promotes facts to `accepted`, and
+    `acceptance._engine` decides which by reading the alias file and the typed
+    file on consecutive lines. A badge computed on the wrong rules is re-rendered
+    next request; a status transition is committed and audited.
+
+    Fact 3 is promoted here only because `자본금: amount as capital` makes `1억`
+    and `100000000원` one normalized value backed by two distinct sources -- the
+    healthy half below is what proves this fixture can see a promotion at all.
+
+    STATED LIMIT: "fact 3 is still needs_review" is also what a pass run with no
+    typed file at all produces, and unlike #570's alias case that build IS
+    reachable here, because an absent typed file is legal. So this assertion
+    does not by itself separate "withheld" from "degraded to `{}`" -- nothing
+    rendered or written could, which is the point of the module docstring's
+    third paragraph. Its falsifying build is the guard's deletion, which 500s
+    the request.
+    """
+    del present, absent
+
+    (tmp_path / "healthy").mkdir()
+    (tmp_path / "broken").mkdir()
+    healthy, healthy_app = _build(
+        tmp_path / "healthy", TYPED_HEALTHY, auto_accept=True
+    )
+    assert healthy.post(f"/facts/{REVIEW_PLAIN}/accept").status_code == 200
+    assert healthy_app.state.store.get_fact(REVIEW_AMOUNT)["status"] == "accepted"
+
+    broken, broken_app = _build(tmp_path / "broken", typed_bytes, auto_accept=True)
+    r = broken.post(f"/facts/{REVIEW_PLAIN}/accept")
+    assert r.status_code == 200
+    assert broken_app.state.store.get_fact(REVIEW_AMOUNT)["status"] == "needs_review"
+
+
+@pytest.mark.parametrize("typed_bytes, present, absent", BROKEN_INPUTS)
+def test_the_sources_post_redirects_land_on_a_page_that_survives(
+    tmp_path, typed_bytes, present, absent
+):
+    """C-3. These four POSTs answer 303 under every input, on the parent commit
+    too -- they read no policy file. They appeared in the issue's population only
+    because its sweep followed the redirect into `GET /sources`, which really was
+    500. Guarding that page is what fixes them, and this test is the only thing
+    that would notice if `GET /sources` were ever guarded differently.
+    """
+    for index, path in enumerate(("/sources/1/reanalyze", "/sources/1/delete")):
+        # A fresh KB per path: `delete` removes the source the next POST would
+        # need, and a shared client would measure a 404 rather than a redirect.
+        endpoint_dir = tmp_path / f"endpoint{index}"
+        endpoint_dir.mkdir()
+        landing_dir = tmp_path / f"landing{index}"
+        landing_dir.mkdir()
+        endpoint = _client(endpoint_dir, typed_bytes).post(path, follow_redirects=False)
+        assert endpoint.status_code == 303
+        assert endpoint.headers["location"] == "/sources"
+        landing = _client(landing_dir, typed_bytes).post(path, follow_redirects=True)
+        assert landing.status_code == 200
+        assert present in landing.text
+        assert absent not in landing.text
+
+
+# ---------------------------------------------------------------------------
+# The interaction with #570: two broken files, and the order they are reported
+# ---------------------------------------------------------------------------
+
+
+def test_both_policy_files_broken_names_one_and_claims_nothing_about_the_other(
+    tmp_path,
+):
+    """`_trust_policy_failure` checks the alias file first and returns on the
+    first failure, so with both files broken the page names
+    `relation-aliases.md` and says nothing at all about `typed-relations.md`.
+
+    What this test really pins is the SECOND half: nothing on the degraded page
+    asserts that the file it does not name is healthy. That sentence used to
+    exist -- the banners said the values "would have been computed under
+    different ALIAS RULES than this KB's file specifies", which on a KB with two
+    broken files named the wrong cause.
+    """
+    body = _build(
+        tmp_path, TYPED_DUP_ALIAS, alias_bytes="- 소속 member_of\n".encode()
+    )[0].get("/sources").text
+    assert "relation-aliases.md:1:" in body
+    assert TYPED_RELATIONS_RELPATH not in body
+    assert "alias rules" not in body
+
+
+def test_repairing_the_alias_file_reveals_the_typed_failure_without_a_500(tmp_path):
+    """The both-broken case is masked on the parent commit: #570's guard returns
+    before `fact_trust_summary` runs, so the typed file is never read and the
+    page answers 200 with an alias-only banner. Repairing the alias file used to
+    turn that page into a fresh 500. It now turns into a second banner.
+    """
+    client, app = _build(
+        tmp_path, TYPED_DUP_ALIAS, alias_bytes="- 소속 member_of\n".encode()
+    )
+    first = client.get("/sources")
+    assert first.status_code == 200
+    assert "relation-aliases.md:1:" in first.text
+
+    (app.state.cfg.root / RELATION_ALIASES_RELPATH).write_bytes(ALIAS_HEALTHY)
+
+    second = client.get("/sources")
+    assert second.status_code == 200
+    assert TYPED_PARSER_MSG in second.text
+
+
+def test_a_broken_alias_file_still_degrades_exactly_as_before(tmp_path):
+    """The rename from `alias_error` to `policy_error` is mechanical, and this is
+    where a silent behaviour change in it would show: a healthy typed file plus a
+    broken alias file must still be the #570 story, message and all."""
+    client = _client(tmp_path, TYPED_HEALTHY)
+    (client.app.state.cfg.root / RELATION_ALIASES_RELPATH).write_bytes(
+        "- 소속 member_of\n".encode()
+    )
+    body = client.get("/sources").text
+    assert "relation-aliases.md:1:" in body
+    assert f"{RELATION_ALIASES_RELPATH} could not be read" not in body
+    assert ROW_NOT_COMPUTED in body
+
+
+# ---------------------------------------------------------------------------
+# The prose: one guard per template, one test per template
+# ---------------------------------------------------------------------------
+
+# The exact phrases that were true of the alias file and false of this one.
+# NOT a bare `"alias" not in body`: the typed parser's own message legitimately
+# contains the word ("typed-relations.md: alias 'capital' used for both ..."),
+# so that assertion would be reddened by the thing it is meant to allow.
+OLD_BANNER_PHRASE = "different alias rules"
+NEW_BANNER_PHRASE = "different rules than this KB's policy files specify"
+OLD_MARKER = "see the alias-file notice above"
+NEW_MARKER = "see the policy-file notice above"
+# C-7. `settings.html` has no typed-relations editor, and `docs/operations.md`
+# records that nothing in verinote writes this file -- so a banner about it that
+# ends "Fix it on Settings" points at a page that cannot repair it.
+SETTINGS_REPAIR_LINK = 'Fix it on <a href="/settings">Settings</a>'
+
+BANNER_RE = re.compile(r'<p class="error" role="alert">.*?</p>', re.S)
+
+
+def _collapse(text: str) -> str:
+    """Collapse runs of whitespace. These sentences are wrapped across source
+    lines, so the newline falls in a different place in each template and a
+    literal substring match would pin the line wrapping rather than the wording.
+    """
+    return re.sub(r"\s+", " ", text)
+
+
+def _banner(body: str) -> str:
+    """This page's own policy banner, so that reverting ANOTHER template's
+    sentence cannot redden this page's test. Within one template the sites are
+    one guard and are declared as such: the three `dashboard.html` markers and
+    the five in `provenance.html` render the same string, so no assertion tells
+    them apart."""
+    banners = BANNER_RE.findall(body)
+    assert len(banners) == 1, f"expected exactly one policy banner, found {len(banners)}"
+    return banners[0]
+
+
+def _assert_banner_prose(body: str) -> None:
+    banner = _collapse(_banner(body))
+    assert TYPED_PARSER_MSG in banner
+    assert OLD_BANNER_PHRASE not in banner
+    assert NEW_BANNER_PHRASE in banner
+    assert SETTINGS_REPAIR_LINK not in banner
+
+
+def test_the_dashboard_banner_names_no_file_it_did_not_read(tmp_path):
+    body = _client(tmp_path, TYPED_DUP_ALIAS).get("/").text
+    _assert_banner_prose(body)
+    assert OLD_MARKER not in body
+    # Six: `dashboard.html` has three marker sites, and one of them is the
+    # `title=` on a suppressed Open button inside the queue loop, which renders
+    # once per policy-dependent row (four of them).
+    assert body.count(NEW_MARKER) == 6
+
+
+def test_the_sources_banner_names_no_file_it_did_not_read(tmp_path):
+    _assert_banner_prose(_client(tmp_path, TYPED_DUP_ALIAS).get("/sources").text)
+
+
+def test_the_review_banner_names_no_file_it_did_not_read(tmp_path):
+    _assert_banner_prose(_client(tmp_path, TYPED_DUP_ALIAS).get("/review").text)
+
+
+def test_the_workbench_banner_names_no_file_it_did_not_read(tmp_path):
+    body = _client(tmp_path, TYPED_DUP_ALIAS).get("/workbench").text
+    _assert_banner_prose(body)
+    assert OLD_MARKER not in body
+    assert body.count(NEW_MARKER) == 2
+
+
+def test_the_provenance_banner_names_no_file_it_did_not_read(tmp_path):
+    body = _client(tmp_path, TYPED_DUP_ALIAS).get(
+        f"/facts/{CONFIRMED_AMOUNT}/provenance"
+    ).text
+    _assert_banner_prose(body)
+    assert OLD_MARKER not in body
+    assert body.count(NEW_MARKER) == 5
+
+
+def test_the_fact_row_reason_line_offers_no_repair_it_cannot_deliver(tmp_path):
+    """The sixth prose site, and the only one on a fragment rather than a page.
+    `fact_row.html`'s sentence was already file-agnostic ("withheld until this
+    file can be read"); its Settings link was not. Asserted on
+    `GET /facts/{id}/row`, which renders this template and nothing else, so
+    reverting any page banner leaves this test green."""
+    body = _client(tmp_path, TYPED_DUP_ALIAS).get(f"/facts/{CONFIRMED_AMOUNT}/row").text
+    assert BANNER_RE.search(body) is None
+    assert "withheld until this file can be read." in body
+    assert SETTINGS_REPAIR_LINK not in body

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -106,6 +106,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
     store_single_valued_conflicts,
     store_typed_relations,
+    TYPED_RELATIONS_RELPATH,
 )
 from verinote.pipeline.workbench import trust_workbench
 from verinote.prompts import (
@@ -1056,44 +1057,29 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _relation_aliases_path() -> Path:
         return _active_cfg().root / RELATION_ALIASES_RELPATH
 
-    def _relation_alias_failure(store: Store) -> str | None:
-        """Why this KB's alias file cannot be applied, or None when it can.
+    def _policy_file_failure(read, relpath: str) -> str | None:
+        """Normalise ONE trust-policy file read into a message, or None.
 
-        Calls `store_relation_aliases` — the function the routes' own failures
-        come out of — rather than re-reading the file here. `store_relation_aliases`
-        resolves `store.db_path.parent / RELATION_ALIASES_RELPATH`, which agrees
-        with `_relation_aliases_path()` (`_active_cfg().root / …`) for every
-        `Config.for_root`, but the two are independent `Config` fields, so a guard
-        that re-derived the path could clear one file while the route read the
-        other and still 500 (#555).
-
-        This call's own read happens chronologically FIRST (measured: it runs
-        before any pipeline function does, since the route calls it before
-        computing anything alias-dependent) — but it is not the ONLY read. When
-        the file is healthy, the route's own pipeline functions
-        (`store_corroboration`, `trust_workbench`, `fact_trust_summary`, …) each
-        call `store_relation_aliases` again themselves; this call does not
-        replace those reads or cache the result for them, and it is not a fix
-        for the check-then-use gap that leaves: a rewrite between this call and
-        the route's own reads still 500s. Freezing one read and threading it
-        through every alias-dependent pipeline function would change signatures
-        shared with the CLI, and is a separate refactor.
-
-        The broad clause below wraps EXACTLY ONE CALL, not a route body, and that
-        call touches no database: `store_relation_aliases` reads `store.db_path` as
-        an attribute, stats the file, and parses it. So the only thing this can
-        swallow is a failure to read or parse that one file.
+        Shared by both legs of `_trust_policy_failure` because the two files
+        fail the same two ways and must be reported the same two ways. `read` is
+        a zero-argument callable so the try wraps EXACTLY ONE CALL, not a route
+        body, and that call touches no database: `store_relation_aliases` and
+        `store_typed_relations` each read `store.db_path` as an attribute, stat
+        their file, and parse it. So the only thing this can swallow is a
+        failure to read or parse that one file.
         """
         try:
-            store_relation_aliases(store)
+            read()
         except CorroborationPolicyError as exc:
             # G1. Already normalised, and its message already begins with the
-            # file name (`relation-aliases.md:1: expected …`). Prefixing it below
-            # would say the file twice, AND would misstate what happened — the
-            # file WAS read; it parsed and failed. That is a false claim about the
-            # system's own state on a user-facing page. Must stay ABOVE G2.
+            # file's own name (`relation-aliases.md:1: expected …`,
+            # `typed-relations.md: alias 'x' used for both …`). Prefixing it
+            # below would say the file twice, AND would misstate what happened —
+            # the file WAS read; it parsed and failed. That is a false claim
+            # about the system's own state on a user-facing page. Must stay
+            # ABOVE G2.
             return str(exc)
-        except Exception as exc:  # noqa: BLE001 - normalise every alias-read failure
+        except Exception as exc:  # noqa: BLE001 - normalise every policy-read failure
             # G2. BROAD, NOT A TYPE LIST. `UnicodeDecodeError` (a file saved as
             # cp949) descends from `ValueError` as `CorroborationPolicyError`
             # does but is no subclass of it; `PermissionError` is not a
@@ -1103,17 +1089,98 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # NAME THE FILE: `str(UnicodeDecodeError)` is a byte offset and no
             # path, so an unprefixed message put a bare codec complaint about
             # nothing in particular on the page.
-            return f"{RELATION_ALIASES_RELPATH} could not be read: {exc}"
+            return f"{relpath} could not be read: {exc}"
         return None
+
+    def _trust_policy_failure(store: Store) -> str | None:
+        """Why this KB's trust policy cannot be applied, or None when it can.
+
+        TWO FILES, ONE SIGNAL. `fact_trust_summary`, `_source_trust_rollup`,
+        `trust_workbench` and `store_single_valued_conflicts` each read BOTH
+        `policy/relation-aliases.md` and `policy/typed-relations.md`, and either
+        one being unreadable 500s them identically. (`store_corroboration` is
+        the one trust function that reads only the alias file — which is why
+        this is a guard on the callers, not a claim that every trust-derived
+        value depends on both files.) The question every caller asks is the same
+        ("can this KB's trust policy be applied?") and the consequence is the
+        same (withhold every trust-derived value), so it is one string rather
+        than two flags. Each parser's message already names its own file, so the
+        returned string carries the attribution without a second value to
+        thread (#585).
+
+        ORDER, AND WHAT THE MESSAGE DOES NOT SAY. Aliases are checked first,
+        typed relations second, and the FIRST failure is what comes back. So
+        when both files are broken the page names the alias file and says
+        nothing at all about the typed one — not that it is healthy. Callers
+        and templates must not turn "the message names one file" into "the
+        other file is fine": repairing the named file can surface a second
+        failure on a page that had been answering 200. That is not a defect
+        being hidden, it is the only ordering available without reading a file
+        the first failure already made irrelevant, and it is why no banner this
+        value feeds claims any file is readable.
+
+        WHY THIS GUARD CARRIES ITS OWN MARKER RATHER THAN CHECKING THE VALUE.
+        On the alias side, degrading means computing under
+        `DEFAULT_RELATION_ALIASES` — a value the user demonstrably does not
+        have, because the delta from the defaults is the only reason their file
+        exists. There is no `DEFAULT_TYPED_RELATIONS`: `store_typed_relations`
+        returns `{}` when the file is absent, which is the normal state of most
+        KBs. So a typed failure degraded to `{}` renders BYTE-IDENTICALLY to a
+        healthy KB that declares no typed relations, and no assertion on the
+        rendered value could tell them apart. The withheld state has to be
+        signalled by this value being non-None, never inferred from the numbers
+        (#585).
+
+        Both calls resolve their file as `store.db_path.parent / <relpath>`,
+        which agrees with `_relation_aliases_path()` (`_active_cfg().root / …`)
+        for every `Config.for_root`, but the two are independent `Config`
+        fields, so a guard that re-derived the path could clear one file while
+        the route read the other and still 500 (#555). Calling the pipeline
+        functions the routes' own failures come out of is what keeps them
+        agreeing.
+
+        These reads happen chronologically FIRST (measured: they run before any
+        pipeline function does, since the route calls this before computing
+        anything policy-dependent) — but they are not the ONLY reads. When the
+        files are healthy, the route's own pipeline functions
+        (`store_corroboration`, `trust_workbench`, `fact_trust_summary`, …) read
+        both files again themselves; this call does not replace those reads or
+        cache the result for them, and it is not a fix for the check-then-use
+        gap that leaves: a rewrite between this call and the route's own reads
+        still 500s. Freezing one read and threading it through every
+        policy-dependent pipeline function would change signatures shared with
+        the CLI, and is a separate refactor.
+
+        NOT EVERY POLICY-DEPENDENT ROUTE CALLS THIS. `POST /ask` and
+        `POST /questions/translate` fail for BOTH files inside
+        `build_query_schema_snapshot` (`query_schema.py`), which
+        `verinote/cli.py` reaches too, and they have no guard here for either
+        file. `POST /ask` is therefore also the one route where the ordering
+        rule above has nothing upstream of it: everywhere else a tripped guard
+        returns before the typed read can run at all (measured). Both are
+        deferred to #570's follow-up, which already owes their alias half.
+        """
+        alias_failure = _policy_file_failure(
+            lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
+        )
+        if alias_failure is not None:
+            return alias_failure
+        # Explicit `is not None` rather than `or`: an exception with no args
+        # stringifies to "", which is falsy, and an `or` chain would silently
+        # step past a real alias failure to read a file the user cannot act on
+        # yet.
+        return _policy_file_failure(
+            lambda: store_typed_relations(store), TYPED_RELATIONS_RELPATH
+        )
 
     def _relation_aliases_context() -> dict[str, object]:
         """The Settings page's own read of the alias file, plus its own guard.
 
-        Deliberately NOT `_relation_alias_failure` + `store_relation_aliases`:
+        Deliberately NOT `_trust_policy_failure` + `store_relation_aliases`:
         this route never calls `store_relation_aliases` (it reads the file
         straight from `_relation_aliases_path()`, which resolves from
         `cfg.root` rather than `store.db_path.parent` — see
-        `_relation_alias_failure`'s docstring), so it needs its own read and its
+        `_trust_policy_failure`'s docstring), so it needs its own read and its
         own broad `except Exception` around that one `read_text` call (same G2
         rationale: no database access, only a stat and a read of this file).
         """
@@ -1524,27 +1591,34 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             view[f"{field}_kind"] = term_input_kind(term)
         return view
 
-    def _fact_row_context(fact, recommendations=None, *, alias_error: str | None):
-        """Row context. `alias_error` withholds every alias-derived signal (#570).
+    def _fact_row_context(fact, recommendations=None, *, policy_error: str | None):
+        """Row context. `policy_error` withholds every trust-derived signal (#570).
 
-        `alias_error` is REQUIRED and keyword-only on purpose. The recurring
-        defect here is a caller that reaches an alias read without guarding it
-        (#570 trap 1): a defaulted parameter turns the next such caller into a
+        `policy_error` is REQUIRED and keyword-only on purpose. The recurring
+        defect here is a caller that reaches a policy-file read without guarding
+        it (#570 trap 1): a defaulted parameter turns the next such caller into a
         silent 500 in production, a required one turns it into a `TypeError` at
         the call site.
 
         When it is set, `trust` and `recommendation` are `None` rather than
-        computed anyway. `store_relation_aliases` returns
+        computed anyway, and the two files reach that conclusion by different
+        routes. `store_relation_aliases` returns
         `merge_default_relation_aliases(user_aliases)`, so the delta between the
         user's file and the defaults is exactly their custom entries — i.e. the
         only reason the file exists. A badge computed without them is a number
         about a KB nobody has, rendered in the same badges a healthy KB uses.
+        `store_typed_relations` has no defaults to fall back to: it degrades to
+        `{}`, which is exactly what a KB with no typed declarations returns, so
+        a badge computed without that file is INDISTINGUISHABLE from a healthy
+        one and nothing in the render could give it away (#585). Either way the
+        answer is to withhold, not to approximate.
+
         `None` is also what lets `fact_row.html` say "not computed" instead of
         borrowing the `trust unavailable` verdict below it, which means
         something else and something measured: this fact has no trust summary.
         """
         view = _fact_view(fact)
-        if alias_error is None:
+        if policy_error is None:
             trust = fact_trust_summary(_active_store(), int(fact["id"])) if fact else None
             if fact and recommendations is None:
                 recommendations = accept_recommendations(_active_store())
@@ -1557,7 +1631,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             "trust": trust,
             "recommendation": recommendation,
             "actionable": bool(fact and is_actionable_fact_status(fact["status"])),
-            "alias_error": alias_error,
+            "policy_error": policy_error,
         }
 
     def _actionable_fact_or_error(fact_id: int):
@@ -1569,22 +1643,24 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return fact
 
     def _maybe_apply_auto_accept(
-        exclude_fact_ids: tuple[int, ...] = (), *, alias_error: str | None
+        exclude_fact_ids: tuple[int, ...] = (), *, policy_error: str | None
     ) -> list:
-        """Run the auto-accept pass, unless the alias file cannot be read (#570).
+        """Run the auto-accept pass, unless a trust-policy file cannot be read.
 
-        The only guard in this change that stops a WRITE.
+        The only guard in this change that stops a WRITE (#570).
         `apply_auto_accept_recommendations` promotes facts to `accepted` and
-        retracts lapsed ones, and it decides which by reading the alias file. A
-        pass run while that file is unreadable would rewrite the KB's review
-        state under `merge_default_relation_aliases(...)` — rules the user did
-        not configure. A badge computed on the wrong rules is re-rendered on the
-        next request; a status transition is committed and audited.
+        retracts lapsed ones, and it decides which by reading BOTH policy files
+        (`acceptance.py::_engine` reads the alias file and the typed file on
+        consecutive lines). A pass run while either is unreadable would rewrite
+        the KB's review state under rules the user did not configure — the
+        packaged alias defaults, or no typed declarations at all. A badge
+        computed on the wrong rules is re-rendered on the next request; a status
+        transition is committed and audited.
 
-        `alias_error` is required and keyword-only for the same reason as on
+        `policy_error` is required and keyword-only for the same reason as on
         `_fact_row_context`.
         """
-        if alias_error is not None:
+        if policy_error is not None:
             return []
         if _active_cfg().auto_accept_recommendations:
             return apply_auto_accept_recommendations(
@@ -1592,12 +1668,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             )
         return []
 
-    def _row(request: Request, fact, *, alias_error: str | None):
+    def _row(request: Request, fact, *, policy_error: str | None):
         # Starlette's current API is TemplateResponse(request, name, context).
         return templates.TemplateResponse(
             request,
             "partials/fact_row.html",
-            _fact_row_context(fact, alias_error=alias_error),
+            _fact_row_context(fact, policy_error=policy_error),
         )
 
     def _row_after_decision(
@@ -1630,18 +1706,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         letting it promote everything else — for the one decision that parks a
         fact back in the tier auto-accept harvests from (see `toggle`).
         """
-        # One alias read per decision POST, threaded into both the auto-accept
-        # pass and the row render, rather than one per consumer (#570).
-        alias_error = _relation_alias_failure(_active_store())
+        # One policy-file check per decision POST, threaded into both the
+        # auto-accept pass and the row render, rather than one per consumer
+        # (#570).
+        policy_error = _trust_policy_failure(_active_store())
         excluded = () if rule_may_act or acted_fact_id is None else (acted_fact_id,)
         applied = (
-            _maybe_apply_auto_accept(excluded, alias_error=alias_error) if decided else []
+            _maybe_apply_auto_accept(excluded, policy_error=policy_error) if decided else []
         )
         if acted_fact_id is not None:
             refreshed = _active_store().get_fact(acted_fact_id)
             if refreshed is not None:
                 fact = refreshed
-        response = _row(request, fact, alias_error=alias_error)
+        response = _row(request, fact, policy_error=policy_error)
         if any(rec.fact_id != acted_fact_id for rec in applied):
             response.headers["HX-Refresh"] = "true"
         return response
@@ -1817,16 +1894,18 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         )
 
     def _source_inspector_rows(
-        store: Store, *, alias_error: str | None
+        store: Store, *, policy_error: str | None
     ) -> list[dict[str, object]]:
         facts = store.facts()
-        # Compute the rollup only when the alias file is usable — an alias_error
-        # means `_source_trust_rollup` would 500 the same way this route used to
-        # (#555). One `store.facts()` scan either way: passing `alias_error` in and
-        # branching here, rather than a caller-side `None if alias_error else
+        # Compute the rollup only when both trust-policy files are usable — a
+        # `policy_error` means `_source_trust_rollup` would 500 the same way this
+        # route used to (#555 for the alias file, #585 for the typed one, which
+        # it reads on the next line).
+        # One `store.facts()` scan either way: passing `policy_error` in and
+        # branching here, rather than a caller-side `None if policy_error else
         # _source_trust_rollup(store, store.facts())`, avoids a second full scan on
         # every healthy request.
-        trust_rollup = None if alias_error else _source_trust_rollup(store, facts)
+        trust_rollup = None if policy_error else _source_trust_rollup(store, facts)
         rows = []
         for source in store.sources_with_counts():
             row = dict(source)
@@ -1931,17 +2010,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return ("raw", obj)
 
     def _dashboard_queues(
-        store: Store, *, alias_error: str | None
+        store: Store, *, policy_error: str | None
     ) -> list[dict[str, object]]:
-        # `jobs` and `recent_lifecycle` are alias-independent (measured, #555 M5) and
-        # keep their real counts either way. The other four rows depend on
-        # `fact_trust_summary`, `trust_workbench`, or `store_corroboration` — all
-        # alias-dependent — so when the file cannot be applied they show `None`
+        # `jobs` and `recent_lifecycle` are policy-file-independent (measured,
+        # #555 M5) and keep their real counts either way. The other four rows
+        # depend on `fact_trust_summary`, `trust_workbench`, or
+        # `store_corroboration` — every one of which reads the alias file, and
+        # the first two the typed file as well — so when either file cannot be
+        # applied they show `None`
         # (rendered as "not computed" by the template) rather than a count computed
         # under rules the user did not configure, or a false `0`.
         jobs = store.source_extraction_jobs()
         recent_lifecycle = store.count_facts_with_events(("amended", "reanalyzed"))
-        if alias_error is None:
+        if policy_error is None:
             review_summaries = [
                 fact_trust_summary(store, int(fact["id"])) for fact in store.review_queue()
             ]
@@ -2007,17 +2088,17 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
         cfg = _active_cfg()
-        alias_error = _relation_alias_failure(store)
+        policy_error = _trust_policy_failure(store)
         counts = store.status_counts()
         # `counts`, `total`, `engine_input`, `sources`, `coverage` are all
-        # alias-independent (measured, #555 M5) and keep their real values even
-        # when the alias file is broken. `corroboration` and
-        # `single_valued_conflicts` are alias-dependent; `None` (not `[]`) so the
+        # policy-file-independent (measured, #555 M5) and keep their real values
+        # even when a policy file is broken. `corroboration` reads the alias
+        # file and `single_valued_conflicts` reads both; `None` (not `[]`) so the
         # template can tell "not computed" apart from "computed, and empty" —
         # `[]` would render the same "No source-backed …" prose a healthy KB with
         # nothing to show gets, which is a false statement about a KB that was
         # never analysed.
-        if alias_error is None:
+        if policy_error is None:
             corroboration = store_corroboration(store)
             single_valued_conflicts = store_single_valued_conflicts(store)
         else:
@@ -2038,8 +2119,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 "coverage": coverage(store, root=cfg.root),
                 "corroboration": corroboration,
                 "single_valued_conflicts": single_valued_conflicts,
-                "queues": _dashboard_queues(store, alias_error=alias_error),
-                "alias_error": alias_error,
+                "queues": _dashboard_queues(store, policy_error=policy_error),
+                "policy_error": policy_error,
                 "provider": app.state.cfg.provider,
                 "provider_label": PROVIDER_LABELS.get(
                     app.state.cfg.provider, app.state.cfg.provider
@@ -2055,7 +2136,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         if app.state.store is None:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
-        alias_error = _relation_alias_failure(store)
+        policy_error = _trust_policy_failure(store)
         jobs = store.source_extraction_jobs()
         latest_job_ids = latest_source_job_ids(jobs)
         # A superseded `pending` row is dead work, and counting it here is what
@@ -2066,11 +2147,11 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             request,
             "sources.html",
             {
-                "sources": _source_inspector_rows(store, alias_error=alias_error),
+                "sources": _source_inspector_rows(store, policy_error=policy_error),
                 "suffixes": ", ".join(sorted(supported_suffixes())),
                 "accept": ",".join(sorted(supported_suffixes())),
                 "error": error,
-                "alias_error": alias_error,
+                "policy_error": policy_error,
                 "jobs": jobs,
                 "has_running_jobs": has_running_jobs,
                 "chunk_chars": app.state.cfg.extraction_chunk_chars,
@@ -2727,10 +2808,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # nothing left in the review tier confirms nothing, so the POST decided
         # nothing and the rule stays out of it.
         if accepted:
-            # The alias file is read here rather than at the top of the route:
-            # a source with nothing left in the review tier never runs the pass,
-            # so it owes no read (#570).
-            _maybe_apply_auto_accept(alias_error=_relation_alias_failure(store))
+            # The policy files are read here rather than at the top of the
+            # route: a source with nothing left in the review tier never runs
+            # the pass, so it owes no read (#570).
+            _maybe_apply_auto_accept(policy_error=_trust_policy_failure(store))
         return RedirectResponse("/sources", status_code=303)
 
     @app.post("/sources/{source_id}/delete", response_class=HTMLResponse)
@@ -2767,13 +2848,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     ):
         store = _active_store()
         active_filter = _active_review_filter(filter)
-        alias_error = _relation_alias_failure(store)
-        if alias_error is not None and active_filter != "needs-human-decision":
+        policy_error = _trust_policy_failure(store)
+        if policy_error is not None and active_filter != "needs-human-decision":
             # #570. Every filter but `needs-human-decision` — `unsupported`,
             # `single-source`, `corroborated`, `conflicted` — selects facts BY the value that
             # could not be computed: `_review_page` runs `fact_trust_summary`
             # over the whole queue and keeps the ids whose labels match. So the
-            # row set, the total and the pager are themselves alias-derived, not
+            # row set, the total and the pager are themselves trust-derived, not
             # just the badges. There is no degraded list to show. Falling back
             # to the default filter would answer a question the user did not
             # ask; rendering an empty one would be a false statement about which
@@ -2782,7 +2863,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # This RETURNS rather than setting a flag the code below reads. With
             # `page_data = None` the `[int(f["id"]) for f in page_data.rows]`
             # argument to `accept_recommendations_for` raises `AttributeError` —
-            # a 500 with nothing to do with the alias file.
+            # a 500 with nothing to do with the policy files.
             #
             # The filter nav is how the user gets back to a page that works, so
             # it survives — and its hrefs must carry the sort and page size the
@@ -2803,32 +2884,36 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                         active_filter, nav.sort, nav.page_size
                     ),
                     "pager": None,
-                    "alias_error": alias_error,
+                    "policy_error": policy_error,
                 },
             )
         page_data = _review_page(store, active_filter, page, page_size, sort)
         # #570. On the default filter the ROWS are real: `store.review_queue_page`
         # reads no policy file. Measured by spying every module that binds
         # `store_relation_aliases` — a healthy `/review` reads it from
-        # `_relation_alias_failure` (this route's own guard, above),
+        # `_trust_policy_failure` (this route's own guard, above),
         # `acceptance._engine`, `trust.fact_trust_summary` and
         # `corroboration.store_single_valued_conflicts`, and from nowhere else.
         # The readers are named rather than counted on purpose: the count moves
         # whenever a guard is added, and what this comment needs to say is that
         # the QUEUE QUERY is not among them. So the queue is the KB's own and
-        # only its trust signals are withheld.
+        # only its trust signals are withheld. `store_typed_relations` is bound
+        # in the same modules and read by the last three of those four, so #585
+        # broadening this route's guard does not widen what is withheld — the
+        # queue query reads neither file.
         # `accept_recommendations_for` is the opposite: it builds its engine off
-        # the alias file before it looks at a single id, so it raises even for an
-        # empty id list. Skipping it and passing `{}` is what keeps this route up.
+        # both policy files before it looks at a single id, so it raises even for
+        # an empty id list. Skipping it and passing `{}` is what keeps this route
+        # up.
         recommendations = (
             {}
-            if alias_error is not None
+            if policy_error is not None
             else accept_recommendations_for(
                 store, [int(f["id"]) for f in page_data.rows]
             )
         )
         rows = [
-            _fact_row_context(f, recommendations, alias_error=alias_error)
+            _fact_row_context(f, recommendations, policy_error=policy_error)
             for f in page_data.rows
         ]
         return templates.TemplateResponse(
@@ -2841,27 +2926,28 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     active_filter, page_data.sort, page_data.page_size
                 ),
                 "pager": _review_pager(active_filter, page_data),
-                "alias_error": alias_error,
+                "policy_error": policy_error,
             },
         )
 
     @app.get("/workbench", response_class=HTMLResponse)
     def workbench(request: Request):
-        # #570. `trust_workbench` reads the alias file in its first statement,
-        # and its whole return value is the page. `None` rather than an empty
+        # #570. `trust_workbench` reads the alias file in its first statement
+        # and the typed file in its second, and its whole return value is the
+        # page. `None` rather than an empty
         # workbench: `{% if workbench.corroborated %}` is falsy either way, so an
         # empty value renders "No facts are corroborated by multiple distinct
         # sources." and "No source-backed single-valued conflicts." — two claims
         # about a KB nothing analysed. Only `None` lets the template tell "not
         # computed" from "computed, and empty".
         store = _active_store()
-        alias_error = _relation_alias_failure(store)
+        policy_error = _trust_policy_failure(store)
         return templates.TemplateResponse(
             request,
             "workbench.html",
             {
-                "workbench": None if alias_error is not None else trust_workbench(store),
-                "alias_error": alias_error,
+                "workbench": None if policy_error is not None else trust_workbench(store),
+                "policy_error": policy_error,
             },
         )
 
@@ -2924,7 +3010,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return _row(
             request,
             store.get_fact(fact_id),
-            alias_error=_relation_alias_failure(store),
+            policy_error=_trust_policy_failure(store),
         )
 
     @app.post("/facts/{fact_id}/amend", response_class=HTMLResponse)
@@ -2980,14 +3066,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # rather than fixed in passing, but it is the same bug.
             #
             # This is `amend_fact`'s SECOND row-rendering exit; the success path
-            # below renders through `_row_after_decision`, which reads the alias
-            # file itself. Guarding only that one leaves this path 500ing on a
-            # broken alias file while a naive amend test passes (#570).
+            # below renders through `_row_after_decision`, which checks the
+            # policy files itself. Guarding only that one leaves this path
+            # 500ing on a broken policy file while a naive amend test passes
+            # (#570).
             store = _active_store()
             return _row(
                 request,
                 store.get_fact(fact_id),
-                alias_error=_relation_alias_failure(store),
+                policy_error=_trust_policy_failure(store),
             )
         # The rule may act on the amended fact itself, unlike a toggle demotion.
         # An amend decides the fact's content, not its tier: correcting a term so
@@ -3002,15 +3089,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         store = _active_store()
         fact = store.get_fact(fact_id)
         # This route calls `fact_trust_summary` DIRECTLY — it does not go
-        # through `_fact_row_context`, so the `alias_error` threaded through
+        # through `_fact_row_context`, so the `policy_error` threaded through
         # that helper never reaches here and this route computes its own (#570
         # trap 1). Withholding `trust` here is inseparable from the
         # `{% if trust %}` blocks in `provenance.html`: that template writes
         # `trust.support.source_count`, and Jinja raises `UndefinedError` on a
         # two-deep attribute of `None`, so guarding this line alone turns one
         # 500 into a different 500. Route and template are one guard.
-        alias_error = _relation_alias_failure(store)
-        trust = fact_trust_summary(store, fact_id) if fact and alias_error is None else None
+        policy_error = _trust_policy_failure(store)
+        trust = fact_trust_summary(store, fact_id) if fact and policy_error is None else None
         run = store.get_run(fact["run_id"]) if fact and fact["run_id"] else None
         job = (
             store.get_extraction_job_detail(fact["job_id"])
@@ -3023,7 +3110,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             {
                 "f": _fact_view(fact),
                 "trust": trust,
-                "alias_error": alias_error,
+                "policy_error": policy_error,
                 "run": run,
                 "job": job,
                 "log": store.fact_log(fact_id) if fact else [],

--- a/verinote/web/templates/dashboard.html
+++ b/verinote/web/templates/dashboard.html
@@ -4,11 +4,10 @@
 <h1>Knowledge base</h1>
 <p class="muted">KB <code>{{ root }}</code> · provider <strong>{{ provider_label }}</strong> · model <code>{{ model }}</code></p>
 
-{% if alias_error %}
-<p class="error" role="alert">{{ alias_error }} Every count on this page marked
+{% if policy_error %}
+<p class="error" role="alert">{{ policy_error }} Every count on this page marked
   <span class="badge muted">not computed</span> is withheld for that reason — it would
-  have been computed under different alias rules than this KB's file specifies. Fix it
-  on <a href="/settings">Settings</a>.</p>
+  have been computed under different rules than this KB's policy files specify.</p>
 {% endif %}
 
 <section class="cards">
@@ -31,7 +30,7 @@
       <td class="conf">{% if queue.count is none %}<span class="badge muted">not computed</span>{% else %}{{ queue.count }}{% endif %}</td>
       <td>
         {% if queue.count is none %}
-        <span class="muted" title="Not offered while its count is not computed — see the alias-file notice above.">—</span>
+        <span class="muted" title="Not offered while its count is not computed — see the policy-file notice above.">—</span>
         {% else %}
         <a class="btn ghost" href="{{ queue.href }}">Open</a>
         {% endif %}
@@ -76,7 +75,7 @@
 
 <h2>Source corroboration <span class="muted">- engine-input facts only</span></h2>
 {% if corroboration is none %}
-<p class="muted">Not computed — see the alias-file notice above.</p>
+<p class="muted">Not computed — see the policy-file notice above.</p>
 {% elif corroboration %}
 <table class="counts">
   <thead><tr><th>Fact</th><th>Sources</th></tr></thead>
@@ -98,7 +97,7 @@
 
 <h2>Single-valued conflicts <span class="muted">- source support by value</span></h2>
 {% if single_valued_conflicts is none %}
-<p class="muted">Not computed — see the alias-file notice above.</p>
+<p class="muted">Not computed — see the policy-file notice above.</p>
 {% elif single_valued_conflicts %}
 <table class="counts">
   <thead><tr><th>Subject / relation</th><th>Competing values</th></tr></thead>

--- a/verinote/web/templates/partials/fact_row.html
+++ b/verinote/web/templates/partials/fact_row.html
@@ -44,22 +44,25 @@
 
        Every branch of that ladder stays inside the `{% elif trust %}` arm below and
        reads only `f`, `trust` and `recommendation` -- the whole context a lone HTMX
-       row swap gets, plus the `alias_error` the arm above it adds (#570). #}
-    {# `alias_error` comes FIRST, ahead of the ladder and ahead of the
+       row swap gets, plus the `policy_error` the arm above it adds (#570). #}
+    {# `policy_error` comes FIRST, ahead of the ladder and ahead of the
        `trust unavailable` fallback (#570). Those two say different things and
        must keep saying different things: `trust unavailable` is a measured
        verdict on the fact (it has no trust summary), while this branch means
-       nobody measured -- the KB's alias file could not be read, and computing
-       the ladder on `merge_default_relation_aliases(...)` would put a number
-       about a KB nobody has into the same badges a healthy KB uses.
+       nobody measured -- one of the KB's two trust-policy files could not be
+       read. Computing the ladder on `merge_default_relation_aliases(...)`
+       would put a number about a KB nobody has into the same badges a healthy
+       KB uses; computing it on the `{}` a failed `store_typed_relations` falls
+       back to would put a number that is indistinguishable from a correct one
+       there instead (#585). The message names whichever file failed.
 
        The reason line lives INSIDE the fragment rather than only in a page
        banner because an HTMX decision swaps this one <tr> and the user may
        never see a banner. That is the difference between a row that degrades
        honestly and one that just goes grey. #}
-    {% if alias_error %}
+    {% if policy_error %}
       <span class="badge muted">trust not computed</span>
-      <div class="src">{{ alias_error }} Trust signals and accept recommendations are withheld until this file can be read. Fix it on <a href="/settings">Settings</a>.</div>
+      <div class="src">{{ policy_error }} Trust signals and accept recommendations are withheld until this file can be read.</div>
     {% elif trust %}
       {% if trust.conflict or 'conflicted' in trust.trust_labels %}
         {% set verdict_label, verdict_class, verdict_text, verdict_risk = 'conflicted', 'trust-conflicted', 'conflicted', true %}
@@ -129,7 +132,7 @@
        assert `No evidence anchor` -- a claim about the fact that nobody
        measured, and one a healthy row makes too, which would leave the degraded
        row and the healthy row indistinguishable on that string. #}
-    {% if alias_error %}
+    {% if policy_error %}
       <span class="muted">not computed</span>
     {% elif trust and trust.evidence %}
       {% set e = trust.evidence[0] %}

--- a/verinote/web/templates/provenance.html
+++ b/verinote/web/templates/provenance.html
@@ -6,18 +6,21 @@
 {% else %}
 <h1>Trust dossier — fact #{{ f["id"] }}</h1>
 
-{# #570. Every section below whose contents come off `trust` is withheld when
-   this KB's alias file cannot be read, because `store_relation_aliases` merges
-   the user's entries over the defaults -- so a dossier computed without their
-   file is a dossier about a different KB, printed in the same tables a healthy
-   one uses. The route and this template are ONE guard: withholding `trust`
-   without these branches replaces the 500 with a different 500, because
-   `{{ trust.support.source_count }}` is a two-deep attribute of `None` and
-   Jinja raises `UndefinedError` on that (measured). #}
-{% if alias_error %}
-<p class="error" role="alert">{{ alias_error }} The trust dossier below is withheld, because it
-  would have been computed under different alias rules than this KB's file specifies. Fix it on
-  <a href="/settings">Settings</a>.</p>
+{# #570, broadened by #585. Every section below whose contents come off `trust`
+   is withheld when EITHER of this KB's two trust-policy files cannot be read.
+   For `policy/relation-aliases.md`, `store_relation_aliases` merges the user's
+   entries over the defaults, so a dossier computed without their file is a
+   dossier about a different KB, printed in the same tables a healthy one uses.
+   For `policy/typed-relations.md` there are no defaults and the degraded value
+   is `{}` -- byte-identical to a KB that declares no typed relations -- so the
+   dossier would look right and be wrong, and nothing in it could give that away.
+   Both reasons end in the same place: withhold. The route and this template are
+   ONE guard: withholding `trust` without these branches replaces the 500 with a
+   different 500, because `{{ trust.support.source_count }}` is a two-deep
+   attribute of `None` and Jinja raises `UndefinedError` on that (measured). #}
+{% if policy_error %}
+<p class="error" role="alert">{{ policy_error }} The trust dossier below is withheld, because it
+  would have been computed under different rules than this KB's policy files specify.</p>
 {% endif %}
 
 <section class="trust-block">
@@ -62,7 +65,7 @@
     </tbody>
   </table>
   {% else %}
-  <p class="muted">Not computed — see the alias-file notice above.</p>
+  <p class="muted">Not computed — see the policy-file notice above.</p>
   {% endif %}
 </section>
 
@@ -79,7 +82,7 @@
   </p>
   {# The triple, its term kinds and the status badge above come off `f` and stay:
      withholding the trust dossier must not withhold the fact's own identity. Only
-     the CANONICAL rendering of it is alias-derived (#570). #}
+     the CANONICAL rendering of it is policy-derived (#570). #}
   {% if trust and trust.canonical_terms %}
   <table class="counts">
     <tbody>
@@ -116,7 +119,7 @@
     </tbody>
   </table>
   {% else %}
-  <p class="muted">Not computed — see the alias-file notice above.</p>
+  <p class="muted">Not computed — see the policy-file notice above.</p>
   {% endif %}
 </section>
 
@@ -126,7 +129,7 @@
      "No deterministic single-valued conflict for this fact." over a conflict
      search that never ran (#570). #}
   {% if trust is none %}
-  <p class="muted">Not computed — see the alias-file notice above.</p>
+  <p class="muted">Not computed — see the policy-file notice above.</p>
   {% elif trust.conflict %}
   <table class="counts">
     <thead><tr><th>value</th><th>sources</th></tr></thead>
@@ -161,7 +164,7 @@
          missing. The words also carry more here, since what is withheld is
          specifically the extraction job and the audit events. #}
       {% if trust is none %}
-      <tr><td class="src">—</td><td><span class="muted">Extraction and review events not computed — see the alias-file notice above.</span></td></tr>
+      <tr><td class="src">—</td><td><span class="muted">Extraction and review events not computed — see the policy-file notice above.</span></td></tr>
       {% endif %}
       {% if trust.job %}
       <tr><td class="src">—</td><td><span class="badge">extracted</span> job #{{ trust.job.id }} · {{ trust.job.status }}</td></tr>
@@ -186,7 +189,7 @@
      "No source evidence anchors recorded for this fact." about anchors nobody
      looked for (#570). #}
   {% if trust is none %}
-  <p class="muted">Not computed — see the alias-file notice above.</p>
+  <p class="muted">Not computed — see the policy-file notice above.</p>
   {% elif trust.evidence %}
     {% for e in trust.evidence %}
     <div class="evidence">

--- a/verinote/web/templates/review.html
+++ b/verinote/web/templates/review.html
@@ -9,14 +9,14 @@
    `None`, so the `{% include %}` below never runs and the fact-row fragment's own
    reason line renders nowhere -- this banner is the only thing on the page that
    says why. Deleting it leaves a 200 that explains nothing. #}
-{% if alias_error %}
-<p class="error" role="alert">{{ alias_error }} Trust signals and accept recommendations on this
-  page are withheld, because they would have been computed under different alias rules than this
-  KB's file specifies. Fix it on <a href="/settings">Settings</a>.</p>
+{% if policy_error %}
+<p class="error" role="alert">{{ policy_error }} Trust signals and accept recommendations on this
+  page are withheld, because they would have been computed under different rules than this KB's
+  policy files specify.</p>
 {% endif %}
 
 {# The filter nav stays on every degraded render: it is built from static labels,
-   reads nothing alias-derived, and is how the user gets back to a queue that
+   reads nothing policy-derived, and is how the user gets back to a queue that
    works. It also sits above every guard below, which is what lets a test assert
    the route survived without that assertion being reddened by a template
    deletion. #}

--- a/verinote/web/templates/sources.html
+++ b/verinote/web/templates/sources.html
@@ -5,10 +5,10 @@
 <p class="muted">Review uploaded sources, analysis progress, fact counts, and next actions.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
-{% if alias_error %}
-<p class="error" role="alert">{{ alias_error }} Per-source trust counts below are not
-  shown, because they would be computed under different alias rules than this KB's
-  file specifies. Fix it on <a href="/settings">Settings</a>.</p>
+{% if policy_error %}
+<p class="error" role="alert">{{ policy_error }} Per-source trust counts below are not
+  shown, because they would be computed under different rules than this KB's policy
+  files specify.</p>
 {% endif %}
 
 <form class="upload" action="/sources" method="post" enctype="multipart/form-data">

--- a/verinote/web/templates/workbench.html
+++ b/verinote/web/templates/workbench.html
@@ -8,10 +8,9 @@
    contains no `{% include %}` at all, so unlike the review queue there is no
    fragment that could say it instead. Deleting this leaves a page that withholds
    both tables and never says why. #}
-{% if alias_error %}
-<p class="error" role="alert">{{ alias_error }} Both tables below are withheld, because they
-  would have been computed under different alias rules than this KB's file specifies. Fix it on
-  <a href="/settings">Settings</a>.</p>
+{% if policy_error %}
+<p class="error" role="alert">{{ policy_error }} Both tables below are withheld, because they
+  would have been computed under different rules than this KB's policy files specify.</p>
 {% endif %}
 
 <h2>Corroborated facts <span class="muted">- grouped by normalized SPO</span></h2>
@@ -20,7 +19,7 @@
    raise, so without this branch the page renders the empty-state prose -- a
    measured claim about corroboration over a KB nothing analysed. #}
 {% if workbench is none %}
-<p class="muted">Not computed — see the alias-file notice above.</p>
+<p class="muted">Not computed — see the policy-file notice above.</p>
 {% elif workbench.corroborated %}
 <table class="counts">
   <thead><tr><th>Normalized fact</th><th>Source support</th><th>Facts</th></tr></thead>
@@ -71,7 +70,7 @@
 {# Same shape, second table: its `{% else %}` claims there are no source-backed
    single-valued conflicts, over a search that never ran. #}
 {% if workbench is none %}
-<p class="muted">Not computed — see the alias-file notice above.</p>
+<p class="muted">Not computed — see the policy-file notice above.</p>
 {% elif workbench.conflicts %}
 <table class="counts">
   <thead><tr><th>Subject / relation</th><th>Competing values</th><th>Related candidates</th></tr></thead>


### PR DESCRIPTION
Closes #585.

`policy/typed-relations.md` is the second policy file the trust layer reads.
#555 and #570 guarded the first one with a guard that asked about that file by
name, so every route they taught to degrade still answered 500 when the typed
file was the broken one.

`_relation_alias_failure` becomes `_trust_policy_failure`, built from a per-file
`_policy_file_failure(read, relpath)` holding the same two guards for whichever
file it is handed. Aliases first, typed second, first failure wins, compared
with an explicit `is not None` (an exception raised with no arguments
stringifies to `""`, so `or` would step past a real alias failure).
`alias_error` is gone from `verinote/web/` entirely; 58 `policy_error` in its
place across routes and templates.

## What this costs

**"Fix it on Settings" is dropped from six banners.** `settings.html` edits the
alias file and has no typed-relations surface; `docs/operations.md` records the
typed file as hand-written with nothing in verinote writing it. One shared
string cannot point at a repair page for one file and stay silent for the
other. Alias-case users lose a working link. A repair surface for the typed
file is follow-up work.

**`POST /ask` and `POST /questions/translate` still 500** on either broken
file, at the same statement in `build_query_schema_snapshot`, which
`verinote/cli.py` reaches too. Both are nav-reachable. Guarding them means
changing a CLI-shared call site — #570's follow-up already owes their alias
half. Disclosed in the new file's module docstring and in
`_trust_policy_failure`'s.

**One failure is reported at a time.** With both files broken the pages name
the alias file and say nothing about the typed one — not that it is healthy.
Repairing the alias file surfaces the typed failure as a 200, which is pinned.
Before this change that same input pair answered 500 with the alias file alone
broken and 200 with both broken, masking the second fault entirely.

## Validation

Measured in real `git worktree` checkouts on both sides, not `git archive`
extracts (an extract has no `.git`, and `tests/test_gitignore.py` fails in one):

- **3447 passed, 12 skipped, 0 failed** on the candidate; **3352 passed, 12
  skipped, 0 failed** on the base. Delta 95 = the new file's collected count
  exactly.
- `ruff@0.15.18 check .` clean.
- Every `href`, `hx-get`, `hx-post` and form action rendered by each degraded
  page was parsed out and followed on both broken inputs, 5–27 controls per
  page: no 5xx target except the disclosed `POST /ask`.
- Mutation matrix: typed leg deleted → 47 red; alias leg → 49; narrowing the
  new guard's `except Exception` to the parse error → 25; swapping the two
  legs' order → 2, and both are the ordering's own tests.

## Tests

`tests/test_typed_relations_web_guard.py` is new — 35 functions, 95 items. The
alias guard file gains no cases; two assertions there track the renamed banner
string.

The fixture declares an `amount` relation on `자본금`. Both halves are
load-bearing, and the reason given in an earlier draft of this PR was wrong.

The **type** must be `amount` — it is the only one of the four that merges this
fixture's two objects. `1억` and `100000000원` both normalize to `100000000`;
`date`, `number` and `ordinal` return `None` for both, leaving two unrelated raw
keys and nothing for the corroboration controls to observe.

The **relation** must be one the alias table leaves alone. `_typed_spec` looks
the declaration up under the *canonical* relation while `typed_relations` keys
it on the *raw* name the file wrote, so a declaration on any aliased label is
silently dropped — regardless of type, and even with no alias file present,
since the packaged defaults still apply. The declaration under test is on
`자본금`, which those defaults do not name — the only reason it observes
anything at all. (The fixture also carries a `소속` fact, and `소속` *is* one of
the 36; it is harmless only because nothing declares a type on it. The property
that matters is the declared name, not which relations appear.)

That drop is a real defect, filed as **#589**. An earlier draft of this PR
described it as "`date` surfaces no typed value on any page"; that was measured
on `설립일`, which the packaged defaults map to `established_on`, so the
measurement varied type and relation at once and blamed the wrong axis. `date`
normalizes correctly on an unaliased relation.

## Gates

Reviewer, final-design and final-risk gates each independently recomputed the
approved candidate tree `e3488fbd0e48f7f27090e9d832e145f9545737d0` and returned
**approved**. The commit was built from that tree directly and its tree verified
equal to it. The repo has no active git hooks, so nothing was bypassed.

### Five revisions, all prose

The executable content is byte-identical across every revision — verified by
comparing the AST with all docstrings stripped. Not one line of behaviour
changed after the first review. What changed five times was one docstring
paragraph explaining why the test fixture declares `amount` on `자본금`, and
each revision's defect lived inside the previous revision's fix:

1. "`date` never surfaces a `typed_value`" — false. The measurement used
   `설립일` for the `date` arm and unaliased relations for the others, varying
   type and relation together.
2. "`자본금`, `매출` and `순위` are absent from those 36" — true clause by
   clause, false by implicature: the fixture uses neither `매출` nor `순위`, and
   does use `소속`, which **is** one of the 36.
3. "the four types accept disjoint object shapes" — false. `2020.03` is both a
   `date` and a `number`, because `_DATE_RE`'s day group is optional.
4. "an object the row's type cannot normalize reads `None` on both sides" —
   false, and **all three gates verified it as true**. Every probe printed
   `tv.normalized_value if tv else None`, collapsing the two states the sentence
   distinguishes: `_typed_value_summary` returns bare `None` only when the spec
   is missing, and a summary with a null value otherwise. Three independent
   sweeps were one confirmation repeated.
5. The paragraph now asserts no universal claim about the parsers. Its
   justification is stated in terms of the table three lines below it, so it can
   only go false if that table changes — and whoever changes the table is
   already editing the paragraph.
