### PR TITLE
fix(ask): guard the CLI-shared schema snapshot so /ask, /questions/translate and verinote query degrade (#591)

### DIFF
--- a/tests/test_query_schema_policy_guard.py
+++ b/tests/test_query_schema_policy_guard.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: MPL-2.0
+r"""A broken trust-policy file degrades the query-schema path instead of raising
+out of it (#591).
+
+`build_query_schema_snapshot` reads `policy/relation-aliases.md` and
+`policy/typed-relations.md` in its first two statements. Three entry points share
+that statement -- `POST /ask`, `POST /questions/translate` and `verinote query`
+-- which is why the guard is `query_schema_policy_failure` in the pipeline and
+not another `web/app.py` nested function: a web guard cannot reach the CLI.
+
+THREE BROKEN INPUTS, NOT TWO. #591's repro section names only cp949 for the
+alias file. Measured on `b4dea1b`, a MALFORMED alias file 500s these routes as
+well: this call site has no narrow `except CorroborationPolicyError` in front of
+it, unlike `verify.py`, so it does not survive the malformed case the way
+`GET /questions` and `GET /report` do.
+
+`TYPED_TYPO` IS NOT A BROKEN INPUT and must never be used as one here. #585
+measured that `typed_relations` silently skips lines it cannot parse, so a
+typo'd typed file parses to `{}` and fails nothing -- measured again on this
+tree: `POST /ask` 200 and `POST /questions/translate` 303 under it, exactly as
+under a healthy file. A test planting it sees green because nothing broke.
+
+THE EMPTY-QUEUE TRAP. `POST /questions/translate` returns 303 when there are no
+pending questions, under a broken policy file just as under a healthy one.
+A fixture without a pending question records a clean cell that is not clean, so
+every fixture here carries one and `test_the_fixture_really_has_a_translatable_question`
+pins that the queue is doing work.
+
+THE VACUITY TRAP ON THE CLI, WHICH IS THE ONE THAT BITES. A policy failure and a
+missing API key produce the SAME status (`translation_failed`) and the SAME exit
+code (1). Measured on `b4dea1b` with no credentials: an `UNKNOWN_OR_UNSUPPORTED`
+question exits 1 with `translation_failed`, and so does every broken policy file.
+So a CLI test asserting `rc != 0`, or even asserting the status, passes
+identically with and without this guard. Every CLI test below therefore asserts
+the POLICY FILE'S OWN MESSAGE, and ships with a healthy-file control on the same
+stub asserting that message is ABSENT -- so the assertion is shown to
+discriminate rather than merely to match.
+
+WHAT THE EXIT CODE DOES AND DOES NOT DO. On each broken file `verinote query`
+exited 1 before this change and exits 1 after it. The number does not move; what
+produces it does, from an unhandled traceback to a reported failure. The healthy
+exit code is a property of the FIXTURE, not of the environment: this fixture's
+question resolves deterministically and exits 0 with no credentials at all,
+which `NoProviderClient` below makes self-enforcing by raising if anything asks
+the provider.
+
+WHAT THIS CHANGE DOES NOT DELIVER, stated so its absence is not read as an
+oversight. `POST /questions/translate` answers 303 and redirects to
+`GET /questions`, and the guard deliberately writes nothing to the question rows
+(see below), so that page has nothing to display about the failure. Rendering
+the page from the translate route instead of redirecting would surface it for
+the malformed and typed inputs and turn the cp949 input from 303 into 500,
+because `GET /questions` itself still fails on a cp949 alias file -- measured
+here, and that route is #590's. So the diagnosis reaches `POST /ask` and
+`verinote query` in this change, and reaching the translate landing page waits
+on #590.
+
+WHY THE QUESTION ROWS STAY `pending`. `translate_questions` reports the policy
+failure per question but does not write it. The justification is comparative and
+deliberately narrow: today's unhandled exception leaves every pending question
+`pending`, so a guard that wrote `translation_failed` to each would leave the KB
+in a worse state than the bug it replaces. It is NOT a rule that an environment
+fault may never be recorded on a question row -- `_fail_pending_translations`
+and `cli.py`'s missing-credential path both do exactly that, deliberately, and
+this change leaves both alone.
+"""
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+import verinote.cli as cli
+import verinote.llm as llm
+import verinote.pipeline.query as query_module
+from verinote.pipeline.query import translate_questions
+import verinote.pipeline.query_schema as query_schema_module
+from verinote.config import Config
+from verinote.policy_defaults import RELATION_ALIASES_RELPATH, TYPED_RELATIONS_RELPATH
+from verinote.store import Store
+from verinote.web import create_app
+
+# The alias parser raises on the FIRST line it cannot parse, so a missing arrow
+# is a real failure here -- unlike the typed parser, which skips such a line.
+ALIAS_MALFORMED = "- 소속 member_of\n".encode()
+ALIAS_CP949 = "- 소속 -> member_of\n".encode("cp949")
+ALIAS_HEALTHY = "- 소속 -> member_of\n".encode()
+# A duplicate alias: one of the four SEMANTIC conditions `typed_relations`
+# raises on. See this file's docstring for why a typo is not one of them.
+TYPED_DUP_ALIAS = "- 자본금: amount as capital\n- 자산: amount as capital\n".encode()
+TYPED_HEALTHY = "- 자본금: amount as capital\n".encode()
+TYPED_TYPO = "- 소속 member_of\n".encode()
+
+ALIAS_PARSER_MSG = "relation-aliases.md:"
+ALIAS_NAMED = f"{RELATION_ALIASES_RELPATH} could not be read"
+TYPED_PARSER_MSG = "typed-relations.md: alias"
+
+# (alias bytes, typed bytes, the message that must appear). Three inputs.
+BROKEN_INPUTS = [
+    pytest.param(ALIAS_MALFORMED, TYPED_HEALTHY, ALIAS_PARSER_MSG, id="alias-malformed"),
+    pytest.param(ALIAS_CP949, TYPED_HEALTHY, ALIAS_NAMED, id="alias-cp949"),
+    pytest.param(ALIAS_HEALTHY, TYPED_DUP_ALIAS, TYPED_PARSER_MSG, id="typed-duplicate-alias"),
+]
+ALL_MESSAGES = (ALIAS_PARSER_MSG, ALIAS_NAMED, TYPED_PARSER_MSG)
+
+# Resolved by `deterministic_query_intent`, so the provider is never asked and
+# the healthy exit code is 0 without credentials. `NoProviderClient` enforces it.
+QUESTION = "A의 자본금은?"
+
+
+class NoProviderClient:
+    """An `LLMClient` that raises if anything asks the provider.
+
+    Not decoration: it is what makes "the provider was never reached" an
+    assertion rather than an assumption, and it is what keeps the CLI tests
+    below from silently measuring the missing-API-key path, which produces the
+    same status and the same exit code as a policy failure.
+    """
+
+    name = "no-provider"
+
+    def extract_query_intent(self, **kwargs):
+        raise AssertionError("the provider was asked: extract_query_intent")
+
+    def translate_query(self, **kwargs):
+        raise AssertionError("the provider was asked: translate_query")
+
+    def answer_question(self, **kwargs):
+        raise AssertionError("the provider was asked: answer_question")
+
+    def extract_facts(self, **kwargs):
+        raise AssertionError("the provider was asked: extract_facts")
+
+
+def _seed(root: Path, alias_bytes: bytes, typed_bytes: bytes) -> Config:
+    cfg = Config(
+        root=root,
+        db_path=root / "kb.sqlite",
+        provider="anthropic",
+        model="m",
+        api_key=None,
+        base_url=None,
+    )
+    store = Store(cfg.db_path)
+    store.init_schema()
+    (root / "sources").mkdir(parents=True, exist_ok=True)
+    (root / "sources" / "a.txt").write_text("x\n", encoding="utf-8")
+    source_id = store.add_source("sources/a.txt")
+    store.add_fact(
+        "A", "자본금", "1억", status="confirmed", confidence=0.9, source_id=source_id
+    )
+    store.add_question(QUESTION)
+    store.close()
+    for relpath, data in (
+        (RELATION_ALIASES_RELPATH, alias_bytes),
+        (TYPED_RELATIONS_RELPATH, typed_bytes),
+    ):
+        path = root / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+    return cfg
+
+
+def _client(tmp_path: Path, alias_bytes: bytes, typed_bytes: bytes):
+    root = tmp_path / "kb"
+    root.mkdir()
+    cfg = _seed(root, alias_bytes, typed_bytes)
+    app = create_app(cfg)
+    return TestClient(app, raise_server_exceptions=False), app
+
+
+ASK_RESULT_RE = re.compile(r'<section class="ask-result.*?</section>', re.S)
+
+
+# ---------------------------------------------------------------------------
+# POST /ask
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_ask_survives_each_broken_policy_file(tmp_path, alias_bytes, typed_bytes, message):
+    """Each of these answered 500 on the parent commit. The assertion is the
+    MESSAGE and not the status, for #590's reason: the guard's two clauses both
+    return a string, so deleting the narrow one leaves the status unchanged and
+    only swaps the bare parser message for a "could not be read" wrapper."""
+    client, _ = _client(tmp_path, alias_bytes, typed_bytes)
+    r = client.post("/ask", data={"question": QUESTION})
+    assert r.status_code == 200
+    assert message in r.text
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_ask_carries_the_diagnosis_in_the_answer_not_only_on_the_page(
+    tmp_path, alias_bytes, typed_bytes, message
+):
+    """`GET /ask` renders clean and stays clean -- it has no page-level banner
+    to fall back on -- so the `AskResult` is the only place a user learns
+    anything. Asserted inside the `ask-result` section rather than anywhere in
+    the body, so a diagnosis printed somewhere else would not satisfy it."""
+    client, _ = _client(tmp_path, alias_bytes, typed_bytes)
+    section = ASK_RESULT_RE.search(client.post("/ask", data={"question": QUESTION}).text)
+    assert section is not None, "the page rendered no ask-result section at all"
+    assert message in section.group(0)
+
+
+def test_a_healthy_policy_pair_still_answers_and_says_nothing_about_policy(tmp_path):
+    """Anti-vacuity control: a guard that fired unconditionally would put a
+    diagnosis on every healthy KB too."""
+    client, _ = _client(tmp_path, ALIAS_HEALTHY, TYPED_HEALTHY)
+    r = client.post("/ask", data={"question": QUESTION})
+    assert r.status_code == 200
+    for message in ALL_MESSAGES:
+        assert message not in r.text
+
+
+def test_a_typod_typed_file_is_not_a_broken_input(tmp_path):
+    """Pins this file's docstring claim, so a later edit cannot promote the typo
+    case into `BROKEN_INPUTS` and make every parametrized test above vacuous."""
+    client, _ = _client(tmp_path, ALIAS_HEALTHY, TYPED_TYPO)
+    r = client.post("/ask", data={"question": QUESTION})
+    assert r.status_code == 200
+    for message in ALL_MESSAGES:
+        assert message not in r.text
+
+
+# ---------------------------------------------------------------------------
+# POST /questions/translate, and the rows it must not write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_translate_survives_each_broken_policy_file(
+    tmp_path, alias_bytes, typed_bytes, message
+):
+    """The POST itself, not the redirect target: `GET /questions` still fails on
+    a cp949 alias file (#590), so following the redirect would measure that
+    route rather than this one."""
+    del message
+    client, _ = _client(tmp_path, alias_bytes, typed_bytes)
+    r = client.post("/questions/translate", follow_redirects=False)
+    assert r.status_code == 303
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_translate_leaves_every_question_pending(
+    tmp_path, alias_bytes, typed_bytes, message
+):
+    """The write suppression. Without it one unreadable policy file marks every
+    pending question `translation_failed` -- a durable, audited claim that each
+    question failed translation, when translation was never attempted. Today's
+    crash writes nothing, so writing here would leave the KB worse than the bug.
+    """
+    del message
+    client, app = _client(tmp_path, alias_bytes, typed_bytes)
+    client.post("/questions/translate", follow_redirects=False)
+    assert [q["status"] for q in app.state.store.questions()] == ["pending"]
+
+
+def test_a_file_that_breaks_mid_run_still_writes_no_row(tmp_path):
+    """The regression an earlier revision of this guard shipped, pinned.
+
+    That revision read the policy files ONCE before the loop and suppressed the
+    write on that reading, while the flow re-read them per question. With the
+    files healthy at the pre-loop read and broken before the first question's
+    flow ran, the two readings disagreed: the fresh one put `translation_failed`
+    and the policy message into the row's `status` and `reason`, and the stale
+    one let the write through. Measured against the parent commit, which raised
+    and wrote nothing, that was strictly worse than the bug the guard replaces
+    -- it is the exact false record the suppression exists to prevent.
+
+    The corruption is injected from `store.questions()` so that it lands after
+    any pre-loop read and before the first flow call, which is the only window
+    where the two readings can differ. A build that reintroduces a separate
+    pre-loop verdict fails here and nowhere else in this file.
+    """
+    root = tmp_path / "kb"
+    root.mkdir()
+    cfg = _seed(root, ALIAS_HEALTHY, TYPED_HEALTHY)
+    store = Store(cfg.db_path)
+    alias_path = root / RELATION_ALIASES_RELPATH
+    real_questions = store.questions
+
+    def questions_then_corrupt(*args, **kwargs):
+        rows = real_questions(*args, **kwargs)
+        alias_path.write_bytes(ALIAS_MALFORMED)
+        return rows
+
+    store.questions = questions_then_corrupt
+    try:
+        results = translate_questions(store, NoProviderClient(), root=root)
+    finally:
+        store.questions = real_questions
+    # The run reports the failure ...
+    assert results and all(r["status"] == "translation_failed" for r in results)
+    assert all(ALIAS_PARSER_MSG in r["reason"] for r in results)
+    # ... and writes none of it to the rows.
+    assert [q["status"] for q in store.questions()] == ["pending"]
+    store.close()
+
+
+def test_the_fixture_really_has_a_translatable_question(tmp_path):
+    """The empty-queue trap. `POST /questions/translate` answers 303 with no
+    pending questions, broken file or not, so the two tests above would pass on
+    an empty queue while proving nothing. On a healthy pair the same fixture
+    really does translate."""
+    client, app = _client(tmp_path, ALIAS_HEALTHY, TYPED_HEALTHY)
+    assert [q["status"] for q in app.state.store.questions()] == ["pending"]
+    client.post("/questions/translate", follow_redirects=False)
+    assert [q["status"] for q in app.state.store.questions()] == ["translated"]
+
+
+# ---------------------------------------------------------------------------
+# The status the guard returns is load-bearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_repair_does_not_reach_the_direct_datalog_fallback(
+    tmp_path, alias_bytes, typed_bytes, message, monkeypatch
+):
+    """`translation_failed` rather than `review_required`, instrumented rather
+    than inferred. `repair.py` falls through to `_translate_direct_datalog_fallback`
+    exactly on `review_required`, which calls `build_query_schema_snapshot`
+    again and would re-raise the failure the guard just caught. Counting the
+    call is the only way to see that; a status code cannot."""
+    del message
+    from verinote.pipeline import repair as repair_module
+
+    root = tmp_path / "kb"
+    root.mkdir()
+    cfg = _seed(root, alias_bytes, typed_bytes)
+    calls = []
+    monkeypatch.setattr(
+        repair_module,
+        "_translate_direct_datalog_fallback",
+        lambda *a, **k: calls.append(1),
+    )
+    store = Store(cfg.db_path)
+    try:
+        prepared = repair_module._prepare_repair_question(
+            store,
+            NoProviderClient(),
+            question_id=1,
+            question=QUESTION,
+            previous_query_dl=None,
+        )
+    finally:
+        store.close()
+    assert calls == []
+    assert prepared.status == "translation_failed"
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_the_guard_stops_the_snapshot_from_being_built_at_all(
+    tmp_path, alias_bytes, typed_bytes, message, monkeypatch
+):
+    """Reachability, measured at the guarded function itself. Every probe routed
+    through `build_query_schema_snapshot` inherits the guard, so the count has to
+    come from that function -- inferring it from a status code proves nothing."""
+    del message
+    calls = []
+    real = query_schema_module.build_query_schema_snapshot
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(query_schema_module, "build_query_schema_snapshot", counting)
+    monkeypatch.setattr(query_module, "build_query_schema_snapshot", counting)
+
+    client, _ = _client(tmp_path, alias_bytes, typed_bytes)
+    client.post("/ask", data={"question": QUESTION})
+    client.post("/questions/translate", follow_redirects=False)
+    assert calls == []
+
+
+def test_a_healthy_policy_pair_does_build_the_snapshot(tmp_path, monkeypatch):
+    """Anti-vacuity control for the count above: zero is only meaningful if the
+    same instrument reads non-zero when the guard does not trip."""
+    calls = []
+    real = query_schema_module.build_query_schema_snapshot
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(query_schema_module, "build_query_schema_snapshot", counting)
+    monkeypatch.setattr(query_module, "build_query_schema_snapshot", counting)
+
+    client, _ = _client(tmp_path, ALIAS_HEALTHY, TYPED_HEALTHY)
+    client.post("/ask", data={"question": QUESTION})
+    assert calls
+
+
+# ---------------------------------------------------------------------------
+# verinote query
+# ---------------------------------------------------------------------------
+
+
+def _run_cli_query(tmp_path: Path, alias_bytes: bytes, typed_bytes: bytes, monkeypatch):
+    """`cmd_query` in process, with the provider stubbed to raise if reached.
+
+    In process rather than as a subprocess on purpose: the thing to assert is
+    that the command RETURNS an exit code instead of raising, which is the
+    "no traceback" half stated as a property rather than as string-matching on
+    stderr. `cmd_query` imports `get_client` inside the function, so patching
+    `verinote.llm.get_client` reaches it.
+    """
+    root = tmp_path / "kb"
+    root.mkdir()
+    cfg = _seed(root, alias_bytes, typed_bytes)
+    monkeypatch.setattr(llm, "get_client", lambda cfg: NoProviderClient())
+    rc = cli.cmd_query(cfg, SimpleNamespace(question=None))
+    store = Store(cfg.db_path)
+    statuses = [q["status"] for q in store.questions()]
+    store.close()
+    return rc, statuses
+
+
+@pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)
+def test_verinote_query_reports_the_policy_failure_instead_of_crashing(
+    tmp_path, alias_bytes, typed_bytes, message, monkeypatch, capsys
+):
+    """`rc=1` before this change and `rc=1` after it -- the number does not move,
+    and this test does not pretend it does. What moves is that `cmd_query`
+    returns rather than raising, and that the file's own message is printed."""
+    rc, statuses = _run_cli_query(tmp_path, alias_bytes, typed_bytes, monkeypatch)
+    assert rc == 1
+    assert message in capsys.readouterr().out
+    assert statuses == ["pending"]
+
+
+def test_a_healthy_policy_pair_produces_no_policy_message_on_the_cli(
+    tmp_path, monkeypatch, capsys
+):
+    """The control that makes the assertion above discriminate. Without it,
+    `rc == 1` plus `translation_failed` is exactly what a missing API key
+    produces, and the test would match that instead of the guard."""
+    rc, statuses = _run_cli_query(tmp_path, ALIAS_HEALTHY, TYPED_HEALTHY, monkeypatch)
+    assert rc == 0
+    out = capsys.readouterr().out
+    for message in ALL_MESSAGES:
+        assert message not in out
+    assert statuses == ["translated"]

