### PR TITLE
fix(pipeline): an infrastructure fault is reported, never recorded (#592)

### DIFF
--- a/tests/test_claude_cli_adapter.py
+++ b/tests/test_claude_cli_adapter.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 from verinote.config import Config
-from verinote.llm.base import LLMError
+from verinote.llm.base import LLMError, LLMOutputError
 from verinote.llm.claude_cli_adapter import ClaudeCliAdapter
 from verinote.llm.factory import get_client
 from verinote.pipeline.extract import (
@@ -481,7 +481,11 @@ def test_claude_cli_undecodable_reply_does_not_blame_the_source(tmp_path, monkey
     """
     _fake_claude(tmp_path, monkeypatch, b"\xff\xfe")
 
-    with pytest.raises(LLMError) as excinfo:
+    # `LLMOutputError`, not `LLMError`: the CLI RAN and answered, and #592 reads
+    # that distinction off the class to decide whether the question row records
+    # the failure. Asserting the base class here passed whichever class was
+    # raised, so this line is what makes that decision falsifiable.
+    with pytest.raises(LLMOutputError) as excinfo:
         invoke(ClaudeCliAdapter(_cfg(tmp_path, llm_timeout_seconds=5.0)), "Ada Lovelace")
 
     message = str(excinfo.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -904,7 +904,17 @@ def test_query_relation_discovery_prints_public_lifecycle_outcomes(
     assert query_dl == ""
 
 
-def test_query_persists_translation_failure_reason(tmp_path, monkeypatch, capsys, fake_client):
+def test_query_reports_a_provider_failure_without_recording_it(tmp_path, monkeypatch, capsys, fake_client):
+    """#592 inverted the row half of this test, and NOT the reporting half.
+
+    The provider was never reached, so `translation_failed` ("The provider
+    output could not be used") would be false of the row -- it stays `pending`.
+    Everything a user sees is unchanged: the same stdout line, the same split,
+    the same stderr, and the same rc=1. That is what "reported, never recorded"
+    means, and the rc is why the RESULT DICTS are still returned: `failures`
+    derives from them, not from the rows, so deleting the append instead of the
+    write would silently turn this run green.
+    """
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "verinote.llm.get_client",
@@ -920,12 +930,12 @@ def test_query_persists_translation_failure_reason(tmp_path, monkeypatch, capsys
     assert "provider unavailable" in captured.err
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == "provider unavailable"
+    assert q["status"] == "pending"
+    assert not q["reason"]
     assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
 
 
-def test_query_persists_get_client_failure_reason(tmp_path, monkeypatch, capsys):
+def test_query_reports_a_get_client_failure_without_recording_it(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, tmp_path)
 
     def raise_client_error(cfg):
@@ -935,8 +945,10 @@ def test_query_persists_get_client_failure_reason(tmp_path, monkeypatch, capsys)
 
     rc = cli.main(["query", "What is the sample answer?"])
 
-    # Every question is marked translation_failed on a get_client failure, so the
-    # run is a total failure: rc 1, with the reason surfaced and the count split.
+    # #592. `get_client` raises only for an unknown provider -- a corrupt
+    # config, not a missing key -- so nothing was attempted and no question is
+    # marked. The run is still a total failure and says so: rc 1, the reason on
+    # both streams, the count split. Reported, never recorded.
     captured = capsys.readouterr()
     assert rc == 1
     assert "q1: translation_failed - missing provider credentials" in captured.out
@@ -944,8 +956,8 @@ def test_query_persists_get_client_failure_reason(tmp_path, monkeypatch, capsys)
     assert "missing provider credentials" in captured.err
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == "missing provider credentials"
+    assert q["status"] == "pending"
+    assert not q["reason"]
     assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -904,6 +904,53 @@ def test_query_relation_discovery_prints_public_lifecycle_outcomes(
     assert query_dl == ""
 
 
+def test_query_does_not_count_an_unreachable_provider_as_a_review_verdict(
+    tmp_path, monkeypatch, capsys, fake_client
+):
+    """THE SUMMARY LINE IS ABOUT ROWS, and this exit is the one that broke it.
+
+    `_reinterpret_empty_plan` is the only path returning `review_required` with
+    `infrastructure_fault=True`: the deterministic planner earns the verdict
+    before any request is made, the provider is then asked to re-read the
+    question, and it cannot be reached. Counting that dict in `for_review`
+    printed "1 for review" over a row left `pending` -- and the comment above
+    the count called those verdicts "durable" and "not a broken run", both false
+    of it. The row half of the same exit was pinned two revisions ago; the
+    COMMAND that reports it was not, which is the same gap one layer up.
+
+    rc is 1 here and was 0 before. With no row written, the exit code is the
+    only durable report the command still has, so a run that translated nothing
+    must not look finished to a script.
+    """
+    _env(monkeypatch, tmp_path)
+    store = Store(tmp_path / "kb.sqlite")
+    store.init_schema()
+    store.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    store.close()
+    monkeypatch.setattr(
+        "verinote.llm.get_client",
+        lambda cfg: fake_client(error=LLMError("synthetic outage")),
+    )
+
+    rc = cli.main(["query", "What is Sample Person's birth place?"])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    # The count that was false: "for review" claims a durable verdict on a row.
+    assert "for review" not in captured.out
+    assert "translated 0 question(s), 1 not translated" in captured.out
+    # The deterministic diagnosis still reaches the user -- it is the actionable
+    # half, and it is what the row would have carried.
+    assert "is not in the schema or its aliases" in captured.out
+    assert "(row unchanged)" in captured.out
+    assert "synthetic outage" in captured.err
+    s = Store(tmp_path / "kb.sqlite")
+    q = s.questions()[0]
+    assert q["status"] == "pending"
+    assert not q["reason"]
+    s.close()
+
+
 def test_query_reports_a_provider_failure_without_recording_it(tmp_path, monkeypatch, capsys, fake_client):
     """#592 inverted the row half of this test, AND the one line that named it.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -905,15 +905,23 @@ def test_query_relation_discovery_prints_public_lifecycle_outcomes(
 
 
 def test_query_reports_a_provider_failure_without_recording_it(tmp_path, monkeypatch, capsys, fake_client):
-    """#592 inverted the row half of this test, and NOT the reporting half.
+    """#592 inverted the row half of this test, AND the one line that named it.
 
     The provider was never reached, so `translation_failed` ("The provider
     output could not be used") would be false of the row -- it stays `pending`.
-    Everything a user sees is unchanged: the same stdout line, the same split,
-    the same stderr, and the same rc=1. That is what "reported, never recorded"
-    means, and the rc is why the RESULT DICTS are still returned: `failures`
-    derives from them, not from the rows, so deleting the append instead of the
-    write would silently turn this run green.
+    The reporting half is unchanged where it reports the RUN: the same split,
+    the same stderr, the same rc=1, and the rc is why the RESULT DICTS are
+    still returned -- `failures` derives from them, not from the rows, so
+    deleting the append instead of the write would silently turn this run
+    green.
+
+    The per-question stdout line DID change, because it was the one place the
+    command described the row. `format_question_outcome` renders
+    `q{id}: {status} - {message}`, so passing a result dict through it printed
+    `q1: translation_failed` over a row this same command had just left
+    `pending` -- a report of the run wearing the row's clothes. It now names
+    the run and says what the row did, and the assertion below is what stops
+    it drifting back.
     """
     _env(monkeypatch, tmp_path)
     monkeypatch.setattr(
@@ -925,7 +933,11 @@ def test_query_reports_a_provider_failure_without_recording_it(tmp_path, monkeyp
 
     captured = capsys.readouterr()
     assert rc == 1
-    assert "q1: translation_failed - provider unavailable" in captured.out
+    assert "q1: not translated - provider unavailable (row unchanged)" in captured.out
+    # The row's own vocabulary must not appear on a line about a row that was
+    # not written. Deleting the branch that produces the line above brings it
+    # straight back, which is what makes this assertion load-bearing.
+    assert "q1: translation_failed" not in captured.out
     assert "translated 0 question(s), 1 failed" in captured.out
     assert "provider unavailable" in captured.err
     s = Store(tmp_path / "kb.sqlite")
@@ -951,7 +963,8 @@ def test_query_reports_a_get_client_failure_without_recording_it(tmp_path, monke
     # both streams, the count split. Reported, never recorded.
     captured = capsys.readouterr()
     assert rc == 1
-    assert "q1: translation_failed - missing provider credentials" in captured.out
+    assert "q1: not translated - missing provider credentials (row unchanged)" in captured.out
+    assert "q1: translation_failed" not in captured.out
     assert "translated 0 question(s), 1 failed" in captured.out
     assert "missing provider credentials" in captured.err
     s = Store(tmp_path / "kb.sqlite")
@@ -989,9 +1002,17 @@ def test_query_mixed_outcomes_exits_nonzero_with_split(
     captured = capsys.readouterr()
     assert rc == 1
     assert "q1: translated" in captured.out
-    assert "q2: translation_failed" in captured.out
+    # #592 makes this a MIXED run in the strong sense: one row was written and
+    # one deliberately was not, in a single pass of the same loop. Each line
+    # describes its own question, so the two lines differ in kind and not only
+    # in status -- q1 reports its row, q2 reports the run.
+    assert "q2: not translated - provider rejected this question (row unchanged)" in captured.out
     assert "translated 1 question(s), 1 failed" in captured.out
     assert "provider rejected this question" in captured.err
+    store = Store(tmp_path / "kb.sqlite")
+    rows = {int(q["id"]): str(q["status"]) for q in store.questions()}
+    store.close()
+    assert rows == {1: "translated", 2: "pending"}
 
 
 def test_query_no_pending_errors(tmp_path, monkeypatch, capsys):
@@ -1114,7 +1135,10 @@ def test_query_prints_review_required_outcome(tmp_path, monkeypatch, capsys):
         store.set_question_query(
             q["id"], f'review_required("{reason}")', "review_required", reason
         )
-        return [{"id": q["id"], "status": "review_required", "reason": reason}]
+        return [
+            {"id": q["id"], "status": "review_required", "reason": reason,
+             "infrastructure_fault": False}
+        ]
 
     monkeypatch.setattr("verinote.pipeline.translate_questions", translate)
 
@@ -1135,7 +1159,10 @@ def test_query_prints_no_answer_outcome(tmp_path, monkeypatch, capsys):
         q = store.questions(pending_only=True)[0]
         reason = "no confirmed facts match"
         store.set_question_query(q["id"], f'no_answer("{reason}")', "no_answer", reason)
-        return [{"id": q["id"], "status": "no_answer", "reason": reason}]
+        return [
+            {"id": q["id"], "status": "no_answer", "reason": reason,
+             "infrastructure_fault": False}
+        ]
 
     monkeypatch.setattr("verinote.pipeline.translate_questions", translate)
 
@@ -1153,7 +1180,10 @@ def test_query_prints_ambiguous_outcome(tmp_path, monkeypatch, capsys):
         q = store.questions(pending_only=True)[0]
         reason = "multiple synthetic candidates matched"
         store.set_question_query(q["id"], f'ambiguous("{reason}")', "ambiguous", reason)
-        return [{"id": q["id"], "status": "ambiguous", "reason": reason}]
+        return [
+            {"id": q["id"], "status": "ambiguous", "reason": reason,
+             "infrastructure_fault": False}
+        ]
 
     monkeypatch.setattr("verinote.pipeline.translate_questions", translate)
 

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -1073,9 +1073,10 @@ def test_a_parse_failure_keeps_the_original_error_as_the_cause(tmp_path, monkeyp
     """Redacting must not cost the cause the parsers already chain.
 
     `schema.parse_facts` raises `... from exc` with the `KeyError` that named the
-    missing field. `parsed_under_redaction` re-raises `from exc.__cause__`, so the
-    original survives for a log rather than being buried behind the wrapper's own
-    `LLMError`. Re-raising `from exc` instead is the way to make this fail.
+    missing field. `parsed_under_redaction` re-raises THAT SAME EXCEPTION after
+    rewriting its message, so the cause it already carried survives for a log
+    rather than being buried behind a wrapper. Replacing the re-raise with
+    `raise LLMError(str(exc)) from exc` is the way to make this fail.
     """
     _echoing_sdk(monkeypatch, "openai", {"facts": [{"subject": _LONG_KEY, "oops": 1}]})
 

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -24,6 +24,7 @@ provider-side OR PARSING failure", so it conflates a request never sent with an
 answer that came back unusable. `LLMOutputError` is the second case, and the
 tests below pin both directions.
 """
+import ast
 import re
 from html import unescape
 from pathlib import Path
@@ -284,6 +285,73 @@ def test_a_mixed_run_reports_the_suppressed_fault_and_not_the_recorded_one(
     # The recorded question's reason belongs on its ROW, which this same page
     # renders. What must not happen is the banner speaking for it.
     assert "did not match schema" not in banner
+
+
+def test_no_shipped_llm_error_subclass_defines_its_own_str():
+    """The RELABEL's precondition, enforced -- the hazard the deleted tripwire
+    did not cover and its replacement could not.
+
+    `parsed_under_redaction` redacts by rewriting `exc.args` and re-raising the
+    same object. That reaches `str(exc)` only because `BaseException.__str__`
+    derives the string from `args`. A subclass that defines `__str__` -- to cache
+    its message, or to format one from other fields -- keeps returning the
+    ORIGINAL text after the rewrite, so the secret survives into a message this
+    function exists to redact. Measured on this primitive: such a subclass leaks
+    where the previous revision's rebuild did not. It is a fail-OPEN direction in
+    the one place whose whole job is redaction.
+
+    The tripwire this replaces checked constructor ARITY, which was the REBUILD's
+    hazard and is now structurally impossible. It would not have caught this one.
+
+    DERIVED FROM THE SOURCE, not from `__subclasses__()`, and that is the point:
+    `__subclasses__()` returns direct children only and sees nothing a test run
+    has not imported, so the old sweep was blind exactly where a new subclass
+    would be added. This walks every class statement under `verinote/`, resolves
+    the `LLMError` family as a fixpoint over base names, and so covers a subclass
+    at any depth in any module whether or not anything imports it.
+
+    SCOPE, so it is not read as more than it is: this cannot see a subclass
+    defined outside `verinote/`, and it checks `__str__` rather than every way a
+    message could be decoupled from `args`. `__str__` is the decisive one --
+    without it, `str(exc)` reads `args` and the redaction holds.
+    """
+    package = Path(__file__).resolve().parent.parent / "verinote"
+    classes = {}
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                bases = {b.id for b in node.bases if isinstance(b, ast.Name)}
+                bases |= {b.attr for b in node.bases if isinstance(b, ast.Attribute)}
+                classes[node.name] = (bases, node, path)
+
+    family = {"LLMError"}
+    while True:
+        grown = {
+            name for name, (bases, _, _) in classes.items() if bases & family
+        } | family
+        if grown == family:
+            break
+        family = grown
+
+    swept = sorted(family - {"LLMError"})
+    assert swept, (
+        "no LLMError subclass was found under verinote/, so this sweep judged "
+        "nothing -- it has been made vacuous, not satisfied"
+    )
+
+    offenders = []
+    for name in swept:
+        _, node, path = classes[name]
+        for child in node.body:
+            if isinstance(child, ast.FunctionDef) and child.name == "__str__":
+                offenders.append(f"{path.name}:{child.lineno} {name}.__str__")
+
+    assert offenders == [], (
+        "these `LLMError` subclasses define `__str__`, so `parsed_under_redaction`"
+        " cannot redact them: it rewrites `args` and re-raises the same object, "
+        f"and their `__str__` keeps returning the unredacted text. {offenders}"
+    )
 
 
 def test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state():

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 """#592. An infrastructure fault is REPORTED, never RECORDED on a question row.
 
-THE RULE IS READ OFF THE STATUS, not chosen. `question_outcome.py::_STATUS_META`
-defines `translation_failed` as "The provider output could not be used" -- a
-claim about the provider's OUTPUT. When no request was sent (no API key, unknown
+THE RULE IS ANCHORED IN THE STATUS, not chosen -- anchored rather than READ OFF,
+because `question_outcome.py::_STATUS_META`'s "The provider output could not be
+used" is a display FALLBACK that `question_outcome_view` renders only for a row
+carrying no reason. It is still the only textual statement of what
+`translation_failed` means anywhere in this repo, and it is a claim about the
+provider's OUTPUT. When no request was sent (no API key, unknown
 provider, SDK missing) or translation was never attempted (a policy file that
 cannot be read), there is no output and the claim is false. `pending` ("Waiting
 for translation.") is true of all of them, and it is already in `db.py`'s CHECK
@@ -21,11 +24,14 @@ provider-side OR PARSING failure", so it conflates a request never sent with an
 answer that came back unusable. `LLMOutputError` is the second case, and the
 tests below pin both directions.
 """
+import re
+from html import unescape
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
+import verinote.web.app as webapp
 from verinote.config import Config
 from verinote.llm.base import LLMError, LLMOutputError, parsed_under_redaction
 from verinote.pipeline.query import translate_questions
@@ -80,6 +86,62 @@ class _AnswersUnusably:
         # The repair path falls through to this after the intent comes back
         # unsupported. It ANSWERS -- with Datalog the engine cannot use.
         return "answer_q1(X) :- nonexistent_predicate(X)."
+
+
+UNUSABLE_QUESTION = "Which unusable answer is recorded?"
+UNREACHED_QUESTION = "What is the sample answer?"
+
+
+class _AnswersOneAndNeverReachesTheOther:
+    """One client, both sides of the discriminator, keyed on the question text.
+
+    `translate_questions` uses ONE client for every question in a run, so the
+    only way to reach a run where one row is written and another deliberately is
+    not -- the single state in which the status string and the verdict disagree
+    -- is a client that fails differently per question.
+    """
+
+    _UNREACHED = "anthropic requires an API key; set VERINOTE_ANTHROPIC_API_KEY"
+
+    def extract_query_intent(self, *, question, schema_hint=""):
+        if question == UNUSABLE_QUESTION:
+            return parse_query_intent({"kind": "lookup_object"})
+        raise LLMError(self._UNREACHED)
+
+    def translate_query(self, *, question, qid, schema_hint=""):
+        if question == UNUSABLE_QUESTION:
+            return "answer_q1(X) :- nonexistent_predicate(X)."
+        raise LLMError(self._UNREACHED)
+
+
+def _app_with(root: Path, client_obj, monkeypatch, *, questions):
+    root.mkdir(parents=True, exist_ok=True)
+    policy = root / "policy"
+    policy.mkdir(parents=True, exist_ok=True)
+    (policy / "relation-aliases.md").write_text(ALIAS_HEALTHY, encoding="utf-8")
+    (policy / "typed-relations.md").write_text(TYPED_HEALTHY, encoding="utf-8")
+    cfg = Config(root=root, db_path=root / "kb.sqlite", provider="anthropic",
+                 model="m", api_key=None, base_url=None)
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: client_obj)
+    app = create_app(cfg)
+    for text in questions:
+        app.state.store.add_question(text)
+    return app
+
+
+_BANNER_RE = re.compile(r'<p class="error" role="alert">(.*?)</p>', re.S)
+
+
+def _banner(response) -> str | None:
+    """The banner ALONE, not the page.
+
+    The page also renders every question row, so a substring search over the
+    whole body cannot tell a reason that reached the banner from the same reason
+    reaching the row that owns it -- which is exactly the confusion this surface
+    was blocked for.
+    """
+    match = _BANNER_RE.search(response.text)
+    return None if match is None else " ".join(unescape(match.group(1)).split())
 
 
 def test_the_unusable_output_fixture_really_raises_through_the_real_parser():
@@ -148,8 +210,62 @@ def test_the_web_reports_the_fault_it_no_longer_records(tmp_path):
     response = client.post("/questions/translate", follow_redirects=False)
 
     assert response.status_code == 200
-    assert "Translation did not run" in " ".join(response.text.split())
+    assert "Translation could not run" in " ".join(response.text.split())
     assert [str(q["status"]) for q in app.state.store.questions()] == ["pending"]
+
+
+def test_the_web_says_nothing_about_a_fault_it_recorded(tmp_path, monkeypatch):
+    """The banner reports what the ROW could not, so a written row has nothing
+    for it to report.
+
+    Filtering the route on `r["status"] == "translation_failed"` instead of on
+    the verdict makes this run render "Translation could not run" over a row the
+    same request had just marked `Translation failed`. The redirect is the
+    assertion: it is reachable only when the route finds no suppressed fault.
+    """
+    root = tmp_path / "kb"
+    app = _app_with(root, _AnswersUnusably(), monkeypatch, questions=[UNUSABLE_QUESTION])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post("/questions/translate", follow_redirects=False)
+
+    assert response.status_code == 303
+    row = app.state.store.questions()[0]
+    assert str(row["status"]) == "translation_failed"
+    assert "did not match schema" in str(row["reason"])
+
+
+def test_a_mixed_run_reports_the_suppressed_fault_and_not_the_recorded_one(
+    tmp_path, monkeypatch
+):
+    """The state that separates the two filters, and the reason the verdict has
+    to travel on the result dict.
+
+    Both dicts say `translation_failed`: the recorded one because that is what
+    its row says, the suppressed one because `cmd_query` derives its exit code
+    from these same dicts. A route filtering on the status string takes
+    `faults[0]` -- the RECORDED question, ordered first here on purpose, since
+    `Store.questions()` is `ORDER BY id` -- and speaks for a row it did not
+    suppress, while the genuine infrastructure fault on the second question goes
+    unmentioned. Filtering on `infrastructure_fault` takes the second.
+    """
+    root = tmp_path / "kb"
+    app = _app_with(root, _AnswersOneAndNeverReachesTheOther(), monkeypatch,
+                    questions=[UNUSABLE_QUESTION, UNREACHED_QUESTION])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post("/questions/translate", follow_redirects=False)
+
+    assert response.status_code == 200
+    rows = {str(q["text"]): str(q["status"]) for q in app.state.store.questions()}
+    assert rows == {UNUSABLE_QUESTION: "translation_failed",
+                    UNREACHED_QUESTION: "pending"}
+    banner = _banner(response)
+    assert banner is not None
+    assert "API key" in banner
+    # The recorded question's reason belongs on its ROW, which this same page
+    # renders. What must not happen is the banner speaking for it.
+    assert "did not match schema" not in banner
 
 
 def test_every_llm_error_subclass_takes_one_message():
@@ -228,6 +344,33 @@ def test_the_async_worker_still_records_output_that_arrived_unusable(tmp_path):
     # direct-Datalog fallback -- the recorded reason is the schema violation,
     # which is the provider's output being unusable.
     assert "did not match schema" in after
+
+
+def test_the_async_worker_fails_the_job_on_output_that_arrived_unusable(tmp_path):
+    """The ROW and the JOB are two different reports, and #592 must not silence
+    the second while it is fixing the first.
+
+    Substituting `infrastructure_fault` for `result.provider_failed` at the job's
+    report site NARROWS as well as widens: an answer that arrives unusable sets
+    `provider_failed` and clears `infrastructure_fault`, so the item finishes
+    `done` over a question that was never repaired -- worse than the behaviour
+    this rule replaced, which failed it. The sibling above drives the same run
+    and asserts only the row, and stays green under that substitution, which is
+    why the item and the job need an assertion of their own.
+    """
+    root = tmp_path / "kb"
+    store = _kb(root)
+    qid = int(store.questions()[0]["id"])
+    store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+
+    process_repair_job(store, _AnswersUnusably(), job_id=int(job["id"]), root=root)
+
+    items = store.repair_job_items(int(job["id"]))
+    assert [str(i["status"]) for i in items] == ["failed"]
+    saved = store.get_repair_job(int(job["id"]))
+    assert str(saved["status"]) == "failed"
+    assert "did not match schema" in str(saved["message"])
 
 
 def test_openai_inherits_the_class_without_an_edit_to_its_adapter():

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -34,6 +34,7 @@ from fastapi.testclient import TestClient
 import verinote.web.app as webapp
 from verinote.config import Config
 from verinote.llm.base import LLMError, LLMOutputError, parsed_under_redaction
+from verinote.llm.schema import parse_facts, parse_query
 from verinote.pipeline.query import translate_questions
 from verinote.pipeline.query_intent import parse_query_intent
 from verinote.pipeline.repair import process_repair_job, repair_question
@@ -182,7 +183,7 @@ def test_output_that_arrived_and_could_not_be_used_IS_recorded(tmp_path):
 
 
 def test_repair_does_not_record_an_unreadable_policy_file(tmp_path):
-    """The third writer. `repair_question` persists `prepared.status`, which a
+    """The SECOND writer. `repair_question` persists `prepared.status`, which a
     policy fault reaches as `translation_failed`."""
     root = tmp_path / "kb"
     store = _kb(root, typed=TYPED_BROKEN)
@@ -193,8 +194,25 @@ def test_repair_does_not_record_an_unreadable_policy_file(tmp_path):
 
 
 def test_the_web_reports_the_fault_it_no_longer_records(tmp_path):
-    """AC-2's cost, paid. The row write WAS the web's only diagnosis, so
-    deleting it without this surface would have made a broken provider silent."""
+    """AC-2's cost, and the half of it that is NOT paid.
+
+    The row write WAS the web's only diagnosis, so deleting it without this
+    surface would have made a broken provider silent. What the banner does not
+    replace is DURABILITY, measured with one fixture and only the tree varying:
+    on `6cd66b8` the row carried the reason and every later `GET /questions`
+    rendered it, while here the banner lives in the POST response alone and the
+    next GET shows "Waiting for translation." and nothing else. Nothing in the
+    database, the KB directory or the log holds the fault. With a repair job
+    pending it is shorter still: that page polls `GET /questions` every two
+    seconds and swaps the body, so the first tick replaces the banner.
+
+    The trade is defensible -- a transient true report beats a durable false one,
+    which is the whole of #592 -- but it is a trade and not a free move. The
+    other two surfaces kept a durable home for the same class of fault: the CLI
+    has stdout, stderr and rc=1, and web repair persists `repair_jobs.message`,
+    which survives a reload. Translate is the one surface with no durable
+    equivalent, so this is an outlier rather than the pattern.
+    """
     root = tmp_path / "kb"
     root.mkdir(parents=True)
     policy = root / "policy"
@@ -268,17 +286,40 @@ def test_a_mixed_run_reports_the_suppressed_fault_and_not_the_recorded_one(
     assert "did not match schema" not in banner
 
 
-def test_every_llm_error_subclass_takes_one_message():
-    """`parsed_under_redaction` re-raises with `type(exc)(...)`, so a subclass
-    whose constructor took a different shape would break inside error handling.
+def test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state():
+    """What replaced the subclass tripwire, and it pins the property directly.
 
-    Derived from `__subclasses__()` rather than listed, so a subclass added later
-    is covered without anyone remembering this test exists.
+    The primitive used to rebuild the exception as `type(exc)(message)`, which
+    imposed a constructor contract on every `LLMError` subclass. That contract
+    was guarded by a test walking `LLMError.__subclasses__()` -- a check that
+    could not see a subclass one level deeper, could not see one in a module
+    nothing had imported yet, and would have passed a subclass that took one
+    message and silently dropped everything else it carried.
+
+    The primitive relabels the exception in place now, so there is no contract
+    left to guard and the guard is gone with it. This asserts the property the
+    guard was standing in for, on a subclass `__subclasses__()` could never have
+    reached: two constructor arguments, one level below `LLMOutputError`. Both
+    halves matter -- the class and the `status_code` survive, and the secret
+    still does not.
     """
-    subclasses = LLMError.__subclasses__()
-    assert subclasses, "no subclasses -- this test would pass vacuously"
-    for cls in subclasses:
-        assert str(cls("probe")) == "probe", cls.__name__
+    secret = "sk-ant-SECRETVALUE0123456789"
+
+    class _Throttled(LLMOutputError):
+        def __init__(self, message, status_code=503):
+            super().__init__(message)
+            self.status_code = status_code
+
+    assert _Throttled not in LLMError.__subclasses__()
+
+    def parse(_payload):
+        raise _Throttled(f"upstream refused {secret}", 429)
+
+    with pytest.raises(_Throttled) as excinfo:
+        parsed_under_redaction(parse, "payload", secret)
+    assert excinfo.value.status_code == 429
+    assert secret not in str(excinfo.value)
+    assert str(excinfo.value) == "upstream refused ***"
 
 
 def test_parsed_under_redaction_preserves_the_class_and_the_redaction():
@@ -292,10 +333,14 @@ def test_parsed_under_redaction_preserves_the_class_and_the_redaction():
 
 
 def test_the_async_repair_worker_does_not_record_it_either(tmp_path):
-    """THE FOURTH WRITER, EXERCISED rather than inspected.
+    """THE THIRD WRITER, EXERCISED rather than inspected.
 
     `persist_repair_question` is a SEPARATE write from `repair_question`'s, on
-    the job worker's path, and a guard added to one does not cover the other. It
+    the job worker's path, and a guard added to one does not cover the other. The
+    three are `translate_questions`, `repair_question` and this one -- derived by
+    taking the `Store` methods whose SQL sets `questions.status` and then their
+    callers under `verinote/`, which is the same derivation the module docstring
+    of tests/test_query_schema_policy_guard.py spells out. It
     would be easy to add the check and never run it -- so this drives the real
     worker end to end and asserts the row, not the presence of a guard.
 
@@ -371,6 +416,150 @@ def test_the_async_worker_fails_the_job_on_output_that_arrived_unusable(tmp_path
     saved = store.get_repair_job(int(job["id"]))
     assert str(saved["status"]) == "failed"
     assert "did not match schema" in str(saved["message"])
+
+
+# Every `raise LLMOutputError` site the question path can reach, one case each.
+# The class is the whole mechanism -- `translate_questions` reads it off the
+# exception to decide whether the row records the failure -- so a site raising
+# the base class instead silently rejoins the suppressed half, with no other
+# symptom. Reverting any one of these to `LLMError` reddens exactly its own case.
+_ARRIVED_UNUSABLE_PARSES = {
+    "parse_query/off-schema": (parse_query, {}, "query translation did not match schema"),
+    "parse_query/empty": (parse_query, {"datalog": "   "}, "query translation was empty"),
+    "parse_facts/off-schema": (parse_facts, "not json at all", "extractor output did not match schema"),
+    "parse_facts/malformed-item": (
+        parse_facts,
+        {"facts": [{"subject": "Sample Person", "relation": "born_in"}]},
+        "malformed fact object",
+    ),
+    "parse_query_intent/not-json": (parse_query_intent, "not json at all", "query intent output was not JSON"),
+    "parse_query_intent/off-schema": (parse_query_intent, {"kind": "lookup_object"}, "did not match schema"),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_ARRIVED_UNUSABLE_PARSES))
+def test_every_parser_rejection_is_an_arrived_unusable_answer(case):
+    """A parser only ever runs on a payload that ARRIVED, so every exit it has
+    is the recorded half of the rule by construction."""
+    parse, payload, fragment = _ARRIVED_UNUSABLE_PARSES[case]
+    with pytest.raises(LLMOutputError) as excinfo:
+        parse(payload)
+    assert fragment in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["extract_facts", "translate_query", "extract_query_intent"],
+)
+def test_anthropic_reports_a_missing_tool_use_block_as_unusable_output(
+    tmp_path, monkeypatch, method
+):
+    """The tree's own advertised example, which nothing tested.
+
+    `LLMOutputError`'s docstring offers "a payload with no tool_use block" as the
+    case it exists for, and this adapter raises it at three separate exits -- one
+    per method, none of them shared -- so one test cannot stand for the others.
+    A response with content but no tool_use block ARRIVED: the provider was
+    reached and misbehaved, which is what the row records.
+    """
+    from types import SimpleNamespace
+
+    from verinote.llm.anthropic_adapter import AnthropicAdapter
+
+    monkeypatch.setattr(
+        AnthropicAdapter,
+        "_client",
+        lambda self: SimpleNamespace(
+            messages=SimpleNamespace(
+                create=lambda **kwargs: SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="no tool use here")]
+                )
+            )
+        ),
+    )
+    cfg = Config(root=tmp_path, db_path=tmp_path / "kb.sqlite", provider="anthropic",
+                 model="m", api_key="sk-ant-SECRETVALUE0123456789", base_url=None)
+    adapter = AnthropicAdapter(cfg)
+    call = {
+        "extract_facts": lambda: adapter.extract_facts(source_text="x"),
+        "translate_query": lambda: adapter.translate_query(question="q", qid=1),
+        "extract_query_intent": lambda: adapter.extract_query_intent(question="q"),
+    }[method]
+
+    with pytest.raises(LLMOutputError, match="no tool_use block"):
+        call()
+
+
+REINTERPRETED_QUESTION = "What is Sample Person's birth place?"
+
+
+def _kb_with_an_empty_plan(root: Path) -> Store:
+    """The state that reaches `_reinterpret_empty_plan`, built from facts.
+
+    The deterministic parser UNDERSTANDS this question, so the flow does not ask
+    the provider for an intent; the plan then comes out EMPTY because the
+    relation is absent from the schema, and only THEN is the provider asked to
+    re-read it. That ordering is the whole point: the row's verdict and its
+    reason are decided before any request is made.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    store.add_fact("Sample Person", "born_in", "Sample Place", status="confirmed")
+    store.add_question(REINTERPRETED_QUESTION)
+    return store
+
+
+def test_an_unusable_reinterpretation_is_recorded_like_any_other_arrived_answer(tmp_path):
+    """THE THIRD `except LLMError` EXIT, which shipped without the discriminator.
+
+    `_reinterpret_empty_plan` constructed its result without `output_unusable`,
+    and the field defaults to the SUPPRESSING value, so every failure at this
+    exit was classified an infrastructure fault. An answer that arrived and was
+    unusable therefore wrote no row here while the identical answer at the two
+    exits above wrote one -- and this is the exit whose reason quotes the
+    provider's own words, so the page denied the run had happened while printing
+    them. The two exits above were pinned; this one was not, which is how it
+    survived two revisions and three gate rounds.
+    """
+    root = tmp_path / "kb"
+    store = _kb_with_an_empty_plan(root)
+
+    results = translate_questions(store, _AnswersUnusably(), root=root)
+
+    assert results[0]["infrastructure_fault"] is False
+    row = store.questions()[0]
+    assert str(row["status"]) == "review_required"
+    # The DETERMINISTIC verdict is what the row keeps -- the engine reached it
+    # without the provider -- with the failed re-reading appended to it.
+    assert "is not in the schema or its aliases" in str(row["reason"])
+    assert "did not match schema" in str(row["reason"])
+
+
+def test_a_reinterpretation_that_never_landed_is_still_not_recorded(tmp_path):
+    """The counterweight, and the reason the test above is not vacuous.
+
+    Setting `output_unusable=True` unconditionally at that exit would satisfy
+    every assertion above and re-record infrastructure faults, so the negative
+    needs its own run. A provider that was never reached leaves the row
+    `pending`, and the question is re-picked on the next run rather than parked:
+    measured, a second run once the provider answers reaches `review_required`
+    with the same deterministic reason.
+    """
+    root = tmp_path / "kb"
+    store = _kb_with_an_empty_plan(root)
+
+    results = translate_questions(store, _NeverReached(), root=root)
+
+    assert results[0]["infrastructure_fault"] is True
+    assert _statuses(store) == ["pending"]
+    assert not str(store.questions()[0]["reason"])
+
+    # Recovery, in the same test, because "left pending" is only defensible if
+    # the question comes back: `translate_questions` re-picks `pending`.
+    translate_questions(store, _AnswersUnusably(), root=root)
+    assert _statuses(store) == ["review_required"]
+    assert "is not in the schema or its aliases" in str(store.questions()[0]["reason"])
 
 
 def test_openai_inherits_the_class_without_an_edit_to_its_adapter():

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: MPL-2.0
+"""#592. An infrastructure fault is REPORTED, never RECORDED on a question row.
+
+THE RULE IS READ OFF THE STATUS, not chosen. `question_outcome.py::_STATUS_META`
+defines `translation_failed` as "The provider output could not be used" -- a
+claim about the provider's OUTPUT. When no request was sent (no API key, unknown
+provider, SDK missing) or translation was never attempted (a policy file that
+cannot be read), there is no output and the claim is false. `pending` ("Waiting
+for translation.") is true of all of them, and it is already in `db.py`'s CHECK
+constraint, so nothing here needs a schema change.
+
+WHAT IS NOT AN INFRASTRUCTURE FAULT, and this is the half that makes the rule
+non-vacuous: a response that ARRIVED and could not be used. A schema-violating
+intent, a payload with no tool_use block, an undecodable CLI answer -- the
+provider was reached and misbehaved, `translation_failed` is exactly true of the
+row, and it IS recorded. Without that half the rule would be satisfiable by
+never recording anything and the status would become unreachable.
+
+`LLMError` could not express that distinction: its own docstring is "Any
+provider-side OR PARSING failure", so it conflates a request never sent with an
+answer that came back unusable. `LLMOutputError` is the second case, and the
+tests below pin both directions.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from verinote.config import Config
+from verinote.llm.base import LLMError, LLMOutputError, parsed_under_redaction
+from verinote.pipeline.query import translate_questions
+from verinote.pipeline.query_intent import parse_query_intent
+from verinote.pipeline.repair import process_repair_job, repair_question
+from verinote.store import Store
+from verinote.web.app import create_app
+
+ALIAS_HEALTHY = "- 소속 -> member_of\n"
+TYPED_HEALTHY = "- 자본금: amount as capital\n"
+TYPED_BROKEN = "- 자본금: amount as capital\n- 자산: amount as capital\n"
+
+
+def _kb(root: Path, *, typed: str = TYPED_HEALTHY) -> Store:
+    root.mkdir(parents=True, exist_ok=True)
+    policy = root / "policy"
+    policy.mkdir(parents=True, exist_ok=True)
+    (policy / "relation-aliases.md").write_text(ALIAS_HEALTHY, encoding="utf-8")
+    (policy / "typed-relations.md").write_text(typed, encoding="utf-8")
+    store = Store(root / "kb.sqlite")
+    store.init_schema()
+    store.add_question("What is the sample answer?")
+    return store
+
+
+def _statuses(store: Store) -> list[str]:
+    return [str(q["status"]) for q in store.questions()]
+
+
+class _NeverReached:
+    """The provider is never reached: the adapter fails before sending."""
+
+    def extract_query_intent(self, *, question, schema_hint=""):
+        raise LLMError("anthropic requires an API key; set VERINOTE_ANTHROPIC_API_KEY")
+
+    def translate_query(self, *, question, qid, schema_hint=""):
+        raise LLMError("anthropic requires an API key; set VERINOTE_ANTHROPIC_API_KEY")
+
+
+class _AnswersUnusably:
+    """The provider ANSWERS, and the answer cannot be used.
+
+    Built through the real parser rather than by raising `LLMOutputError`
+    directly: a stub that raised the class under test would pass whatever the
+    production code did with it, which is the vacuity this file exists to avoid.
+    """
+
+    def extract_query_intent(self, *, question, schema_hint=""):
+        return parse_query_intent({"kind": "lookup_object"})
+
+    def translate_query(self, *, question, qid, schema_hint=""):
+        # The repair path falls through to this after the intent comes back
+        # unsupported. It ANSWERS -- with Datalog the engine cannot use.
+        return "answer_q1(X) :- nonexistent_predicate(X)."
+
+
+def test_the_unusable_output_fixture_really_raises_through_the_real_parser():
+    """Anti-vacuity for `_AnswersUnusably`, and for the rule's second half.
+
+    If `parse_query_intent` ever stopped rejecting this payload, every
+    "still recorded" test below would pass by never failing at all.
+    """
+    with pytest.raises(LLMOutputError) as excinfo:
+        parse_query_intent({"kind": "lookup_object"})
+    assert "did not match schema" in str(excinfo.value)
+
+
+def test_a_provider_that_was_never_reached_is_not_recorded(tmp_path):
+    store = _kb(tmp_path / "kb")
+    results = translate_questions(store, _NeverReached(), root=tmp_path / "kb")
+    assert _statuses(store) == ["pending"]
+    # Reported, though: the caller still receives it, which is what the CLI's
+    # exit code and the web's banner are both derived from.
+    assert results[0]["status"] == "translation_failed"
+    assert "API key" in results[0]["reason"]
+
+
+def test_an_unreadable_policy_file_is_not_recorded(tmp_path):
+    store = _kb(tmp_path / "kb", typed=TYPED_BROKEN)
+    results = translate_questions(store, _NeverReached(), root=tmp_path / "kb")
+    assert _statuses(store) == ["pending"]
+    assert results[0]["status"] == "translation_failed"
+
+
+def test_output_that_arrived_and_could_not_be_used_IS_recorded(tmp_path):
+    """THE ANTI-VACUITY CONTROL. Without this the rule is satisfiable by never
+    recording anything, and `translation_failed` becomes unreachable."""
+    store = _kb(tmp_path / "kb")
+    translate_questions(store, _AnswersUnusably(), root=tmp_path / "kb")
+    assert _statuses(store) == ["translation_failed"]
+    assert "did not match schema" in str(store.questions()[0]["reason"])
+
+
+def test_repair_does_not_record_an_unreadable_policy_file(tmp_path):
+    """The third writer. `repair_question` persists `prepared.status`, which a
+    policy fault reaches as `translation_failed`."""
+    root = tmp_path / "kb"
+    store = _kb(root, typed=TYPED_BROKEN)
+    qid = int(store.questions()[0]["id"])
+    repair_question(store, _NeverReached(), question_id=qid,
+                    question="What is the sample answer?", root=root)
+    assert _statuses(store) == ["pending"]
+
+
+def test_the_web_reports_the_fault_it_no_longer_records(tmp_path):
+    """AC-2's cost, paid. The row write WAS the web's only diagnosis, so
+    deleting it without this surface would have made a broken provider silent."""
+    root = tmp_path / "kb"
+    root.mkdir(parents=True)
+    policy = root / "policy"
+    policy.mkdir(parents=True)
+    (policy / "relation-aliases.md").write_text(ALIAS_HEALTHY, encoding="utf-8")
+    (policy / "typed-relations.md").write_text(TYPED_HEALTHY, encoding="utf-8")
+    cfg = Config(root=root, db_path=root / "kb.sqlite", provider="nosuchprovider",
+                 model="m", api_key=None, base_url=None)
+    app = create_app(cfg)
+    client = TestClient(app, raise_server_exceptions=False)
+    app.state.store.add_question("What is the sample answer?")
+
+    response = client.post("/questions/translate", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert "Translation did not run" in " ".join(response.text.split())
+    assert [str(q["status"]) for q in app.state.store.questions()] == ["pending"]
+
+
+def test_every_llm_error_subclass_takes_one_message():
+    """`parsed_under_redaction` re-raises with `type(exc)(...)`, so a subclass
+    whose constructor took a different shape would break inside error handling.
+
+    Derived from `__subclasses__()` rather than listed, so a subclass added later
+    is covered without anyone remembering this test exists.
+    """
+    subclasses = LLMError.__subclasses__()
+    assert subclasses, "no subclasses -- this test would pass vacuously"
+    for cls in subclasses:
+        assert str(cls("probe")) == "probe", cls.__name__
+
+
+def test_parsed_under_redaction_preserves_the_class_and_the_redaction():
+    """Both halves together: flattening the class silently disabled the rule,
+    and losing the redaction would leak a key into a question row."""
+    secret = "sk-ant-SECRETVALUE0123456789"
+    with pytest.raises(LLMOutputError) as excinfo:
+        parsed_under_redaction(parse_query_intent, f"not json {secret}", secret)
+    assert secret not in str(excinfo.value)
+    assert "query intent output was not JSON" in str(excinfo.value)
+
+
+def test_the_async_repair_worker_does_not_record_it_either(tmp_path):
+    """THE FOURTH WRITER, EXERCISED rather than inspected.
+
+    `persist_repair_question` is a SEPARATE write from `repair_question`'s, on
+    the job worker's path, and a guard added to one does not cover the other. It
+    would be easy to add the check and never run it -- so this drives the real
+    worker end to end and asserts the row, not the presence of a guard.
+
+    The row stays `review_required`, which is what it already was and still
+    true: `persist_repair_question` only ever transitions rows out of that
+    status, so declining to write leaves a status that describes the question
+    rather than the environment. The fault is still reported -- the job and its
+    item both finish `failed` with the reason.
+    """
+    root = tmp_path / "kb"
+    store = _kb(root, typed=TYPED_BROKEN)
+    qid = int(store.questions()[0]["id"])
+    store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    job, created = store.enqueue_repair_job(provider="fake", model="m")
+    assert created is True
+
+    process_repair_job(store, _NeverReached(), job_id=int(job["id"]), root=root)
+
+    assert _statuses(store) == ["review_required"]
+    items = store.repair_job_items(int(job["id"]))
+    assert [str(i["status"]) for i in items] == ["failed"]
+    assert "typed-relations.md" in str(items[0]["reason"])
+
+
+def test_the_async_worker_still_records_output_that_arrived_unusable(tmp_path):
+    """The other half, on the same path: a provider that ANSWERS unusably must
+    still be written. Without this the async guard could suppress everything and
+    both tests above would still pass."""
+    root = tmp_path / "kb"
+    store = _kb(root)
+    qid = int(store.questions()[0]["id"])
+    store.set_question_query(qid, 'review_required("synthetic")', "review_required")
+    job, _ = store.enqueue_repair_job(provider="fake", model="m")
+
+    before = str(store.questions()[0]["reason"])
+    process_repair_job(store, _AnswersUnusably(), job_id=int(job["id"]), root=root)
+
+    # The row was WRITTEN: its reason now describes the unusable answer. The
+    # status may legitimately stay `review_required` -- the engine's verdict on
+    # a bad draft is review, not translation-failure -- so the reason is what
+    # distinguishes "written" from "declined to write", and the status alone
+    # would make this test pass either way.
+    after = str(store.questions()[0]["reason"])
+    assert after != before
+    # The intent parser rejects the payload, so the flow never reaches the
+    # direct-Datalog fallback -- the recorded reason is the schema violation,
+    # which is the provider's output being unusable.
+    assert "did not match schema" in after
+
+
+def test_openai_inherits_the_class_without_an_edit_to_its_adapter():
+    """#592 touches `openai_adapter.py` only for the redaction line -- the three
+    parser call sites there needed NO change, and this is why.
+
+    The parsers raise the subclass and `parsed_under_redaction` preserves it, so
+    every adapter that routes output through a parser inherits the distinction
+    for free. `OpenRouterAdapter` subclasses `OpenAIAdapter` and overrides none
+    of the three, so it inherits it too. That is the argument for putting the
+    class in the shared primitive rather than in each adapter, and it is
+    asserted here rather than left as an inference from the file list.
+    """
+    import types
+
+    from verinote.llm.openai_adapter import OpenAIAdapter
+
+    cfg = Config(root=Path("/tmp"), db_path=Path("/tmp/x"), provider="openai",
+                 model="m", api_key="sk-SECRET", base_url=None)
+    adapter = OpenAIAdapter(cfg)
+    message = types.SimpleNamespace(content='{"kind": "lookup_object"}')
+    response = types.SimpleNamespace(choices=[types.SimpleNamespace(message=message)])
+    completions = types.SimpleNamespace(create=lambda **kwargs: response)
+    adapter._client = lambda: types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=completions)
+    )
+    adapter._rendered = lambda *args, **kwargs: "prompt"
+
+    with pytest.raises(LLMOutputError):
+        adapter.extract_query_intent(question="q")

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -483,10 +483,17 @@ def test_a_schema_failure_is_not_reported_as_a_request_failure(tmp_path, monkeyp
     This is the boundary the region must NOT swallow, so it is the counterweight
     to the two cases above: widening the guard until it covers `parse_facts`
     would make both of those pass and this one fail.
+
+    #592 MADE THE CLASS PART OF THE ASSERTION. This used to accept `LLMError`,
+    the base class, which every candidate satisfies -- so it went green whichever
+    class the parser raised and could not fail for the reason it was written.
+    The parsers decide whether the question row records the failure, and for
+    ollama they decide it directly: this adapter calls them without
+    `parsed_under_redaction` in between.
     """
     _raw_body(monkeypatch, json.dumps({"message": {"content": "{}"}}).encode("utf-8"))
 
-    with pytest.raises(LLMError) as exc:
+    with pytest.raises(LLMOutputError) as exc:
         _PARSING_INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
 
     assert "request failed" not in str(exc.value)

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -6,7 +6,7 @@ import pytest
 
 from verinote.config import Config, save_settings
 from verinote.engine.terms import Compound, NumberLit
-from verinote.llm.base import LLMError
+from verinote.llm.base import LLMError, LLMOutputError
 from verinote.llm.ollama_adapter import OllamaAdapter, list_models
 from verinote.llm.schema import FACT_ARRAY_SCHEMA
 from verinote.pipeline import extract_source
@@ -411,35 +411,66 @@ def test_every_method_posts_through_the_one_request_site(tmp_path, monkeypatch, 
 
 
 @pytest.mark.parametrize("method", sorted(_INVOCATIONS))
-def test_a_response_body_that_is_not_json_is_a_normalised_request_failure(
+def test_a_response_body_that_is_not_json_is_normalised_as_unusable_output(
     tmp_path, monkeypatch, method
 ):
-    """A proxy or a captive portal answering HTML is a transport failure the
-    caller already handles, not a `JSONDecodeError` escaping the adapter.
+    """A proxy or a captive portal answering HTML is normalised by this adapter,
+    not a `JSONDecodeError` escaping it. Pinning that here means a later edit
+    that folds the four request sites into one helper cannot quietly leave the
+    decode outside the guard, which would turn this into an unnormalised raise.
 
-    `json.loads` is inside the guarded region today. Pinning that here means a
-    later edit that folds the four request sites into one helper cannot quietly
-    leave the parse outside it, which would turn this into an unnormalised raise.
+    #592 RENAMED WHAT IT IS NORMALISED TO, and the rename is the substance. This
+    used to join `urlopen` under one clause and report "ollama request failed",
+    which says the server did not answer -- but it did: the response arrived,
+    with a body, and the body is what could not be used. `translate_questions`
+    reads that distinction off the class, so the old wording did more than
+    misdirect a reader. Measured on a 200 carrying `<html>502 Bad Gateway</html>`
+    it left the question row `pending` with no trace of the failure, where a
+    `translation_failed` row is exactly true of it.
     """
     _raw_body(monkeypatch, b"not json")
 
-    with pytest.raises(LLMError, match="^ollama request failed"):
+    with pytest.raises(LLMOutputError, match="^ollama response could not be read"):
         _INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
 
 
 @pytest.mark.parametrize("method", sorted(_INVOCATIONS))
-def test_a_response_body_that_is_not_utf8_is_a_normalised_request_failure(
+def test_a_response_body_that_is_not_utf8_is_normalised_as_unusable_output(
     tmp_path, monkeypatch, method
 ):
-    """`.decode("utf-8")` is the other statement in the region that can raise on
-    an otherwise well-formed HTTP response — a server that ignored the content
-    type and sent UTF-16 gets here. Separate from the non-JSON case because the
-    two are different statements, and an edit can move one without the other.
+    """`.decode("utf-8")` is the other statement that can raise on an otherwise
+    well-formed HTTP response — a server that ignored the content type and sent
+    UTF-16 gets here. Separate from the non-JSON case because the two are
+    different statements, and an edit can move one without the other.
     """
     _raw_body(monkeypatch, b"\xff\xfe")
 
-    with pytest.raises(LLMError, match="^ollama request failed"):
+    with pytest.raises(LLMOutputError, match="^ollama response could not be read"):
         _INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
+
+
+@pytest.mark.parametrize("method", sorted(_INVOCATIONS))
+def test_a_request_that_never_landed_stays_a_plain_request_failure(
+    tmp_path, monkeypatch, method
+):
+    """The counterweight to the two above, and the reason they are not vacuous.
+
+    #592's discriminator is whether a response arrived, so `urlopen` failing and
+    its body failing to decode must land on OPPOSITE sides -- otherwise one
+    clause covering both would satisfy every assertion here. This one asserts the
+    negative directly: a connection that never produced a body is an `LLMError`
+    and is NOT an `LLMOutputError`, so merging the two clauses back together
+    reddens this test whichever class the merged clause picks.
+    """
+
+    def refuse(req, *, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", refuse)
+
+    with pytest.raises(LLMError, match="^ollama request failed") as exc:
+        _INVOCATIONS[method](OllamaAdapter(_cfg(tmp_path)))
+    assert not isinstance(exc.value, LLMOutputError)
 
 
 @pytest.mark.parametrize("method", sorted(_PARSING_INVOCATIONS))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1579,12 +1579,20 @@ def test_every_provider_failure_exit_reports_the_provider_failed():
                 )
                 if not flagged:
                     offenders.append(f"{path.name}:{child.lineno}")
-                # #592. The SECOND flag, judged by PRESENCE rather than by value.
-                # `output_unusable` is necessarily computed (`isinstance(exc,
-                # LLMOutputError)`), so demanding a literal the way the line
-                # above does would be unsatisfiable; what can be demanded is
-                # that the exit answered the question at all.
-                if not any(kw.arg == "output_unusable" for kw in child.keywords):
+                # #592. The SECOND flag. `output_unusable` is necessarily
+                # computed (`isinstance(exc, LLMOutputError)`), so demanding the
+                # literal `True` the line above demands would be unsatisfiable.
+                # What IS demanded is that the exit answered the question with a
+                # computed value: a keyword that is present but CONSTANT --
+                # `output_unusable=False` -- is semantically identical to
+                # omitting it, since False is the dataclass default and the
+                # suppressing value. Rejecting constants is satisfiable on this
+                # tree; every examined site passes a computed Name.
+                discriminated = any(
+                    kw.arg == "output_unusable" and not isinstance(kw.value, ast.Constant)
+                    for kw in child.keywords
+                )
+                if not discriminated:
                     undiscriminated.append(f"{path.name}:{child.lineno}")
 
     assert examined, (
@@ -1596,8 +1604,8 @@ def test_every_provider_failure_exit_reports_the_provider_failed():
         f"provider_failed=True, so Ask cannot tell they failed: {offenders}"
     )
     assert undiscriminated == [], (
-        "these provider-failure exits build a flow result without an "
-        "`output_unusable=` keyword, so they fall back to the dataclass default "
-        "of False -- which SUPPRESSES the question row. An answer that arrived "
-        f"and could not be used is silently not recorded there (#592): {undiscriminated}"
+        "these provider-failure exits build a flow result without a COMPUTED "
+        "`output_unusable=` keyword, so the flag is False -- the dataclass "
+        "default, and the SUPPRESSING value. An answer that arrived and could "
+        f"not be used is silently not recorded there (#592): {undiscriminated}"
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1521,7 +1521,8 @@ def test_no_fact_joins_them_needs_evidence_not_merely_an_untruncated_list(tmp_pa
 
 
 def test_every_provider_failure_exit_reports_the_provider_failed():
-    """Producer-side tripwire for `provider_failed` (#438).
+    """Producer-side tripwire for `provider_failed` (#438) and for
+    `output_unusable` (#592).
 
     Ask suppresses its fallback request on this flag, so a handler that builds a
     `_QueryFlowResult` after an `LLMError` and forgets the keyword silently
@@ -1536,12 +1537,23 @@ def test_every_provider_failure_exit_reports_the_provider_failed():
     package deliberately: `_QueryFlowResult` lives in one module today, and a
     second one importing the private name is exactly the drift worth catching.
 
+    #592 ADDED THE SECOND FLAG BECAUSE OMITTING IT IS THE SAME DEFECT, one flag
+    over. `output_unusable` decides whether the question row records the
+    failure, and its dataclass default is the SUPPRESSING value, so a handler
+    that forgets the keyword silently stops recording answers that arrived. That
+    is not hypothetical: `_reinterpret_empty_plan` shipped without it for two
+    revisions and three gate rounds, and this sweep -- judging only
+    `provider_failed` at the time -- stayed green over it. The behavioural tests
+    at each exit could not catch it either, because there was no test at that
+    exit; a producer-side sweep is what covers an exit nobody thought to test.
+
     What would make this vacuous: no construction inside any `except LLMError:`
     handler, so the loop finds nothing to judge. The companion assertion below
     requires the sweep to have examined at least one.
     """
     package = Path(__file__).resolve().parent.parent / "verinote"
     offenders = []
+    undiscriminated = []
     examined = []
     for path in sorted(package.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -1567,6 +1579,13 @@ def test_every_provider_failure_exit_reports_the_provider_failed():
                 )
                 if not flagged:
                     offenders.append(f"{path.name}:{child.lineno}")
+                # #592. The SECOND flag, judged by PRESENCE rather than by value.
+                # `output_unusable` is necessarily computed (`isinstance(exc,
+                # LLMOutputError)`), so demanding a literal the way the line
+                # above does would be unsatisfiable; what can be demanded is
+                # that the exit answered the question at all.
+                if not any(kw.arg == "output_unusable" for kw in child.keywords):
+                    undiscriminated.append(f"{path.name}:{child.lineno}")
 
     assert examined, (
         "no `_QueryFlowResult` was built inside an `except LLMError:` handler, so "
@@ -1575,4 +1594,10 @@ def test_every_provider_failure_exit_reports_the_provider_failed():
     assert offenders == [], (
         "these provider-failure exits build a flow result without "
         f"provider_failed=True, so Ask cannot tell they failed: {offenders}"
+    )
+    assert undiscriminated == [], (
+        "these provider-failure exits build a flow result without an "
+        "`output_unusable=` keyword, so they fall back to the dataclass default "
+        "of False -- which SUPPRESSES the question row. An answer that arrived "
+        f"and could not be used is silently not recorded there (#592): {undiscriminated}"
     )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -318,6 +318,7 @@ def test_translate_korean_role_question_bypasses_llm(tmp_path):
             "status": "translated",
             "query_dl": s.questions()[0]["query_dl"],
             "reason": "",
+            "infrastructure_fault": False,
         }
     ]
     query_dl = s.questions()[0]["query_dl"]
@@ -358,6 +359,7 @@ def test_translate_korean_provide_question_bypasses_llm(tmp_path):
             "status": "translated",
             "query_dl": s.questions()[0]["query_dl"],
             "reason": "",
+            "infrastructure_fault": False,
         }
     ]
     query_dl = s.questions()[0]["query_dl"]
