### PR TITLE
fix(web): GET /questions and GET /report degrade on an unreadable alias file (#590)

### DIFF
--- a/tests/test_query_schema_policy_guard.py
+++ b/tests/test_query_schema_policy_guard.py
@@ -48,12 +48,15 @@ WHAT THIS CHANGE DOES NOT DELIVER, stated so its absence is not read as an
 oversight. `POST /questions/translate` answers 303 and redirects to
 `GET /questions`, and the guard deliberately writes nothing to the question rows
 (see below), so that page has nothing to display about the failure. Rendering
-the page from the translate route instead of redirecting would surface it for
-the malformed and typed inputs and turn the cp949 input from 303 into 500,
-because `GET /questions` itself still fails on a cp949 alias file -- measured
-here, and that route is #590's. So the diagnosis reaches `POST /ask` and
-`verinote query` in this change, and reaching the translate landing page waits
-on #590.
+the page from the translate route instead of redirecting would have turned the
+cp949 input from 303 into 500, because `GET /questions` itself failed on a cp949
+alias file when this was written. **#590 has since fixed that** -- `GET /questions`
+answers 200 on both broken-alias entries in `BROKEN_INPUTS` below
+(`alias-malformed` and `alias-cp949`; the third has a healthy alias) -- so the
+500 half of this obstacle is gone. What remains is the other half: this guard
+deliberately writes nothing to the question rows, so the landing page still has
+no per-question record to render. Delivering the diagnosis needs the message
+carried from the POST to the render, which is neither issue's.
 
 WHY THE QUESTION ROWS STAY `pending`. `translate_questions` reports the policy
 failure per question but does not write it. The justification is comparative and
@@ -236,9 +239,15 @@ def test_a_typod_typed_file_is_not_a_broken_input(tmp_path):
 def test_translate_survives_each_broken_policy_file(
     tmp_path, alias_bytes, typed_bytes, message
 ):
-    """The POST itself, not the redirect target: `GET /questions` still fails on
-    a cp949 alias file (#590), so following the redirect would measure that
-    route rather than this one."""
+    """The POST itself, not the redirect target.
+
+    When this was written the reason was that `GET /questions` 500ed on a cp949
+    alias file, so following the redirect measured that route instead of this
+    one. #590 fixed that and the reason changed rather than disappearing: the
+    redirect target is a different route with its own guard and its own tests,
+    so asserting on it here would attribute #590's behaviour to #591's guard.
+    The 303 is what this test owns.
+    """
     del message
     client, _ = _client(tmp_path, alias_bytes, typed_bytes)
     r = client.post("/questions/translate", follow_redirects=False)

--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -3,9 +3,10 @@ r"""A broken `policy/relation-aliases.md` degrades `/`, `/sources`, `/settings`
 instead of 500ing them (#555).
 
 WHY THE MALFORMED TESTS ASSERT THE MESSAGE, NOT THE STATUS. Deleting the narrow
-`except CorroborationPolicyError` clause (G1) inside
-`verinote/pipeline/query_schema.py::_policy_file_failure`
-does NOT turn any route back into a 500: the malformed case falls through to the
+`except CorroborationPolicyError` clause (G1) inside `policy_file_failure`
+(`verinote/pipeline/corroboration.py`, since #590 moved it there from
+`query_schema.py`, which is where #591 had put it) does NOT turn any route back
+into a 500: the malformed case falls through to the
 broad `except Exception` clause (G2) underneath, which also returns a string, so
 every affected route still renders 200 (measured — see plan555.md §2.2/M9,
 critique555.md's independent reproduction). What changes is the MESSAGE: the

--- a/tests/test_report_policy_guard.py
+++ b/tests/test_report_policy_guard.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: MPL-2.0
+r"""`GET /questions` and `GET /report` degrade on an unreadable
+`policy/relation-aliases.md` instead of 500ing (#590).
+
+This is the web-only half of #570's deferral; #591 was the CLI-shared half.
+Read `tests/test_query_schema_policy_guard.py` (#591) and
+`tests/test_typed_relations_web_guard.py` (#585) first -- this file extends
+their constants and reasons rather than restating them.
+
+TWO BROKEN INPUT CLASSES, AND MALFORMED IS NOT ONE OF THEM. Unlike #591's call
+site, these two routes already survive a malformed alias file: the narrow
+`except CorroborationPolicyError` clauses in `verify.py` and `report_trace.py`
+catch the PARSE class and turn it into a proper `policy_error` report. Measured
+on `c0dd1cc`, both routes:
+
+    healthy                 200      malformed (parse error)      200
+    self-map (parse error)  200      is-a-directory               200
+    cp949 (decode)          500      chmod 000 (PermissionError)  500
+    broken typed file       200
+
+So the guard exists for exactly two classes, and both are here. A cp949-only
+suite would leave the `PermissionError` half unpinned -- and that half is
+precisely what #555's G2 rationale was written for: `PermissionError` is not a
+`ValueError` at all, so an `except ValueError` that looks right would miss it.
+`ALIAS_MALFORMED` appears below as a case that must STAY 200 with its report
+unchanged, never as a broken input.
+
+THE ALIAS FILE ONLY -- AND WHY NOT `query_schema_policy_failure`. #591 made that
+function the established entry point, and using it here would be wrong: it
+checks BOTH policy files, and `verify.py` reads only the alias one
+(`store_typed_relations` appears nowhere in it), so routing these routes through
+the two-file check would withhold a report for a file `verify()` never read.
+The guard calls `policy_file_failure` with the alias reader alone.
+`test_a_broken_typed_file_does_not_trigger_this_guard_on_questions` is what
+stops that simplification.
+
+**Do not read that as "these routes never touch the typed file."** An earlier
+draft of this very docstring said exactly that, twenty lines above the paragraph
+below recording the measured opposite. `/report` also calls `report_trace`,
+which reaches `fact_trust_summary`, which reads BOTH files. The true claim is
+about `verify.py`; generalising it to the routes is what made it false, and the
+true half is what made it read as checked.
+
+THE THREE NARROW CLAUSES ARE LIVE AND MUST NOT BE DELETED. An earlier revision
+of this change's plan called them dead code. They are not:
+`query.py::expand_query_relation_aliases` raises `CorroborationPolicyError` when
+a rule's alias expansion exceeds `MAX_ALIAS_EXPANDED_RULES_PER_RULE`, and that
+is reachable on a KB where BOTH policy files are valid -- three raw labels
+mapping to one canonical name and a draft rule with four `relation/3` atoms is
+4**4 = 256 against a cap of 64. Deleting the clauses would turn that valid
+configuration into a 500. `test_the_alias_expansion_cap_still_answers` pins it,
+and it is not a new guard: it is an existing one this change must not break.
+
+A DEFECT THIS CHANGE FOUND AND DOES NOT FIX, recorded so its absence is not
+read as an oversight. `report_trace` reaches `fact_trust_summary`, which reads
+BOTH policy files, so on a KB whose report has a traceable answer a broken
+`policy/typed-relations.md` makes `GET /report` answer 500. Measured, and
+measured identically on this change's base commit, so it predates this work.
+It is invisible to any sweep whose fixture has no traceable answer -- which is
+how #585 missed it and how this change's own plan concluded these two routes
+never read the typed file. `/questions` is unaffected: it does not call
+`report_trace`. Tracked as #595; this issue is the alias file.
+
+WHAT DEGRADES, AND WHAT DOES NOT. `/questions` is `/review`'s shape: the queue
+and the repair job come from the store, read no policy file, and stay; only
+`answers` is withheld, and it is rendered AS withheld rather than as an empty
+list, which would read as an engine run that found nothing. `/report` is
+`/workbench`'s shape: `rep` and `trace` are both alias-derived, so there is no
+half of the page that survives, and it says not-computed rather than rendering a
+finding-free report -- a positive claim that the KB checked clean.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from verinote.config import Config
+from verinote.policy_defaults import RELATION_ALIASES_RELPATH, TYPED_RELATIONS_RELPATH
+from verinote.pipeline.query import MAX_ALIAS_EXPANDED_RULES_PER_RULE
+from verinote.pipeline.verify import verify
+from verinote.web import create_app
+
+ALIAS_HEALTHY = "- 자본금 -> capital_of\n".encode()
+ALIAS_CP949 = "- 자본금 -> capital_of\n".encode("cp949")
+# Parse error. NOT a broken input here -- it is 200 today and must stay 200.
+ALIAS_MALFORMED = "- 자본금 capital_of\n".encode()
+TYPED_HEALTHY = "- 자본금: amount as capital\n".encode()
+TYPED_DUP_ALIAS = "- 자본금: amount as capital\n- 자산: amount as capital\n".encode()
+
+ALIAS_MSG = "relation-aliases.md"
+NOT_COMPUTED = "Not computed — see the policy-file notice above."
+# The two empty-state sentences that must never stand over a run that did not happen.
+QUESTIONS_HEALTHY_EMPTY = "No engine answers yet"
+REPORT_HEALTHY_EMPTY = "No direct relation fact traces are available"
+THE_ANSWER = "q1: 1억"
+
+# The query asks about the CANONICAL relation; the fact is stored under the RAW
+# label. Only an applied alias file connects them, which is what makes every
+# control here non-vacuous -- verified by diffing the rendered bodies with and
+# without the file before any assertion below was written. Without the `.decl`
+# the engine reports `unknown predicate` and BOTH builds render identically,
+# which is how the first version of this fixture proved nothing.
+QUERY_DL = (
+    ".decl answer_q1(value: symbol)\n"
+    'answer_q1(O) :- relation("A", "capital_of", O).\n'
+)
+
+
+def _build(tmp_path: Path, *, alias: bytes | None, typed: bytes = TYPED_HEALTHY,
+           query_dl: str = QUERY_DL, raw_relation: str = "자본금"):
+    root = tmp_path / "kb"
+    root.mkdir(parents=True)
+    cfg = Config(root=root, db_path=root / "kb.sqlite", provider="anthropic",
+                 model="m", api_key=None, base_url=None)
+    app = create_app(cfg)
+    store = app.state.store
+    (root / "sources").mkdir(parents=True, exist_ok=True)
+    (root / "sources" / "a.txt").write_text("x\n", encoding="utf-8")
+    source_id = store.add_source("sources/a.txt")
+    store.add_fact("A", raw_relation, "1억", status="confirmed", confidence=0.9,
+                   source_id=source_id)
+    store.add_question("A의 자본금은?")
+    path = root / RELATION_ALIASES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if alias is not None:
+        path.write_bytes(alias)
+    (root / TYPED_RELATIONS_RELPATH).write_bytes(typed)
+    query_path = root / "facts" / "query.dl"
+    query_path.parent.mkdir(parents=True, exist_ok=True)
+    query_path.write_text(query_dl, encoding="utf-8")
+    return TestClient(app, raise_server_exceptions=False), app, path
+
+
+@pytest.fixture
+def unreadable_client(tmp_path):
+    """A well-formed alias file at mode 0o000 -- `PermissionError`, which is not
+    a `ValueError` and so escapes every narrow clause.
+
+    Skips rather than passing vacuously if the mode does not actually deny the
+    read (running as root), because a test that cannot reach its own failure
+    mode is green for the wrong reason.
+    """
+    client, app, path = _build(tmp_path, alias=ALIAS_HEALTHY)
+    os.chmod(path, 0o000)
+    try:
+        try:
+            path.read_bytes()
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this process can read a 0o000 file; the mode denies nothing here")
+        yield client
+    finally:
+        os.chmod(path, 0o644)
+
+
+BROKEN = [
+    pytest.param(ALIAS_CP949, id="cp949-decode"),
+    pytest.param(None, id="permission-denied"),  # None => use the unreadable fixture
+]
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2 -- both routes survive both broken classes, and say which file
+# ---------------------------------------------------------------------------
+
+
+def test_questions_survives_an_undecodable_alias_file(tmp_path):
+    """The assertion is the MESSAGE, not the status. #585 measured that deleting
+    the narrow clause in front of the broad one leaves every status unchanged
+    and reddens 25 tests with ZERO status assertions among them."""
+    client, _, _ = _build(tmp_path, alias=ALIAS_CP949)
+    r = client.get("/questions")
+    assert r.status_code == 200
+    assert ALIAS_MSG in r.text
+
+
+def test_report_survives_an_undecodable_alias_file(tmp_path):
+    client, _, _ = _build(tmp_path, alias=ALIAS_CP949)
+    r = client.get("/report")
+    assert r.status_code == 200
+    assert ALIAS_MSG in r.text
+
+
+def test_questions_survives_an_unreadable_alias_file(unreadable_client):
+    """The `PermissionError` half. `except ValueError` would look right and miss
+    this one entirely."""
+    r = unreadable_client.get("/questions")
+    assert r.status_code == 200
+    assert ALIAS_MSG in r.text
+
+
+def test_report_survives_an_unreadable_alias_file(unreadable_client):
+    r = unreadable_client.get("/report")
+    assert r.status_code == 200
+    assert ALIAS_MSG in r.text
+
+
+# ---------------------------------------------------------------------------
+# The parse class must be untouched by the pre-flight
+# ---------------------------------------------------------------------------
+
+
+def test_a_malformed_alias_file_still_reports_the_same_policy_error(tmp_path):
+    """Malformed is 200 today and must stay 200 with the same report. The
+    pre-flight returns the narrow clause's exact shape, code and message for
+    this class, so the outcome is unchanged rather than merely still-200."""
+    client, app, _ = _build(tmp_path, alias=ALIAS_MALFORMED)
+    rep = verify(app.state.store)
+    assert (rep.ok, rep.errors) == (False, 1)
+    assert [d.code for d in rep.finding_details] == ["policy_error"]
+    for route in ("/questions", "/report"):
+        assert client.get(route).status_code == 200
+
+
+def test_the_alias_expansion_cap_still_answers(tmp_path):
+    """THE ANTI-DELETION GUARD. Both policy files are valid here; what raises is
+    `expand_query_relation_aliases`'s cap, from inside `load_query`. The three
+    narrow clauses that catch it are live, and an earlier plan for this very
+    change called them dead code and said to delete them -- which would have
+    turned this valid configuration into a 500.
+
+    Red the moment `verify.py`'s second clause, `report_trace.py`'s, or
+    `app.py`'s `_questions` clause is removed.
+    """
+    aliases = "".join(f"- r{i} -> R\n" for i in range(1, 4)).encode()
+    atoms = ", ".join(['relation(_, "R", _)'] * 4)
+    client, app, _ = _build(
+        tmp_path,
+        alias=aliases,
+        query_dl=f".decl answer_q1(value: symbol)\nanswer_q1(S) :- relation(S, \"R\", _), {atoms}.\n",
+        raw_relation="r1",
+    )
+    assert 4 ** 4 > MAX_ALIAS_EXPANDED_RULES_PER_RULE
+    for route in ("/questions", "/report"):
+        r = client.get(route)
+        assert r.status_code == 200
+        assert "exceeds" in r.text, f"{route} lost the cap diagnosis"
+
+
+# ---------------------------------------------------------------------------
+# AC-2 -- withheld, and withheld visibly
+# ---------------------------------------------------------------------------
+
+
+def test_questions_keeps_the_queue_it_can_still_read(tmp_path):
+    """`/review`'s shape: the store-derived queue survives, only `answers` is
+    withheld, and it is rendered as withheld rather than as an empty list."""
+    client, _, _ = _build(tmp_path, alias=ALIAS_CP949)
+    body = client.get("/questions").text
+    assert "A의 자본금은?" in body           # the queue is still the KB's own
+    assert NOT_COMPUTED in body              # and the answers say why they are gone
+    assert QUESTIONS_HEALTHY_EMPTY not in body
+    assert THE_ANSWER not in body
+
+
+def test_report_does_not_render_a_finding_free_report(tmp_path):
+    """`/workbench`'s shape: no half of this page survives, so it must not print
+    the traceability empty-state, which reads as a search that found nothing."""
+    client, _, _ = _build(tmp_path, alias=ALIAS_CP949)
+    body = client.get("/report").text
+    assert NOT_COMPUTED in body
+    assert REPORT_HEALTHY_EMPTY not in body
+    assert THE_ANSWER not in body
+
+
+REPORT_BANNER = "The report and its traceability are"
+
+
+def test_the_report_banner_says_what_was_withheld(tmp_path):
+    """`report.html`'s banner, pinned on its own sentence.
+
+    It was unpinned when this file was written, and the reason is worth keeping:
+    it is NOT the sole carrier of the file NAME. `verify()`'s pre-flight puts the
+    message into `rep.findings` and `rep.text`, which the page renders anyway, so
+    `test_the_banner_claims_nothing_about_a_file_it_did_not_read` passed with the
+    whole `{% if policy_error %}` block deleted. A test named for the banner did
+    not test the banner. What the block IS sole carrier of is the explanation of
+    WITHHELD-NESS -- that the report and trace are missing on purpose rather than
+    empty -- so that is what this asserts.
+    """
+    client, _, _ = _build(tmp_path, alias=ALIAS_CP949)
+    body = client.get("/report").text
+    assert REPORT_BANNER in body
+    assert ALIAS_MSG in body
+
+
+def test_a_healthy_alias_file_still_answers(tmp_path):
+    """Anti-vacuity for every test above: a guard that fired unconditionally
+    would pass all of them. The fixture's answer exists only because the alias
+    file connects a fact stored under `자본금` to a query asking `capital_of`."""
+    client, _, _ = _build(tmp_path, alias=ALIAS_HEALTHY)
+    for route in ("/questions", "/report"):
+        body = client.get(route).text
+        assert THE_ANSWER in body, f"{route} lost the fixture's answer"
+        assert NOT_COMPUTED not in body
+        assert ALIAS_MSG not in body
+
+
+def test_the_fixture_answer_really_depends_on_the_alias_file(tmp_path):
+    """The measurement the controls rest on. Without this, "the answer is
+    withheld" could be pinning a value that was never there -- the failure mode
+    #585 spent five revisions on."""
+    with_file, _, _ = _build(tmp_path / "with", alias=ALIAS_HEALTHY)
+    without, _, _ = _build(tmp_path / "without", alias=None)
+    assert THE_ANSWER in with_file.get("/report").text
+    assert THE_ANSWER not in without.get("/report").text
+
+
+# ---------------------------------------------------------------------------
+# Scope: the typed file is not this guard's business
+# ---------------------------------------------------------------------------
+
+
+def test_a_broken_typed_file_does_not_trigger_this_guard_on_questions(tmp_path):
+    """Scope. `/questions` never reads `policy/typed-relations.md`, so a broken
+    one must leave it fully intact -- answer included.
+
+    Red if anyone "simplifies" the guard to `query_schema_policy_failure`, which
+    checks BOTH files: that would withhold this page's answer for a file it
+    never read. That is the most likely wrong turn here, because
+    `query_schema_policy_failure` is #591's established entry point.
+    """
+    client, _, _ = _build(tmp_path, alias=ALIAS_HEALTHY, typed=TYPED_DUP_ALIAS)
+    body = client.get("/questions").text
+    assert NOT_COMPUTED not in body
+    assert ALIAS_MSG not in body
+    assert THE_ANSWER in body
+
+
+def test_a_broken_typed_file_does_not_trigger_this_guard_on_report(tmp_path):
+    """Same scope claim for `/report`, on a KB with no traceable answer.
+
+    THE FIXTURE IS DELIBERATELY THE WEAKER ONE, and the reason is a defect this
+    change does not fix. `report_trace` reaches `fact_trust_summary`, which
+    reads BOTH policy files, so on a KB whose report HAS a traceable answer a
+    broken `typed-relations.md` makes `/report` answer 500 -- measured, and
+    measured identically on this change's base commit, so it predates this work
+    and is out of its scope (this issue is the alias file). Asserting 200 on the
+    answer-bearing fixture here would fail for a reason that has nothing to do
+    with this guard; asserting the 500 would lock a defect in as desired
+    behaviour. So the scope claim is pinned on the configuration where the typed
+    file genuinely is not read, and the `/questions` test above -- which is
+    unaffected by that defect -- is what actually catches the two-file
+    simplification.
+
+    SO THIS TEST DOES NOT PIN `report_trace`'s OWN alias-only choice, and nothing
+    else does either. Measured, not inferred: swapping that pre-flight to
+    `query_schema_policy_failure` and running all of `tests/` leaves it green,
+    with the same counts as the unmutated tree. The configuration that would
+    expose the difference is the answer-bearing one #595 owns, so there is no
+    input in this file that can separate the two. Stated rather than implied --
+    the `/questions` test above covers `/questions`'s choice, not this module's.
+
+    WHAT THE UNPINNED SWAP WOULD COST, on that same answer-bearing KB, measured:
+    status 500 -> 200, the answer still rendered, and the trace section printing
+    "No direct relation fact traces are available for these report rows" -- with
+    no banner, no "Not computed", and no mention of the file that failed. Green
+    suite, healthier-looking page, and a searched-and-found-nothing verdict on a
+    search that never ran. That is why `report_trace.py` keeps the alias-only
+    reader and says so in a comment; the comment is the only thing holding it.
+    """
+    client, _, _ = _build(tmp_path, alias=ALIAS_HEALTHY, typed=TYPED_DUP_ALIAS,
+                          query_dl="")
+    r = client.get("/report")
+    assert r.status_code == 200
+    assert NOT_COMPUTED not in r.text
+    assert ALIAS_MSG not in r.text
+
+
+def test_the_banner_claims_nothing_about_a_file_it_did_not_read(tmp_path):
+    """AC-5. The message names the alias file because the alias file is what
+    failed, and says nothing at all about `typed-relations.md`."""
+    client, _, _ = _build(tmp_path, alias=ALIAS_CP949)
+    for route in ("/questions", "/report"):
+        body = client.get(route).text
+        assert ALIAS_MSG in body
+        assert "typed-relations" not in body

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -64,6 +64,50 @@ class CorroborationPolicyError(ValueError):
     """Raised when optional corroboration policy files are malformed."""
 
 
+def policy_file_failure(read, relpath: str) -> str | None:
+    """Normalise ONE trust-policy file read into a message, or None.
+
+    `read` is a zero-argument callable so the try wraps EXACTLY ONE CALL, and
+    that call touches no database: `store_relation_aliases` and
+    `store_typed_relations` each read `store.db_path` as an attribute, stat
+    their file, and parse it. So the only thing this can swallow is a failure to
+    read or parse that one file.
+
+    THE ONLY COPY, and it lives here because this is where its parts live:
+    `CorroborationPolicyError` is defined in this module and the relpath arrives
+    as a parameter, so it needs nothing imported to sit here. It was in
+    `query_schema.py` until #590 gave it callers in four modules, at which point
+    a function about policy files reached from `verify.py` and
+    `report_trace.py` was importing from a module about query schemas.
+
+    #585 wrote it nested inside `create_app`, and #591 added a second copy on
+    the stated ground that the first was "closed over the request context" and
+    so could not be imported. That was false -- measured with the symbol table,
+    it closed over nothing; nesting was where it had been typed, not a
+    constraint. The web copy is gone and `web/app.py::_trust_policy_failure`
+    delegates to `query_schema_policy_failure`, which calls this. Do not
+    reintroduce a second copy: the argument for doing so has already been wrong
+    once.
+    """
+    try:
+        read()
+    except CorroborationPolicyError as exc:
+        # G1. Already normalised, and its message already begins with the file's
+        # own name (`relation-aliases.md:1: expected …`, `typed-relations.md:
+        # alias 'x' used for both …`). Prefixing it below would say the file
+        # twice AND would misstate what happened -- the file WAS read; it parsed
+        # and failed. Must stay ABOVE G2.
+        return str(exc)
+    except Exception as exc:  # noqa: BLE001 - normalise every policy-read failure
+        # G2. BROAD, NOT A TYPE LIST. `UnicodeDecodeError` (a file saved as
+        # cp949) descends from `ValueError` as `CorroborationPolicyError` does
+        # but is no subclass of it; `PermissionError` is not a `ValueError` at
+        # all. NAME THE FILE: `str(UnicodeDecodeError)` is a byte offset and no
+        # path.
+        return f"{relpath} could not be read: {exc}"
+    return None
+
+
 @dataclass(frozen=True)
 class FactSupport:
     subject: str

--- a/verinote/pipeline/query_schema.py
+++ b/verinote/pipeline/query_schema.py
@@ -23,7 +23,7 @@ from verinote.engine.terms import (
     render_term,
 )
 from verinote.pipeline.corroboration import (
-    CorroborationPolicyError,
+    policy_file_failure,
     RELATION_ALIASES_RELPATH,
     TYPED_RELATIONS_RELPATH,
     TypedRelationSpec,
@@ -165,43 +165,6 @@ class _Fact:
     status: str
 
 
-def _policy_file_failure(read, relpath: str) -> str | None:
-    """Normalise ONE trust-policy file read into a message, or None.
-
-    `read` is a zero-argument callable so the try wraps EXACTLY ONE CALL, and
-    that call touches no database: `store_relation_aliases` and
-    `store_typed_relations` each read `store.db_path` as an attribute, stat
-    their file, and parse it. So the only thing this can swallow is a failure to
-    read or parse that one file.
-
-    THE ONLY COPY. #585 wrote this helper nested inside `create_app`, and #591
-    added a second copy here on the stated ground that the first was "closed
-    over the request context" and so could not be imported. That was false --
-    measured with the symbol table, it closed over nothing; nesting was where it
-    had been typed, not a constraint. The web copy is gone and
-    `web/app.py::_trust_policy_failure` delegates here, so there is no second
-    implementation to keep in step. Do not reintroduce one: the argument for
-    doing so has already been wrong once.
-    """
-    try:
-        read()
-    except CorroborationPolicyError as exc:
-        # G1. Already normalised, and its message already begins with the file's
-        # own name (`relation-aliases.md:1: expected …`, `typed-relations.md:
-        # alias 'x' used for both …`). Prefixing it below would say the file
-        # twice AND would misstate what happened -- the file WAS read; it parsed
-        # and failed. Must stay ABOVE G2.
-        return str(exc)
-    except Exception as exc:  # noqa: BLE001 - normalise every policy-read failure
-        # G2. BROAD, NOT A TYPE LIST. `UnicodeDecodeError` (a file saved as
-        # cp949) descends from `ValueError` as `CorroborationPolicyError` does
-        # but is no subclass of it; `PermissionError` is not a `ValueError` at
-        # all. NAME THE FILE: `str(UnicodeDecodeError)` is a byte offset and no
-        # path.
-        return f"{relpath} could not be read: {exc}"
-    return None
-
-
 def query_schema_policy_failure(store: Store) -> str | None:
     """Why this KB's trust policy cannot be applied, or None when it can.
 
@@ -231,7 +194,7 @@ def query_schema_policy_failure(store: Store) -> str | None:
     `build_query_schema_snapshot` reads them again. A rewrite in that window
     still raises. Do not claim atomicity.
     """
-    alias_failure = _policy_file_failure(
+    alias_failure = policy_file_failure(
         lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
     )
     if alias_failure is not None:
@@ -239,7 +202,7 @@ def query_schema_policy_failure(store: Store) -> str | None:
     # Explicit `is not None` rather than `or`: an exception raised with no
     # arguments stringifies to "", which is falsy, and an `or` chain would step
     # past a real alias failure.
-    return _policy_file_failure(
+    return policy_file_failure(
         lambda: store_typed_relations(store), TYPED_RELATIONS_RELPATH
     )
 

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -23,7 +23,12 @@ from verinote.engine.terms import (
     terms_equal,
 )
 from verinote.engine.wirelog import answer_bucket_sort_key, answer_qid
-from verinote.pipeline.corroboration import CorroborationPolicyError
+from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    RELATION_ALIASES_RELPATH,
+    policy_file_failure,
+    store_relation_aliases,
+)
 from verinote.pipeline.engine_input import engine_relation_rows
 from verinote.pipeline.query import load_query
 from verinote.pipeline.trust import fact_trust_summary
@@ -119,6 +124,32 @@ def _excluded_by_status(store: Store) -> tuple[tuple[str, int], ...]:
 def report_trace(store: Store) -> ReportTrace:
     by_status = _excluded_by_status(store)
     excluded = sum(count for _, count in by_status)
+    # #590. `/report` calls this independently of `verify()`, so it needs the
+    # same pre-flight: `load_query` reads the alias file, and the narrow clause
+    # below catches only the parse class. Returns exactly what that clause's
+    # fallback returns -- the store-derived exclusion counts survive, because
+    # they read no policy file and are true either way.
+    #
+    # THE ALIAS READER ONLY, and NOT because this module is innocent of the
+    # typed file -- it is not. `_trace_fact` calls `fact_trust_summary`, which
+    # reads BOTH policy files, so on a KB whose report has a traceable answer a
+    # broken `typed-relations.md` raises out of here. That is #595, it predates
+    # this guard (measured identically on `c0dd1cc`), and widening this
+    # pre-flight would REPLACE the 500 with a silent false negative rather than
+    # fix it: the page then answers 200, still renders the answer, and prints
+    # "No direct relation fact traces are available for these report rows" --
+    # with no banner, no "Not computed", and no mention of the file that failed.
+    # That is the searched-and-found-nothing verdict the `{% elif policy_error %}`
+    # arm in `report.html` exists to prevent, reached from the other side.
+    # The alias file is what this guard is for; the typed read is #595's.
+    if policy_file_failure(
+        lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
+    ) is not None:
+        return ReportTrace(
+            answers=(),
+            excluded_review_count=excluded,
+            excluded_by_status=by_status,
+        )
     try:
         query = load_query(store)
     except CorroborationPolicyError:

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 
 from verinote.engine import NO_FINDINGS_TEXT, CheckReport, FindingDetail
 from verinote.engine.wirelog import review_rule_count
-from verinote.pipeline.corroboration import CorroborationPolicyError
+from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    RELATION_ALIASES_RELPATH,
+    policy_file_failure,
+    store_relation_aliases,
+)
 from verinote.pipeline.engine_input import (
     annotate_source_labels,
     compatible_finding_details,
@@ -113,6 +118,43 @@ def verify(store: Store) -> CheckReport:
             text=f"backend: DuckDB\n\npolicy error: {message}",
             findings=[finding],
             finding_details=[FindingDetail(finding, "error", "policy_empty")],
+        )
+
+    # #590. `engine_relation_rows` and `load_query` below both read
+    # `policy/relation-aliases.md`, and the two narrow clauses guarding them
+    # catch only `CorroborationPolicyError` -- the PARSE class. A file saved as
+    # cp949 raises `UnicodeDecodeError`, and one at mode 0o000 raises
+    # `PermissionError`; neither is a `CorroborationPolicyError` and neither is
+    # even a `ValueError`, so both escaped every clause and 500ed `GET /questions`
+    # and `GET /report`. Measured on `c0dd1cc`: those two routes and no others.
+    #
+    # ALIAS FILE ONLY, not `query_schema_policy_failure`. THIS MODULE never
+    # reads `policy/typed-relations.md` -- `store_typed_relations` appears
+    # nowhere in it -- so widening the check here would withhold a report for a
+    # file this function never read. Do not generalise that to the routes:
+    # `/report` also calls `report_trace`, which reaches `fact_trust_summary`
+    # and DOES read the typed file, so a broken one 500s `/report` on a KB with
+    # a traceable answer. That is #595 and it predates this guard.
+    #
+    # The clauses below STAY. They are not made dead by this: `query.py`'s alias
+    # expansion cap raises `CorroborationPolicyError` from `load_query` on a KB
+    # whose policy files BOTH parse, so deleting them would turn a valid
+    # configuration into a 500.
+    policy_failure = policy_file_failure(
+        lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
+    )
+    if policy_failure is not None:
+        # Deliberately the same shape, code and message the narrow clause below
+        # already returns, so the parse classes it still catches render exactly
+        # as they do today and only the two escaping classes change outcome.
+        finding = f"ERROR policy error: {policy_failure}"
+        return CheckReport(
+            ok=False,
+            errors=1,
+            warnings=0,
+            text=f"backend: DuckDB\n\npolicy/error: {policy_failure}",
+            findings=[finding],
+            finding_details=[FindingDetail(finding, "error", "policy_error")],
         )
 
     try:

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -104,6 +104,7 @@ from verinote.pipeline.corroboration import (
     RELATION_ALIASES_RELPATH,
     relation_aliases,
     store_corroboration,
+    policy_file_failure,
     store_relation_aliases,
     store_single_valued_conflicts,
     store_typed_relations,
@@ -1149,7 +1150,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         `cfg.root` rather than `store.db_path.parent` — see
         `_trust_policy_failure`'s docstring), so it needs its own read and its
         own broad `except Exception` around that one `read_text` call (the same
-        rationale as G2 in `pipeline/query_schema.py::_policy_file_failure`: no
+        rationale as G2 in `corroboration.py::policy_file_failure`: no
         database access, only a stat and a read of this file).
         """
         path = _relation_aliases_path()
@@ -1180,8 +1181,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # message (already file-and-line-prefixed) rather than wrapping it —
             # wrapping would say the file twice and misstate that it could not be
             # read at all -- the same reasoning as G1 in
-            # `pipeline/query_schema.py::_policy_file_failure`, which is where
-            # that clause lives since #591 hoisted it out of this file.
+            # `corroboration.py::policy_file_failure`, which is where that
+            # clause lives. Cited by symbol rather than by path: #591 hoisted it
+            # out of this file and #590 moved it again, breaking this reference
+            # both times, and a symbol survives the next move.
             return {
                 "relation_aliases": text,
                 "relation_aliases_error": str(exc),
@@ -3092,7 +3095,25 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             return _kb_select(request, error=error, status_code=status_code)
         store = _active_store()
         rep = verify(store)
+        # #590. `answers` is alias-derived: `engine_relation_rows` canonicalizes
+        # each fact's relation through this file, and `load_query` expands the
+        # draft's `relation/3` atoms through it. When the file cannot be read,
+        # `verify()` returns before the engine runs, so `rep.answers` is `[]` --
+        # and rendering `[]` prints "No engine answers yet", a measured claim
+        # about a run that never happened. `None` is what lets the template say
+        # "not computed" instead. The queue and the repair job come from the
+        # store, read no policy file, and stay: this is `/review`'s shape.
+        #
+        # ALIAS ONLY. THIS page never reads `policy/typed-relations.md` -- it
+        # does not call `report_trace` -- so a broken one leaves it at 200 and
+        # unwithheld (measured). `/report` is not in that position: see #595.
+        policy_failure = policy_file_failure(
+            lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
+        )
+        answers = None if policy_failure is not None else rep.answers
         page_error = error
+        if page_error is None and policy_failure is not None:
+            page_error = f"policy error: {policy_failure}"
         if page_error is None:
             # Ask the thing that owns the answer, never the report's prose: a
             # finding string is human-readable output, not a state field. (The
@@ -3107,7 +3128,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             "questions.html",
             {
                 "questions": [question_outcome_view(q) for q in store.questions()],
-                "answers": rep.answers,
+                "answers": answers,
                 "error": page_error,
                 "repair_job": store.latest_repair_job(),
             },
@@ -3191,6 +3212,15 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def report(request: Request):
         store = _active_store()
         rep = verify(store)
+        # #590. BOTH `rep` and `trace` are alias-derived here -- this is
+        # `/workbench`'s shape, not `/review`'s: there is no half of this page
+        # that survives the file being unreadable. Without this the page renders
+        # a report with no findings of its own and a traceability section
+        # reading "No direct relation fact traces are available", which together
+        # are a positive claim that the KB checked clean.
+        policy_failure = policy_file_failure(
+            lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
+        )
         try:
             trace = report_trace(store)
         except PolicyMissingError:
@@ -3202,7 +3232,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         return templates.TemplateResponse(
             request,
             "report.html",
-            {"rep": rep, "trace": trace},
+            {"rep": rep, "trace": trace, "policy_error": policy_failure},
         )
 
     @app.get("/analytics", response_class=HTMLResponse)

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -62,7 +62,14 @@
 {% endif %}
 
 <h2>Answers</h2>
-{% if answers %}
+{# #590. `is none` FIRST, and it is not the same test as the `{% else %}` below.
+   `None` and `[]` are both falsy, so without this branch an unreadable alias
+   file prints the "No engine answers yet" prose -- a measured claim about an
+   engine run that never happened, on a page that otherwise looks healthy. The
+   banner above carries the reason; this says which value it cost. #}
+{% if answers is none %}
+<p class="muted">Not computed — see the policy-file notice above.</p>
+{% elif answers %}
 <ul class="findings">{% for a in answers %}<li>{{ a }}</li>{% endfor %}</ul>
 {% else %}
 <p class="muted">No engine answers yet. Check each question outcome above for translation, review, ambiguity, or no-answer details.</p>

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -2,6 +2,11 @@
 {% block title %}Report — verinote{% endblock %}
 {% block content %}
 <h1>Logic check report</h1>
+{% if policy_error %}
+<p class="error" role="alert">{{ policy_error }} The report and its traceability are
+  withheld, because both would have been computed under different rules than this KB's
+  alias file specifies.</p>
+{% endif %}
 {% if not rep.engine_available %}
 <p class="warn">DuckDB verification backend is not available.</p>
 {% endif %}
@@ -71,6 +76,11 @@
     {% endfor %}
   </tbody>
 </table>
+{% elif policy_error %}
+{# #590. Without this arm the empty trace prints "no traces are available for
+   these report rows", which reads as a searched-and-found-nothing verdict on a
+   search that never ran. #}
+<p class="muted">Not computed — see the policy-file notice above.</p>
 {% else %}
 <p class="muted">No direct relation fact traces are available for these report rows.</p>
 {% endif %}


### PR DESCRIPTION
Closes #590 — the last of #570's deferral.

All three gates independently recomputed and approved tree `68af2c528809a0340acba282357ff5e18400fb08`.

## What it does
Two pre-flights, at the top of `verify()` and `report_trace()`, each returning a shape those functions already return. Ten production lines go, all renames or replacements; **no guard is deleted**. `policy_file_failure` moved to `corroboration.py` — one definition tree-wide.

## Alias-only, deliberately
`query_schema_policy_failure` checks both files and would have been the obvious reuse. It is wrong here: a broken `typed-relations.md` leaves both routes at 200.

But `report_trace` **is not** innocent of the typed file — it reaches `fact_trust_summary`, which reads both, so a broken typed file 500s `/report` on a KB with a traceable answer. Measured identically on the parent, so it predates this change: **#595**. Widening the pre-flight would not fix it — measured, the page answers 200, renders the answer, and prints the searched-and-found-nothing verdict with no banner and no mention of the failing file.

## Three clauses that are not dead code
An earlier plan revision would have deleted three `except CorroborationPolicyError` clauses as unreachable. `query.py:861` raises from `expand_query_relation_aliases` past the 64-rule cap, reachable from `load_query`, which all three wrap — **on a KB where both policy files are valid**. Deleting them turns a working configuration into a 500. The enumeration behind that near-miss was scoped to one file: 14 raisers in `corroboration.py`, and the 15th outside it decided the design.

## Validation
**3488 passed, 12 skipped, 0 failed** (base 3474, +13 = the new file + the banner pin). `ruff@0.15.18` clean.

Two broken input classes, not one: cp949 **and** permission-denied. The AC-2 fixture was vacuous in its first form — both rendered bodies identical for want of a `.decl`.

`report.html`'s banner was **unpinned**: deleting the whole block reddened nothing, because it is not the sole carrier of the file *name* — only of the withheld-ness *explanation*, which is what the new test asserts.

Separation: unique-overall is G1, G5, G6; four of seven guards redden no test uniquely; all seven separate once the two nested pre-flights are excluded.

## Not pinned, and why
`report_trace`'s alias-only choice is held by prose. No test can separate it while **#595** owns that configuration — asserting the 500 locks a defect in, asserting 200 fails for an unrelated reason. The comment and T9 carry the same six measured values so they stand or fall together, but that is prose agreement, not a test.

## Still deferred
The diagnosis does not reach `/questions/translate`'s landing page: #590 removes the 500, but #591 writes nothing to the rows. Carrying the message from POST to render is a third change and flips a 303 that #591's tests assert. Flake observed and unattributed → **#593**.