--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -3,7 +3,8 @@ r"""A broken `policy/relation-aliases.md` degrades `/`, `/sources`, `/settings`
 instead of 500ing them (#555).
 
 WHY THE MALFORMED TESTS ASSERT THE MESSAGE, NOT THE STATUS. Deleting the narrow
-`except CorroborationPolicyError` clause (G1) inside `_trust_policy_failure`
+`except CorroborationPolicyError` clause (G1) inside
+`verinote/pipeline/query_schema.py::_policy_file_failure`
 does NOT turn any route back into a 500: the malformed case falls through to the
 broad `except Exception` clause (G2) underneath, which also returns a string, so
 every affected route still renders 200 (measured — see plan555.md §2.2/M9,

--- a/tests/test_typed_relations_web_guard.py
+++ b/tests/test_typed_relations_web_guard.py
@@ -123,12 +123,14 @@ that only ever landed on 500 by redirecting into `GET /sources`; they are fixed
 by guarding that page and have no guard of their own
 (`test_the_sources_post_redirects_land_on_a_page_that_survives`).
 
-`POST /ask` and `POST /questions/translate` are NOT fixed here. Both files fail
-for them at the same statement in `query_schema.build_query_schema_snapshot`,
-which `verinote/cli.py` reaches too, and the ALIAS half of that same statement
-is already owed to #570's follow-up. `POST /ask` is also the one route in the
-population with no upstream guard of any kind, which is why the ordering rule in
-`_trust_policy_failure` has nothing above it there.
+`POST /ask` and `POST /questions/translate` are not fixed by THIS file's guard.
+Both files fail for them at the same statement in
+`query_schema.build_query_schema_snapshot`, which `verinote/cli.py` reaches too,
+so they are guarded by `query_schema_policy_failure` beside that statement
+instead (#591, which #570 deferred); their tests live in
+`tests/test_query_schema_policy_guard.py`. `POST /ask` is also the one route in
+the population with no upstream guard of any kind, which is why the ordering
+rule in `_trust_policy_failure` has nothing above it there.
 """
 
 import re

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -39,6 +39,7 @@ from verinote.pipeline.query_planner import plan_query_candidates
 from verinote.pipeline.query_schema import (
     QuerySchemaSnapshot,
     build_query_schema_snapshot,
+    query_schema_policy_failure,
 )
 from verinote.store import Store
 