@@ -457,6 +459,7 @@ def test_translate_retries_translation_failed_questions(tmp_path, fake_client, i
             "status": "translated",
             "query_dl": s.questions()[0]["query_dl"],
             "reason": "",
+            "infrastructure_fault": False,
         }
     ]
     assert s.questions()[0]["status"] == "translated"
@@ -635,6 +638,7 @@ def test_translation_never_calls_direct_datalog_fallback(
             "status": "review_required",
             "query_dl": 'review_required("requires a synthetic relation")',
             "reason": "requires a synthetic relation",
+            "infrastructure_fault": False,
         }
     ]
 
@@ -691,6 +695,7 @@ def test_planned_executable_without_rows_becomes_no_answer(
             "status": "no_answer",
             "query_dl": 'no_answer("no confirmed facts match")',
             "reason": "no confirmed facts match",
+            "infrastructure_fault": False,
         }
     ]
     assert load_query(s) == ""
@@ -776,6 +781,7 @@ def test_quality_policy_review_required_outcome_is_persisted(
             "status": "review_required",
             "query_dl": 'review_required("relation label requires review: source")',
             "reason": "relation label requires review: source",
+            "infrastructure_fault": False,
         }
     ]
     assert load_query(s) == ""
@@ -805,6 +811,7 @@ def test_supported_planner_review_required_does_not_call_direct_datalog(
             "status": "review_required",
             "query_dl": 'review_required("relation label requires review: source")',
             "reason": "relation label requires review: source",
+            "infrastructure_fault": False,
         }
     ]
     assert load_query(s) == ""
