### PR TITLE
fix(web): /report degrades instead of 500ing when a traceable answer meets a broken typed file (#595)

### DIFF
--- a/tests/test_report_policy_guard.py
+++ b/tests/test_report_policy_guard.py
@@ -51,15 +51,17 @@ mapping to one canonical name and a draft rule with four `relation/3` atoms is
 configuration into a 500. `test_the_alias_expansion_cap_still_answers` pins it,
 and it is not a new guard: it is an existing one this change must not break.
 
-A DEFECT THIS CHANGE FOUND AND DOES NOT FIX, recorded so its absence is not
-read as an oversight. `report_trace` reaches `fact_trust_summary`, which reads
-BOTH policy files, so on a KB whose report has a traceable answer a broken
-`policy/typed-relations.md` makes `GET /report` answer 500. Measured, and
-measured identically on this change's base commit, so it predates this work.
-It is invisible to any sweep whose fixture has no traceable answer -- which is
-how #585 missed it and how this change's own plan concluded these two routes
-never read the typed file. `/questions` is unaffected: it does not call
-`report_trace`. Tracked as #595; this issue is the alias file.
+A DEFECT THIS CHANGE FOUND AND DID NOT FIX, SINCE FIXED BY #595. `report_trace`
+reaches `fact_trust_summary`, which reads BOTH policy files, so on a KB whose
+report had a traceable answer a broken `policy/typed-relations.md` MADE
+`GET /report` answer 500 -- measured here and identically on this change's base
+commit, so it predated this work and was left to #595, which guards it in the
+route. It answers 200 now.
+
+The reason it went unseen is the part worth keeping: it was invisible to any
+sweep whose fixture had no traceable answer, which is how #585 missed it and how
+this change's own plan concluded these two routes never read the typed file.
+`/questions` was unaffected throughout: it does not call `report_trace`.
 
 WHAT DEGRADES, AND WHAT DOES NOT. `/questions` is `/review`'s shape: the queue
 and the repair job come from the store, read no policy file, and stay; only
@@ -79,6 +81,7 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from verinote.config import Config
+from verinote.pipeline.report_trace import report_trace
 from verinote.policy_defaults import RELATION_ALIASES_RELPATH, TYPED_RELATIONS_RELPATH
 from verinote.pipeline.query import MAX_ALIAS_EXPANDED_RULES_PER_RULE
 from verinote.pipeline.verify import verify
@@ -333,42 +336,40 @@ def test_a_broken_typed_file_does_not_trigger_this_guard_on_questions(tmp_path):
 
 
 def test_a_broken_typed_file_does_not_trigger_this_guard_on_report(tmp_path):
-    """Same scope claim for `/report`, on a KB with no traceable answer.
+    """Same scope claim for `/report`, RE-WIDENED BY #595 to the fixture that can
+    express it.
 
-    THE FIXTURE IS DELIBERATELY THE WEAKER ONE, and the reason is a defect this
-    change does not fix. `report_trace` reaches `fact_trust_summary`, which
-    reads BOTH policy files, so on a KB whose report HAS a traceable answer a
-    broken `typed-relations.md` makes `/report` answer 500 -- measured, and
-    measured identically on this change's base commit, so it predates this work
-    and is out of its scope (this issue is the alias file). Asserting 200 on the
-    answer-bearing fixture here would fail for a reason that has nothing to do
-    with this guard; asserting the 500 would lock a defect in as desired
-    behaviour. So the scope claim is pinned on the configuration where the typed
-    file genuinely is not read, and the `/questions` test above -- which is
-    unaffected by that defect -- is what actually catches the two-file
-    simplification.
+    THIS TEST USED THE WEAKER FIXTURE ON PURPOSE, and the narrowing is now
+    resolved rather than merely explained. `report_trace` reaches
+    `fact_trust_summary`, which reads BOTH policy files -- but only when there is
+    an answer to trace. So on a KB with a traceable answer a broken
+    `typed-relations.md` made `/report` answer 500, measured identically on
+    `c0dd1cc` before #590, which is why it was out of #590's scope: asserting 200
+    would have failed for an unrelated reason, and asserting 500 would have
+    locked a defect in as desired behaviour. The fixture here therefore had no
+    `query_dl`, and this docstring recorded that it could not pin
+    `report_trace`'s own alias-only choice.
 
-    SO THIS TEST DOES NOT PIN `report_trace`'s OWN alias-only choice, and nothing
-    else does either. Measured, not inferred: swapping that pre-flight to
-    `query_schema_policy_failure` and running all of `tests/` leaves it green,
-    with the same counts as the unmutated tree. The configuration that would
-    expose the difference is the answer-bearing one #595 owns, so there is no
-    input in this file that can separate the two. Stated rather than implied --
-    the `/questions` test above covers `/questions`'s choice, not this module's.
-
-    WHAT THE UNPINNED SWAP WOULD COST, on that same answer-bearing KB, measured:
-    status 500 -> 200, the answer still rendered, and the trace section printing
-    "No direct relation fact traces are available for these report rows" -- with
-    no banner, no "Not computed", and no mention of the file that failed. Green
-    suite, healthier-looking page, and a searched-and-found-nothing verdict on a
-    search that never ran. That is why `report_trace.py` keeps the alias-only
-    reader and says so in a comment; the comment is the only thing holding it.
+    #595 fixed the 500 in the route, so the full scope claim is assertable now
+    and is asserted: an answer-bearing KB, a broken typed file, 200, and this
+    guard's own message absent because the ALIAS file is healthy. The typed
+    file's own diagnosis is `test_report_names_the_typed_file_and_not_the_alias_file`
+    in `test_report_trace_typed_guard.py`; what belongs here is only that THIS
+    guard stays quiet about a file it never read.
     """
-    client, _, _ = _build(tmp_path, alias=ALIAS_HEALTHY, typed=TYPED_DUP_ALIAS,
-                          query_dl="")
+    # The widening is only meaningful on a KB that HAS an answer to trace: with
+    # no answer `report_trace` never reaches `fact_trust_summary`, the typed file
+    # is never read, and the 200 below would prove nothing -- which is precisely
+    # the state this test was left in. Pinned on the HEALTHY pair, because on the
+    # broken one `report_trace` raises: that raise IS the defect #595 fixed, and
+    # calling it directly there would measure the defect instead of the fixture.
+    _, healthy_app, _ = _build(tmp_path / "healthy", alias=ALIAS_HEALTHY)
+    assert len(report_trace(healthy_app.state.store).answers) >= 1
+
+    client, _, _ = _build(tmp_path / "broken", alias=ALIAS_HEALTHY,
+                          typed=TYPED_DUP_ALIAS)
     r = client.get("/report")
     assert r.status_code == 200
-    assert NOT_COMPUTED not in r.text
     assert ALIAS_MSG not in r.text
 
 

--- a/tests/test_report_trace_typed_guard.py
+++ b/tests/test_report_trace_typed_guard.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: MPL-2.0
+"""#595. `GET /report` degrades instead of 500ing when `typed-relations.md` is
+broken AND the KB has a traceable answer.
+
+THE FIXTURE IS THE ISSUE. `report_trace` only reaches `fact_trust_summary` --
+the function that reads BOTH policy files -- when there is an answer to trace.
+A KB with no traceable answer therefore cannot express this defect at all: it
+answered 200 before the fix and 200 after, proving nothing. That is why #585 and
+#590 both missed it, and why #590's T9 was deliberately narrowed to the weaker
+fixture rather than asserting a number it could not justify.
+
+So `test_the_fixture_has_a_traceable_answer` runs first and asserts the answer
+exists. Every other test here is vacuous without it, and three attempts at this
+fixture produced a 200 that proved nothing before the cause was found: the query
+needs its own `.decl` line, or the engine reports `unknown predicate` and there
+is no answer to trace.
+
+WHY THE GUARD IS IN THE ROUTE AND NOT IN `report_trace`. Widening
+`report_trace`'s alias-only pre-flight to check both files also removes the 500,
+and it is measurably worse: the page answers 200, prints "No direct relation
+fact traces are available for these report rows", and names no file -- a
+searched-and-found-nothing verdict on a search that never ran. Measured, it also
+costs the entire traceability table, not merely a banner. The route can say why;
+an empty `ReportTrace` cannot carry a reason.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from verinote.config import Config
+from verinote.pipeline.report_trace import report_trace
+from verinote.policy_defaults import RELATION_ALIASES_RELPATH, TYPED_RELATIONS_RELPATH
+from verinote.web.app import create_app
+
+ALIAS_HEALTHY = "- 소속 -> member_of\n".encode()
+ALIAS_CP949 = "- 소속 -> member_of\n".encode("cp949")
+TYPED_HEALTHY = "- 자본금: amount as capital\n".encode()
+# A duplicate alias -- one of the conditions `typed_relations` raises on; its own
+# docstring enumerates them, and #589's derivation test keeps that list honest.
+TYPED_BROKEN = "- 자본금: amount as capital\n- 자산: amount as capital\n".encode()
+
+# The `.decl` line is load-bearing. Without it the engine reports `unknown
+# predicate`, `answers` is empty, and every test below passes for the wrong
+# reason -- which is exactly how this fixture failed three times before working.
+QUERY_DL = (
+    ".decl answer_q1(value: symbol)\n"
+    'answer_q1(O) :- relation("A", "member_of", O).\n'
+)
+
+# The BARE parser message, not the `policy/`-prefixed relpath. #590's G1 clause
+# returns `str(exc)` for a `CorroborationPolicyError`, and the parser names its
+# own file without the directory; the `policy/... could not be read` wrapper is
+# G2, for failures that are not policy errors (a cp949 file, say). Asserting the
+# relpath here fails against a page that is behaving correctly.
+TYPED_NAMED = "typed-relations.md"
+ALIAS_NAMED = "relation-aliases.md"
+TRACE_WITHHELD = "The traceability below is withheld"
+PAGE_WITHHELD = "The report and its traceability are withheld"
+NOT_COMPUTED = "Not computed"
+SEARCHED_AND_FOUND_NOTHING = "No direct relation fact traces"
+
+
+def _build(tmp_path: Path, *, typed: bytes = TYPED_HEALTHY, alias: bytes = ALIAS_HEALTHY):
+    root = tmp_path / "kb"
+    root.mkdir(parents=True)
+    cfg = Config(root=root, db_path=root / "kb.sqlite", provider="anthropic",
+                 model="m", api_key=None, base_url=None)
+    app = create_app(cfg)
+    store = app.state.store
+    (root / "sources").mkdir(parents=True, exist_ok=True)
+    (root / "sources" / "a.txt").write_text("x\n", encoding="utf-8")
+    source_id = store.add_source("sources/a.txt")
+    store.add_fact("A", "소속", "B", status="confirmed", confidence=0.9,
+                   source_id=source_id)
+    alias_path = root / RELATION_ALIASES_RELPATH
+    alias_path.parent.mkdir(parents=True, exist_ok=True)
+    alias_path.write_bytes(alias)
+    (root / TYPED_RELATIONS_RELPATH).write_bytes(typed)
+    query_path = root / "facts" / "query.dl"
+    query_path.parent.mkdir(parents=True, exist_ok=True)
+    query_path.write_text(QUERY_DL, encoding="utf-8")
+    return TestClient(app, raise_server_exceptions=False), store
+
+
+def _flat(client) -> str:
+    """The body with runs of whitespace collapsed.
+
+    The banners wrap across source lines, so a contiguous needle does not match
+    the raw text -- a probe written without this reported the whole-page banner
+    ABSENT under a broken alias file, which would have been read as a #590
+    regression rather than as a bad needle.
+    """
+    return " ".join(client.get("/report").text.split())
+
+
+def test_the_fixture_has_a_traceable_answer(tmp_path):
+    """AC-2, and it gates everything else in this file.
+
+    If this fails, no other test here means anything: `report_trace` never
+    reaches `fact_trust_summary` without an answer, so the defect cannot occur
+    and a green suite says nothing about it.
+    """
+    _, store = _build(tmp_path)
+    trace = report_trace(store)
+    assert len(trace.answers) >= 1
+    assert trace.answers[0].facts, "an answer with no contributing facts traces nothing"
+
+
+def test_report_survives_a_broken_typed_file_with_a_traceable_answer(tmp_path):
+    """AC-1. 500 before the fix, on this fixture and on `c0dd1cc` before #590."""
+    client, _ = _build(tmp_path, typed=TYPED_BROKEN)
+    assert client.get("/report").status_code == 200
+
+
+def test_report_names_the_typed_file_and_not_the_alias_file(tmp_path):
+    """AC-3. The banner names only the file that actually failed."""
+    body = _flat(_build(tmp_path, typed=TYPED_BROKEN)[0])
+    assert TYPED_NAMED in body
+    # The bare name, which is the stronger negative: it would also catch the
+    # `policy/`-prefixed wrapper form.
+    assert ALIAS_NAMED not in body
+
+
+def test_the_withheld_trace_does_not_claim_it_searched(tmp_path):
+    """THE TEST THAT SEPARATES THIS FIX FROM THE WRONG ONE.
+
+    Widening `report_trace`'s pre-flight also turns the 500 into a 200 and would
+    pass every other test in this file. It renders "No direct relation fact
+    traces are available for these report rows" -- a searched-and-found-nothing
+    verdict about a search that never ran -- with no banner and no file named.
+    This asserts the opposite of that page, so the wrong fix reddens here.
+
+    SCOPED TO THE TRACE ARM ALONE, deliberately. It does NOT assert the banner:
+    the banner is a separate arm of the template, and a version of this test
+    that checked both reddened whenever EITHER was removed, leaving the trace
+    arm with no test of its own. `test_report_names_the_typed_file_and_not_the_alias_file`
+    and `test_the_report_itself_still_renders` carry the banner; this carries the
+    sentence the trace section prints.
+    """
+    body = _flat(_build(tmp_path, typed=TYPED_BROKEN)[0])
+    assert SEARCHED_AND_FOUND_NOTHING not in body
+    assert NOT_COMPUTED in body
+
+
+def test_the_report_itself_still_renders(tmp_path):
+    """The trace is withheld; the report is NOT. `verify()` returns the same
+    `ok=True, errors=0, answers=1` under a healthy and a broken typed file, so
+    withholding the whole page would withhold correct numbers under a banner
+    naming the wrong file. The page must not claim otherwise."""
+    body = _flat(_build(tmp_path, typed=TYPED_BROKEN)[0])
+    assert PAGE_WITHHELD not in body
+    assert "the report itself is unaffected" in body
+
+
+def test_a_broken_alias_file_still_withholds_the_whole_page(tmp_path):
+    """#590 unchanged, and the ORDERING that keeps it honest.
+
+    With the alias file broken the whole page is withheld and the typed file is
+    neither read nor named -- naming it would be a claim about a file this
+    request never needed. Both files are broken here on purpose: only the alias
+    one may be named.
+    """
+    body = _flat(_build(tmp_path, typed=TYPED_BROKEN, alias=ALIAS_CP949)[0])
+    assert PAGE_WITHHELD in body
+    # A cp949 file is not a policy error, so this one arrives through G2's
+    # wrapper and carries the full relpath -- a different shape from the typed
+    # case above, and the reason both needles are spelled out rather than shared.
+    assert RELATION_ALIASES_RELPATH in body
+    assert TYPED_NAMED not in body
+    assert TRACE_WITHHELD not in body
+
+
+def test_a_broken_alias_file_does_not_even_read_the_typed_file(monkeypatch, tmp_path):
+    """The ordering guard, pinned on the READ rather than on the banner.
+
+    THE BANNER HALF IS ALREADY PROTECTED BY THE TEMPLATE, which is why this test
+    is here: `report.html` renders `{% if policy_error %}` before
+    `{% elif trace_error %}`, so removing the `policy_failure is not None`
+    short-circuit in the route leaves the page IDENTICAL -- the typed message is
+    computed and then never rendered. Measured: with that short-circuit deleted
+    the whole suite stays green, so every page-level assertion, including the
+    one above, is blind to it.
+
+    What the ordering actually buys is that a request whose alias file already
+    failed does not READ a file it does not need. That is observable only at the
+    call, so it is asserted at the call.
+    """
+    from verinote.web import app as web_app
+
+    calls = []
+    real = web_app.store_typed_relations
+
+    def spy(store):
+        calls.append(1)
+        return real(store)
+
+    monkeypatch.setattr(web_app, "store_typed_relations", spy)
+
+    client, _ = _build(tmp_path / "broken_alias", typed=TYPED_BROKEN,
+                       alias=ALIAS_CP949)
+    assert client.get("/report").status_code == 200
+    assert calls == [], "the typed file was read although the alias file failed"
+
+    # Anti-vacuity: the spy DOES fire when the alias file is healthy, so the
+    # assertion above is not passing because the patch missed its target.
+    calls.clear()
+    healthy, _ = _build(tmp_path / "healthy_alias", typed=TYPED_BROKEN)
+    assert healthy.get("/report").status_code == 200
+    assert calls, "the spy never fired -- it is patched at the wrong name"
+
+
+def test_a_healthy_pair_renders_the_trace(tmp_path):
+    """Anti-vacuity for every assertion above: a guard that fired unconditionally
+    would satisfy them all. The traced answer exists only because both files are
+    healthy."""
+    client, _ = _build(tmp_path)
+    body = _flat(client)
+    assert PAGE_WITHHELD not in body
+    assert TRACE_WITHHELD not in body
+    assert NOT_COMPUTED not in body
+    assert "Contributing facts" in body
+    assert "sources/a.txt" in body
+
+
+@pytest.mark.parametrize(
+    "route", ["/questions", "/", "/workbench", "/review", "/facts/1/row",
+              "/facts/1/provenance"]
+)
+def test_no_other_route_is_disturbed_by_a_broken_typed_file(tmp_path, route):
+    """AC-5, at the routes rather than by reading. `fact_trust_summary` reads
+    both policy files and is reached from five places package-wide; every one
+    other than `/report` is already covered upstream -- #585/#570's
+    `_trust_policy_failure` for the fact-row family and the dashboard, #591's
+    snapshot guard for `POST /ask`. Spied on this tree: on a broken typed file
+    these make ZERO calls to it and stay 200."""
+    client, _ = _build(tmp_path, typed=TYPED_BROKEN)
+    assert client.get(route).status_code == 200

--- a/verinote/pipeline/report_trace.py
+++ b/verinote/pipeline/report_trace.py
@@ -133,14 +133,26 @@ def report_trace(store: Store) -> ReportTrace:
     # THE ALIAS READER ONLY, and NOT because this module is innocent of the
     # typed file -- it is not. `_trace_fact` calls `fact_trust_summary`, which
     # reads BOTH policy files, so on a KB whose report has a traceable answer a
-    # broken `typed-relations.md` raises out of here. That is #595, it predates
-    # this guard (measured identically on `c0dd1cc`), and widening this
+    # broken `typed-relations.md` raises out of here -- still true of THIS
+    # function, which is why the argument below still binds. #595 predated this
+    # guard and fixed it in the ROUTE, which no longer calls this function when
+    # the typed file is broken; it did not change what happens if you do. And
+    # widening this
     # pre-flight would REPLACE the 500 with a silent false negative rather than
-    # fix it: the page then answers 200, still renders the answer, and prints
-    # "No direct relation fact traces are available for these report rows" --
-    # with no banner, no "Not computed", and no mention of the file that failed.
-    # That is the searched-and-found-nothing verdict the `{% elif policy_error %}`
-    # arm in `report.html` exists to prevent, reached from the other side.
+    # fix it: the page then answers 200 and prints "No direct relation fact
+    # traces are available for these report rows" -- with no banner, no "Not
+    # computed", and no mention of the file that failed. That is the
+    # searched-and-found-nothing verdict the `{% elif policy_error %}` arm in
+    # `report.html` exists to prevent, reached from the other side.
+    #
+    # AND IT COSTS THE WHOLE TRACEABILITY TABLE, not just a banner. An earlier
+    # draft of this comment said the widened page "still renders the answer",
+    # which is ambiguous between two things on one page and false for the one it
+    # is about: the traceability answer row and its contributing facts are
+    # exactly what disappears. A value does survive, but in `verify()`'s own
+    # answers section, which reads the alias file only and is unaffected. #595
+    # measured both -- widened, the page loses "Contributing facts" and the
+    # source path while `rep.text` still shows the answer value.
     # The alias file is what this guard is for; the typed read is #595's.
     if policy_file_failure(
         lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH

--- a/verinote/pipeline/verify.py
+++ b/verinote/pipeline/verify.py
@@ -133,8 +133,11 @@ def verify(store: Store) -> CheckReport:
     # nowhere in it -- so widening the check here would withhold a report for a
     # file this function never read. Do not generalise that to the routes:
     # `/report` also calls `report_trace`, which reaches `fact_trust_summary`
-    # and DOES read the typed file, so a broken one 500s `/report` on a KB with
-    # a traceable answer. That is #595 and it predates this guard.
+    # and DOES read the typed file, so a broken one USED TO 500 `/report` on a
+    # KB with a traceable answer -- #595, which predated this guard and is now
+    # fixed in the route rather than here. This module's scope is unchanged by
+    # that fix: it still never reads the typed file, which is why the check
+    # here is still alias-only.
     #
     # The clauses below STAY. They are not made dead by this: `query.py`'s alias
     # expansion cap raises `CorroborationPolicyError` from `load_query` on a KB

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -107,6 +107,7 @@ from verinote.pipeline.corroboration import (
     store_relation_aliases,
     store_single_valued_conflicts,
     store_typed_relations,
+    TYPED_RELATIONS_RELPATH,
     typed_spec_for_canonical,
 )
 from verinote.pipeline.workbench import trust_workbench
@@ -3221,18 +3222,50 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         policy_failure = policy_file_failure(
             lambda: store_relation_aliases(store), RELATION_ALIASES_RELPATH
         )
-        try:
-            trace = report_trace(store)
-        except PolicyMissingError:
-            # The report itself already carries the policy_missing error; the
-            # trace needs the same (lost) policy, so it has nothing to say.
-            trace = ReportTrace(
-                answers=(), excluded_review_count=0, excluded_by_status=()
+        # #595. A SECOND, TRACE-SCOPED signal, and it is deliberately not the
+        # same key. `report_trace` reaches `fact_trust_summary`, which reads the
+        # TYPED file too -- but only on a KB whose report has a traceable
+        # answer, which is why a fixture without one measured 200 here and why
+        # this went unseen through #585 and #590.
+        #
+        # It is scoped to the trace because the report itself is unaffected:
+        # `verify(store)` returns the same `ok=True, errors=0, answers=1` under
+        # a healthy and a broken typed file, so withholding the whole page --
+        # which is what reusing `policy_error` would do -- would withhold
+        # numbers that are computed and correct, under a banner naming the wrong
+        # file.
+        #
+        # ORDERING IS LOAD-BEARING. When the ALIAS file fails, `policy_failure`
+        # already withholds the whole page, and the typed file must then be
+        # neither read nor named: a message about it there would be a claim
+        # about a file this request never needed.
+        trace_failure = (
+            None
+            if policy_failure is not None
+            else policy_file_failure(
+                lambda: store_typed_relations(store), TYPED_RELATIONS_RELPATH
             )
+        )
+        trace = ReportTrace(answers=(), excluded_review_count=0, excluded_by_status=())
+        if trace_failure is None:
+            try:
+                trace = report_trace(store)
+            except PolicyMissingError:
+                # The report itself already carries the policy_missing error;
+                # the trace needs the same (lost) policy, so it has nothing to
+                # say.
+                trace = ReportTrace(
+                    answers=(), excluded_review_count=0, excluded_by_status=()
+                )
         return templates.TemplateResponse(
             request,
             "report.html",
-            {"rep": rep, "trace": trace, "policy_error": policy_failure},
+            {
+                "rep": rep,
+                "trace": trace,
+                "policy_error": policy_failure,
+                "trace_error": trace_failure,
+            },
         )
 
     @app.get("/analytics", response_class=HTMLResponse)

--- a/verinote/web/templates/report.html
+++ b/verinote/web/templates/report.html
@@ -6,6 +6,15 @@
 <p class="error" role="alert">{{ policy_error }} The report and its traceability are
   withheld, because both would have been computed under different rules than this KB's
   alias file specifies.</p>
+{% elif trace_error %}
+{# #595. A SEPARATE arm, not a rewording of the one above, because the two cases
+   withhold DIFFERENT amounts and the difference is what tells a reader whether
+   the numbers below can be trusted. Here the report is computed and correct --
+   `verify()` does not read the typed file -- and only the traceability is
+   withheld. The arm above would claim the report was withheld too, and would
+   name the alias file, which is not the file that failed. #}
+<p class="error" role="alert">{{ trace_error }} The traceability below is withheld;
+  the report itself is unaffected and was computed normally.</p>
 {% endif %}
 {% if not rep.engine_available %}
 <p class="warn">DuckDB verification backend is not available.</p>
@@ -76,7 +85,7 @@
     {% endfor %}
   </tbody>
 </table>
-{% elif policy_error %}
+{% elif policy_error or trace_error %}
 {# #590. Without this arm the empty trace prints "no traces are available for
    these report rows", which reads as a searched-and-found-nothing verdict on a
    search that never ran. #}


### PR DESCRIPTION
Closes #595 — filed while closing #590, which narrowed a test around this rather than assert a 200 that fails for an unrelated reason or a 500 that would lock a defect in as intended.

All three gates independently recomputed and approved tree `e48c2d2e200f5f81ca27551f8b905e99436407c6`.

## The defect
`report_trace` reaches `fact_trust_summary`, which reads **both** policy files — so #590's deliberately alias-only pre-flight doesn't cover it. `GET /report` answered 500 on a broken typed file, but **only when the KB has a traceable answer**, because without one `report_trace` never reaches that call.

That's why it survived #585 and #590: both measured 200 honestly, on fixtures that could not express it.

## The guard is in the route, not the pre-flight
Widening the pre-flight was measured by three parties and is **worse than the 500** — the page answers 200 and prints a searched-and-found-nothing verdict while the whole traceability table vanishes, "Contributing facts" and the source path with it, naming nothing. So the route carries the guard, where the template can attribute it.

`report.html` gains a trace-scoped arm: the existing banner named the **alias** file when the report is computed and correct and the **typed** file failed — wrong on both halves.

## The fixture is the issue
Three attempts produced a 200 that proved nothing; the query needs its own `.decl`. `test_the_fixture_has_a_traceable_answer` asserts both `len(trace.answers) >= 1` and `trace.answers[0].facts`.

Measured both trees: healthy 200/200, **broken 500 → 200**, absent 200/200, `/questions` 200 throughout.

## Two guards were unpinned until the matrix said so
The ordering guard **reddened nothing** — the template already enforces `{% if policy_error %}` before `{% elif trace_error %}`, so deleting the short-circuit left every page byte-identical. Its comment claimed the typed file is "neither read nor named"; only *named* was observable. The **read** is now asserted at the call with a spy, plus an anti-vacuity arm proving the spy fires on a healthy alias file.

**A zero-red mutant and a failed patch are indistinguishable in the output.** Both guards came back zero-red and the correct reading was "unpinned" — but nothing in a pytest summary separates that from "the patch did not apply". The post-patch assertion must run *before* the count is read. One mutation here did silently fail to apply, and was caught that way.

## Prose this change falsified
Three sites asserted in present tense that a broken typed file 500s `/report` — one in this change's own test file, its twin 200 lines away, and a third in `verify.py` that **no gate named**, surfacing only on a tree-wide sweep. The rule that finds them: enumerate every assertion of the **proposition**, not every occurrence of the symbol.

`verify.py` is a trap for the next sweep — `store_typed_relations` appears in its text and not as a call, and the string count went **up** when the comment was repaired.

## Validation
**3524 passed, 12 skipped, 0 failed** (base 3510). Ruff clean. Five reaches of `fact_trust_summary` re-derived with nested spans excluded; `GET /report` alone.