@@ -70,6 +71,11 @@ class _QueryFlowResult:
     # Repair-only eligibility: ordinary translation is always schema-only.
     allow_direct_datalog_fallback: bool = False
     provider_failed: bool = False
+    # Set only by the trust-policy guard below. `translate_questions` keys its
+    # write suppression on THIS, not on a read of its own: the status alone
+    # cannot carry it, because a missing API key produces `translation_failed`
+    # too and that one IS meant to be written to the row (#591).
+    policy_failed: bool = False
 
 
 def query_path(root: Path) -> Path:
@@ -249,6 +255,29 @@ def _schema_aware_query_flow_result(
     question: str,
     llm_error_status: str,
 ) -> _QueryFlowResult:
+    # G1 (#591). `build_query_schema_snapshot` reads both trust-policy files in
+    # its first two statements, so an unreadable one raised straight out of this
+    # function -- a 500 on `POST /ask` and `POST /questions/translate`, and an
+    # unhandled traceback from `verinote query`. All three entry points
+    # (`ask.py`, `translate_questions`, `repair.py`) funnel through here, and the
+    # other two `build_query_schema_snapshot` calls in this module are downstream
+    # of this one, so this is the single upstream point for all of them.
+    #
+    # `translation_failed`, NOT `review_required`: `repair.py` falls through to
+    # `_translate_direct_datalog_fallback` exactly on `review_required`, which
+    # would call `build_query_schema_snapshot` again and re-raise the thing this
+    # guard just caught. It is also already in `QUESTION_STATUSES` and in the
+    # `questions.status` CHECK constraint, so this needs no schema migration --
+    # a dedicated `policy_error` status would be more precise and would cost one.
+    #
+    # `provider_failed` stays False on purpose: no provider was asked. The
+    # producer-side tripwire in tests/test_query.py judges only constructions
+    # inside an `except LLMError:` handler, and this is not one.
+    policy_failure = query_schema_policy_failure(store)
+    if policy_failure is not None:
+        return _QueryFlowResult(
+            "translation_failed", None, _short_reason(policy_failure), policy_failed=True
+        )
     snapshot = build_query_schema_snapshot(store)
     intent = deterministic_query_intent(question)
     deterministic_intent_supported = (
@@ -681,7 +710,40 @@ def translate_questions(
             llm_error_status="translation_failed",
         )
         status, query_dl, reason = flow.status, flow.query_dl, flow.reason
-        store.set_question_query(q["id"], query_dl, status, reason)
+        # G2 (#591). Report the policy failure, but do NOT write it to the row.
+        # The justification is comparative, not a principle: today's unhandled
+        # exception leaves every pending question `pending`, so a guard that
+        # wrote `translation_failed` to each of them would leave the KB in a
+        # worse state than the bug it replaces -- a durable, audited claim that
+        # each question failed translation, when translation was never attempted
+        # and nothing about the questions is wrong. Repairing the file and
+        # re-running then translates them, with no intervening state for the
+        # user to notice and undo.
+        #
+        # This is NOT a rule that an environment fault may never be recorded on a
+        # question row. `web/app.py::_fail_pending_translations` and `cli.py`'s
+        # own missing-credential path both do exactly that, deliberately, and
+        # this change leaves both alone. The inconsistency that leaves --
+        # credentials mark the rows, an unreadable policy file does not -- is
+        # real and is tracked as #592; it is a contract question across three
+        # call sites, not this guard's to settle.
+        #
+        # ONE VERDICT GOVERNS BOTH DECISIONS, and an earlier revision of this
+        # guard got that wrong in the one direction that matters. It read the
+        # policy files once before this loop and suppressed on THAT, while the
+        # flow above re-read them per question. With the files healthy at the
+        # pre-loop read and broken before a question's flow ran, the fresh
+        # verdict said "failed" -- so `translation_failed` and the policy
+        # message went into `status` and `reason` -- while the stale verdict
+        # said "healthy", so the write was not suppressed. Measured: the parent
+        # raised and wrote NOTHING; that revision wrote the failure to every
+        # row. Keying on `flow.policy_failed` is what makes the value written
+        # and the decision to write it come from the same read.
+        #
+        # The result dict is still appended, so the CLI and the web report
+        # normally and no caller's contract changes.
+        if not flow.policy_failed:
+            store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
             {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}
         )