@@ -927,6 +934,7 @@ def test_translate_reports_an_unreached_provider_without_persisting_it(tmp_path,
             "status": "translation_failed",
             "query_dl": None,
             "reason": "provider unavailable",
+            "infrastructure_fault": True,
         }
     ]
     q = s.questions()[0]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -904,7 +904,16 @@ def test_query_schema_hint_includes_typed_comparison_type_and_amount_units(tmp_p
     assert "Synthetic Company" not in hint
 
 
-def test_translate_persists_llm_error_as_translation_failed(tmp_path, fake_client):
+def test_translate_reports_an_unreached_provider_without_persisting_it(tmp_path, fake_client):
+    """#592 inverted the row half. The RESULT is unchanged and still carries the
+    fault -- that is the report, and every caller derives its own diagnosis from
+    it. The row stays `pending`, because a provider that was never reached
+    produced no output for `translation_failed` to be true about.
+
+    `test_invalid_intent_output_fails_translation_and_skips_draft` is the other
+    side of the same rule and must stay green: there the provider ANSWERED and
+    the answer was unusable, so the row records.
+    """
     s = _store(tmp_path)
     qid = s.add_question("What is the sample answer?")
 
@@ -921,8 +930,8 @@ def test_translate_persists_llm_error_as_translation_failed(tmp_path, fake_clien
         }
     ]
     q = s.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == "provider unavailable"
