### PR TITLE
fix(pipeline): resolve typed relations through the alias table, and stop skipping lines the parser cannot read (#589)

### DIFF
--- a/tests/test_query_schema_policy_guard.py
+++ b/tests/test_query_schema_policy_guard.py
@@ -14,11 +14,27 @@ well: this call site has no narrow `except CorroborationPolicyError` in front of
 it, unlike `verify.py`, so it does not survive the malformed case the way
 `GET /questions` and `GET /report` do.
 
-`TYPED_TYPO` IS NOT A BROKEN INPUT and must never be used as one here. #585
-measured that `typed_relations` silently skips lines it cannot parse, so a
-typo'd typed file parses to `{}` and fails nothing -- measured again on this
-tree: `POST /ask` 200 and `POST /questions/translate` 303 under it, exactly as
-under a healthy file. A test planting it sees green because nothing broke.
+`TYPED_TYPO` BECAME A BROKEN INPUT IN #589, and this paragraph used to say the
+opposite. #585 measured that `typed_relations` silently skipped lines it could
+not parse, so a typo'd typed file parsed to `{}` and failed nothing. #589 made
+that line raise, so the guard now fires on it and `POST /ask` names the typed
+file in its body.
+
+The STATUS codes did not move -- `POST /ask` is still 200 and
+`POST /questions/translate` still 303, because this guard degrades rather than
+500s -- which is why the test below kept passing after the behaviour inverted:
+`ALL_MESSAGES` had been enumerated when the only typed-file message was the
+duplicate-alias one, so the unparseable-line message #589 added was not in it.
+It IS in it now -- the set gained `TYPED_TYPO_MSG` in the same change that
+found the gap, and both consuming loops picked it up without being touched.
+A message set that lists the conditions known at the time silently stops
+covering a condition added later; the test below asserts the message that IS
+produced, rather than that no known message appears.
+
+Promoting `TYPED_TYPO` into `BROKEN_INPUTS` would now be correct and would give
+every parametrized test above a fourth real input. It is deliberately NOT done
+here, because that is coverage this issue did not set out to add and belongs to
+whoever next works this file.
 
 THE EMPTY-QUEUE TRAP. `POST /questions/translate` returns 303 when there are no
 pending questions, under a broken policy file just as under a healthy one.
@@ -88,12 +104,20 @@ from verinote.store import Store
 from verinote.web import create_app
 
 # The alias parser raises on the FIRST line it cannot parse, so a missing arrow
-# is a real failure here -- unlike the typed parser, which skips such a line.
+# is a real failure here. Since #589 the typed parser has the same rule, so this
+# input is a real failure in BOTH files -- it used to be a real failure only in
+# this one.
 ALIAS_MALFORMED = "- 소속 member_of\n".encode()
 ALIAS_CP949 = "- 소속 -> member_of\n".encode("cp949")
 ALIAS_HEALTHY = "- 소속 -> member_of\n".encode()
-# A duplicate alias: one of the four SEMANTIC conditions `typed_relations`
-# raises on. See this file's docstring for why a typo is not one of them.
+# A duplicate alias: one of the conditions `typed_relations` raises on. They are
+# enumerated in `test_typed_relations_web_guard.py`'s module docstring and
+# DERIVED from the source by
+# `test_the_raise_conditions_are_derived_from_the_source_not_listed_by_hand`,
+# which reddens if that list stops matching the parser. Cited rather than
+# counted or copied here: this comment said "four" and an earlier repair said
+# the parser's own docstring enumerated them, and all three were wrong -- the
+# count twice, and the pointer at a docstring that lists no condition at all.
 TYPED_DUP_ALIAS = "- 자본금: amount as capital\n- 자산: amount as capital\n".encode()
 TYPED_HEALTHY = "- 자본금: amount as capital\n".encode()
 TYPED_TYPO = "- 소속 member_of\n".encode()
@@ -101,6 +125,9 @@ TYPED_TYPO = "- 소속 member_of\n".encode()
 ALIAS_PARSER_MSG = "relation-aliases.md:"
 ALIAS_NAMED = f"{RELATION_ALIASES_RELPATH} could not be read"
 TYPED_PARSER_MSG = "typed-relations.md: alias"
+# #589's unparseable-line message. A DIFFERENT string from the one above, which
+# is exactly why `ALL_MESSAGES` did not catch it.
+TYPED_TYPO_MSG = "typed-relations.md:1: expected"
 
 # (alias bytes, typed bytes, the message that must appear). Three inputs.
 BROKEN_INPUTS = [
@@ -108,7 +135,13 @@ BROKEN_INPUTS = [
     pytest.param(ALIAS_CP949, TYPED_HEALTHY, ALIAS_NAMED, id="alias-cp949"),
     pytest.param(ALIAS_HEALTHY, TYPED_DUP_ALIAS, TYPED_PARSER_MSG, id="typed-duplicate-alias"),
 ]
-ALL_MESSAGES = (ALIAS_PARSER_MSG, ALIAS_NAMED, TYPED_PARSER_MSG)
+# Every policy-file message a guarded route can render. `TYPED_TYPO_MSG` is a
+# member because #589 made the typed parser strict: a false-positive parse error
+# on a VALID file is newly possible, and the healthy-KB controls that consume
+# this tuple are what would catch it. Add to this tuple, never to its consumers
+# -- both surviving loops read it, and the previous member added to one of them
+# instead is why a test kept passing after its behaviour inverted.
+ALL_MESSAGES = (ALIAS_PARSER_MSG, ALIAS_NAMED, TYPED_PARSER_MSG, TYPED_TYPO_MSG)
 
 # Resolved by `deterministic_query_intent`, so the provider is never asked and
 # the healthy exit code is 0 without credentials. `NoProviderClient` enforces it.
@@ -220,14 +253,28 @@ def test_a_healthy_policy_pair_still_answers_and_says_nothing_about_policy(tmp_p
         assert message not in r.text
 
 
-def test_a_typod_typed_file_is_not_a_broken_input(tmp_path):
-    """Pins this file's docstring claim, so a later edit cannot promote the typo
-    case into `BROKEN_INPUTS` and make every parametrized test above vacuous."""
+def test_a_typod_typed_file_is_reported_since_589(tmp_path):
+    """INVERTED BY #589, which is why the assertion is on the MESSAGE.
+
+    This asserted that no member of `ALL_MESSAGES` appeared, and it kept passing
+    that way after the behaviour inverted: the set had been enumerated when the
+    only typed-file message was the duplicate-alias one, so the unparseable-line
+    message #589 added slipped straight through it, and the status is 200 either
+    way. Nothing about the old form could fail.
+
+    Both halves have since been fixed and they are independent. The set gained
+    `TYPED_TYPO_MSG`, so the old form would now FAIL here -- measured, that
+    message is in the body. And this test no longer uses the old form: asserting
+    the message that IS produced is what tells the two eras apart regardless of
+    what the set happens to contain.
+    """
     client, _ = _client(tmp_path, ALIAS_HEALTHY, TYPED_TYPO)
     r = client.post("/ask", data={"question": QUESTION})
     assert r.status_code == 200
-    for message in ALL_MESSAGES:
-        assert message not in r.text
+    assert TYPED_TYPO_MSG in r.text
+    # Still not the OTHER file's failure, and still not a read failure.
+    assert ALIAS_PARSER_MSG not in r.text
+    assert ALIAS_NAMED not in r.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_relation_aliases_web_guard.py
+++ b/tests/test_relation_aliases_web_guard.py
@@ -104,12 +104,15 @@ Settings" any more — `settings.html` has an editor for the alias file and none
 for the typed one.
 
 Do not read the two files as parametrizations of each other. Their affected
-route sets differ in BOTH directions, their malformed INPUT classes differ (a
-line `typed_relations` cannot parse is silently skipped, not raised), and an
-absent typed file degrades to `{}` — the same value a healthy KB with no typed
-declarations produces — so #585's guard cannot pin itself on the rendered value
-the way this file's can. The sibling file's docstring carries all three
-measurements.
+route sets differ in BOTH directions, and an absent typed file degrades to `{}`
+— the same value a healthy KB with no typed declarations produces — so #585's
+guard cannot pin itself on the rendered value the way this file's can. The
+sibling file's docstring carries both measurements.
+
+A third difference used to be listed here and is GONE: a line `typed_relations`
+could not parse was silently skipped rather than raised. #589 gave that parser
+this one's rule, so both now raise on any line that is neither blank nor a `#`
+comment. The two remaining differences are the ones that still matter.
 
 (#571, which an earlier draft of this paragraph cited for the typed-relations
 hole, is a different defect in a different file: an unusable PATH at

--- a/tests/test_typed_relations_resolution.py
+++ b/tests/test_typed_relations_resolution.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: MPL-2.0
+"""#589 path 2: a typed declaration written under an ALIASED label takes effect.
+
+`typed_relations` keys its dict by the label the user WROTE. Every consumer
+looks the spec up by the CANONICAL label. So a declaration on any label the
+alias table rewrites was stored under a key nobody queries, and did nothing --
+with no error, no warning, and nothing distinguishable in any rendered value.
+
+WHY THE FIXTURE USES `설립일` AND NOT AN INVENTED LABEL. It is one of the raw
+keys in the PACKAGED `DEFAULT_RELATION_ALIASES`, so this reproduces on a default
+install with no user alias file at all. Every test here pairs it with `자본금`,
+which that table leaves alone, DECLARED AT THE SAME TYPE -- holding the type
+constant is the control the original #585 diagnosis lacked, which is how the
+defect got misreported as "the `date` type never surfaces a typed value".
+
+WHY `established_on` MUST BE FUNCTIONAL HERE. The conflict half of the harm only
+appears when the canonical relation is single-valued. On a default install the
+functional relations are exactly the ones a user names in their own words, so
+this is the represented case rather than a corner.
+
+THE BASELINE ARM IS LOAD-BEARING, not decoration. Before the fix the aliased arm
+was byte-identical to having NO typed file at all -- measured, cell for cell. So
+a test that compares "declared under an alias" against "declared canonically"
+cannot tell a working remedy from a default; it needs the no-file arm to show
+that the numbers it asserts are the REMEDY's and not the default's. `A3` carries
+that arm for exactly this reason.
+"""
+import pytest
+
+from fastapi.testclient import TestClient
+
+from verinote.config import Config
+from verinote.pipeline.acceptance import _engine
+from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    relation_aliases,
+    store_relation_aliases,
+    store_single_valued_conflicts,
+    store_typed_relations,
+    typed_spec_for_canonical,
+)
+from verinote.pipeline.trust import fact_trust_summary
+from verinote.pipeline.workbench import trust_workbench
+from verinote.policy_defaults import DEFAULT_RELATION_ALIASES
+from verinote.store import Store
+from verinote.web.app import create_app
+
+ALIASED = "설립일"           # a raw key in the PACKAGED table -> established_on
+CANONICAL = "established_on"
+UNALIASED = "자본금"          # absent from that table; canonicalises to itself
+SIBLING = "창립일"            # a SECOND raw key routing to established_on
+V1, V2 = "1976.04.01", "date(1976,4,1)"   # one date, two notations
+
+
+def _decl(relation: str, alias: str = "founded") -> str:
+    # The alias TAG must differ per declaration: `typed-relations.md` already
+    # refuses one tag used for two relations, and that refusal is not what any
+    # test here is about.
+    return f"- {relation} : date as {alias}\n"
+
+
+def _seed(tmp_path, typed: str | None, *, relation: str, functional: str):
+    policy = tmp_path / "policy"
+    policy.mkdir(parents=True)
+    (policy / "logic-policy.dl").write_text(
+        f'.decl functional(rel: symbol)\nfunctional("{functional}").\n', encoding="utf-8"
+    )
+    # No user relation-aliases.md on purpose: the packaged defaults are the
+    # population the defect actually hits.
+    if typed is not None:
+        (policy / "typed-relations.md").write_text(typed, encoding="utf-8")
+    return relation
+
+
+def _store(tmp_path, typed: str | None, *, relation=ALIASED, functional=CANONICAL):
+    _seed(tmp_path, typed, relation=relation, functional=functional)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    a = store.add_source("sources/a.txt")
+    b = store.add_source("sources/b.txt")
+    store.add_fact("Acme", relation, V1, status="confirmed", source_id=a)
+    store.add_fact("Acme", relation, V2, status="confirmed", source_id=b)
+    return store
+
+
+def _client(tmp_path, typed: str | None, *, relation=ALIASED, functional=CANONICAL):
+    _seed(tmp_path, typed, relation=relation, functional=functional)
+    cfg = Config(
+        root=tmp_path, db_path=tmp_path / "kb.sqlite",
+        provider="anthropic", model="m", api_key=None, base_url=None,
+    )
+    app = create_app(cfg)
+    client = TestClient(app)
+    store = app.state.store
+    a = store.add_source("sources/a.txt")
+    b = store.add_source("sources/b.txt")
+    store.add_fact("Acme", relation, V1, status="confirmed", source_id=a)
+    store.add_fact("Acme", relation, V2, status="confirmed", source_id=b)
+    return client
+
+
+def _badges(body: str, name: str) -> list[int]:
+    import re
+    return [int(x) for x in re.findall(rf"{name}[^0-9]{{0,40}}(\d+)", body)]
+
+
+def test_the_fixture_label_is_one_the_packaged_table_rewrites(tmp_path):
+    """Anti-vacuity for every test below, and the exact check #585 skipped.
+
+    If `설립일` ever stops being a packaged raw key, or `자본금` starts being
+    one, the pairing stops being a controlled comparison and every assertion
+    below would still pass while proving nothing about aliased declarations.
+    """
+    aliases = relation_aliases(DEFAULT_RELATION_ALIASES)
+    assert aliases.get(ALIASED) == CANONICAL
+    assert aliases.get(SIBLING) == CANONICAL
+    assert UNALIASED not in aliases
+
+
+def test_an_aliased_declaration_resolves(tmp_path):
+    """A1 / G1. The resolver and the dossier row, at the same type as the control."""
+    store = _store(tmp_path, _decl(ALIASED))
+    typed = store_typed_relations(store)
+    aliases = store_relation_aliases(store)
+
+    assert list(typed) == [ALIASED], "the dict still keys by the written label"
+    spec = typed_spec_for_canonical(typed, CANONICAL, aliases)
+    assert spec is not None and spec.type == "date"
+
+    fact_id = next(int(r["id"]) for r in store.facts())
+    summary = fact_trust_summary(store, fact_id)
+    assert summary.typed_value is not None
+    assert summary.typed_value.normalized_value == 19760401
+
+
+def test_an_unaliased_declaration_still_resolves(tmp_path):
+    """A4. The control arm: same type, a label the packaged table leaves alone."""
+    store = _store(tmp_path, _decl(UNALIASED), relation=UNALIASED, functional=UNALIASED)
+    typed = store_typed_relations(store)
+    aliases = store_relation_aliases(store)
+    spec = typed_spec_for_canonical(typed, UNALIASED, aliases)
+    assert spec is not None and spec.type == "date"
+
+    fact_id = next(int(r["id"]) for r in store.facts())
+    summary = fact_trust_summary(store, fact_id)
+    assert summary.typed_value is not None
+    assert summary.typed_value.normalized_value == 19760401
+
+
+def test_two_agreeing_sources_corroborate_under_an_aliased_declaration(tmp_path):
+    """A2 / G2. `trust_workbench` -- 0 before the fix, and NOT via `trust.py`.
+
+    This number is formed by `workbench.py`'s own spec lookup, not by the one in
+    `trust.py`: patching `trust.py` alone leaves it at 0. Measured that way, per
+    site, which is the only thing that could have shown it.
+    """
+    store = _store(tmp_path, _decl(ALIASED))
+    workbench = trust_workbench(store)
+    assert len(workbench.corroborated) == 1
+    assert workbench.corroborated[0].source_count == 2
+    assert workbench.conflicts == ()
+
+
+def test_a_typed_declaration_resolves_the_notation_conflict(tmp_path):
+    """A3 / G4. `single_valued_conflicts` -- 1 before the fix."""
+    store = _store(tmp_path, _decl(ALIASED))
+    assert store_single_valued_conflicts(store) == []
+
+
+def test_the_sources_rollup_stops_reporting_the_false_conflict(tmp_path):
+    """A3 / G4 + G5, at the rendered surface, WITH the baseline arm.
+
+    The two badges come from different sites -- `conflicted` from
+    `store_single_valued_conflicts`, `corroborated` from `_source_object_key` --
+    so both are asserted. The no-typed-file arm is what makes this test able to
+    fail for the right reason: before the fix the declared arm was identical to
+    it, so asserting the declared arm alone could not tell a working remedy from
+    the default.
+    """
+    declared = _client(tmp_path / "declared", _decl(ALIASED)).get("/sources").text
+    assert _badges(declared, "conflicted") == [0, 0]
+    assert _badges(declared, "corroborated") == [1, 1]
+
+    baseline = _client(tmp_path / "baseline", None).get("/sources").text
+    assert _badges(baseline, "conflicted") == [1, 1]
+    assert _badges(baseline, "corroborated") == [0, 0]
+
+
+def test_the_rollup_corroborates_an_aliased_declaration_with_no_conflict(tmp_path):
+    """G5 alone. `_source_object_key`, isolated from `single_valued_conflicts`.
+
+    WITHOUT THIS TEST G5 IS UNPINNED, which the matrix showed: its only red was
+    a test `G4` reddens too, so reverting `_source_object_key` alone would have
+    been caught by nothing of its own. The two are separated here by making the
+    canonical relation NON-functional -- `single_valued_conflicts` then returns
+    nothing whatever the typed lookup does, so `conflicted` cannot move and the
+    `corroborated` badge is left as the only thing under test.
+
+    This is also the plan's own §1.3 caveat, which was otherwise unpinned: on a
+    non-functional relation the aliased declaration still silently fails, it
+    just fails quietly -- corroboration is lost with no conflict raised to show
+    that anything went wrong.
+    """
+    client = _client(tmp_path, _decl(ALIASED), functional="unrelated_relation")
+    body = client.get("/sources").text
+    assert _badges(body, "conflicted") == [0, 0]
+    assert _badges(body, "corroborated") == [1, 1]
+
+
+def test_the_acceptance_view_resolves_an_aliased_declaration(tmp_path):
+    """G3. `acceptance._view_fact` -- the fifth site, and the one with no
+    consumer in this issue's harm story, so nothing else here would pin it."""
+    store = _store(tmp_path, _decl(ALIASED))
+    engine = _engine(store)
+    keys = {f.object_key for f in engine.facts}
+    assert keys == {("scalar", 19760401)}, keys
+
+
+def test_two_declarations_canonicalising_to_one_relation_are_refused(tmp_path):
+    """A5 / G4-collision. Ambiguity the fix creates, refused rather than ordered.
+
+    Before this change these were separate keys and BOTH were ignored, so there
+    was nothing to disambiguate. Resolving them makes dict order decide which
+    declaration wins -- the defect class this change exists to remove -- so it
+    raises the way `typed-relations.md` already refuses a duplicate alias.
+
+    IT RAISES FROM `store_typed_relations`, NOT FROM THE RESOLVER, and the test
+    below this one is what pins that distinction. Raising from the resolver put
+    the error below every guard the trust path has.
+    """
+    store = _store(tmp_path, _decl(ALIASED) + _decl(SIBLING, "incorporated"))
+    with pytest.raises(CorroborationPolicyError) as excinfo:
+        store_typed_relations(store)
+    message = str(excinfo.value)
+    assert ALIASED in message
+    assert SIBLING in message
+    assert CANONICAL in message
+
+
+@pytest.mark.parametrize(
+    "route", ["/", "/sources", "/review", "/workbench", "/report", "/questions"]
+)
+def test_a_collision_degrades_every_page_instead_of_500ing_it(tmp_path, route):
+    """THE REGRESSION GUARD, and the reason the refusal lives where it does.
+
+    An earlier revision refused the collision inside the resolver. That made the
+    `CorroborationPolicyError` a NEW raiser, reached deep in the pipeline below
+    every guard written for the file's existing refusals -- measured, six of
+    these routes answered 500 while the same KB with a plain duplicate-alias
+    file left all of them at 200.
+
+    Moving the refusal to `store_typed_relations` is what fixes it: the error
+    now comes from the same place the duplicate-alias refusal always did, so it
+    reaches guards that already exist and no new ones were added. Deleting the
+    `_refuse_canonical_collisions` call there and refusing in the resolver again
+    reddens FOUR of these six -- measured by building it, not four of six
+    because six sounded wrong.
+
+    The other two, `/report` and `/questions`, stay 200 even under the bad
+    version, because #590 gave them pre-flights that read the alias file and
+    degrade before the resolver is ever reached. They are parametrized here
+    anyway rather than dropped: they cost nothing, and a change that regressed
+    them would be a #590 regression this is the cheapest place to notice. Do
+    not read their passing as evidence about THIS guard -- the four are what
+    carry it.
+    """
+    client = _client(tmp_path, _decl(ALIASED) + _decl(SIBLING, "incorporated"))
+    r = client.get(route)
+    assert r.status_code == 200, f"{route} should degrade, not 500"
+
+
+def test_a_declaration_under_the_canonical_label_still_wins_alone(tmp_path):
+    """The collision refusal must not fire on a KB with one declaration per
+    canonical relation, however many relations are declared."""
+    store = _store(tmp_path, _decl(ALIASED) + _decl(UNALIASED, "capital"))
+    workbench = trust_workbench(store)
+    assert len(workbench.corroborated) == 1

--- a/tests/test_typed_relations_web_guard.py
+++ b/tests/test_typed_relations_web_guard.py
@@ -7,82 +7,86 @@ are deliberately NOT parametrizations of each other. Read the four paragraphs
 below before adding to either: three of them are measurements that make an
 "obvious" simplification of this file silently stop proving anything.
 
-WHY THE MALFORMED INPUT IS A DUPLICATE ALIAS AND NOT A SYNTAX ERROR.
-`relation_aliases` raises on the first line it cannot parse. `typed_relations`
-does the opposite: a line that does not match `_TYPED_REL_RE`, or whose type tag
-is outside `_TYPED_TYPES = {date, number, ordinal, amount}`, hits `continue` --
-no error, no 500, the declaration is just dropped. Measured on this tree by
-calling the parser directly:
+WHY THE MALFORMED INPUT IS A DUPLICATE ALIAS, AND WHY THE REASON HAS CHANGED.
+When this file was written `typed_relations` was the opposite of its sibling: a
+line that did not match `_TYPED_REL_RE`, or whose type tag was outside
+`_TYPED_TYPES = {date, number, ordinal, amount}`, hit `continue` and the
+declaration was dropped with no error and no 500. So a test that planted the
+alias file's malformed bytes here saw 200, passed, and pinned NOTHING -- the
+file had parsed cleanly to `{}`. `TYPED_DUP_ALIAS` below is a duplicate alias
+for that reason.
 
-    "- 소속 member_of"            (the alias file's MALFORMED_BYTES)  -> {}
-    "- 설립일: colour as founded" (unknown type tag)                  -> {}
-    "- 자본금: amount as capital
-     - 자산: amount as capital"   (duplicate alias)                   -> RAISES
+#589 closed that path. A line that is neither blank nor a `#` comment must now
+parse, which is `relation_aliases`' rule adopted rather than re-invented.
+SEVEN conditions raise, and this list is not maintained by hand --
+`test_the_raise_conditions_are_derived_from_the_source_not_listed_by_hand`
+derives them from `corroboration.py` by AST and fails if this paragraph stops
+naming one of them:
 
-Exactly four SEMANTIC conditions raise: a duplicate alias, units on a non-amount
-type, a unit pair with no `=`, and a non-numeric unit value. So a test that
-plants the alias file's malformed bytes here sees 200, passes, and pins
-NOTHING -- the file parsed cleanly to `{}`. `TYPED_DUP_ALIAS` below is a
-duplicate alias for that reason, and
-`test_a_typo_in_typed_relations_is_silently_ignored_rather_than_reported`
-pins the distinction so a later edit cannot quietly promote the typo case into
-the malformed slot and make this whole file vacuous.
+    unparseable line, unknown type tag, duplicate alias, units on a
+    non-`amount` type, malformed unit pair, non-numeric unit value,
+    invalid unit mapping
 
-WHY THE FIXTURE IS AN `amount` DECLARATION ON AN UNALIASED RELATION NAME.
-Two separate constraints, and the second one is the trap.
+Blanks, `#` comments and `##` markdown headings are still tolerated -- headings
+survive because they begin with `#`.
 
+THE COUNT HAS BEEN WRONG TWICE AND BOTH TIMES IT WAS WRONG WHEN WRITTEN, not
+stale. #585 said "exactly four SEMANTIC conditions"; five raised on the tree it
+described. #589 replaced it with six; seven raised. The omission was the same
+one both times -- `invalid unit mapping`, which `_parse_amount_units` raises on
+an empty unit name, a non-integral value, or a value <= 0. A hand-written list
+rots exactly the way a count does, which is why one is derived now instead.
+
+So the hazard that shaped this file is gone: no non-comment input degrades
+silently to `{}` any more, and the malformed slot cannot be quietly filled with
+something vacuous. What still needs pinning is narrower, and
+`test_the_parser_reports_a_typo_instead_of_dropping_it` carries it: the
+duplicate-alias message differs from the unparseable-line message, so asserting
+the MESSAGE keeps `TYPED_DUP_ALIAS` tied to the condition it is named for
+rather than to "something raised".
+
+WHY THE FIXTURE IS AN `amount` DECLARATION.
 The TYPE has to be `amount` because it is the only one of the four that makes
 this fixture's two objects one value: `normalize_typed_value` maps both `1억`
 and `100000000원` to `100000000`, while `date`, `number` and `ordinal` each
 return `None` for BOTH of them, leaving two unrelated raw keys. Every
 corroboration control below rests on that merge.
 
-The declared NAME has to be one the alias table leaves alone, and this part is
-type-independent. `typed_relations()` keys its dict on the RAW name written in
-the file, but `fact_trust_summary` canonicalizes before looking it up --
-`relation = canonical_relation(display.relation, aliases)`, then
-`_typed_spec(typed, relation)`. A declaration whose name appears in the alias
-table is therefore stored under a key it is never read back by, and is dropped
-without a word. Each row below fixes a type AND an object and varies only the
-declared name, so the two results in a row differ in exactly one thing. The
-object is named in every row because the result depends on it as much as on the
-type and the name; a row giving only a type and a name is not a controlled
-comparison, which is the defect an earlier draft of this table carried. The
-objects differ between rows because each row's object is one its own type
-normalizes: `'2020.03.01'` as a date, `'1억'` as an amount, `'3'` as a number,
-`'3위'` as an ordinal. Every `None` in the aliased column is the same `None`:
-`fact_trust_summary` found no declaration under `established_on`, so there is
-no typed summary at all, rather than a summary carrying a null value. A
-declaration on `설립일` is stored under key `설립일` and looked up under
-`established_on`; one on `자본금` is stored and looked up under `자본금`:
+THE DECLARED NAME NO LONGER MATTERS, AND RETIRING THAT RULE IS #589's POINT.
+Until #589 the name also had to be one the alias table leaves alone.
+`typed_relations()` keys its dict on the RAW name written in the file, while
+every consumer canonicalizes before looking it up, so a declaration whose name
+appears in the alias table was stored under a key it was never read back by and
+was dropped without a word. This paragraph carried a four-row table of `None`s
+showing exactly that. #589 made every consumer resolve through the alias table,
+so the two columns now agree -- re-derived here, declaration and fact sharing
+the name in each column:
 
-    type     object         on '설립일' (aliased)  on '자본금' (unaliased)
-    date     '2020.03.01'   None                  20200301
-    amount   '1억'           None                  100000000
-    number   '3'            None                  3000
-    ordinal  '3위'           None                  3
+    type     object         declared on 설립일   declared on 자본금
+    date     '2020.03.01'   20200301             20200301
+    amount   '1억'          100000000            100000000
+    number   '3'            3000                 3000
+    ordinal  '3위'          3                    3
 
-Declaring `date` on the canonical `established_on`, with the fact's relation
-still `설립일` and the object still `'2020.03.01'`, yields 20200301 -- the
-mechanism, not merely the absence.
+Declaring `date` on the canonical `established_on` while the fact's relation is
+still `설립일` also yields 20200301, as it did before -- that path was never the
+broken one.
 
-`설립일` is `DEFAULT_RELATION_ALIASES`' own mapping to `established_on`, so this
-bites a KB with NO alias file too: an absent file yields the packaged defaults,
-not an empty table. The declaration under test below is on `자본금`, which is
-absent from those 36 entries, and that absence is the only reason it observes
-anything at all -- a declaration on any label the table does name would be
-dropped instead, whatever its type.
+So the prohibition that stood here -- do not "simplify" the fixture to a
+relation name `DEFAULT_RELATION_ALIASES` canonicalizes -- is RETIRED, not
+relaxed. The configuration it forbade now works, and a warning left standing
+would send the next reader hunting a defect that is fixed. The `amount`
+constraint above is the one that still binds, and it is unaffected: it is about
+which type merges two objects, not about which names resolve.
 
 An earlier draft of this paragraph said `date` never surfaces a `typed_value`
 and blamed the type. It had measured only `설립일` declarations, so it read the
 alias mismatch as a property of `date`; `date` in fact normalizes every
 well-formed input that draft listed -- `2020.03.01`, `2020-03-01`, `2020/3/1`,
-`date(2020,3,1)` and `2020.03`, each to 20200301. So do not "simplify" the fixture
-to a relation name `DEFAULT_RELATION_ALIASES` canonicalizes -- of ANY type --
-or every healthy control and every AC-2 control here silently stops proving
-anything. The silent drop is itself a state-honesty defect with no 500 attached,
-out of #585's scope and tracked as #589, which treats it and the unparseable-line
-drop above as one defect.
+`date(2020,3,1)` and `2020.03`, each to 20200301. That record is kept because
+the lesson outlived the bug it was about: the variable that draft failed to hold
+constant was the LABEL, not the type, and the same confound produced the wrong
+severity story in #589's own plan two revisions running.
 
 WHY THE GUARD HAS TO CARRY ITS OWN MARKER, AND CANNOT PIN ITSELF ON THE VALUE.
 `policy_defaults.py` defines `DEFAULT_RELATION_ALIASES` and no
@@ -136,13 +140,22 @@ rule in `_trust_policy_failure` has nothing above it there.
 import re
 from pathlib import Path
 
+import ast
+import inspect
+import pathlib
+
 import pytest
 
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from verinote.config import Config
-from verinote.pipeline.corroboration import typed_relations
+from verinote.pipeline import corroboration
+from verinote.store import Store
+from verinote.pipeline.corroboration import (
+    CorroborationPolicyError,
+    typed_relations,
+)
 from verinote.policy_defaults import RELATION_ALIASES_RELPATH, TYPED_RELATIONS_RELPATH
 from verinote.web import create_app
 
@@ -156,12 +169,18 @@ TYPED_PARSER_MSG = "typed-relations.md: alias"
 TYPED_NAMED = f"{TYPED_RELATIONS_RELPATH} could not be read"
 
 TYPED_HEALTHY = "- 자본금: amount as capital\n".encode()
-# Raises `CorroborationPolicyError`. See the module docstring: the alias file's
-# malformed input parses to `{}` here and would prove nothing.
+# Raises `CorroborationPolicyError`. See the module docstring: this input was
+# chosen when it was the ONLY class that raised here. Since #589 the alias
+# file's malformed bytes raise too, so what keeps this fixture honest is the
+# MESSAGE its tests assert, not the fact that it raises at all.
 TYPED_DUP_ALIAS = "- 자본금: amount as capital\n- 자산: amount as capital\n".encode()
 TYPED_CP949 = "- 자본금: amount as capital\n".encode("cp949")
-# Parses to `{}` -- used ONLY by the silent-skip test, never as a broken input.
+# Parsed to `{}` until #589; now raises with the unparseable-line message, which
+# is a DIFFERENT string from `TYPED_DUP_ALIAS`'. Kept out of `BROKEN_INPUTS` on
+# purpose: the tests below use it to pin that the two conditions stay
+# distinguishable, which is the job the old silent-skip test used to do.
 TYPED_TYPO = "- 소속 member_of\n".encode()
+TYPED_TYPO_MSG = "typed-relations.md:1: expected"
 ALIAS_HEALTHY = "- 소속 -> member_of\n".encode()
 
 # (typed bytes, message that must be present, message that must be absent).
@@ -378,34 +397,144 @@ def test_an_absent_typed_relations_file_is_not_treated_as_a_failure(
     assert 'class="error"' not in r.text
 
 
-def test_a_typo_in_typed_relations_is_silently_ignored_rather_than_reported():
-    """C-1, at the parser, so the reason this file's malformed input is a
-    duplicate alias is recorded next to the evidence for it.
+def test_the_parser_reports_a_typo_instead_of_dropping_it():
+    """C-1, at the parser. INVERTED BY #589 -- this test asserted the opposite.
 
-    A later edit that "simplifies" `TYPED_DUP_ALIAS` to the alias file's
-    malformed bytes would leave every test above green and pinning nothing.
-    This test fails the moment those two inputs stop being different classes.
+    It used to assert `typed_relations(TYPED_TYPO) == {}`, and its job was to
+    keep `TYPED_DUP_ALIAS` from being "simplified" into a silent input that
+    would leave the whole file vacuous. That hazard no longer exists: nothing
+    non-comment degrades to `{}`.
+
+    The job that remains is to keep the two conditions DISTINGUISHABLE, because
+    "both raise" is now the weaker fact. Each is pinned on its own message, so
+    swapping one fixture for the other still reddens something.
     """
-    assert typed_relations(TYPED_TYPO.decode()) == {}
-    assert typed_relations("- 설립일: colour as founded_on\n") == {}
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(CorroborationPolicyError) as typo:
+        typed_relations(TYPED_TYPO.decode())
+    assert TYPED_TYPO_MSG in str(typo.value)
+
+    with pytest.raises(CorroborationPolicyError) as duplicate:
         typed_relations(TYPED_DUP_ALIAS.decode())
-    assert "used for both" in str(excinfo.value)
+    assert "used for both" in str(duplicate.value)
+
+    assert TYPED_TYPO_MSG not in str(duplicate.value)
+
+
+RAISE_CONDITIONS = {
+    "unparseable line":       ("- 소속 member_of\n",              "expected `- name : type as alias`"),
+    "unknown type tag":       ("- x: colour as y\n",              "unknown type"),
+    "duplicate alias":        ("- 자본금: amount as capital\n- 자산: amount as capital\n", "used for both"),
+    "units on a non-`amount` type": ("- x: date as y (원=1)\n",   "units are only valid for amount"),
+    "malformed unit pair":    ("- x: amount as y (원)\n",         "malformed unit pair"),
+    "non-numeric unit value": ("- x: amount as y (원=abc)\n",     "non-numeric unit value"),
+    "invalid unit mapping":   ("- x: amount as y (=5)\n",         "invalid unit mapping"),
+}
+
+
+def _parser_raise_sites() -> list[tuple[str, int]]:
+    """Every `raise` reachable from `typed_relations`, transitively, from source.
+
+    Transitive rather than a scan of one function, so a raise added in a NEW
+    helper is still counted. Scoped by reachability rather than by grepping the
+    filename: `_refuse_canonical_collisions` raises a message beginning
+    `typed-relations.md` too, but it is called from `store_typed_relations` and
+    is not a parse condition, so a filename grep returns eight and this returns
+    the seven that belong to the parser.
+    """
+    source = inspect.getsource(corroboration)
+    tree = ast.parse(source)
+    functions = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
+    seen: set[str] = set()
+    stack = ["typed_relations"]
+    sites: list[tuple[str, int]] = []
+    while stack:
+        name = stack.pop()
+        if name in seen or name not in functions:
+            continue
+        seen.add(name)
+        for node in ast.walk(functions[name]):
+            if isinstance(node, ast.Raise):
+                sites.append((name, node.lineno))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                stack.append(node.func.id)
+    return sorted(sites, key=lambda site: site[1])
+
+
+def test_the_raise_conditions_are_derived_from_the_source_not_listed_by_hand():
+    """THE TRIPWIRE UNDER THIS FILE'S ENUMERATION, and the reason it exists.
+
+    The count in the module docstring has been wrong twice, and both times it
+    was wrong WHEN WRITTEN rather than having gone stale: #585 said four when
+    five raised, #589 said six when seven did, omitting `invalid unit mapping`
+    both times. Three gates read that paragraph across eight revisions without
+    catching it. So the list is not trusted -- it is checked against the source.
+
+    Adding a raise to the parser without adding a case here reddens the count
+    assertion; adding a case without naming it in the module docstring reddens
+    the last one. That is the closed property underneath an open-looking set:
+    the raise SITES are derivable even though the conditions are not.
+    """
+    sites = _parser_raise_sites()
+    assert len(sites) == len(RAISE_CONDITIONS), (
+        f"{len(sites)} raise sites reachable from `typed_relations` but "
+        f"{len(RAISE_CONDITIONS)} conditions listed here: {sites}"
+    )
+    # Whitespace-normalised: the docstring wraps the list across lines, and the
+    # claim under test is that it NAMES each condition, not how it wraps them.
+    prose = " ".join(__doc__.split())
+    for label, (text, needle) in RAISE_CONDITIONS.items():
+        with pytest.raises(CorroborationPolicyError) as excinfo:
+            typed_relations(text)
+        assert needle in str(excinfo.value), label
+        assert label in prose, f"the module docstring no longer names {label!r}"
+
+
+def test_an_unknown_type_tag_is_reported_not_skipped():
+    """#589's SECOND raise, pinned apart from the first on purpose.
+
+    `- x: colour as y` MATCHES `_TYPED_REL_RE`; only the type tag is wrong. So
+    it is refused by a different branch than an unparseable line, and reverting
+    either branch alone leaves the other one raising. Asserted in its own test
+    because the matrix showed that folding it in with the unparseable case left
+    this branch pinned by nothing: every test that covered it covered the other
+    branch too, so deleting this raise reddened only tests that would have gone
+    red anyway.
+
+    Matching the shape is also why refusing it is safe: a line this close to a
+    declaration cannot be mistaken for prose the user never meant as one.
+    """
+    with pytest.raises(CorroborationPolicyError) as excinfo:
+        typed_relations("- 설립일: colour as founded_on\n")
+    message = str(excinfo.value)
+    assert "unknown type 'colour'" in message
+    assert TYPED_TYPO_MSG not in message
+
+
+def test_comments_and_blanks_and_markdown_headings_still_parse():
+    """The tolerance half of #589's rule, which is what makes it the SIBLING's
+    rule rather than a stricter one invented here. A parser that raised on
+    these would break every policy file with a heading in it."""
+    assert typed_relations("## Types\n\n# a note\n") == {}
+    assert typed_relations("- 자본금: amount as capital  # trailing note\n") != {}
 
 
 @pytest.mark.parametrize("method, path, kwargs", BODY_ENDPOINTS)
-def test_a_typod_declaration_renders_no_banner_because_nothing_failed(
+def test_a_typod_declaration_now_renders_the_banner_it_used_to_suppress(
     tmp_path, method, path, kwargs
 ):
-    """The page half of the test above. A dropped declaration is a real
-    state-honesty defect -- trust is computed under rules the user believes they
-    configured -- but it is not this issue's, and reporting it through THIS
-    guard would mean claiming a file that was read and parsed could not be. It
-    is one of the two silent-drop paths #589 tracks."""
+    """The page half, INVERTED BY #589 -- it asserted no banner on every page.
+
+    The old rationale was that reporting a dropped declaration through THIS
+    guard would mean claiming a file that was read and parsed could not be read.
+    #589 removed the premise rather than the objection: the file no longer
+    parses, so the banner is not a false claim about it -- it names a line the
+    parser refused. The page still answers 200, which is the part of #585's
+    guarantee that must survive a change like this.
+    """
     r = _request(_client(tmp_path, TYPED_TYPO), method, path, kwargs)
     assert r.status_code == 200
-    assert TYPED_RELATIONS_RELPATH not in r.text
-    assert 'class="error"' not in r.text
+    assert TYPED_TYPO_MSG in r.text
+    assert TYPED_NAMED not in r.text
 
 
 # ---------------------------------------------------------------------------
@@ -667,8 +796,15 @@ def test_the_sources_post_redirects_land_on_a_page_that_survives(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "alias_bytes, alias_marker",
+    [
+        pytest.param("- 소속 member_of\n".encode(), "relation-aliases.md:1:", id="alias-malformed"),
+        pytest.param("- 소속 -> member_of\n".encode("cp949"), RELATION_ALIASES_RELPATH, id="alias-cp949"),
+    ],
+)
 def test_both_policy_files_broken_names_one_and_claims_nothing_about_the_other(
-    tmp_path,
+    tmp_path, alias_bytes, alias_marker
 ):
     """`_trust_policy_failure` checks the alias file first and returns on the
     first failure, so with both files broken the page names
@@ -679,13 +815,134 @@ def test_both_policy_files_broken_names_one_and_claims_nothing_about_the_other(
     exist -- the banners said the values "would have been computed under
     different ALIAS RULES than this KB's file specifies", which on a KB with two
     broken files named the wrong cause.
+
+    THE CP949 ARM COVERS THE ORDERING, NOT THE TOLERANCE CLAUSE -- and saying so
+    matters, because it was added believing it did the latter. Both arms pass
+    whether `store_typed_relations`' alias-read tolerance catches one exception
+    class or all of them, MEASURED by narrowing it back and re-running: 99
+    passed either way. The reason is this route: `_trust_policy_failure` reads
+    the alias file FIRST and returns, so the page never reaches
+    `store_typed_relations` at all. Every page-level probe inherits that
+    pre-check, so no test driven through a route can pin what happens when the
+    typed guard runs without it. `test_the_typed_guard_never_names_its_own_file_for_an_alias_failure`
+    below is the pin that can, and it is deliberately NOT a route test.
     """
-    body = _build(
-        tmp_path, TYPED_DUP_ALIAS, alias_bytes="- 소속 member_of\n".encode()
-    )[0].get("/sources").text
-    assert "relation-aliases.md:1:" in body
+    body = _build(tmp_path, TYPED_DUP_ALIAS, alias_bytes=alias_bytes)[0].get("/sources").text
+    assert alias_marker in body
     assert TYPED_RELATIONS_RELPATH not in body
     assert "alias rules" not in body
+
+
+def _own_calls(node: ast.AST, name: str) -> list[int]:
+    """Calls to ``name`` in this function's OWN body, excluding nested ``def``s.
+
+    Excluding the nested spans is the whole point. `ast.walk` descends into
+    inner functions, so a scan that does not exclude them credits an OUTER
+    function with its inner one's calls -- which is exactly how the comment
+    this test replaces came to say eight callers when there are seven. The
+    eighth was `create_app`, which does not call it; `_source_trust_rollup`,
+    nested inside it, does.
+
+    A `lambda` is deliberately NOT excluded, and the distinction is load-bearing
+    here rather than pedantic: `query_schema_policy_failure` passes
+    `lambda: store_typed_relations(store)` to the guard, and that lambda runs in
+    its enclosing function's scope, on that function's alias read. Crediting it
+    to the enclosing `def` is what makes the property mean what it says. A
+    nested `def` is a separate callable that could be invoked from anywhere, so
+    it is counted on its own.
+    """
+    nested = [
+        (inner.lineno, inner.end_lineno)
+        for inner in ast.walk(node)
+        if isinstance(inner, (ast.FunctionDef, ast.AsyncFunctionDef)) and inner is not node
+    ]
+    return [
+        sub.lineno
+        for sub in ast.walk(node)
+        if isinstance(sub, ast.Call)
+        and getattr(sub.func, "id", None) == name
+        and not any(start <= sub.lineno <= end for start, end in nested)
+    ]
+
+
+def test_every_typed_reader_reads_the_alias_file_itself():
+    """#589. The property that licenses `store_typed_relations`' broad `except`.
+
+    That function reads the alias file to refuse canonical collisions, and
+    swallows ANY failure of that read rather than reporting the alias file's
+    problem under the typed file's name. Swallowing is safe only because every
+    caller reads the alias file itself and will report the failure against the
+    right file -- so this checks that, rather than trusting a sentence.
+
+    Derived, not listed: the caller set comes from the source, so a NEW caller
+    that skipped the alias read reddens here instead of quietly making the
+    comment in `corroboration.py` false.
+    """
+    package = pathlib.Path(corroboration.__file__).parent.parent
+    callers: list[tuple[str, bool]] = []
+    for path in sorted(package.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "store_typed_relations(" not in source:
+            continue
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name == "store_typed_relations":
+                continue
+            if not _own_calls(node, "store_typed_relations"):
+                continue
+            callers.append(
+                (f"{path.relative_to(package)}::{node.name}",
+                 bool(_own_calls(node, "store_relation_aliases")))
+            )
+
+    assert callers, "no callers found -- the derivation itself is broken"
+    offenders = [name for name, reads_alias in callers if not reads_alias]
+    assert not offenders, (
+        "these read the typed file without reading the alias file, so a "
+        f"swallowed alias failure would go unreported: {offenders}"
+    )
+
+
+def test_the_typed_guard_never_names_its_own_file_for_an_alias_failure(tmp_path):
+    """#589. The typed guard applied WITHOUT an alias pre-check ahead of it.
+
+    `store_typed_relations` reads the alias file since #589, to refuse two
+    declarations that canonicalise to one relation. So it can now fail for a
+    reason that belongs to the OTHER file, and a guard wrapping it would name
+    `typed-relations.md` for an alias problem -- with a byte offset from a file
+    it is not talking about.
+
+    ITS TOLERANCE CLAUSE MUST CATCH EVERY CLASS, not just the policy one. A
+    malformed alias file raises `CorroborationPolicyError`; a cp949 one raises
+    `UnicodeDecodeError`, a SIBLING of `ValueError` and not a policy error at
+    all. The narrow form let the second through, and this test reddens on the
+    cp949 row under it -- measured, which is the whole reason it exists rather
+    than a parametrized arm on a route test: every route reads the alias file
+    first, so no page can reach this.
+
+    The healthy row is the anti-vacuity control: it proves the guard returns
+    `None` because nothing failed, not because the assertion cannot fire.
+    """
+    for label, alias_bytes in (
+        ("malformed", "- 소속 member_of\n".encode()),
+        ("cp949", "- 소속 -> member_of\n".encode("cp949")),
+        ("healthy", "- 소속 -> member_of\n".encode()),
+    ):
+        root = tmp_path / label
+        policy = root / "policy"
+        policy.mkdir(parents=True)
+        (policy / "relation-aliases.md").write_bytes(alias_bytes)
+        (policy / TYPED_RELATIONS_RELPATH.split("/")[-1]).write_text(
+            "- 자본금 : amount as capital\n", encoding="utf-8"
+        )
+        store = Store(root / "kb.sqlite")
+        store.init_schema()
+        failure = corroboration.policy_file_failure(
+            lambda: corroboration.store_typed_relations(store),
+            TYPED_RELATIONS_RELPATH,
+        )
+        assert failure is None, f"{label}: typed guard reported {failure!r}"
 
 
 def test_repairing_the_alias_file_reveals_the_typed_failure_without_a_500(tmp_path):

--- a/verinote/pipeline/acceptance.py
+++ b/verinote/pipeline/acceptance.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable
-import unicodedata
 
 from verinote.pipeline.corroboration import (
     canonical_relation,
@@ -13,6 +12,7 @@ from verinote.pipeline.corroboration import (
     store_functional_relations,
     store_relation_aliases,
     store_typed_relations,
+    typed_spec_for_canonical,
     TypedRelationSpec,
 )
 from verinote.pipeline.policy_state import assert_writable
@@ -372,7 +372,7 @@ def _view_fact(
 ) -> _FactView:
     relation = str(row["relation"])
     canonical = canonical_relation(relation, aliases)
-    spec = _typed_spec(canonical, typed)
+    spec = _typed_spec(canonical, typed, aliases)
     object_key, typed_normalization = _object_key(str(row["object"]), spec)
     return _FactView(
         id=int(row["id"]),
@@ -390,9 +390,9 @@ def _view_fact(
 
 
 def _typed_spec(
-    relation: str, typed: dict[str, TypedRelationSpec]
+    relation: str, typed: dict[str, TypedRelationSpec], aliases: dict[str, str]
 ) -> TypedRelationSpec | None:
-    return typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+    return typed_spec_for_canonical(typed, relation, aliases)
 
 
 def _object_key(

--- a/verinote/pipeline/corroboration.py
+++ b/verinote/pipeline/corroboration.py
@@ -245,24 +245,48 @@ def merge_default_relation_aliases(user_aliases: dict[str, str]) -> dict[str, st
 
 
 def typed_relations(text: str) -> dict[str, TypedRelationSpec]:
-    """Parse factlog-style ``policy/typed-relations.md`` declarations."""
+    """Parse factlog-style ``policy/typed-relations.md`` declarations.
+
+    A line that is neither blank nor a ``#`` comment MUST parse (#589). This is
+    `relation_aliases`'s rule, adopted rather than invented -- the two files are
+    siblings and a user has no way to know why one would forgive a typo the
+    other refuses. Markdown headings survive because they begin with ``#``.
+
+    Before this, anything the shape did not match was skipped and the function
+    returned whatever else it found. One mistyped line silently voided one
+    declaration with no error, no warning, and -- because `{}` is also the
+    normal state of a KB with no typed file -- nothing distinguishable in any
+    rendered value. That is why the report has to happen HERE, at the parse, and
+    cannot be inferred downstream.
+
+    Raising is safe now and was not before #585: `store_typed_relations`'s
+    callers degrade on a `CorroborationPolicyError` instead of returning 500.
+    """
     specs: dict[str, TypedRelationSpec] = {}
     aliases: dict[str, str] = {}
-    for line in text.splitlines():
+    for line_no, line in enumerate(text.splitlines(), start=1):
         stripped = re.sub(r"^\s*[-*]\s+", "", line.strip()).strip()
         if not stripped or stripped.startswith("#"):
             continue
         stripped = re.sub(r"\s*#.*$", "", stripped).strip()
         match = _TYPED_REL_RE.match(stripped)
         if match is None:
-            continue
+            raise CorroborationPolicyError(
+                f"typed-relations.md:{line_no}: expected "
+                f"`- name : type as alias`, got {stripped!r}"
+            )
         name = unicodedata.normalize(
             "NFC", (match.group("qname") or match.group("name")).strip()
         )
         type_tag = match.group("type").strip()
         alias = match.group("alias").strip()
         if type_tag not in _TYPED_TYPES:
-            continue
+            # Matched the declaration shape, so it is unambiguously an intended
+            # declaration -- reporting it cannot be mistaken for prose.
+            raise CorroborationPolicyError(
+                f"typed-relations.md:{line_no}: unknown type {type_tag!r} for "
+                f"{name!r}; known types are {', '.join(sorted(_TYPED_TYPES))}"
+            )
         if alias in aliases and aliases[alias] != name:
             raise CorroborationPolicyError(
                 f"typed-relations.md: alias {alias!r} used for both "
@@ -284,7 +308,117 @@ def store_typed_relations(store: Store) -> dict[str, TypedRelationSpec]:
     path = store.db_path.parent / TYPED_RELATIONS_RELPATH
     if not path.is_file():
         return {}
-    return typed_relations(path.read_text(encoding="utf-8"))
+    specs = typed_relations(path.read_text(encoding="utf-8"))
+    try:
+        aliases = store_relation_aliases(store)
+    except Exception:  # noqa: BLE001 - ANY alias-read failure, not one class
+        # The alias file has its own guard and its own message. A typed-file
+        # reader that reported the ALIAS file's failure would name the wrong
+        # file, so the collision check is skipped and the alias guard speaks.
+        #
+        # `except Exception` and not `except CorroborationPolicyError`, matching
+        # `policy_file_failure`'s G2 clause above: a cp949 alias file raises
+        # `UnicodeDecodeError`, a SIBLING of `ValueError` and not a subclass of
+        # the policy error, so the narrow form let it through and the typed
+        # guard wrapped it as "policy/typed-relations.md could not be read" --
+        # naming the wrong file, with a byte offset from the alias file.
+        # Nothing is lost by catching broadly, and the reason is a PROPERTY
+        # rather than a count: EVERY caller of this function reads the alias
+        # file itself, so a swallowed alias failure is reported by that caller
+        # against the right file, and the worst case is the behaviour this
+        # function had before #589.
+        #
+        # `test_every_typed_reader_reads_the_alias_file_itself` derives the
+        # caller set from the source and checks that property, so a new caller
+        # that skipped the alias read would redden rather than silently make
+        # this comment false. An earlier draft said "all eight, checked" -- it
+        # is seven; the eighth was `create_app`, counted because
+        # `_source_trust_rollup` is nested inside it. That number licensed
+        # nothing the property does not, and it was wrong.
+        return specs
+    _refuse_canonical_collisions(specs, aliases)
+    return specs
+
+
+def _refuse_canonical_collisions(
+    typed: dict[str, TypedRelationSpec], aliases: dict[str, str]
+) -> None:
+    """Refuse two declarations that canonicalise to one relation (#589).
+
+    WHY HERE AND NOT IN THE RESOLVER. Before this change the two were separate
+    keys and both were ignored, so there was nothing to disambiguate; resolving
+    them makes dict order decide which declaration takes effect, which is the
+    defect class #589 exists to remove. But refusing it inside the resolver made
+    the error a NEW raiser, below every guard the trust path has: measured, six
+    of eight routes answered 500, while this file's existing duplicate-alias
+    refusal -- raised from `typed_relations`, one frame up from here -- leaves
+    all eight at 200. Raising from the file read inherits those guards instead
+    of needing new ones.
+
+    The WHOLE table is checked rather than the queried relation, so the verdict
+    depends on the file alone and not on which facts a page happens to touch.
+    """
+    seen: dict[str, str] = {}
+    for declared in typed:
+        key = unicodedata.normalize("NFC", canonical_relation(declared, aliases))
+        if key in seen:
+            raise CorroborationPolicyError(
+                f"typed-relations.md: {seen[key]!r} and {declared!r} "
+                f"both declare a type for the relation {key!r}"
+            )
+        seen[key] = declared
+
+
+def typed_spec_for_canonical(
+    typed: dict[str, TypedRelationSpec],
+    canonical: str,
+    aliases: dict[str, str],
+) -> TypedRelationSpec | None:
+    """Resolve a typed declaration for ``canonical``, through the alias table.
+
+    THE ONLY COPY OF THIS LOOKUP -- scoped deliberately, because it is not the
+    only place in the package that knows this rule. Every consumer that had
+    `typed.get(relation)` open-coded now calls this, because `typed_relations`
+    keys the dict by the label the user WROTE while every consumer looks up the
+    CANONICAL label -- so a declaration on any label the alias table rewrites
+    was stored under a key nobody queries and silently did nothing (#589).
+
+    Two other resolvers exist and BOTH are deliberate, so a reader who finds
+    them does not have to guess whether they were missed.
+    `query_planner._typed_specs_for_canonical_relation` already resolved this
+    way and is the prior art this follows. `query_schema._typed_for_relation`
+    is NOT converted: it tries `display`, NFC(display), `canonical` and
+    NFC(canonical), which resolves a declaration written under the label the
+    fact itself uses but not one under a DIFFERENT raw label sharing the same
+    canonical. That residual gap is measured and tracked as #597, left out of
+    #589 on purpose because that snapshot feeds the LLM planner's prompts.
+
+    The keys stay as written on purpose, and for ONE reason rather than the two
+    an earlier draft of this docstring gave. It said canonicalising them inside
+    `store_typed_relations` would also need the alias table in a signature the
+    CLI and the schema snapshot share; that stopped being true when the
+    collision check moved there -- it reads the alias table now, and needed no
+    signature change, because that function already takes the `Store`. The
+    reason that survives is the other one: canonical keys would leave the stored
+    dict disagreeing with the user's file, so a diagnostic could no longer quote
+    their own line back to them.
+
+    THIS FUNCTION DOES NOT RAISE, and that is load-bearing rather than
+    incidental. Ambiguity -- two labels canonicalising to one relation -- is
+    refused, but by `_refuse_canonical_collisions` at the point the FILE is
+    read. Refusing it here instead raised a `CorroborationPolicyError` from a
+    NEW raiser, one that every existing guard sits above rather than below:
+    measured, six of eight routes answered 500 where the file's own
+    duplicate-alias refusal leaves all eight at 200. Raising from
+    `store_typed_relations` inherits the guards that already exist for that
+    refusal; raising from here would have needed a sixth guard rollout to
+    reach the same place.
+    """
+    want = unicodedata.normalize("NFC", canonical)
+    for declared, spec in typed.items():
+        if unicodedata.normalize("NFC", canonical_relation(declared, aliases)) == want:
+            return spec
+    return None
 
 
 def corroboration(
@@ -334,7 +468,9 @@ def single_valued_conflicts(
         relation = _canonical_relation(str(row["relation"]), aliases)
         if relation not in canonical_single_valued:
             continue
-        spec = typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+        # #589. This site produces the conflict count -- and the /sources
+        # `conflicted` badge through `store_single_valued_conflicts`.
+        spec = typed_spec_for_canonical(typed, relation, aliases)
         source = _source_ref(row)
         if not source:
             continue

--- a/verinote/pipeline/trust.py
+++ b/verinote/pipeline/trust.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import unicodedata
 from typing import Any
 
 from verinote.engine.terms import render_term
@@ -15,6 +14,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
     store_single_valued_conflicts,
     store_typed_relations,
+    typed_spec_for_canonical,
     TypedRelationSpec,
 )
 from verinote.store import Store, engine_statuses, is_engine_input, is_review_eligible
@@ -163,7 +163,7 @@ def fact_trust_summary(store: Store, fact_id: int) -> FactTrustSummary | None:
     relation = canonical_relation(display.relation, aliases)
     support = _support_summary(store, display, aliases, typed)
     conflict = _conflict_summary(store, display.subject, relation)
-    typed_value = _typed_value_summary(typed, relation, display.object)
+    typed_value = _typed_value_summary(typed, relation, display.object, aliases)
     evidence = tuple(_evidence_anchor(row) for row in store.fact_evidence(fact_id))
     status = str(fact["status"])
 
@@ -213,7 +213,7 @@ def _support_summary(
     typed: dict[str, TypedRelationSpec],
 ) -> SupportSummary:
     relation = canonical_relation(display.relation, aliases)
-    object_key = _object_key(relation, display.object, typed)
+    object_key = _object_key(relation, display.object, typed, aliases)
     sources: set[str] = set()
     for row in store.facts(statuses=engine_statuses()):
         if str(row["subject"]) != display.subject:
@@ -221,7 +221,7 @@ def _support_summary(
         row_relation = canonical_relation(str(row["relation"]), aliases)
         if row_relation != relation:
             continue
-        if _object_key(row_relation, str(row["object"]), typed) != object_key:
+        if _object_key(row_relation, str(row["object"]), typed, aliases) != object_key:
             continue
         source_path = str(row["source_path"] or "").strip()
         if source_path:
@@ -251,9 +251,9 @@ def _conflict_value(value: CompetingValue) -> ConflictValueSummary:
 
 
 def _typed_value_summary(
-    typed: dict[str, Any], relation: str, obj: str
+    typed: dict[str, Any], relation: str, obj: str, aliases: dict[str, str]
 ) -> TypedValueSummary | None:
-    spec = _typed_spec(typed, relation)
+    spec = _typed_spec(typed, relation, aliases)
     if spec is None:
         return None
     return TypedValueSummary(
@@ -265,9 +265,12 @@ def _typed_value_summary(
 
 
 def _object_key(
-    relation: str, obj: str, typed: dict[str, TypedRelationSpec]
+    relation: str,
+    obj: str,
+    typed: dict[str, TypedRelationSpec],
+    aliases: dict[str, str],
 ) -> tuple[str, object]:
-    spec = _typed_spec(typed, relation)
+    spec = _typed_spec(typed, relation, aliases)
     if spec is not None:
         scalar = normalize_typed_value(spec.type, obj, spec.units)
         if scalar is not None:
@@ -276,9 +279,13 @@ def _object_key(
 
 
 def _typed_spec(
-    typed: dict[str, TypedRelationSpec], relation: str
+    typed: dict[str, TypedRelationSpec],
+    relation: str,
+    aliases: dict[str, str],
 ) -> TypedRelationSpec | None:
-    return typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+    # #589. `relation` is already canonical at both call sites; the declaration
+    # it must match may be written under any label that canonicalises to it.
+    return typed_spec_for_canonical(typed, relation, aliases)
 
 
 def _canonical_terms(store: Store, fact_id: int) -> FactTriple | None:

--- a/verinote/pipeline/workbench.py
+++ b/verinote/pipeline/workbench.py
@@ -12,6 +12,7 @@ from verinote.pipeline.corroboration import (
     store_functional_relations,
     store_relation_aliases,
     store_typed_relations,
+    typed_spec_for_canonical,
     TypedRelationSpec,
 )
 from verinote.store import Store, is_engine_input, is_review_eligible
@@ -92,7 +93,7 @@ def trust_workbench(store: Store) -> TrustWorkbench:
         relation = str(row["relation"])
         obj = str(row["object"])
         canonical = canonical_relation(relation, aliases)
-        spec = _typed_spec(canonical, typed)
+        spec = _typed_spec(canonical, typed, aliases)
         object_key, normalization = _normalized_object_key(obj, spec)
         fact = WorkbenchFact(
             id=int(row["id"]),
@@ -177,9 +178,11 @@ def trust_workbench(store: Store) -> TrustWorkbench:
 
 
 def _typed_spec(
-    relation: str, typed: dict[str, TypedRelationSpec]
+    relation: str, typed: dict[str, TypedRelationSpec], aliases: dict[str, str]
 ) -> TypedRelationSpec | None:
-    return typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+    # #589. This site forms `corroborated`; it was one of the two the fix's own
+    # severity measurement turns on, and neither was in the plan's site list.
+    return typed_spec_for_canonical(typed, relation, aliases)
 
 
 def _normalized_object_key(

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -17,7 +17,6 @@ import sqlite3
 import tempfile
 import threading
 from threading import Lock
-import unicodedata
 from urllib.parse import urlencode, urlsplit
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, Response, UploadFile
@@ -108,6 +107,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
     store_single_valued_conflicts,
     store_typed_relations,
+    typed_spec_for_canonical,
 )
 from verinote.pipeline.workbench import trust_workbench
 from verinote.prompts import (
@@ -1937,7 +1937,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 (
                     str(fact["subject"]),
                     relation,
-                    _source_object_key(relation, str(fact["object"]), typed),
+                    _source_object_key(relation, str(fact["object"]), typed, aliases),
                 ),
                 set(),
             ).add(source_path)
@@ -1961,7 +1961,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                     (
                         str(fact["subject"]),
                         relation,
-                        _source_object_key(relation, str(fact["object"]), typed),
+                        _source_object_key(relation, str(fact["object"]), typed, aliases),
                     ),
                     set(),
                 )
@@ -1974,8 +1974,8 @@ def create_app(cfg: Config | None = None) -> FastAPI:
                 bucket["conflicted"] += 1
         return counts
 
-    def _source_object_key(relation: str, obj: str, typed) -> tuple[str, object]:
-        spec = typed.get(relation) or typed.get(unicodedata.normalize("NFC", relation))
+    def _source_object_key(relation: str, obj: str, typed, aliases) -> tuple[str, object]:
+        spec = typed_spec_for_canonical(typed, relation, aliases)
         if spec is not None:
             scalar = normalize_typed_value(spec.type, obj, spec.units)
             if scalar is not None:


### PR DESCRIPTION
Closes #589 — the root cause #585 first misdiagnosed.

All three gates independently recomputed and approved tree `b8ecbf5235f3f95d5f232efffb0ef2a5325fc061`.

## The defect
`typed_relations()` keys declarations on the **raw** name; consumers looked them up by the **canonical** one. A declaration on any label the alias table rewrites was stored under a key it was never read back by — type-independent, so #585's `date` framing was a misdiagnosis.

Canonical resolution is what the codebase already intends: `query_planner._typed_specs_for_canonical_relation` has always resolved alias-awarely. `_typed_spec` handled key *normalisation* and not key *canonicalisation* — an incomplete version of the same rule.

**Five sites** now share one resolver. A sixth, `query_schema._typed_for_relation`, resolves partially and is deliberately left — different consumer (the LLM planner's snapshot), different blast radius. Filed as **#597** and named in the code.

## What it cost, stated carefully
Two sources asserting one value in two notations, on an aliased relation, were reported as **conflicting**. But the aliased case is byte-identical to having **no typed file at all** — so the declaration doesn't manufacture the conflict. The conflict is the default, and defensible. The declaration is the documented remedy, and it silently did nothing.

## Regression, disclosed
Any two labels in one alias group now collide — six of seven packaged groups qualify, `established_on` has eight members. **The regression population is the defect's own population.** Such a KB degrades with a banner naming both labels and the canonical relation; it does not 500.

An earlier revision raised the collision from the resolver, below every guard, and 500'd six of eight routes. The **existing** raiser was fully guarded — that control arm located the fix: raise from `store_typed_relations`, one frame from the refusal it mirrors, reaching guards that already exist. Zero call sites touched.

## Falsifiability
Seven guards, each with a test no other guard's removal reddens. BASE 588/0; reverting the five resolver sites **7**, the two parser raises **15**, both **22** — and `7 + 15 = 22` is the check, since the units touch disjoint tests.

**This table was published wrong once** (84/88/18/140/155). Those were crash counts: the revert reintroduced a body using an `import unicodedata` this change removes, raising `NameError` only on a **miss**, because `a or b` never evaluates `b` on a hit. It reddened healthy-path tests and counted the crash. The three inflated rows were exactly the three modules that had lost the import.

It can be trusted now because **two harnesses built by two parties agree, and one of those parties did not build the artifact.** Re-measurement by the author is not support — that harness reproduced the same wrong table four revisions running.

## Tests
`tests/test_typed_relations_resolution.py` new; suite 3488 → **3510**. The parser's raise-condition set is **derived by AST** — reachability from `typed_relations` returns seven where a filename grep returns eight — with a tripwire that reddens if a raise is added or removed without a case. The hand-written count it replaces said four, then six. Both wrong; the four was wrong the day it was written.