--- a/verinote/pipeline/query_schema.py
+++ b/verinote/pipeline/query_schema.py
@@ -23,6 +23,9 @@ from verinote.engine.terms import (
     render_term,
 )
 from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    RELATION_ALIASES_RELPATH,
+    TYPED_RELATIONS_RELPATH,
     TypedRelationSpec,
     canonical_relation,
     store_relation_aliases,
@@ -160,6 +163,85 @@ class _Fact:
     relation: TermRef
     object: TermRef
     status: str
+
+
+def _policy_file_failure(read, relpath: str) -> str | None:
+    """Normalise ONE trust-policy file read into a message, or None.
+
+    `read` is a zero-argument callable so the try wraps EXACTLY ONE CALL, and
+    that call touches no database: `store_relation_aliases` and
+    `store_typed_relations` each read `store.db_path` as an attribute, stat
+    their file, and parse it. So the only thing this can swallow is a failure to
+    read or parse that one file.
+
+    THE ONLY COPY. #585 wrote this helper nested inside `create_app`, and #591
+    added a second copy here on the stated ground that the first was "closed
+    over the request context" and so could not be imported. That was false --
+    measured with the symbol table, it closed over nothing; nesting was where it
+    had been typed, not a constraint. The web copy is gone and
+    `web/app.py::_trust_policy_failure` delegates here, so there is no second
+    implementation to keep in step. Do not reintroduce one: the argument for
+    doing so has already been wrong once.
+    """
+    try:
+        read()
+    except CorroborationPolicyError as exc:
+        # G1. Already normalised, and its message already begins with the file's
+        # own name (`relation-aliases.md:1: expected …`, `typed-relations.md:
+        # alias 'x' used for both …`). Prefixing it below would say the file
+        # twice AND would misstate what happened -- the file WAS read; it parsed
+        # and failed. Must stay ABOVE G2.
+        return str(exc)
+    except Exception as exc:  # noqa: BLE001 - normalise every policy-read failure
+        # G2. BROAD, NOT A TYPE LIST. `UnicodeDecodeError` (a file saved as
+        # cp949) descends from `ValueError` as `CorroborationPolicyError` does
+        # but is no subclass of it; `PermissionError` is not a `ValueError` at
+        # all. NAME THE FILE: `str(UnicodeDecodeError)` is a byte offset and no
+        # path.
+        return f"{relpath} could not be read: {exc}"
+    return None
+
+
+def query_schema_policy_failure(store: Store) -> str | None:
+    """Why this KB's trust policy cannot be applied, or None when it can.
+
+    THE NAME RECORDS WHERE THIS LIVES, NOT WHAT MAY USE IT. The question it
+    answers -- can this KB's two trust-policy files be read and parsed? -- is
+    not specific to a schema snapshot, and `web/app.py::_trust_policy_failure`
+    delegates straight to it for the web banners. It is defined here because
+    `build_query_schema_snapshot` reads `policy/relation-aliases.md` and
+    `policy/typed-relations.md` in its first two statements, and either being
+    unreadable raises out of it; three entry points share that statement --
+    `POST /ask`, `POST /questions/translate` and `verinote query` -- and a guard
+    defined in the web layer could not reach the CLI (#591). Renaming it to drop
+    the `query_schema_` prefix would fit its callers better and is deliberately
+    left alone here rather than folded into a fix for something else.
+
+    A plain diagnostic string, not a banner: the return value crosses into
+    `verinote/cli.py`, which has no HTTP vocabulary. Each parser's message
+    already names its own file, so the string carries its own attribution.
+
+    ORDER. Aliases first, typed second, first failure returned. The web banner
+    and the CLI name the same file on a KB with both files broken, and that is
+    now an identity rather than a convention two copies had to keep: there is
+    one implementation. The message says nothing about the file it does not
+    name; it is not a claim that the other file is healthy.
+
+    CHECK-THEN-USE, inherited and not fixed here: this reads the files, then
+    `build_query_schema_snapshot` reads them again. A rewrite in that window
+    still raises. Do not claim atomicity.
+    """
+    alias_failure = _policy_file_failure(
+        lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
+    )
+    if alias_failure is not None:
+        return alias_failure
+    # Explicit `is not None` rather than `or`: an exception raised with no
+    # arguments stringifies to "", which is falsy, and an `or` chain would step
+    # past a real alias failure.
+    return _policy_file_failure(
+        lambda: store_typed_relations(store), TYPED_RELATIONS_RELPATH
+    )
 
 
 def build_query_schema_snapshot(

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -87,6 +87,7 @@ from verinote.pipeline.policy_state import (
     write_default_policy,
 )
 from verinote.pipeline.query import load_query
+from verinote.pipeline.query_schema import query_schema_policy_failure
 from verinote.pipeline.question_outcome import question_outcome_view
 from verinote.pipeline.ask import ask_question
 from verinote.pipeline.acceptance import (
@@ -106,7 +107,6 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
     store_single_valued_conflicts,
     store_typed_relations,
-    TYPED_RELATIONS_RELPATH,
 )
 from verinote.pipeline.workbench import trust_workbench
 from verinote.prompts import (
@@ -1057,41 +1057,6 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _relation_aliases_path() -> Path:
         return _active_cfg().root / RELATION_ALIASES_RELPATH
 
-    def _policy_file_failure(read, relpath: str) -> str | None:
-        """Normalise ONE trust-policy file read into a message, or None.
-
-        Shared by both legs of `_trust_policy_failure` because the two files
-        fail the same two ways and must be reported the same two ways. `read` is
-        a zero-argument callable so the try wraps EXACTLY ONE CALL, not a route
-        body, and that call touches no database: `store_relation_aliases` and
-        `store_typed_relations` each read `store.db_path` as an attribute, stat
-        their file, and parse it. So the only thing this can swallow is a
-        failure to read or parse that one file.
-        """
-        try:
-            read()
-        except CorroborationPolicyError as exc:
-            # G1. Already normalised, and its message already begins with the
-            # file's own name (`relation-aliases.md:1: expected …`,
-            # `typed-relations.md: alias 'x' used for both …`). Prefixing it
-            # below would say the file twice, AND would misstate what happened —
-            # the file WAS read; it parsed and failed. That is a false claim
-            # about the system's own state on a user-facing page. Must stay
-            # ABOVE G2.
-            return str(exc)
-        except Exception as exc:  # noqa: BLE001 - normalise every policy-read failure
-            # G2. BROAD, NOT A TYPE LIST. `UnicodeDecodeError` (a file saved as
-            # cp949) descends from `ValueError` as `CorroborationPolicyError`
-            # does but is no subclass of it; `PermissionError` is not a
-            # `ValueError` at all. Same reasoning, and the same shape, as
-            # `extract.py::_relation_aliases_or_error` (#553).
-            #
-            # NAME THE FILE: `str(UnicodeDecodeError)` is a byte offset and no
-            # path, so an unprefixed message put a bare codec complaint about
-            # nothing in particular on the page.
-            return f"{relpath} could not be read: {exc}"
-        return None
-
     def _trust_policy_failure(store: Store) -> str | None:
         """Why this KB's trust policy cannot be applied, or None when it can.
 
@@ -1151,27 +1116,29 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         policy-dependent pipeline function would change signatures shared with
         the CLI, and is a separate refactor.
 
-        NOT EVERY POLICY-DEPENDENT ROUTE CALLS THIS. `POST /ask` and
+        THE LOGIC LIVES IN THE PIPELINE, AND THIS IS A NAME FOR IT. The body
+        was once a copy of `query_schema_policy_failure`; measured, the two were
+        the same function under two names, and the helper each called was
+        AST-identical across the two files. So this delegates rather than
+        repeating, and there is one implementation to keep correct instead of
+        two that can drift. The name and this docstring stay because they are
+        what the web layer's nine call sites read, and because the ordering
+        contract below is a promise those call sites depend on. (Nine is the
+        AST call count, unchanged since `b4dea1b`. An earlier draft said
+        thirteen, which is how many times the identifier appears -- nine calls,
+        this definition, and three mentions in prose.)
+
+        WHY THE IMPLEMENTATION IS OVER THERE RATHER THAN HERE. `POST /ask` and
         `POST /questions/translate` fail for BOTH files inside
         `build_query_schema_snapshot` (`query_schema.py`), which
-        `verinote/cli.py` reaches too, and they have no guard here for either
-        file. `POST /ask` is therefore also the one route where the ordering
-        rule above has nothing upstream of it: everywhere else a tripped guard
-        returns before the typed read can run at all (measured). Both are
-        deferred to #570's follow-up, which already owes their alias half.
+        `verinote/cli.py` reaches too (#591). A guard defined in this module
+        could not reach the CLI; one defined beside the failing statement
+        reaches all three entry points and this one. `POST /ask` is also the one
+        route with no upstream guard of its own: everywhere else a tripped guard
+        returns before the typed read can run at all (measured). #570 is where
+        the deferral was recorded.
         """
-        alias_failure = _policy_file_failure(
-            lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
-        )
-        if alias_failure is not None:
-            return alias_failure
-        # Explicit `is not None` rather than `or`: an exception with no args
-        # stringifies to "", which is falsy, and an `or` chain would silently
-        # step past a real alias failure to read a file the user cannot act on
-        # yet.
-        return _policy_file_failure(
-            lambda: store_typed_relations(store), TYPED_RELATIONS_RELPATH
-        )
+        return query_schema_policy_failure(store)
 
     def _relation_aliases_context() -> dict[str, object]:
         """The Settings page's own read of the alias file, plus its own guard.
@@ -1181,8 +1148,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         straight from `_relation_aliases_path()`, which resolves from
         `cfg.root` rather than `store.db_path.parent` — see
         `_trust_policy_failure`'s docstring), so it needs its own read and its
-        own broad `except Exception` around that one `read_text` call (same G2
-        rationale: no database access, only a stat and a read of this file).
+        own broad `except Exception` around that one `read_text` call (the same
+        rationale as G2 in `pipeline/query_schema.py::_policy_file_failure`: no
+        database access, only a stat and a read of this file).
         """
         path = _relation_aliases_path()
         if not path.is_file():
@@ -1211,7 +1179,9 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # The file WAS read; it parsed and failed. Keep the parser's own
             # message (already file-and-line-prefixed) rather than wrapping it —
             # wrapping would say the file twice and misstate that it could not be
-            # read at all (same reasoning as G1 above).
+            # read at all -- the same reasoning as G1 in
+            # `pipeline/query_schema.py::_policy_file_failure`, which is where
+            # that clause lives since #591 hoisted it out of this file.
             return {
                 "relation_aliases": text,
                 "relation_aliases_error": str(exc),


### PR DESCRIPTION
Closes #591. The half #570 deferred.

All three gates independently recomputed and approved tree `234ffaa8fd68f423fea46e60e3c4cbb26d0e3d9b`; the commit was built from it and verified equal.

## What it does
`query_schema_policy_failure(store) -> str | None`, module-level beside the failing statement. No shared signature changed. The duplicate went with it — `_trust_policy_failure` and the new function were AST-identical after name normalisation, and the web copy closed over nothing, so `web/app.py` now has zero copies and one delegation across nine unchanged call sites.

## Two sites, because the obvious fix writes a false record
`translate_questions` loops calling `set_question_query`. A guard that only stopped the 500 marked every pending question `translation_failed` — a durable audited claim that each failed translation when it was never attempted. The write is suppressed; rows stay `pending`.

The rationale is comparative rather than principled on purpose: a principled version would condemn `_fail_pending_translations` and `cli.py`'s missing-credential path, which do exactly this deliberately today. That inconsistency is **#592**.

## A regression this change introduced, then removed
The first revision read the verdict once before the loop while the flow recomputed it per question — writing the exact false record above where the parent wrote nothing:

```
parent  raised,   rows written: 0
rev 1   returned, rows written: 2
final   returned, rows written: 0
```

`_QueryFlowResult.policy_failed` is set only by the guard, so the written value and the decision to write it come from one read at one construction site. Policy reads N+1 → N.

## Validation
Real `git worktree` checkouts both sides. **3474 passed, 12 skipped, 0 failed** (base 3447; +26 = the new file's items, +1 the race pin). `ruff@0.15.18` clean.

The CLI coverage would have been vacuous without care: a policy failure and a missing API key give the same status and the same rc. The stub raises if anything asks the provider, the assertion is on the policy file's own message, and a healthy-file control on the same stub asserts that message is absent.

Reachability is measured at the function — a counter on `build_query_schema_snapshot`, patched in both modules since `query.py` imports the name directly: zero under every broken input, non-zero on the healthy control.

## Known gaps
The diagnosis does not reach `/questions/translate`'s landing page — rendering instead of redirecting would turn a cp949 alias file from 303 into 500, because `GET /questions` still fails on one. That is **#590**. Check-then-use is narrowed, not closed. Intermittent credentials-test flake tracked as **#593**.