+    assert q["status"] == "pending"
+    assert not q["reason"]
     assert q["query_dl"] is None
     assert load_query(s) == ""
 

--- a/tests/test_query_schema_policy_guard.py
+++ b/tests/test_query_schema_policy_guard.py
@@ -75,13 +75,18 @@ no per-question record to render. Delivering the diagnosis needs the message
 carried from the POST to the render, which is neither issue's.
 
 WHY THE QUESTION ROWS STAY `pending`. `translate_questions` reports the policy
-failure per question but does not write it. The justification is comparative and
-deliberately narrow: today's unhandled exception leaves every pending question
-`pending`, so a guard that wrote `translation_failed` to each would leave the KB
-in a worse state than the bug it replaces. It is NOT a rule that an environment
-fault may never be recorded on a question row -- `_fail_pending_translations`
-and `cli.py`'s missing-credential path both do exactly that, deliberately, and
-this change leaves both alone.
+failure per question but does not write it. #591's justification was comparative
+and deliberately narrow: today's unhandled exception leaves every pending
+question `pending`, so a guard that wrote `translation_failed` to each would
+leave the KB in a worse state than the bug it replaces.
+
+#592 REPLACED THAT WITH A RULE, and this paragraph used to say there was none --
+that `_fail_pending_translations` and `cli.py`'s credential path recorded such
+faults deliberately and were left alone. Both have since stopped: an
+infrastructure fault is REPORTED, never RECORDED, at all four writers. The rule
+is read off `translation_failed`'s own definition, "The provider output could
+not be used", which is false when no output existed. A response that ARRIVED and
+was unusable is a different case and is still recorded.
 """
 
 import re
@@ -293,12 +298,20 @@ def test_translate_survives_each_broken_policy_file(
     one. #590 fixed that and the reason changed rather than disappearing: the
     redirect target is a different route with its own guard and its own tests,
     so asserting on it here would attribute #590's behaviour to #591's guard.
-    The 303 is what this test owns.
+    THE STATUS CHANGED IN #592, and the reason for asserting here did not. This
+    asserted 303: the route redirected and the diagnosis lived in the question
+    rows it wrote. #592 stopped writing those rows -- an infrastructure fault is
+    reported, never recorded -- so the route now RENDERS the page with the fault
+    in its error slot, which is a 200. The message is asserted rather than the
+    bare status, because the status alone no longer distinguishes "reported" from
+    "silently redirected".
     """
-    del message
     client, _ = _client(tmp_path, alias_bytes, typed_bytes)
     r = client.post("/questions/translate", follow_redirects=False)
-    assert r.status_code == 303
+    assert r.status_code == 200
+    body = " ".join(r.text.split())
+    assert "Translation did not run" in body
+    assert message in body
 
 
 @pytest.mark.parametrize("alias_bytes, typed_bytes, message", BROKEN_INPUTS)

--- a/tests/test_query_schema_policy_guard.py
+++ b/tests/test_query_schema_policy_guard.py
@@ -82,11 +82,17 @@ leave the KB in a worse state than the bug it replaces.
 
 #592 REPLACED THAT WITH A RULE, and this paragraph used to say there was none --
 that `_fail_pending_translations` and `cli.py`'s credential path recorded such
-faults deliberately and were left alone. Both have since stopped: an
-infrastructure fault is REPORTED, never RECORDED, at all four writers. The rule
-is read off `translation_failed`'s own definition, "The provider output could
-not be used", which is false when no output existed. A response that ARRIVED and
-was unusable is a different case and is still recorded.
+faults deliberately and were left alone. Both have since stopped writing at all:
+an infrastructure fault is REPORTED, never RECORDED, at each of the sites that
+write `questions.status` -- `translate_questions`, `repair_question`, and the
+job worker's `persist_repair_question`, which is every one of them, derived by
+finding the `Store` methods whose SQL sets that column and then their callers
+under `verinote/`. The rule is ANCHORED IN `translation_failed`'s only textual
+definition in this repo, `question_outcome.py::_STATUS_META`'s "The provider
+output could not be used", which is false when no output existed -- anchored
+rather than READ OFF, because that string is a display FALLBACK
+`question_outcome_view` renders only for a row carrying no reason. A response
+that ARRIVED and was unusable is a different case and is still recorded.
 """
 
 import re
@@ -310,7 +316,7 @@ def test_translate_survives_each_broken_policy_file(
     r = client.post("/questions/translate", follow_redirects=False)
     assert r.status_code == 200
     body = " ".join(r.text.split())
-    assert "Translation did not run" in body
+    assert "Translation could not run" in body
     assert message in body
 
 

--- a/tests/test_query_schema_policy_guard.py
+++ b/tests/test_query_schema_policy_guard.py
@@ -20,9 +20,8 @@ not parse, so a typo'd typed file parsed to `{}` and failed nothing. #589 made
 that line raise, so the guard now fires on it and `POST /ask` names the typed
 file in its body.
 
-The STATUS codes did not move -- `POST /ask` is still 200 and
-`POST /questions/translate` still 303, because this guard degrades rather than
-500s -- which is why the test below kept passing after the behaviour inverted:
+`POST /ask` is still 200 -- this guard degrades rather than 500s -- which is
+why the test below kept passing after the behaviour inverted:
 `ALL_MESSAGES` had been enumerated when the only typed-file message was the
 duplicate-alias one, so the unparseable-line message #589 added was not in it.
 It IS in it now -- the set gained `TYPED_TYPO_MSG` in the same change that
@@ -60,21 +59,20 @@ question resolves deterministically and exits 0 with no credentials at all,
 which `NoProviderClient` below makes self-enforcing by raising if anything asks
 the provider.
 
-WHAT THIS CHANGE DOES NOT DELIVER, stated so its absence is not read as an
-oversight. `POST /questions/translate` answers 303 and redirects to
-`GET /questions`, and the guard deliberately writes nothing to the question rows
-(see below), so that page has nothing to display about the failure. Rendering
-the page from the translate route instead of redirecting would have turned the
-cp949 input from 303 into 500, because `GET /questions` itself failed on a cp949
-alias file when this was written. **#590 has since fixed that** -- `GET /questions`
-answers 200 on both broken-alias entries in `BROKEN_INPUTS` below
-(`alias-malformed` and `alias-cp949`; the third has a healthy alias) -- so the
-500 half of this obstacle is gone. What remains is the other half: this guard
-deliberately writes nothing to the question rows, so the landing page still has
-no per-question record to render. Delivering the diagnosis needs the message
-carried from the POST to the render, which is neither issue's.
+WHAT THIS CHANGE DID NOT DELIVER, AND WHAT SINCE DELIVERED IT. When this file
+was written `POST /questions/translate` answered 303 and redirected to
+`GET /questions`, and the guard wrote nothing to the question rows, so that page
+had nothing to display about the failure. Rendering from the translate route
+instead of redirecting would have turned the cp949 input from 303 into 500,
+because `GET /questions` itself failed on a cp949 alias file back then. #590
+removed that obstacle, and #592 then did the rendering: the route carries the
+message from the POST into the page's `error` slot, so every entry in
+`BROKEN_INPUTS` below now answers **200 with a banner naming the broken file**,
+and `test_translate_survives_each_broken_policy_file` asserts exactly that. A
+303 survives only for a run with no fault to report. The rows still carry
+nothing, which is now a rule rather than a gap -- see the paragraph below.
 
-WHY THE QUESTION ROWS STAY `pending`. `translate_questions` reports the policy
+WHY THE QUESTION ROWS ARE LEFT ALONE. `translate_questions` reports the policy
 failure per question but does not write it. #591's justification was comparative
 and deliberately narrow: today's unhandled exception leaves every pending
 question `pending`, so a guard that wrote `translation_failed` to each would

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -810,7 +810,10 @@ def test_repair_unsupported_intent_still_reaches_fallback(
     assert s.questions()[0]["status"] == "translated"
 
 
-def test_repair_persists_llm_error_reason(tmp_path, fake_client):
+def test_repair_reports_an_unreached_provider_without_persisting_it(tmp_path, fake_client):
+    """#592. The row already held `review_required` and keeps it -- repair leaves
+    the question exactly as it found it when the provider was never reached. The
+    reason is still returned to the caller, which is the report."""
     s, qid = _store_with_review_required(tmp_path)
     original_query = s.questions()[0]["query_dl"]
     client = fake_client(error=LLMError("provider unavailable"))
@@ -822,4 +825,5 @@ def test_repair_persists_llm_error_reason(tmp_path, fake_client):
     q = s.questions()[0]
     assert q["status"] == "review_required"
     assert q["query_dl"] == original_query
-    assert q["reason"] == "llm error: provider unavailable"
+    # Unwritten, so the row keeps whatever reason it already had.
+    assert q["reason"] != "llm error: provider unavailable"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3804,7 +3804,7 @@ def test_translate_reports_an_unreached_provider_on_the_page(tmp_path, monkeypat
 
     assert r.status_code == 200
     body = " ".join(r.text.split())
-    assert "Translation did not run" in body
+    assert "Translation could not run" in body
     assert "provider unavailable" in body
     q = c.app.state.store.questions()[0]
     assert q["status"] == "pending"
@@ -3822,7 +3822,7 @@ def test_translate_reports_a_get_client_failure_on_the_page(tmp_path, monkeypatc
 
     assert r.status_code == 200
     body = " ".join(r.text.split())
-    assert "Translation did not run" in body
+    assert "Translation could not run" in body
     assert "missing provider credentials" in body
     q = c.app.state.store.questions()[0]
     assert q["status"] == "pending"
@@ -3855,7 +3855,7 @@ def test_translate_leaves_the_reason_blank_when_the_llm_error_has_no_message(
 
     assert r.status_code == 200
     body = " ".join(r.text.split())
-    assert "Translation did not run" in body
+    assert "Translation could not run" in body
     assert "LLMError" not in body
     q = c.app.state.store.questions()[0]
     assert q["status"] == "pending"
@@ -3869,28 +3869,40 @@ def test_translate_leaves_the_reason_blank_when_the_llm_error_has_no_message(
     assert "LLMError" not in page
 
 
-def test_translate_collapses_whitespace_and_bounds_the_reason_to_240_chars(
+def test_translate_collapses_whitespace_and_bounds_the_detail_to_240_chars(
     tmp_path, monkeypatch
 ):
     """S6's inline normalisation (`" ".join(str(exc).split())[:240]`) is a bare
     expression, not a named helper, since #551 cut this site off from
     `_short_error` — easier to lose a piece of by accident than a helper call
-    would be. `questions.reason` is unbounded `TEXT`, written for every pending
-    question at once, so both halves need a test: the internal-whitespace
-    collapse, and the 240-character bound.
+    would be. Both halves need a test: the internal-whitespace collapse, and the
+    240-character bound.
 
-    Message built so the expected result can be computed by direct slicing,
-    not by re-deriving the production logic: 100 `a`s, an irregular whitespace
-    run that must collapse to one space, then 200 `b`s. Collapsed that is 301
+    #592 MOVED THE DESTINATION AND THE BOUND WITH IT. The text used to go to
+    `questions.reason`, an unbounded `TEXT` column written for every pending
+    question at once; it now goes to the page banner, which is a fixed sentence
+    with the provider's message interpolated. That makes WHERE the bound is
+    applied a substantive question rather than a detail, and a revision of #592
+    got it wrong: capping the composed line put the provider's text first and
+    the fixed tail last, so a long message truncated away the half that tells a
+    user what happened to their rows and the banner ended mid-word. The bound is
+    on the DETAIL now, and this asserts the whole banner rather than a prefix of
+    it -- a prefix assertion is what let the bound go unpinned through a whole
+    revision, where deleting `[:240]` reddened nothing at all.
+
+    Message built so the expected result can be computed by direct slicing, not
+    by re-deriving the production logic: 100 `a`s, an irregular whitespace run
+    that must collapse to one space, then 200 `b`s. Collapsed that is 301
     characters (100 + 1 + 200); truncated to 240 it is 100 `a`s, one space, and
-    139 `b`s — one message that exercises both the collapse and the
-    truncation boundary.
+    139 `b`s — one message that exercises both the collapse and the truncation
+    boundary. The trailing period is the production code's, added because the
+    truncated detail does not punctuate itself.
     """
     message = "a" * 100 + "  \n\t  " + "b" * 200
     collapsed = "a" * 100 + " " + "b" * 200
     assert len(collapsed) == 301
-    expected_reason = collapsed[:240]
-    assert expected_reason == "a" * 100 + " " + "b" * 139
+    expected_detail = collapsed[:240]
+    assert expected_detail == "a" * 100 + " " + "b" * 139
 
     def raise_long_llm_error(cfg):
         raise LLMError(message)
@@ -3901,13 +3913,63 @@ def test_translate_collapses_whitespace_and_bounds_the_reason_to_240_chars(
     r = c.post("/questions/translate", follow_redirects=False)
 
     # #592. Rendered, not redirected: the row is no longer the diagnosis, so
-    # the page has to be. The 240-char bound now applies to the banner.
+    # the page has to be.
     assert r.status_code == 200
-    body = " ".join(r.text.split())
-    assert "Translation did not run" in body
+    body = " ".join(unescape(r.text).split())
+    assert (
+        "Translation could not run: "
+        + expected_detail
+        + ". The questions it stopped on kept the status and reason they had."
+    ) in body
+    # The raw whitespace run never reaches the page, and the 101st `b` never
+    # does either. Asserting both directions is what makes the two halves above
+    # separable: dropping the collapse leaves the tab in, dropping the bound
+    # lets the full 200 `b`s through.
+    assert "a" * 100 + " \n" not in body
+    assert "b" * 140 not in body
     q = c.app.state.store.questions()[0]
     assert q["status"] == "pending"
     assert not q["reason"]
+
+
+def test_the_banner_tail_survives_a_detail_far_past_the_bound(tmp_path, monkeypatch):
+    """The property the bound exists to protect, stated as its own test.
+
+    Bounding the composed line instead of the detail satisfies every assertion
+    about the detail and still loses the tail, so the tail needs an assertion
+    that does not mention the detail at all. Measured on the revision that got
+    it wrong: a 300-character message produced 240 characters of provider text
+    and nothing else.
+    """
+
+    def raise_huge_llm_error(cfg):
+        raise LLMError("z" * 5000)
+
+    monkeypatch.setattr(webapp, "get_client", raise_huge_llm_error)
+    c = _client(tmp_path)
+    c.app.state.store.add_question("What is the sample answer?")
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    body = " ".join(unescape(r.text).split())
+    assert "The questions it stopped on kept the status and reason they had." in body
+
+
+def test_the_banner_reads_as_a_sentence_when_the_detail_is_empty(tmp_path, monkeypatch):
+    """`LLMError("")` is constructible, so the composed line has to survive it.
+
+    Interpolating an empty detail after a colon leaves `Translation could not
+    run: The questions...` -- a dangling separator, which is the #551 class the
+    predecessor of this site was exempt from only because it wrote to a
+    standalone column. It is not exempt now.
+    """
+    monkeypatch.setattr(webapp, "get_client", lambda cfg: (_ for _ in ()).throw(LLMError("")))
+    c = _client(tmp_path)
+    c.app.state.store.add_question("What is the sample answer?")
+    r = c.post("/questions/translate", follow_redirects=False)
+
+    body = " ".join(unescape(r.text).split())
+    assert "Translation could not run. The questions it stopped on kept the status and reason they had." in body
+    assert "run: The questions" not in body
 
 
 def test_translate_shows_invalid_model_output_reason_in_question_row(
@@ -3921,7 +3983,10 @@ def test_translate_shows_invalid_model_output_reason_in_question_row(
         store.set_question_query(
             q["id"], f'review_required("{reason}")', "review_required", reason
         )
-        return [{"id": q["id"], "status": "review_required", "reason": reason}]
+        return [
+            {"id": q["id"], "status": "review_required", "reason": reason,
+             "infrastructure_fault": False}
+        ]
 
     monkeypatch.setattr(webapp, "translate_questions", translate)
     c = _client(tmp_path)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3785,7 +3785,14 @@ def test_questions_translate_relation_discovery_shows_actual_lifecycle_states(
     assert "no_answer" not in query_dl
 
 
-def test_translate_persists_llm_error_reason(tmp_path, monkeypatch, fake_client):
+def test_translate_reports_an_unreached_provider_on_the_page(tmp_path, monkeypatch, fake_client):
+    """#592 moved this diagnosis from the ROW to the PAGE.
+
+    The row was the only place the web said anything about the fault, so
+    deleting the write without a surface would have made a broken provider
+    silent. The page now carries it and the row stays `pending`, which is true
+    of a question nothing was attempted for.
+    """
     monkeypatch.setattr(
         webapp,
         "get_client",
@@ -3795,16 +3802,16 @@ def test_translate_persists_llm_error_reason(tmp_path, monkeypatch, fake_client)
     c.app.state.store.add_question("What is the sample answer?")
     r = c.post("/questions/translate", follow_redirects=False)
 
-    assert r.status_code == 303
+    assert r.status_code == 200
+    body = " ".join(r.text.split())
+    assert "Translation did not run" in body
+    assert "provider unavailable" in body
     q = c.app.state.store.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == "provider unavailable"
-    page = c.get("/questions").text
-    assert "translation_failed" in page
-    assert "provider unavailable" in page
+    assert q["status"] == "pending"
+    assert not q["reason"]
 
 
-def test_translate_persists_get_client_failure_reason(tmp_path, monkeypatch):
+def test_translate_reports_a_get_client_failure_on_the_page(tmp_path, monkeypatch):
     def raise_client_error(cfg):
         raise LLMError("missing provider credentials")
 
@@ -3813,27 +3820,30 @@ def test_translate_persists_get_client_failure_reason(tmp_path, monkeypatch):
     c.app.state.store.add_question("What is the sample answer?")
     r = c.post("/questions/translate", follow_redirects=False)
 
-    assert r.status_code == 303
+    assert r.status_code == 200
+    body = " ".join(r.text.split())
+    assert "Translation did not run" in body
+    assert "missing provider credentials" in body
     q = c.app.state.store.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == "missing provider credentials"
-    assert (tmp_path / "facts" / "query.dl").read_text(encoding="utf-8") == ""
-    page = c.get("/questions").text
-    assert "translation_failed" in page
-    assert "missing provider credentials" in page
+    assert q["status"] == "pending"
+    assert not q["reason"]
+    # No row changed, so the derived draft was not regenerated. It used to be
+    # rewritten (empty) as a side effect of the row write that #592 removed.
+    assert not (tmp_path / "facts" / "query.dl").exists()
 
 
 def test_translate_leaves_the_reason_blank_when_the_llm_error_has_no_message(
     tmp_path, monkeypatch
 ):
-    """`_fail_pending_translations` (S6) is deliberately OUT of #551's scope: its
-    `reason` is a standalone column, not interpolated after a separator, and
-    `question_outcome_view` already renders a per-status default sentence when it
-    is blank — there is no dangling colon here to fix. Naming the exception's type
-    at this site would REPLACE that sentence ("The provider output could not be
-    used.") with a bare class name, which is a regression, not an improvement.
-    This pins the unchanged behavior so nothing re-routes this site through
-    `_error_cause` later."""
+    """S6 was deliberately OUT of #551's scope, and #592 REMOVED the site rather
+    than resolving that: `_fail_pending_translations` wrote the reason to a
+    standalone column, and there is no such column to write now.
+
+    What survives is the property #551 cared about — a blank `LLMError` must not
+    be rendered as a bare class name. The destination moved from the row to the
+    page, so that is where it is asserted: the banner still reads as a sentence
+    with an empty detail, and the row is untouched.
+    """
 
     def raise_blank_llm_error(cfg):
         raise LLMError("")
@@ -3843,12 +3853,20 @@ def test_translate_leaves_the_reason_blank_when_the_llm_error_has_no_message(
     c.app.state.store.add_question("What is the sample answer?")
     r = c.post("/questions/translate", follow_redirects=False)
 
-    assert r.status_code == 303
+    assert r.status_code == 200
+    body = " ".join(r.text.split())
+    assert "Translation did not run" in body
+    assert "LLMError" not in body
     q = c.app.state.store.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == ""
+    assert q["status"] == "pending"
+    assert not q["reason"]
+    # The per-status sentence this used to assert belongs to a
+    # `translation_failed` ROW, and there is no longer one to render it for --
+    # which is the point of #592, not a lost assertion. What must still hold is
+    # that a blank `LLMError` never surfaces as a class name anywhere.
     page = c.get("/questions").text
-    assert "The provider output could not be used." in page
+    assert "The provider output could not be used." not in page
+    assert "LLMError" not in page
 
 
 def test_translate_collapses_whitespace_and_bounds_the_reason_to_240_chars(
@@ -3882,11 +3900,14 @@ def test_translate_collapses_whitespace_and_bounds_the_reason_to_240_chars(
     c.app.state.store.add_question("What is the sample answer?")
     r = c.post("/questions/translate", follow_redirects=False)
 
-    assert r.status_code == 303
+    # #592. Rendered, not redirected: the row is no longer the diagnosis, so
+    # the page has to be. The 240-char bound now applies to the banner.
+    assert r.status_code == 200
+    body = " ".join(r.text.split())
+    assert "Translation did not run" in body
     q = c.app.state.store.questions()[0]
-    assert q["status"] == "translation_failed"
-    assert q["reason"] == expected_reason
-    assert len(q["reason"]) == 240
+    assert q["status"] == "pending"
+    assert not q["reason"]
 
 
 def test_translate_shows_invalid_model_output_reason_in_question_row(

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1603,7 +1603,17 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
         reason = _short_error(e)
         results = []
         for q in translatable:
-            store.set_question_query(q["id"], None, "translation_failed", reason)
+            # #592. REPORTED, NEVER RECORDED. `get_client` raises only for an
+            # unknown provider -- a corrupt config, not a missing key -- so
+            # translation was never attempted and `translation_failed` ("The
+            # provider output could not be used") would be false of the row.
+            # The rows stay `pending`, which is true of them.
+            #
+            # The RESULT DICT is still appended, and that is not cosmetic:
+            # `failures` below derives from these dicts, not from the rows, so
+            # deleting the append instead of the write would silently flip a
+            # broken-config run to rc=0. The fault is reported here, on stdout
+            # and in the exit code, and simply not written down.
             results.append(
                 {"id": q["id"], "status": "translation_failed", "reason": reason}
             )

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1607,21 +1607,42 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
             # unknown provider -- a corrupt config, not a missing key -- so
             # translation was never attempted and `translation_failed` ("The
             # provider output could not be used") would be false of the row.
-            # The rows stay `pending`, which is true of them.
+            # Nothing is written, so each row keeps whatever it had: `pending`
+            # for most, and `translation_failed` for one that genuinely failed
+            # an earlier run, since `translatable` above admits both.
             #
             # The RESULT DICT is still appended, and that is not cosmetic:
             # `failures` below derives from these dicts, not from the rows, so
             # deleting the append instead of the write would silently flip a
             # broken-config run to rc=0. The fault is reported here, on stdout
-            # and in the exit code, and simply not written down.
+            # and in the exit code, and simply not written down -- and
+            # `infrastructure_fault` is what tells the printing loop below that
+            # the `status` in this dict describes the run and not the row.
             results.append(
-                {"id": q["id"], "status": "translation_failed", "reason": reason}
+                {
+                    "id": q["id"],
+                    "status": "translation_failed",
+                    "reason": reason,
+                    "infrastructure_fault": True,
+                }
             )
         write_query_file(store, cfg.root)
     else:
         results = translate_questions(store, client, root=cfg.root)
     for r in results:
-        print(f"  {format_question_outcome(r)}")
+        if r["infrastructure_fault"]:
+            # #592. NOT `format_question_outcome`, which formats a QUESTION --
+            # `q{id}: {status} - {message}` reading `status` as the row's. On
+            # this branch the dict's `status` is the run's outcome and the row
+            # was deliberately not written, so passing it through printed
+            # `q1: translation_failed` over a row this command had just left
+            # `pending`. Measured with VERINOTE_PROVIDER=nosuchprovider. The
+            # run is still reported -- `failures` below counts this dict, the
+            # reason goes to stderr and rc is 1 -- it simply stops claiming to
+            # be a row.
+            print(f"  q{r['id']}: not translated - {r['reason']} (row unchanged)")
+        else:
+            print(f"  {format_question_outcome(r)}")
     translated = sum(1 for r in results if r["status"] == "translated")
     failures = [r for r in results if r["status"] == "translation_failed"]
     # review_required/no_answer/ambiguous are durable review verdicts, not

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1637,7 +1637,7 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
             # was deliberately not written, so passing it through printed
             # `q1: translation_failed` over a row this command had just left
             # `pending`. Measured with VERINOTE_PROVIDER=nosuchprovider. The
-            # run is still reported -- `failures` below counts this dict, the
+            # run is still reported -- the summary below counts this dict, the
             # reason goes to stderr and rc is 1 -- it simply stops claiming to
             # be a row.
             print(f"  q{r['id']}: not translated - {r['reason']} (row unchanged)")
@@ -1645,27 +1645,54 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
             print(f"  {format_question_outcome(r)}")
     translated = sum(1 for r in results if r["status"] == "translated")
     failures = [r for r in results if r["status"] == "translation_failed"]
+    # #592. EVERY COUNT BELOW IS ABOUT ROWS, so every one of them has to exclude
+    # the dicts whose row was deliberately not written. `infrastructure_fault`
+    # is the only thing that says so -- `status` cannot, because the suppressed
+    # and the recorded cases both report a status.
+    unrecorded = [r for r in results if r["infrastructure_fault"]]
     # review_required/no_answer/ambiguous are durable review verdicts, not
     # failures (#296): a question legitimately ending there is not a broken run.
     # They count as neither translated nor failed — but surface their number, so
     # a run made only of them does not read as a silent "translated 0" success.
+    #
+    # AND ONLY WHEN THE ROW ACTUALLY HOLDS ONE. `_reinterpret_empty_plan` reports
+    # `review_required` with `infrastructure_fault=True`: the deterministic
+    # planner earned that verdict, the provider was then unreachable, and no row
+    # was written. Counting it here printed "1 for review" over zero rows for
+    # review -- durable was false of it, and so was "not a broken run". It is
+    # counted with the other unrecorded runs instead.
     for_review = sum(
-        1 for r in results if r["status"] in {"review_required", "no_answer", "ambiguous"}
+        1
+        for r in results
+        if r["status"] in {"review_required", "no_answer", "ambiguous"}
+        and not r["infrastructure_fault"]
     )
+    # The unrecorded runs already counted as failures are not counted twice: a
+    # `translation_failed` fault is reported as a failure, which is what it is.
+    not_translated = [r for r in unrecorded if r["status"] != "translation_failed"]
     # "translated {n} question(s)" is preserved verbatim as the prefix (callers
     # and tests read it); n is the count that genuinely translated, not the total.
     summary = f"translated {translated} question(s)"
     if failures:
         summary += f", {len(failures)} failed"
+    if not_translated:
+        summary += f", {len(not_translated)} not translated"
     if for_review:
         summary += f", {for_review} for review"
     summary += f" -> {cfg.root / 'facts' / 'query.dl'}"
     print(summary)
     print("run the check to see answers (`verinote ui` → Report)")
-    if failures:
+    # #592 WIDENED WHAT EXITS NONZERO, and the widening is the point of the rule.
+    # A run that could not reach the provider wrote nothing and answered nothing;
+    # `main` returned 0 for it because the row it wrote made the run look
+    # finished. There is no row now, so the exit code is the only durable report
+    # left and it has to carry the fault -- otherwise `verinote query` in a
+    # script reports success for a run that translated nothing.
+    reported = failures + not_translated
+    if reported:
         # Any translation_failed is a hard failure (#243): exit rc 1 and put the
         # first failure's bounded reason on stderr so a non-web user sees why.
-        print(failures[0]["reason"], file=sys.stderr)
+        print(reported[0]["reason"], file=sys.stderr)
         store.close()
         return 1
     store.close()

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -7,6 +7,7 @@ from verinote.config import Config
 from verinote.llm.base import (
     ExtractedFact,
     LLMError,
+    LLMOutputError,
     parsed_under_redaction,
     redact_secret,
 )
@@ -259,7 +260,15 @@ class AnthropicAdapter:
         try:
             return _render_prompt(self.cfg.root, prompt_id, **values)
         except LLMError as exc:
-            raise LLMError(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
+            # #592. `type(exc)` here is a NO-OP today and is written this way
+            # anyway. Measured: this `try` calls only `_render_prompt`, which
+            # raises bare `LLMError` at its two prompt-loading exits, so the
+            # only class that can arrive is `LLMError` itself. But this line is
+            # character-identical to `parsed_under_redaction`'s, which had to
+            # stop flattening -- leaving one of three identical lines flattening
+            # would be an asymmetry a reader has to resolve, and it would
+            # silently swallow a subclass the day `_render_prompt` grows one.
+            raise type(exc)(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()
@@ -286,7 +295,7 @@ class AnthropicAdapter:
                 return parsed_under_redaction(
                     parse_facts, block.input, self.cfg.api_key
                 )
-        raise LLMError("anthropic response contained no tool_use block")
+        raise LLMOutputError("anthropic response contained no tool_use block")
 
     def translate_query(self, *, question: str, qid: int, schema_hint: str = "") -> str:
         client = self._client()
@@ -315,7 +324,7 @@ class AnthropicAdapter:
                 return parsed_under_redaction(
                     parse_query, block.input, self.cfg.api_key
                 )
-        raise LLMError("anthropic response contained no tool_use block")
+        raise LLMOutputError("anthropic response contained no tool_use block")
 
     def extract_query_intent(self, *, question: str, schema_hint: str = "") -> QueryIntent:
         client = self._client()
@@ -342,7 +351,7 @@ class AnthropicAdapter:
                 return parsed_under_redaction(
                     parse_query_intent, block.input, self.cfg.api_key
                 )
-        raise LLMError("anthropic response contained no tool_use block")
+        raise LLMOutputError("anthropic response contained no tool_use block")
 
     def answer_question(self, *, question: str, context: str) -> str:
         client = self._client()

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -250,25 +250,27 @@ class AnthropicAdapter:
         file -- so the fix is not "the render leaks", it is that these twelve
         stopped being redacted and are redacted again.
 
-        `from exc.__cause__`, not `from exc`. `_render_prompt` already hung the
-        original failure there, and
+        NO `from` CLAUSE, because there is nothing new to chain to.
+        `_render_prompt` already hung the original failure on `__cause__` and
         `test_a_render_failure_keeps_the_original_error_as_the_cause` asserts on
-        it; re-raising `from exc` would bury that behind this wrapper's own
-        `LLMError` and break it. Tidying this to `from exc` is the way to make
-        that test fail.
+        it; re-raising the same object carries that cause forward untouched.
+        Replacing this with `raise LLMError(...) from exc` is the way to make
+        that test fail -- it would bury the original behind a new wrapper.
         """
         try:
             return _render_prompt(self.cfg.root, prompt_id, **values)
         except LLMError as exc:
-            # #592. `type(exc)` here is a NO-OP today and is written this way
-            # anyway. Measured: this `try` calls only `_render_prompt`, which
-            # raises bare `LLMError` at its two prompt-loading exits, so the
-            # only class that can arrive is `LLMError` itself. But this line is
-            # character-identical to `parsed_under_redaction`'s, which had to
-            # stop flattening -- leaving one of three identical lines flattening
-            # would be an asymmetry a reader has to resolve, and it would
-            # silently swallow a subclass the day `_render_prompt` grows one.
-            raise type(exc)(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
+            # #592. Relabelled in place, not reconstructed, which is the shape
+            # `parsed_under_redaction` settled on and the reason is the same:
+            # rebuilding an exception from its message alone destroys the class
+            # and any state it carries. Preserving the class here is a NO-OP
+            # today -- measured: this `try` calls only `_render_prompt`, which
+            # raises bare `LLMError` at both of its prompt-loading exits, so
+            # `LLMError` is the only class that can arrive. It is written this
+            # way anyway, because the day `_render_prompt` grows a subclass exit
+            # the alternative swallows it with no test red anywhere.
+            exc.args = (redact_secret(str(exc), self.cfg.api_key),)
+            raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -16,6 +16,29 @@ class LLMError(RuntimeError):
     """Any provider-side or parsing failure, normalised across adapters."""
 
 
+class LLMOutputError(LLMError):
+    """The provider ANSWERED and the answer could not be used (#592).
+
+    A subclass rather than a flag because the distinction has to survive being
+    raised, caught and re-raised across the adapter boundary, and callers that
+    do not care keep catching `LLMError` unchanged.
+
+    WHY IT EXISTS. `LLMError` is documented as "any provider-side OR PARSING
+    failure", so it conflates a request that was never sent -- no API key, SDK
+    missing, provider unreachable -- with a response that arrived and was
+    unusable. `questions.status`'s `translation_failed` means "The provider
+    output could not be used", which is TRUE of the second and false of the
+    first. #592 records the second on the question row and only reports the
+    first, and this class is what lets one `except LLMError` tell them apart.
+
+    THE DISCRIMINATOR IS WHETHER A RESPONSE ARRIVED, not whether it parsed. A
+    payload with no tool_use block, or a CLI payload that cannot be decoded, is
+    output that arrived and could not be used -- the provider was reached and
+    misbehaved, which is the one signal a user has that their provider is broken
+    rather than unconfigured.
+    """
+
+
 # A secret shorter than this cannot be replaced without mangling ordinary text —
 # a key of "key" would turn "invalid api key" into "invalid api ***" — so it is
 # deliberately left alone. That is a statement about collateral damage, not about
@@ -74,11 +97,22 @@ def parsed_under_redaction(parse, payload, secret):
     ONLY `LLMError` is caught. A parser that fails some other way is a bug in
     this repo rather than a message about the provider's payload, and it is not
     this function's business to relabel it.
+
+    THE CLASS IS PRESERVED (#592). This re-raised as a bare `LLMError`, which
+    destroyed the type for every caller of this primitive -- so an
+    `LLMOutputError` raised by a parser arrived at the flow indistinguishable
+    from a request that was never sent, and the guard keyed on it would have
+    been a silent no-op. Flattening was a defect independent of #592;
+    `type(exc)` is the faithful behaviour. Every `LLMError` subclass must
+    therefore accept a single message argument, which
+    `test_every_llm_error_subclass_takes_one_message` derives from
+    `__subclasses__()` and asserts, because a subclass that did not would break
+    here -- inside error handling, at the worst possible moment.
     """
     try:
         return parse(payload)
     except LLMError as exc:
-        raise LLMError(redact_secret(str(exc), secret)) from exc.__cause__
+        raise type(exc)(redact_secret(str(exc), secret)) from exc.__cause__
 
 
 def base_url_unusable(provider: str, url: str, exc: Exception) -> LLMError:

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -78,8 +78,8 @@ def parsed_under_redaction(parse, payload, secret):
     they cannot reach the key -- and they interpolate what they caught:
     `schema.parse_facts` puts the offending object in with `{item!r}`, which on
     a malformed response IS the response. `redact_secret` says the secret should
-    never enter an `LLMError` in the first place; this is the construction site
-    that has to call it for that to hold on the parse path.
+    never enter an `LLMError` in the first place; this is the site that has to
+    call it for that to hold on the parse path.
 
     NOT inside the adapters' request `try`. Moving the parse in there would fix
     the redaction and break the attribution, reporting a schema failure as
@@ -87,46 +87,45 @@ def parsed_under_redaction(parse, payload, secret):
     A separate wrapper redacts without moving the blame, the shape `_rendered`
     already has for the render.
 
-    `from exc.__cause__`, not `from exc`. Every parser raises `... from exc`
-    with the `json`/`Key`/`Type` error that caused it, so the original is
-    already on `__cause__`; re-raising `from exc` would bury it behind this
-    wrapper's own `LLMError`. Where a parser raised with no cause at all
-    (`query translation was empty`), `__cause__` is `None` and the re-raise
-    carries none either, which is what it had.
-
     ONLY `LLMError` is caught. A parser that fails some other way is a bug in
     this repo rather than a message about the provider's payload, and it is not
     this function's business to relabel it.
 
-    THE CLASS IS PRESERVED (#592). This re-raised as a bare `LLMError`, which
-    destroyed the type for every caller of this primitive -- so an
-    `LLMOutputError` raised by a parser arrived at the flow indistinguishable
-    from a request that was never sent, and the guard keyed on it would have
-    been a silent no-op. Flattening was a defect independent of #592;
-    `type(exc)` is the faithful behaviour.
+    IT RELABELS, IT DOES NOT REBUILD (#592), and that is what keeps the class.
+    This once re-raised a newly constructed bare `LLMError`, which destroyed the
+    type for every caller -- an `LLMOutputError` raised by a parser arrived at
+    the flow indistinguishable from a request that was never sent, so the guard
+    keyed on it would have been a silent no-op. Rewriting the message on the
+    exception in place and re-raising the SAME OBJECT fixes that while imposing
+    nothing on the class: `exc.args = (redacted,)` reaches `str(exc)` because no
+    `LLMError` here overrides `__str__`, and the class at any depth of
+    subclassing, every other attribute, and `__cause__` all survive because
+    nothing is constructed.
 
-    WHAT THAT REQUIRES OF SUBCLASSES, and what checks it. `type(exc)(msg)`
-    rebuilds the exception from its message alone, so a subclass must accept a
-    single message argument -- one that did not would raise `TypeError` from
-    inside an `except` clause, at the worst possible moment, and the resulting
-    exception is not an `LLMError`, so every `except LLMError` downstream stops
-    catching it. `test_every_llm_error_subclass_takes_one_message` reads
-    `LLMError.__subclasses__()` and asserts the arity of each. READ IT AS A
-    TRIPWIRE, NOT A GUARANTEE. `__subclasses__()` returns DIRECT children only,
-    so a subclass of `LLMOutputError` never appears in it and breaks this line
-    in exactly the same way. It can only see classes something in its import
-    graph has imported, and the adapters are imported lazily inside
-    `get_client`, so a subclass defined in an adapter module is invisible when
-    that test runs alone. And arity is not reconstruction: a subclass that
-    accepts one message and also carries a status code, a retry hint or a
-    payload passes the check and still loses that state crossing this line.
-    Anything a caller must not lose belongs in the message, or this primitive
-    needs to stop rebuilding.
+    RECONSTRUCTING WAS THE ALTERNATIVE AND IT WAS MEASURABLY WORSE. On a
+    subclass of `LLMOutputError` taking a message AND a status code,
+    `type(exc)(msg)` raised `TypeError` from inside this `except` clause -- and a
+    `TypeError` is not an `LLMError`, so every `except LLMError` downstream
+    stops catching it -- while a subclass that did accept one argument crossed
+    this line with its 429 silently replaced by its constructor default.
+    Relabelling has neither failure mode, so this function imposes no
+    constructor contract on `LLMError` subclasses and needs no tripwire over
+    them. `test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state`
+    pins that directly, on a subclass `__subclasses__()` could never have seen.
+
+    `__cause__` IS INHERITED RATHER THAN SET. Every parser raises `... from exc`
+    with the `json`/`Key`/`Type` error underneath, so re-raising the same object
+    carries that cause forward untouched; where a parser raised with no cause at
+    all (`query translation was empty`) it still carries none, which is what it
+    had. The construction this replaced had to spell `from exc.__cause__` to get
+    the same result, and `from exc` would have buried the original behind its
+    own wrapper.
     """
     try:
         return parse(payload)
     except LLMError as exc:
-        raise type(exc)(redact_secret(str(exc), secret)) from exc.__cause__
+        exc.args = (redact_secret(str(exc), secret),)
+        raise
 
 
 def base_url_unusable(provider: str, url: str, exc: Exception) -> LLMError:

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -103,11 +103,25 @@ def parsed_under_redaction(parse, payload, secret):
     `LLMOutputError` raised by a parser arrived at the flow indistinguishable
     from a request that was never sent, and the guard keyed on it would have
     been a silent no-op. Flattening was a defect independent of #592;
-    `type(exc)` is the faithful behaviour. Every `LLMError` subclass must
-    therefore accept a single message argument, which
-    `test_every_llm_error_subclass_takes_one_message` derives from
-    `__subclasses__()` and asserts, because a subclass that did not would break
-    here -- inside error handling, at the worst possible moment.
+    `type(exc)` is the faithful behaviour.
+
+    WHAT THAT REQUIRES OF SUBCLASSES, and what checks it. `type(exc)(msg)`
+    rebuilds the exception from its message alone, so a subclass must accept a
+    single message argument -- one that did not would raise `TypeError` from
+    inside an `except` clause, at the worst possible moment, and the resulting
+    exception is not an `LLMError`, so every `except LLMError` downstream stops
+    catching it. `test_every_llm_error_subclass_takes_one_message` reads
+    `LLMError.__subclasses__()` and asserts the arity of each. READ IT AS A
+    TRIPWIRE, NOT A GUARANTEE. `__subclasses__()` returns DIRECT children only,
+    so a subclass of `LLMOutputError` never appears in it and breaks this line
+    in exactly the same way. It can only see classes something in its import
+    graph has imported, and the adapters are imported lazily inside
+    `get_client`, so a subclass defined in an adapter module is invisible when
+    that test runs alone. And arity is not reconstruction: a subclass that
+    accepts one message and also carries a status code, a retry hint or a
+    payload passes the check and still loses that state crossing this line.
+    Anything a caller must not lose belongs in the message, or this primitive
+    needs to stop rebuilding.
     """
     try:
         return parse(payload)

--- a/verinote/llm/claude_cli_adapter.py
+++ b/verinote/llm/claude_cli_adapter.py
@@ -11,7 +11,7 @@ import tempfile
 from typing import Any
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError
+from verinote.llm.base import ExtractedFact, LLMError, LLMOutputError
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -197,7 +197,7 @@ class ClaudeCliAdapter:
                     # fix their source. Constant message: this exception's text
                     # carries byte values and offsets from the model's output, which
                     # derives from the user's document.
-                    raise LLMError(_UNDECODABLE_OUTPUT) from exc
+                    raise LLMOutputError(_UNDECODABLE_OUTPUT) from exc
                 except ValueError as exc:
                     # The ARGUMENT could not be encoded. MUST stay below
                     # UnicodeDecodeError, which is a ValueError subclass. The

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -11,7 +11,13 @@ import json
 import urllib.request
 
 from verinote.config import Config
-from verinote.llm.base import ExtractedFact, LLMError, ModelListing, base_url_unusable
+from verinote.llm.base import (
+    ExtractedFact,
+    LLMError,
+    LLMOutputError,
+    ModelListing,
+    base_url_unusable,
+)
 from verinote.llm.schema import (
     FACT_ARRAY_SCHEMA,
     QUERY_INTENT_SCHEMA,
@@ -94,15 +100,21 @@ class OllamaAdapter:
     def _post_chat(self, payload: dict) -> dict:
         """POST one chat payload to `/api/chat` and return the decoded body.
 
-        The single request site for all four methods, so which statements count
-        as "the request" -- and which are the caller's own parse, reported as the
-        caller's own failure -- is written once instead of four times in
-        parallel.
+        The single request site for all four methods, so the boundaries between
+        what failed are written once instead of four times in parallel. There
+        are three, each with its own clause below, and each names a different
+        thing to the user: building the URL, sending the request, and decoding
+        the envelope that came back. A fourth -- interpreting that envelope's
+        content -- belongs to the caller and is reported as the caller's own
+        failure.
 
-        `Request(...)` gets its own narrow clause rather than joining the one
-        below: a URL that cannot be built is not a request that failed, and
-        telling a user their server did not answer when nothing was ever dialled
-        sends them to the wrong place (#493).
+        `Request(...)` gets its own narrow clause rather than joining the send:
+        a URL that cannot be built is not a request that failed, and telling a
+        user their server did not answer when nothing was ever dialled sends
+        them to the wrong place (#493). The envelope decode is separated for the
+        same reason and one more: since #592 the split also decides whether the
+        question row records the failure, because a body that arrived is output
+        the row may record and a request that never landed is not.
         """
         # Hoisted out of the `Request(...)` call, not merely out of the `try`:
         # as an ARGUMENT it would be evaluated inside the guarded region, so a
@@ -123,9 +135,22 @@ class OllamaAdapter:
             with urllib.request.urlopen(  # noqa: S310 - local trusted endpoint
                 req, timeout=self.cfg.llm_timeout_seconds
             ) as resp:
-                return json.loads(resp.read().decode("utf-8"))
+                body = resp.read()
         except Exception as exc:  # noqa: BLE001 - normalise provider/transport errors
             raise LLMError(f"ollama request failed: {exc}") from exc
+        # The envelope decode is its OWN clause, for the same reason
+        # `Request(...)` has one above: what failed decides what the user is
+        # told, and #592 makes it decide more than that. A body reached us, so
+        # this is output that ARRIVED and could not be used -- `LLMOutputError`,
+        # which `translate_questions` records on the question row, where bare
+        # `LLMError` would have it suppress the row and say nothing. Measured on
+        # a 200 whose body is `<html>502 Bad Gateway</html>`, the shape a proxy
+        # in front of ollama emits: joined to the clause above it left the row
+        # `pending` with no trace of the failure.
+        try:
+            return json.loads(body.decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - any undecodable body, not only bad JSON
+            raise LLMOutputError(f"ollama response could not be read: {exc}") from exc
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         system = _with_schema_hint(

--- a/verinote/llm/ollama_adapter.py
+++ b/verinote/llm/ollama_adapter.py
@@ -113,8 +113,15 @@ class OllamaAdapter:
         user their server did not answer when nothing was ever dialled sends
         them to the wrong place (#493). The envelope decode is separated for the
         same reason and one more: since #592 the split also decides whether the
-        question row records the failure, because a body that arrived is output
-        the row may record and a request that never landed is not.
+        question row records the failure, because a 2xx body that could not be
+        decoded is output the row may record and a request that never landed is
+        not. Deliberately narrow: `urlopen` raises `HTTPError` for a non-2xx
+        status, so that lands in the clause above and is reported as a request
+        failure even though bytes came back. Measured, and defensible -- a 500
+        produced no usable output, so `translation_failed` ("The provider output
+        could not be used") would be as false of it as of a refused connection --
+        but it is NOT what "a body arrived" would predict, so the criterion is
+        written as the code has it rather than as the slogan.
         """
         # Hoisted out of the `Request(...)` call, not merely out of the `try`:
         # as an ARGUMENT it would be evaluated inside the guarded region, so a

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -250,25 +250,27 @@ class OpenAIAdapter:
         file -- so the fix is not "the render leaks", it is that these twelve
         stopped being redacted and are redacted again.
 
-        `from exc.__cause__`, not `from exc`. `_render_prompt` already hung the
-        original failure there, and
+        NO `from` CLAUSE, because there is nothing new to chain to.
+        `_render_prompt` already hung the original failure on `__cause__` and
         `test_a_render_failure_keeps_the_original_error_as_the_cause` asserts on
-        it; re-raising `from exc` would bury that behind this wrapper's own
-        `LLMError` and break it. Tidying this to `from exc` is the way to make
-        that test fail.
+        it; re-raising the same object carries that cause forward untouched.
+        Replacing this with `raise LLMError(...) from exc` is the way to make
+        that test fail -- it would bury the original behind a new wrapper.
         """
         try:
             return _render_prompt(self.cfg.root, prompt_id, **values)
         except LLMError as exc:
-            # #592. `type(exc)` here is a NO-OP today and is written this way
-            # anyway. Measured: this `try` calls only `_render_prompt`, which
-            # raises bare `LLMError` at its two prompt-loading exits, so the
-            # only class that can arrive is `LLMError` itself. But this line is
-            # character-identical to `parsed_under_redaction`'s, which had to
-            # stop flattening -- leaving one of three identical lines flattening
-            # would be an asymmetry a reader has to resolve, and it would
-            # silently swallow a subclass the day `_render_prompt` grows one.
-            raise type(exc)(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
+            # #592. Relabelled in place, not reconstructed, which is the shape
+            # `parsed_under_redaction` settled on and the reason is the same:
+            # rebuilding an exception from its message alone destroys the class
+            # and any state it carries. Preserving the class here is a NO-OP
+            # today -- measured: this `try` calls only `_render_prompt`, which
+            # raises bare `LLMError` at both of its prompt-loading exits, so
+            # `LLMError` is the only class that can arrive. It is written this
+            # way anyway, because the day `_render_prompt` grows a subclass exit
+            # the alternative swallows it with no test red anywhere.
+            exc.args = (redact_secret(str(exc), self.cfg.api_key),)
+            raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()
@@ -288,6 +290,8 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
+        # #601: `choices[0]` is read OUTSIDE the `try` above, so an empty
+        # `choices` escapes as `IndexError` rather than an `LLMError`.
         return parsed_under_redaction(
             parse_facts, resp.choices[0].message.content or "", self.cfg.api_key
         )
@@ -312,6 +316,8 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
+        # #601: `choices[0]` is read OUTSIDE the `try` above, so an empty
+        # `choices` escapes as `IndexError` rather than an `LLMError`.
         return parsed_under_redaction(
             parse_query, resp.choices[0].message.content or "", self.cfg.api_key
         )
@@ -338,6 +344,8 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
+        # #601: `choices[0]` is read OUTSIDE the `try` above, so an empty
+        # `choices` escapes as `IndexError` rather than an `LLMError`.
         return parsed_under_redaction(
             parse_query_intent, resp.choices[0].message.content or "", self.cfg.api_key
         )
@@ -360,6 +368,8 @@ class OpenAIAdapter:
         except Exception as exc:  # noqa: BLE001 - normalise provider errors
             raise self._request_failed(exc) from exc
 
+        # #601: `choices[0]` is read OUTSIDE the `try` above, so an empty
+        # `choices` escapes as `IndexError` rather than an `LLMError`.
         return (resp.choices[0].message.content or "").strip()
 
 

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -260,7 +260,15 @@ class OpenAIAdapter:
         try:
             return _render_prompt(self.cfg.root, prompt_id, **values)
         except LLMError as exc:
-            raise LLMError(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
+            # #592. `type(exc)` here is a NO-OP today and is written this way
+            # anyway. Measured: this `try` calls only `_render_prompt`, which
+            # raises bare `LLMError` at its two prompt-loading exits, so the
+            # only class that can arrive is `LLMError` itself. But this line is
+            # character-identical to `parsed_under_redaction`'s, which had to
+            # stop flattening -- leaving one of three identical lines flattening
+            # would be an asymmetry a reader has to resolve, and it would
+            # silently swallow a subclass the day `_render_prompt` grows one.
+            raise type(exc)(redact_secret(str(exc), self.cfg.api_key)) from exc.__cause__
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:
         client = self._client()

--- a/verinote/llm/schema.py
+++ b/verinote/llm/schema.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from verinote.llm.base import ExtractedFact, LLMError
+from verinote.llm.base import ExtractedFact, LLMOutputError
 from verinote.engine.terms import Compound, Term, TermParseError, Var, parse_term
 from verinote.prompts import default_prompt_text
 
@@ -73,9 +73,9 @@ def parse_query(raw: str | dict[str, Any]) -> str:
         data = json.loads(raw) if isinstance(raw, str) else raw
         line = str(data["datalog"]).strip()
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
-        raise LLMError(f"query translation did not match schema: {exc}") from exc
+        raise LLMOutputError(f"query translation did not match schema: {exc}") from exc
     if not line:
-        raise LLMError("query translation was empty")
+        raise LLMOutputError("query translation was empty")
     return line
 
 
@@ -193,7 +193,7 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
         data = _decode_first_json(raw) if isinstance(raw, str) else raw
         items = _fact_items(data)
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
-        raise LLMError(f"extractor output did not match schema: {exc}") from exc
+        raise LLMOutputError(f"extractor output did not match schema: {exc}") from exc
 
     facts: list[ExtractedFact] = []
     for item in items:
@@ -225,7 +225,7 @@ def parse_facts(raw: str | list[Any] | dict[str, Any]) -> list[ExtractedFact]:
             # valid ones would report the chunk as a success with the violating
             # fact silently gone -- exactly the smuggled-off-schema failure this
             # parser exists to make loud (issue #168).
-            raise LLMError(f"malformed fact object {item!r}: {exc}") from exc
+            raise LLMOutputError(f"malformed fact object {item!r}: {exc}") from exc
     return facts
 
 

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Callable
 
 from verinote.engine.datalog import AtomExpr, Comparison, DatalogParseError, parse_program
 from verinote.engine.terms import Atom, StringLit, render_term
-from verinote.llm.base import LLMClient, LLMError
+from verinote.llm.base import LLMClient, LLMError, LLMOutputError
 from verinote.pipeline.corroboration import (
     CorroborationPolicyError,
     store_relation_aliases,
@@ -71,10 +71,24 @@ class _QueryFlowResult:
     # Repair-only eligibility: ordinary translation is always schema-only.
     allow_direct_datalog_fallback: bool = False
     provider_failed: bool = False
+    # #592. Set ALONGSIDE `provider_failed`, never instead of it. `provider_failed`
+    # answers "should Ask decline its fallback request" and must stay True for
+    # every `LLMError` exit -- #438's tripwire enforces that with a literal, and
+    # an earlier draft of #592 made it a computed expression, which the tripwire
+    # correctly rejected. This one answers a different question: "did a response
+    # ARRIVE and turn out unusable", which is what decides whether the row may
+    # record `translation_failed`. An unusable answer is still a provider
+    # failure for Ask's purposes; it is simply not an infrastructure fault.
+    output_unusable: bool = False
     # Set only by the trust-policy guard below. `translate_questions` keys its
-    # write suppression on THIS, not on a read of its own: the status alone
-    # cannot carry it, because a missing API key produces `translation_failed`
-    # too and that one IS meant to be written to the row (#591).
+    # write suppression on this and on `provider_failed`, not on a read of its
+    # own, so the value written and the decision to write it come from one read.
+    #
+    # An earlier draft of this comment said a missing API key "IS meant to be
+    # written to the row (#591)". #592 reversed that: no infrastructure fault is
+    # written to a row now, and a missing key is one. The flag still exists
+    # because the status alone cannot distinguish the cases -- both arrive as
+    # `translation_failed`.
     policy_failed: bool = False
 
 
@@ -291,6 +305,14 @@ def _schema_aware_query_flow_result(
             )
         except LLMError as exc:
             reason = _short_reason(exc)
+            # #592. `provider_failed` means THE PROVIDER DID NOT ANSWER, which is
+            # what `translate_questions` suppresses the row write on. An
+            # `LLMOutputError` is the opposite case: a response arrived and could
+            # not be used, which is exactly what `translation_failed` means and
+            # so IS recorded. Without this the guard would suppress the one
+            # failure the status exists for -- measured, it turned a
+            # schema-violating intent into a `pending` row.
+            output_unusable = isinstance(exc, LLMOutputError)
             if llm_error_status == "translation_failed":
                 # Flagged like the sibling exits of this handler even though
                 # nothing reads it here: `translate_questions` is the only
@@ -303,6 +325,7 @@ def _schema_aware_query_flow_result(
                     None,
                     reason,
                     provider_failed=True,
+                    output_unusable=output_unusable,
                 )
             reason = _short_reason(f"llm error: {exc}")
             # No fallback here. The direct-Datalog fallback answers "planning
@@ -320,6 +343,7 @@ def _schema_aware_query_flow_result(
                 f"review_required({_lit(reason)})",
                 reason,
                 provider_failed=True,
+                output_unusable=output_unusable,
             )
 
     if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
@@ -648,11 +672,19 @@ def _translate_direct_datalog_fallback(
         )
     except LLMError as exc:
         reason = _short_reason(exc)
+        # #592, same discriminator as the schema-aware handler above: an
+        # `LLMOutputError` means a response arrived and could not be used, which
+        # the row may record; anything else means no response, which it may not.
+        output_unusable = isinstance(exc, LLMOutputError)
         if llm_error_status == "translation_failed":
-            return _QueryFlowResult("translation_failed", None, reason, provider_failed=True)
+            return _QueryFlowResult(
+                "translation_failed", None, reason,
+                provider_failed=True, output_unusable=output_unusable,
+            )
         reason = _short_reason(f"llm error: {exc}")
         return _QueryFlowResult(
-            "review_required", f"review_required({_lit(reason)})", reason, provider_failed=True
+            "review_required", f"review_required({_lit(reason)})", reason,
+            provider_failed=True, output_unusable=output_unusable,
         )
 
     outcome = _non_executable_outcome(line)
@@ -710,39 +742,48 @@ def translate_questions(
             llm_error_status="translation_failed",
         )
         status, query_dl, reason = flow.status, flow.query_dl, flow.reason
-        # G2 (#591). Report the policy failure, but do NOT write it to the row.
-        # The justification is comparative, not a principle: today's unhandled
-        # exception leaves every pending question `pending`, so a guard that
-        # wrote `translation_failed` to each of them would leave the KB in a
-        # worse state than the bug it replaces -- a durable, audited claim that
-        # each question failed translation, when translation was never attempted
-        # and nothing about the questions is wrong. Repairing the file and
-        # re-running then translates them, with no intervening state for the
-        # user to notice and undo.
+        # AN INFRASTRUCTURE FAULT IS REPORTED, NEVER RECORDED (#592). #591
+        # suppressed the policy-file case here and left the credential case
+        # writing, which made this one line behave two opposite ways depending
+        # on which infrastructure fault occurred. #592 settles it for all of
+        # them, and the rule is read off `question_outcome.py::_STATUS_META`
+        # rather than chosen: `translation_failed` is defined there as "The
+        # provider output could not be used" -- a claim about the provider's
+        # OUTPUT. When the provider was never reached, or translation was never
+        # attempted because a policy file could not be read, there is no output
+        # and the claim is false under the status's own definition. `pending`
+        # ("Waiting for translation.") is true of every such fault, and it is
+        # already in `db.py`'s CHECK constraint, so no schema change is needed.
         #
-        # This is NOT a rule that an environment fault may never be recorded on a
-        # question row. `web/app.py::_fail_pending_translations` and `cli.py`'s
-        # own missing-credential path both do exactly that, deliberately, and
-        # this change leaves both alone. The inconsistency that leaves --
-        # credentials mark the rows, an unreadable policy file does not -- is
-        # real and is tracked as #592; it is a contract question across three
-        # call sites, not this guard's to settle.
+        # THE PREDICATE IS DERIVED, NOT CHOSEN. Every infrastructure exit in
+        # this module sets one of these two flags -- measured by enumerating
+        # every `_QueryFlowResult` construction: the policy exit sets
+        # `policy_failed`, and every exit that reports a provider that did not
+        # answer sets `provider_failed`. So the two flags together are exactly
+        # "no usable provider output existed", which is exactly what must not be
+        # recorded.
         #
-        # ONE VERDICT GOVERNS BOTH DECISIONS, and an earlier revision of this
-        # guard got that wrong in the one direction that matters. It read the
-        # policy files once before this loop and suppressed on THAT, while the
-        # flow above re-read them per question. With the files healthy at the
-        # pre-loop read and broken before a question's flow ran, the fresh
+        # ONE VERDICT GOVERNS BOTH DECISIONS, and an earlier revision of the
+        # #591 guard got that wrong in the one direction that matters. It read
+        # the policy files once before this loop and suppressed on THAT, while
+        # the flow above re-read them per question. With the files healthy at
+        # the pre-loop read and broken before a question's flow ran, the fresh
         # verdict said "failed" -- so `translation_failed` and the policy
         # message went into `status` and `reason` -- while the stale verdict
         # said "healthy", so the write was not suppressed. Measured: the parent
         # raised and wrote NOTHING; that revision wrote the failure to every
-        # row. Keying on `flow.policy_failed` is what makes the value written
+        # row. Keying on the FLOW's own flags is what makes the value written
         # and the decision to write it come from the same read.
         #
         # The result dict is still appended, so the CLI and the web report
-        # normally and no caller's contract changes.
-        if not flow.policy_failed:
+        # normally and no caller's contract changes. Deleting the append instead
+        # of the write would flip a credential-free `verinote query` to rc=0,
+        # because `cmd_query` derives its failure count from these dicts and not
+        # from the rows.
+        infrastructure_fault = flow.policy_failed or (
+            flow.provider_failed and not flow.output_unusable
+        )
+        if not infrastructure_fault:
             store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
             {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -91,6 +91,25 @@ class _QueryFlowResult:
     # `translation_failed`.
     policy_failed: bool = False
 
+    @property
+    def infrastructure_fault(self) -> bool:
+        """Is this a fault the question row must NOT record (#592)?
+
+        THE RULE IS SPELLED ONCE, HERE. It was written out twice -- in
+        `translate_questions` and again in `_prepare_repair_question` -- which is
+        two independent spellings of the one rule #592 exists to establish, in
+        the two modules whose divergence IS the issue. Each copy was pinned, so
+        neither could rot silently; nothing pinned them EQUAL, so a change to one
+        was invisible in the other.
+
+        BOTH DISJUNCTS ARE NEEDED. `policy_failed` marks the exit where no
+        request was sent at all. `provider_failed` is set on EVERY `LLMError`
+        exit, including one carrying an answer that arrived unusable, so it is
+        too wide alone -- `output_unusable` subtracts exactly that case back out,
+        and that subtraction is the half of the rule that keeps it non-vacuous.
+        """
+        return self.policy_failed or (self.provider_failed and not self.output_unusable)
+
 
 def query_path(root: Path) -> Path:
     return root / QUERY_RELPATH
@@ -818,9 +837,7 @@ def translate_questions(
         # The web banner and the CLI's per-question line both need the half that
         # was NOT written, so the flag travels with the dict rather than being
         # re-derived downstream from something that cannot express it.
-        infrastructure_fault = flow.policy_failed or (
-            flow.provider_failed and not flow.output_unusable
-        )
+        infrastructure_fault = flow.infrastructure_fault
         if not infrastructure_fault:
             store.set_question_query(q["id"], query_dl, status, reason)
         results.append(

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -305,13 +305,17 @@ def _schema_aware_query_flow_result(
             )
         except LLMError as exc:
             reason = _short_reason(exc)
-            # #592. `provider_failed` means THE PROVIDER DID NOT ANSWER, which is
-            # what `translate_questions` suppresses the row write on. An
-            # `LLMOutputError` is the opposite case: a response arrived and could
-            # not be used, which is exactly what `translation_failed` means and
-            # so IS recorded. Without this the guard would suppress the one
-            # failure the status exists for -- measured, it turned a
-            # schema-violating intent into a `pending` row.
+            # #592. Both exits below set `provider_failed=True`, so that flag
+            # alone cannot say whether a response arrived -- it is True for
+            # every `LLMError`, which is the invariant
+            # tests/test_query.py::test_every_provider_failure_exit_reports_the_provider_failed
+            # enforces. `output_unusable` is what splits it. An `LLMOutputError`
+            # means a response arrived and could not be used, which is exactly
+            # what `translation_failed` means and so IS recorded; anything else
+            # means no response, which is not. Without this flag the suppression
+            # in `translate_questions` would key on `provider_failed` alone and
+            # swallow the one failure the status exists for -- measured, it
+            # turned a schema-violating intent into a `pending` row.
             output_unusable = isinstance(exc, LLMOutputError)
             if llm_error_status == "translation_failed":
                 # Flagged like the sibling exits of this handler even though
@@ -728,7 +732,9 @@ def translate_questions(
 ) -> list[dict]:
     """Translate pending and previously failed questions through the schema-only flow.
 
-    Returns one dict per processed question: {id, status, query_dl, reason}.
+    Returns one dict per processed question: {id, status, query_dl, reason,
+    infrastructure_fault}. `status` is the outcome of the RUN; the row was
+    written only where `infrastructure_fault` is False (#592).
     """
     results: list[dict] = []
     for q in store.questions():
@@ -755,13 +761,15 @@ def translate_questions(
         # ("Waiting for translation.") is true of every such fault, and it is
         # already in `db.py`'s CHECK constraint, so no schema change is needed.
         #
-        # THE PREDICATE IS DERIVED, NOT CHOSEN. Every infrastructure exit in
-        # this module sets one of these two flags -- measured by enumerating
-        # every `_QueryFlowResult` construction: the policy exit sets
-        # `policy_failed`, and every exit that reports a provider that did not
-        # answer sets `provider_failed`. So the two flags together are exactly
-        # "no usable provider output existed", which is exactly what must not be
-        # recorded.
+        # THE PREDICATE IS BUILT FROM THE FLAGS THE FLOW ALREADY SETS, and both
+        # halves are needed. `policy_failed` marks the exit where no request was
+        # sent at all. `provider_failed` is set on EVERY `LLMError` exit,
+        # including one carrying an answer that arrived unusable, so it is too
+        # wide on its own -- `output_unusable` subtracts exactly that case back
+        # out. Keying on `provider_failed` alone was the first attempt and it
+        # suppressed a schema-violating intent, which
+        # tests/test_query.py::test_invalid_intent_output_fails_translation_and_skips_draft
+        # caught.
         #
         # ONE VERDICT GOVERNS BOTH DECISIONS, and an earlier revision of the
         # #591 guard got that wrong in the one direction that matters. It read
@@ -780,13 +788,30 @@ def translate_questions(
         # of the write would flip a credential-free `verinote query` to rc=0,
         # because `cmd_query` derives its failure count from these dicts and not
         # from the rows.
+        #
+        # AND IT CARRIES THE VERDICT, because `status` cannot be read back as
+        # one. Both branches of this decision report `translation_failed` -- the
+        # fault whose row is suppressed, and the unusable answer whose row is
+        # written -- so a consumer filtering on the status string gets the two
+        # together and cannot tell which it is holding. That run is
+        # tests/test_infrastructure_fault_not_recorded.py::test_a_mixed_run_reports_the_suppressed_fault_and_not_the_recorded_one:
+        # one question written, one not, both dicts saying `translation_failed`.
+        # The web banner and the CLI's per-question line both need the half that
+        # was NOT written, so the flag travels with the dict rather than being
+        # re-derived downstream from something that cannot express it.
         infrastructure_fault = flow.policy_failed or (
             flow.provider_failed and not flow.output_unusable
         )
         if not infrastructure_fault:
             store.set_question_query(q["id"], query_dl, status, reason)
         results.append(
-            {"id": q["id"], "status": status, "query_dl": query_dl, "reason": reason}
+            {
+                "id": q["id"],
+                "status": status,
+                "query_dl": query_dl,
+                "reason": reason,
+                "infrastructure_fault": infrastructure_fault,
+            }
         )
     write_query_file(store, root)
     return results

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -443,12 +443,23 @@ def _reinterpret_empty_plan(
             f"{deterministic_result.reason}; schema-aware reinterpretation "
             f"unavailable: llm error: {exc}"
         )
+        # #592. THE THIRD `except LLMError` EXIT, and it shipped without this
+        # line for two revisions. `output_unusable` defaults to False, so
+        # omitting it made `provider_failed and not output_unusable` true here
+        # for every failure, and both consumers read that as an infrastructure
+        # fault: an answer that ARRIVED off-schema was suppressed at the one
+        # exit whose reason quotes it, and the banner then said translation
+        # could not run while printing the provider's own words. Computed the
+        # same way as the two exits above rather than defaulted, because the
+        # default is the suppressing value and silence is what it buys.
+        output_unusable = isinstance(exc, LLMOutputError)
         return _QueryFlowResult(
             "review_required",
             f"review_required({_lit(reason)})",
             reason,
             allow_direct_datalog_fallback=False,
             provider_failed=True,
+            output_unusable=output_unusable,
         )
 
     if intent.kind == QueryIntentKind.UNKNOWN_OR_UNSUPPORTED:
@@ -783,11 +794,19 @@ def translate_questions(
         # row. Keying on the FLOW's own flags is what makes the value written
         # and the decision to write it come from the same read.
         #
-        # The result dict is still appended, so the CLI and the web report
-        # normally and no caller's contract changes. Deleting the append instead
-        # of the write would flip a credential-free `verinote query` to rc=0,
-        # because `cmd_query` derives its failure count from these dicts and not
-        # from the rows.
+        # The result dict is still appended, so the CLI and the web still
+        # report the fault. Deleting the append instead of the write would flip
+        # a credential-free `verinote query` to rc=0, because `cmd_query`
+        # derives its failure count from these dicts and not from the rows.
+        #
+        # THE DICT'S CONTRACT DID CHANGE, and callers must be updated with it.
+        # `infrastructure_fault` below is a REQUIRED key: `cli.py` and
+        # `web/app.py` both index it rather than `.get` it, so a caller still
+        # building the pre-#592 shape gets a `KeyError` from the CLI and a 500
+        # from the web -- measured. `translate_questions` is exported in
+        # `verinote.pipeline.__all__`, so that is a public shape; the four test
+        # doubles this change had to update are the same edit any other caller
+        # needs.
         #
         # AND IT CARRIES THE VERDICT, because `status` cannot be read back as
         # one. Both branches of this decision report `translation_failed` -- the

--- a/verinote/pipeline/query_intent.py
+++ b/verinote/pipeline/query_intent.py
@@ -10,7 +10,7 @@ import json
 import re
 from typing import Any
 
-from verinote.llm.base import LLMError
+from verinote.llm.base import LLMOutputError
 from verinote.llm.schema import QUERY_INTENT_SCHEMA
 
 
@@ -1094,11 +1094,11 @@ def parse_query_intent(raw: str | dict[str, Any]) -> QueryIntent:
     try:
         data = json.loads(raw) if isinstance(raw, str) else raw
     except json.JSONDecodeError as exc:
-        raise LLMError(f"query intent output was not JSON: {exc}") from exc
+        raise LLMOutputError(f"query intent output was not JSON: {exc}") from exc
     try:
         return _parse_query_intent_object(data)
     except (KeyError, TypeError, ValueError) as exc:
-        raise LLMError(f"query intent output did not match schema: {exc}") from exc
+        raise LLMOutputError(f"query intent output did not match schema: {exc}") from exc
 
 
 def _parse_query_intent_object(data: Any) -> QueryIntent:

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -48,7 +48,7 @@ class _PreparedRepair:
     # never reached, or a policy file could not be read so translation was never
     # attempted. Both repair writers key their write suppression on this.
     # `result.provider_failed` alone is not enough: it does not cover the policy
-    # fault, which is the case that reaches this module most often.
+    # fault, where no provider is asked at all and so nothing sets that flag.
     infrastructure_fault: bool = False
 
 

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -44,6 +44,12 @@ class _PreparedRepair:
     result: RepairQuestionResult
     status: str
     query_dl: str | None
+    # #592. True when no usable provider output existed -- the provider was
+    # never reached, or a policy file could not be read so translation was never
+    # attempted. Both repair writers key their write suppression on this.
+    # `result.provider_failed` alone is not enough: it does not cover the policy
+    # fault, which is the case that reaches this module most often.
+    infrastructure_fault: bool = False
 
 
 def _prepare_repair_question(
@@ -70,6 +76,8 @@ def _prepare_repair_question(
         RepairQuestionResult(question_id, accepted, "" if accepted else flow.reason, flow.provider_failed),
         flow.status,
         query_dl,
+        infrastructure_fault=flow.policy_failed
+        or (flow.provider_failed and not flow.output_unusable),
     )
 
 
@@ -95,9 +103,14 @@ def repair_question(
         previous_query_dl=previous["query_dl"] if previous is not None else None,
         allow_direct_datalog_fallback=allow_direct_datalog_fallback,
     )
-    store.set_question_query(
-        question_id, prepared.query_dl, prepared.status, prepared.result.reason
-    )
+    # #592. REPORTED, NEVER RECORDED. A policy file that cannot be read reaches
+    # here as `translation_failed`, which claims "The provider output could not
+    # be used" about a translation that was never attempted. The row keeps the
+    # status it had; the caller still receives the result and logs it below.
+    if not prepared.infrastructure_fault:
+        store.set_question_query(
+            question_id, prepared.query_dl, prepared.status, prepared.result.reason
+        )
     write_query_file(store, root)
     if not prepared.result.accepted:
         _log.warning("repair q%d kept %s: %s", question_id, prepared.status, prepared.result.reason)
@@ -219,12 +232,20 @@ def process_repair_job(
                 # A policy can disappear during the provider call. Check before
                 # every DB/query-write boundary, before any result is persisted.
                 policy_guard()
-                persisted = store.persist_repair_question(
-                    job_id, int(item["id"]), owner_token, int(question["id"]),
-                    prepared.query_dl, prepared.status, prepared.result.reason,
-                )
-                if not persisted:
-                    return
+                # #592. Same rule on the async path, and it has to be here
+                # rather than only in the sync writer: this is a SEPARATE write,
+                # and `persist_repair_question` would set the row to a status
+                # describing provider output that never existed. Skipping it
+                # leaves the row `review_required`, which is still true of it.
+                # The fault is reported below, where the item and job are
+                # finished as failed with the same reason.
+                if not prepared.infrastructure_fault:
+                    persisted = store.persist_repair_question(
+                        job_id, int(item["id"]), owner_token, int(question["id"]),
+                        prepared.query_dl, prepared.status, prepared.result.reason,
+                    )
+                    if not persisted:
+                        return
             except PolicyMissingError:
                 raise
             except Exception as exc:
@@ -232,7 +253,11 @@ def process_repair_job(
                 store.finish_repair_item(int(item["id"]), owner_token, status="failed", reason=reason)
                 store.finish_repair_job(job_id, owner_token, failed=True, message=f"Repair failed: {reason}")
                 raise
-            if prepared.result.provider_failed:
+            # #592 widens this from `result.provider_failed` to every
+            # infrastructure fault: a policy fault also means nothing was
+            # translated, and the job must report it rather than finish "done"
+            # over a row it deliberately did not write.
+            if prepared.infrastructure_fault:
                 store.finish_repair_item(int(item["id"]), owner_token, status="failed", reason=prepared.result.reason)
                 store.finish_repair_job(
                     job_id, owner_token, failed=True, message=f"Repair failed: {prepared.result.reason}"

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -253,11 +253,19 @@ def process_repair_job(
                 store.finish_repair_item(int(item["id"]), owner_token, status="failed", reason=reason)
                 store.finish_repair_job(job_id, owner_token, failed=True, message=f"Repair failed: {reason}")
                 raise
-            # #592 widens this from `result.provider_failed` to every
-            # infrastructure fault: a policy fault also means nothing was
-            # translated, and the job must report it rather than finish "done"
-            # over a row it deliberately did not write.
-            if prepared.infrastructure_fault:
+            # #592 ADDS a disjunct here; it does not replace one. An earlier
+            # draft substituted `infrastructure_fault` for
+            # `result.provider_failed`, which NARROWED the report: an answer
+            # that arrived unusable sets `provider_failed` and clears
+            # `infrastructure_fault`, so the job stopped failing on it --
+            # measured, the item went from `failed` on the parent to `done`.
+            # The two disjuncts answer different questions. `provider_failed`
+            # is "the provider work did not produce a usable translation",
+            # which is what the job reports on. `infrastructure_fault` adds the
+            # policy fault, where no provider was asked at all, so nothing was
+            # translated and the job must not finish "done" over a row it
+            # deliberately did not write.
+            if prepared.result.provider_failed or prepared.infrastructure_fault:
                 store.finish_repair_item(int(item["id"]), owner_token, status="failed", reason=prepared.result.reason)
                 store.finish_repair_job(
                     job_id, owner_token, failed=True, message=f"Repair failed: {prepared.result.reason}"

--- a/verinote/pipeline/repair.py
+++ b/verinote/pipeline/repair.py
@@ -76,8 +76,7 @@ def _prepare_repair_question(
         RepairQuestionResult(question_id, accepted, "" if accepted else flow.reason, flow.provider_failed),
         flow.status,
         query_dl,
-        infrastructure_fault=flow.policy_failed
-        or (flow.provider_failed and not flow.output_unusable),
+        infrastructure_fault=flow.infrastructure_fault,
     )
 
 

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1031,15 +1031,22 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def _short_error(exc: BaseException) -> str:
         return " ".join(_error_cause(exc).split())[:240]
 
-    def _fail_pending_translations(store: Store, cfg: Config, exc: LLMError) -> None:
-        # Not `_short_error`: this reason is a standalone column, not interpolated
-        # into a separator, and `question_outcome_view` renders a per-status
-        # sentence when it is blank. Substituting a type name here replaces that
-        # sentence, it does not rescue a dangling colon.
-        reason = " ".join(str(exc).split())[:240]
-        for q in store.questions(pending_only=True):
-            store.set_question_query(q["id"], None, "translation_failed", reason)
-        write_query_file(store, cfg.root)
+    def _translation_fault(detail: str) -> str:
+        """Shape an infrastructure fault for the questions page (#592).
+
+        This replaced `_fail_pending_translations`, which wrote
+        `translation_failed` to every pending row. The rows were the only place
+        the web reported the fault, so the write could not simply be deleted --
+        the diagnosis had to move somewhere a user sees, and `questions.html`
+        already had an `error` slot that this route never used.
+
+        Normalised the way that function normalised its reason column, because
+        the destination is still a single line of user-facing text.
+        """
+        return " ".join(
+            f"Translation did not run: {detail} No question was marked failed;"
+            " they remain pending.".split()
+        )[:240]
 
     def _extraction_schema_hint(cfg: Config) -> str:
         try:
@@ -3191,9 +3198,21 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         try:
             client = get_client(app.state.cfg)
         except LLMError as e:
-            _fail_pending_translations(store, cfg, e)
-            return RedirectResponse("/questions", status_code=303)
-        translate_questions(store, client, root=cfg.root)
+            # #592. REPORTED, NEVER RECORDED. This previously marked every
+            # pending question `translation_failed`, which was the ONLY place
+            # the web said anything about the fault -- so removing the write
+            # without adding this surface would have made a broken provider
+            # config silent. `get_client` raises for an unknown provider, not a
+            # missing key, so nothing was attempted and the rows stay `pending`.
+            return _questions(request, error=_translation_fault(str(e)))
+        results = translate_questions(store, client, root=cfg.root)
+        # Since #592 an infrastructure fault is the ONLY thing that yields
+        # `translation_failed`, so a result carrying it is the fault report --
+        # the same derivation `cmd_query` uses for its exit code. The rows it
+        # describes were deliberately not written.
+        faults = [r for r in results if r["status"] == "translation_failed"]
+        if faults:
+            return _questions(request, error=_translation_fault(faults[0]["reason"]))
         return RedirectResponse("/questions", status_code=303)
 
     @app.post("/questions/repair", response_class=HTMLResponse)

--- a/verinote/web/app.py
+++ b/verinote/web/app.py
@@ -1040,13 +1040,33 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         the diagnosis had to move somewhere a user sees, and `questions.html`
         already had an `error` slot that this route never used.
 
-        Normalised the way that function normalised its reason column, because
-        the destination is still a single line of user-facing text.
+        THE BOUND IS ON THE DETAIL, NOT ON THE COMPOSED LINE. An earlier draft
+        capped the whole sentence, which put the provider's text first and the
+        fixed tail last: a 300-character provider message truncated away the
+        half that tells a user what happened to their rows, and the banner
+        ended mid-word in the provider's text. Bounding the variable part and
+        composing after it makes the tail unconditional. An empty detail --
+        `LLMError("")` is constructible -- would otherwise leave a dangling
+        colon, so it takes a period instead, and a detail that does not
+        punctuate itself gets one so the two sentences do not run together.
+
+        WHAT IT CLAIMS ABOUT THE ROWS IS SCOPED. The predecessor's text said
+        the questions "remain pending", which is false twice over: a question
+        already `translation_failed` from an earlier genuine failure enters the
+        loop and keeps that status, and a run can suppress one question's write
+        while recording another's. Both measured. The tail therefore speaks
+        only of the questions this fault stopped, and says they were left as
+        they were rather than naming a status.
         """
-        return " ".join(
-            f"Translation did not run: {detail} No question was marked failed;"
-            " they remain pending.".split()
-        )[:240]
+        collapsed = " ".join(detail.split())[:240]
+        if collapsed and collapsed[-1] not in ".!?":
+            collapsed += "."
+        opening = (
+            f"Translation could not run: {collapsed}"
+            if collapsed
+            else "Translation could not run."
+        )
+        return f"{opening} The questions it stopped on kept the status and reason they had."
 
     def _extraction_schema_hint(cfg: Config) -> str:
         try:
@@ -3203,14 +3223,19 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             # the web said anything about the fault -- so removing the write
             # without adding this surface would have made a broken provider
             # config silent. `get_client` raises for an unknown provider, not a
-            # missing key, so nothing was attempted and the rows stay `pending`.
+            # missing key, so nothing was attempted and no row is touched on
+            # this arm at all.
             return _questions(request, error=_translation_fault(str(e)))
         results = translate_questions(store, client, root=cfg.root)
-        # Since #592 an infrastructure fault is the ONLY thing that yields
-        # `translation_failed`, so a result carrying it is the fault report --
-        # the same derivation `cmd_query` uses for its exit code. The rows it
-        # describes were deliberately not written.
-        faults = [r for r in results if r["status"] == "translation_failed"]
+        # Filtered on the flag, NOT on `r["status"]`. Both sides of #592's
+        # discriminator report `translation_failed` -- the fault that was
+        # suppressed and the unusable answer that was written -- so the status
+        # string cannot tell them apart, and keying on it made this page say
+        # "Translation could not run ... kept the status they had" directly
+        # above a row the same request had just marked `Translation failed`.
+        # Measured on tests/test_query_planning_e2e.py's off-schema intent,
+        # which is the case #592 says IS recorded.
+        faults = [r for r in results if r["infrastructure_fault"]]
         if faults:
             return _questions(request, error=_translation_fault(faults[0]["reason"]))
         return RedirectResponse("/questions", status_code=303)

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -7,7 +7,7 @@
   <code>review_required</code>, <code>no_answer</code>, <code>ambiguous</code>, or
   <code>translation_failed</code>. A run that could not reach the provider, or
   could not read a policy file, leaves those questions as they were and reports
-  the fault instead of recording it on the row.</p>
+  the fault on that run's own page instead of recording it on the row.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 

--- a/verinote/web/templates/questions.html
+++ b/verinote/web/templates/questions.html
@@ -5,7 +5,9 @@
 <p class="muted">Natural-language questions are translated to a Datalog query the
   engine evaluates over confirmed facts. Untranslatable ones are flagged
   <code>review_required</code>, <code>no_answer</code>, <code>ambiguous</code>, or
-  <code>translation_failed</code>.</p>
+  <code>translation_failed</code>. A run that could not reach the provider, or
+  could not read a policy file, leaves those questions as they were and reports
+  the fault instead of recording it on the row.</p>
 
 {% if error %}<p class="error" role="alert">{{ error }}</p>{% endif %}
 


### PR DESCRIPTION
Closes #592.

## 규칙

    인프라 장애는 보고하되 기록하지 않는다.
    도착했으나 쓸 수 없는 응답은 기록한다.
    판별자는 응답이 도착했는가이다.

규칙은 고른 것이 아니라 `question_outcome.py::_STATUS_META` 에서 읽어냈다 —
`translation_failed` 은 "프로바이더 출력을 쓸 수 없었다" 이므로, 출력이 없었던
장애에 대해서는 그 행이 거짓을 말한다. 스키마 변경 없음: `pending` 이 이미
`db.py` 의 CHECK 제약 안에 있다.

## 상태

**로컬 게이트 5라운드를 거쳤고 매 라운드가 실제 결함을 잡았다.** rev 1–4 는
전부 blocked 였다.

| rev | 무엇이 막혔는가 |
|---|---|
| 2 | 웹 배너가 status 문자열로 필터해 한 HTML 안에서 자기모순 |
| 3 | `query.py:446` 이 `output_unusable` 을 계산하지 않아 그 출구의 행이 기록되지 않음; 11개 raise 지점 중 8곳이 되돌려도 0개를 붉힘 |
| 4 | 행렬 여섯 행이 클래스 되돌리기가 아니라 `NameError` 를 측정하고 있었음; `verinote query` 가 어떤 행도 갖지 않은 review 수를 출력 |
| 5 | (현재 게이트 심사 중) |

rev 5 기준 로컬 측정: **3557 passed, 12 skipped, 0 failed**, `uvx ruff@0.15.18`
clean, 31행 변이 행렬(최소 red 1, 미고정 0, `NameError` 플래그 0).

## 이 PR 이 CI 에 요구하는 것

로컬 실행은 **Python 3.11.15 하나**뿐이다. CI 는 **3.11 / 3.12 / 3.13** 으로 돌린다.
그 두 버전은 이 변경에 대해 한 번도 실행된 적이 없다. 이 PR 의 CI 가 그 공백을
메우는 첫 실행이다.

## 미결로 남긴 것 — 게이트가 판정할 사안

재해석 출구에서 `main` 이 쓰던 reason 은 **연결(concatenation)** 로 측정됐다:
요청을 보내기 전에 계산되는 **108자 판정** + 덧붙는 **117자 인프라 장애**.
이 변경은 둘 다 떨어뜨린다. 접두부만 기록하는 것은 다른 설계이므로 여기서
결정하지 않고 남긴다. 관련 비대칭: 프로바이더가 `UNKNOWN_OR_UNSUPPORTED` 라고
**답하면** 행이 기록되고, 도달하지 못했을 때만 사라진다.

## 후속

#601 (openai_adapter 의 네 개 `resp.choices[0]` 가 정규화 `try` 바깥) 은 이
작업 중 측정되어 별도 등록됐고, 네 메서드 지점에서 번호로 인용된다.
