### PR TITLE
fix(llm,cli): close #592's redaction fail-open and the failed-count it left behind (#603, #604)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -909,10 +909,15 @@ def test_query_does_not_count_an_unreachable_provider_as_a_review_verdict(
 ):
     """THE SUMMARY LINE IS ABOUT ROWS, and this exit is the one that broke it.
 
-    `_reinterpret_empty_plan` is the only path returning `review_required` with
-    `infrastructure_fault=True`: the deterministic planner earns the verdict
-    before any request is made, the provider is then asked to re-read the
-    question, and it cannot be reached. Counting that dict in `for_review`
+    `_reinterpret_empty_plan` is the path this test drives, and the one that
+    reaches it through `translate_questions`: the deterministic planner earns
+    the verdict before any request is made, the provider is then asked to
+    re-read the question, and it cannot be reached. It is NOT the only
+    construction that can pair `review_required` with `infrastructure_fault` --
+    `_schema_aware_query_flow_result` and `_translate_direct_datalog_fallback`
+    build that pair too, and `_prepare_repair_question` reaches one of them --
+    so the claim here is about what this fixture exercises, not about the
+    program. Counting that dict in `for_review`
     printed "1 for review" over a row left `pending` -- and the comment above
     the count called those verdicts "durable" and "not a broken run", both false
     of it. The row half of the same exit was pinned two revisions ago; the
@@ -985,7 +990,13 @@ def test_query_reports_a_provider_failure_without_recording_it(tmp_path, monkeyp
     # not written. Deleting the branch that produces the line above brings it
     # straight back, which is what makes this assertion load-bearing.
     assert "q1: translation_failed" not in captured.out
-    assert "translated 0 question(s), 1 failed" in captured.out
+    # THE SUMMARY OBEYS THE SAME RULE AS THE LINE ABOVE IT. This asserted
+    # "1 failed" while asserting, two lines up, that the row's own vocabulary
+    # must not appear on a line about a row that was not written -- so the test
+    # pinned the contradiction rather than catching it. `failed` counts rows
+    # that SAY `translation_failed`; this run left its row `pending`.
+    assert "translated 0 question(s), 1 not translated" in captured.out
+    assert "1 failed" not in captured.out
     assert "provider unavailable" in captured.err
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
@@ -1012,7 +1023,8 @@ def test_query_reports_a_get_client_failure_without_recording_it(tmp_path, monke
     assert rc == 1
     assert "q1: not translated - missing provider credentials (row unchanged)" in captured.out
     assert "q1: translation_failed" not in captured.out
-    assert "translated 0 question(s), 1 failed" in captured.out
+    assert "translated 0 question(s), 1 not translated" in captured.out
+    assert "1 failed" not in captured.out
     assert "missing provider credentials" in captured.err
     s = Store(tmp_path / "kb.sqlite")
     q = s.questions()[0]
@@ -1054,7 +1066,11 @@ def test_query_mixed_outcomes_exits_nonzero_with_split(
     # describes its own question, so the two lines differ in kind and not only
     # in status -- q1 reports its row, q2 reports the run.
     assert "q2: not translated - provider rejected this question (row unchanged)" in captured.out
-    assert "translated 1 question(s), 1 failed" in captured.out
+    # The mixed run in the strong sense: one row written, one deliberately not.
+    # "1 failed" would have described the second question as a recorded failure
+    # while the assertion below shows its row is `pending`.
+    assert "translated 1 question(s), 1 not translated" in captured.out
+    assert "1 failed" not in captured.out
     assert "provider rejected this question" in captured.err
     store = Store(tmp_path / "kb.sqlite")
     rows = {int(q["id"]): str(q["status"]) for q in store.questions()}

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -890,9 +890,10 @@ def test_a_render_failure_keeps_the_original_error_as_the_cause(
     #592 replaced `raise type(exc)(...) from exc.__cause__` with rewriting the
     message on the exception and re-raising it, so on the common path the cause
     is INHERITED rather than re-attached. #603 then added a guard that replaces
-    the object when it cannot be made to show the redacted text, and that exit
-    DOES spell `from exc.__cause__` -- re-attaching the same cause, so this test
-    passes on both paths. Making either copy chain to the WRAPPER instead --
+    the object when it cannot be made to show the redacted text, and that
+    replacement chains to the cause the guard read off the original before
+    giving up on it -- re-attaching the same cause, so this test passes on both
+    paths. Making either copy chain to the WRAPPER instead --
     `raise LLMError(str(exc)) from exc` -- is what fails the matching case
     here.
     """

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -885,9 +885,14 @@ def test_a_render_failure_keeps_the_original_error_as_the_cause(
     render path did not, and the docstring now argues from it.
 
     BOTH adapters, because each carries its own `_rendered` and each re-raises
-    `from exc.__cause__` in its own copy of that line. Covering one left the
-    other's unpinned while its docstring named this test as what pins it —
-    change either copy to `from exc` and the matching case here fails.
+    the caught exception in its own copy of that clause. Covering one left the
+    other's unpinned while its docstring named this test as what pins it.
+    #592 replaced `raise type(exc)(...) from exc.__cause__` with rewriting the
+    message on the exception and re-raising it, so the cause is now INHERITED
+    rather than re-attached and there is no `from` clause left in either copy:
+    `grep -rn "raise .* from exc.__cause__" verinote/` returns nothing. Making
+    either copy construct a new exception -- `raise LLMError(str(exc)) from exc`
+    -- is what fails the matching case here now.
     """
     boom = TypeError("render_prompt() got an unexpected keyword argument")
 

--- a/tests/test_cloud_adapters.py
+++ b/tests/test_cloud_adapters.py
@@ -888,11 +888,13 @@ def test_a_render_failure_keeps_the_original_error_as_the_cause(
     the caught exception in its own copy of that clause. Covering one left the
     other's unpinned while its docstring named this test as what pins it.
     #592 replaced `raise type(exc)(...) from exc.__cause__` with rewriting the
-    message on the exception and re-raising it, so the cause is now INHERITED
-    rather than re-attached and there is no `from` clause left in either copy:
-    `grep -rn "raise .* from exc.__cause__" verinote/` returns nothing. Making
-    either copy construct a new exception -- `raise LLMError(str(exc)) from exc`
-    -- is what fails the matching case here now.
+    message on the exception and re-raising it, so on the common path the cause
+    is INHERITED rather than re-attached. #603 then added a guard that replaces
+    the object when it cannot be made to show the redacted text, and that exit
+    DOES spell `from exc.__cause__` -- re-attaching the same cause, so this test
+    passes on both paths. Making either copy chain to the WRAPPER instead --
+    `raise LLMError(str(exc)) from exc` -- is what fails the matching case
+    here.
     """
     boom = TypeError("render_prompt() got an unexpected keyword argument")
 

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -337,6 +337,122 @@ def test_a_subclass_that_hides_the_redaction_does_not_leave_this_function():
     assert type(excinfo.value) is LLMOutputError
 
 
+def test_a_failure_in_the_lines_the_guard_guards_cannot_skip_it():
+    """A GUARD PLACED AFTER THE LINES IT GUARDS IS NOT A GUARD.
+
+    The redaction works by mutating the caught exception, and mutation can FAIL:
+    a subclass whose `args` setter raises, or whose `__notes__` is a read-only
+    property, throws from inside the very lines the post-condition exists to
+    police. Measured before those lines were wrapped: an `AttributeError` came
+    straight out of this function -- `isinstance(e, LLMError)` False, so every
+    `except LLMError` between here and the user stopped catching it. The two
+    shapes do not leak alike, which is why both are driven here: the `args` one
+    leaks every time, because the redaction never lands; the `__notes__` one
+    leaks when the note carries the key, so the note below carries it. That is
+    strictly worse than the behaviour #592 replaced, which never touched the
+    object and so could not fail this way.
+
+    Both directions are asserted: nothing leaks, AND what leaves is still an
+    `LLMError`, because a redaction that escapes its own error handling as a
+    foreign exception is a different outage from a redaction that works.
+    """
+    secret = "sk-ant-SECRETVALUE0123456789"
+
+    class _ArgsLocked(LLMOutputError):
+        def __setattr__(self, name, value):
+            if name == "args":
+                raise AttributeError("args is read-only")
+            super().__setattr__(name, value)
+
+    class _NotesLocked(LLMOutputError):
+        @property
+        def __notes__(self):
+            return [f"request signed with {secret}"]
+
+    for cls in (_ArgsLocked, _NotesLocked):
+        def parse(_payload, _cls=cls):
+            raise _cls(f"upstream refused {secret}")
+
+        with pytest.raises(LLMError) as excinfo:
+            parsed_under_redaction(parse, "payload", secret)
+
+        assert secret not in str(excinfo.value), cls.__name__
+        rendered = "".join(
+            traceback.format_exception(
+                type(excinfo.value), excinfo.value, excinfo.value.__traceback__
+            )
+        )
+        assert secret not in rendered, cls.__name__
+
+
+def test_the_replacement_keeps_the_kind_it_replaced():
+    """THE REPLACEMENT MUST NOT CROSS #592's DISCRIMINATOR.
+
+    `output_unusable = isinstance(exc, LLMOutputError)` is what decides whether
+    the question row records `translation_failed` or is suppressed. So a
+    replacement raised as a fixed class re-classifies the failure: raising
+    `LLMOutputError` unconditionally PROMOTES a bare `LLMError` into "the
+    provider produced output", and raising `LLMError` unconditionally -- which
+    is what the two adapters' copies did -- DEMOTES the other way.
+
+    That is the same defect as the type destruction this primitive was changed
+    to stop, pointed the other way, and it was unpinned: the class-preserving
+    line reddened nothing when it was measured.
+    """
+    secret = "sk-ant-SECRETVALUE0123456789"
+
+    class _HidingOutput(LLMOutputError):
+        def __init__(self, message):
+            super().__init__(message)
+            self._cached = message
+
+        def __str__(self):
+            return self._cached
+
+    class _HidingPlain(LLMError):
+        def __init__(self, message):
+            super().__init__(message)
+            self._cached = message
+
+        def __str__(self):
+            return self._cached
+
+    for cls, expect_output in ((_HidingOutput, True), (_HidingPlain, False)):
+        def parse(_payload, _cls=cls):
+            raise _cls(f"upstream refused {secret}")
+
+        with pytest.raises(LLMError) as excinfo:
+            parsed_under_redaction(parse, "payload", secret)
+
+        assert secret not in str(excinfo.value), cls.__name__
+        assert isinstance(excinfo.value, LLMOutputError) is expect_output, cls.__name__
+
+
+def test_a_decorating_str_does_not_leak_and_does_not_compound():
+    """#603's third shape, which nothing pinned.
+
+    A `__str__` that DECORATES rather than caches does not leak -- its
+    decoration wraps whatever `args` holds, so it wraps the redacted text. What
+    it used to do is COMPOUND: the already-decorated `str(exc)` was written back
+    into `args[0]`, so the prefix accumulated on every pass through this
+    function. The guard replaces the object instead, so the prefix appears once.
+    """
+    secret = "sk-ant-SECRETVALUE0123456789"
+
+    class _Decorating(LLMOutputError):
+        def __str__(self):
+            return "provider: " + super().__str__()
+
+    def parse(_payload):
+        raise _Decorating(f"upstream refused {secret}")
+
+    with pytest.raises(LLMOutputError) as excinfo:
+        parsed_under_redaction(parse, "payload", secret)
+
+    assert secret not in str(excinfo.value)
+    assert str(excinfo.value).count("provider: ") <= 1
+
+
 def test_a_note_is_redacted_alongside_the_message():
     """`__notes__` (PEP 678) reaches `traceback.format_exception`, and the
     relabel keeps the object, so a note survives where the rebuild dropped it.

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -24,8 +24,8 @@ provider-side OR PARSING failure", so it conflates a request never sent with an
 answer that came back unusable. `LLMOutputError` is the second case, and the
 tests below pin both directions.
 """
-import ast
 import re
+import traceback
 from html import unescape
 from pathlib import Path
 
@@ -287,71 +287,81 @@ def test_a_mixed_run_reports_the_suppressed_fault_and_not_the_recorded_one(
     assert "did not match schema" not in banner
 
 
-def test_no_shipped_llm_error_subclass_defines_its_own_str():
-    """The RELABEL's precondition, enforced -- the hazard the deleted tripwire
-    did not cover and its replacement could not.
+def test_a_subclass_that_hides_the_redaction_does_not_leave_this_function():
+    """THE POST-CONDITION, which replaced a source sweep over class definitions.
 
-    `parsed_under_redaction` redacts by rewriting `exc.args` and re-raising the
-    same object. That reaches `str(exc)` only because `BaseException.__str__`
-    derives the string from `args`. A subclass that defines `__str__` -- to cache
-    its message, or to format one from other fields -- keeps returning the
-    ORIGINAL text after the rewrite, so the secret survives into a message this
-    function exists to redact. Measured on this primitive: such a subclass leaks
-    where the previous revision's rebuild did not. It is a fail-OPEN direction in
-    the one place whose whole job is redaction.
+    Rewriting `args` reaches `str(exc)` only while `str` is
+    `BaseException.__str__`. A subclass that CACHES its message and returns the
+    cache keeps showing the original text after the rewrite, so the secret
+    survives the one function whose job is removing it. Measured on the shipped
+    primitive before this check existed: `str(exc)` carried the key, and so did
+    `traceback.format_exception`.
 
-    The tripwire this replaces checked constructor ARITY, which was the REBUILD's
-    hazard and is now structurally impossible. It would not have caught this one.
-
-    DERIVED FROM THE SOURCE, not from `__subclasses__()`, and that is the point:
-    `__subclasses__()` returns direct children only and sees nothing a test run
-    has not imported, so the old sweep was blind exactly where a new subclass
-    would be added. This walks every class statement under `verinote/`, resolves
-    the `LLMError` family as a fixpoint over base names, and so covers a subclass
-    at any depth in any module whether or not anything imports it.
-
-    SCOPE, so it is not read as more than it is: this cannot see a subclass
-    defined outside `verinote/`, and it checks `__str__` rather than every way a
-    message could be decoupled from `args`. `__str__` is the decisive one --
-    without it, `str(exc)` reads `args` and the redaction holds.
+    WHY NOT A SWEEP OVER SUBCLASSES. The previous revision guarded this by
+    scanning class statements under `verinote/`. That scan could not see a base
+    named through an import alias, a class built by `type()`, `__str__` assigned
+    after the class body, or a `__str__` nested in an `if` inside it -- each
+    measured -- and it could never see a subclass defined outside the package at
+    all. The check here does not enumerate shapes: it compares what the
+    exception WILL SHOW against what was redacted, so a shape nobody thought of
+    is covered by construction. The cost is the subclass identity, and only in
+    the case the sweep used to forbid outright.
     """
-    package = Path(__file__).resolve().parent.parent / "verinote"
-    classes = {}
-    for path in sorted(package.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                bases = {b.id for b in node.bases if isinstance(b, ast.Name)}
-                bases |= {b.attr for b in node.bases if isinstance(b, ast.Attribute)}
-                classes[node.name] = (bases, node, path)
+    secret = "sk-ant-SECRETVALUE0123456789"
 
-    family = {"LLMError"}
-    while True:
-        grown = {
-            name for name, (bases, _, _) in classes.items() if bases & family
-        } | family
-        if grown == family:
-            break
-        family = grown
+    class _Caching(LLMOutputError):
+        def __init__(self, message):
+            super().__init__(message)
+            self._cached = message
 
-    swept = sorted(family - {"LLMError"})
-    assert swept, (
-        "no LLMError subclass was found under verinote/, so this sweep judged "
-        "nothing -- it has been made vacuous, not satisfied"
+        def __str__(self):
+            return self._cached
+
+    def parse(_payload):
+        raise _Caching(f"upstream refused {secret}")
+
+    with pytest.raises(LLMError) as excinfo:
+        parsed_under_redaction(parse, "payload", secret)
+
+    assert secret not in str(excinfo.value)
+    rendered = "".join(
+        traceback.format_exception(
+            type(excinfo.value), excinfo.value, excinfo.value.__traceback__
+        )
     )
+    assert secret not in rendered
+    # The identity is what it costs, and only here: the class is replaced
+    # precisely because its own `__str__` could not be trusted to show the
+    # redacted text. The deep-subclass test below is the counterweight -- a
+    # subclass that does NOT hide the redaction keeps its class and its state.
+    assert type(excinfo.value) is LLMOutputError
 
-    offenders = []
-    for name in swept:
-        _, node, path = classes[name]
-        for child in node.body:
-            if isinstance(child, ast.FunctionDef) and child.name == "__str__":
-                offenders.append(f"{path.name}:{child.lineno} {name}.__str__")
 
-    assert offenders == [], (
-        "these `LLMError` subclasses define `__str__`, so `parsed_under_redaction`"
-        " cannot redact them: it rewrites `args` and re-raises the same object, "
-        f"and their `__str__` keeps returning the unredacted text. {offenders}"
+def test_a_note_is_redacted_alongside_the_message():
+    """`__notes__` (PEP 678) reaches `traceback.format_exception`, and the
+    relabel keeps the object, so a note survives where the rebuild dropped it.
+
+    Measured on the shipped primitive before this: the note carried the key into
+    the rendered traceback while `str(exc)` was clean -- a leak that reading
+    `str(exc)` alone would never show.
+    """
+    secret = "sk-ant-SECRETVALUE0123456789"
+
+    def parse(_payload):
+        error = LLMOutputError("query translation did not match schema")
+        error.add_note(f"request signed with {secret}")
+        raise error
+
+    with pytest.raises(LLMOutputError) as excinfo:
+        parsed_under_redaction(parse, "payload", secret)
+
+    rendered = "".join(
+        traceback.format_exception(
+            type(excinfo.value), excinfo.value, excinfo.value.__traceback__
+        )
     )
+    assert secret not in rendered
+    assert "***" in "".join(excinfo.value.__notes__)
 
 
 def test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state():
@@ -588,7 +598,9 @@ def test_an_unusable_reinterpretation_is_recorded_like_any_other_arrived_answer(
     exits above wrote one -- and this is the exit whose reason quotes the
     provider's own words, so the page denied the run had happened while printing
     them. The two exits above were pinned; this one was not, which is how it
-    survived two revisions and three gate rounds.
+    survived three revisions and three gate rounds -- counted per tag by AST
+    over `query.py`'s `_QueryFlowResult` constructions: four carry the keyword
+    at revisions 1, 2 and 3, five from revision 4 on.
     """
     root = tmp_path / "kb"
     store = _kb_with_an_empty_plan(root)

--- a/tests/test_infrastructure_fault_not_recorded.py
+++ b/tests/test_infrastructure_fault_not_recorded.py
@@ -302,10 +302,15 @@ def test_a_subclass_that_hides_the_redaction_does_not_leave_this_function():
     named through an import alias, a class built by `type()`, `__str__` assigned
     after the class body, or a `__str__` nested in an `if` inside it -- each
     measured -- and it could never see a subclass defined outside the package at
-    all. The check here does not enumerate shapes: it compares what the
-    exception WILL SHOW against what was redacted, so a shape nobody thought of
-    is covered by construction. The cost is the subclass identity, and only in
-    the case the sweep used to forbid outright.
+    all. The check here does not enumerate shapes, but it does not cover all of
+    them either: it compares ONE rendering channel -- `str(exc)` -- at ONE
+    instant, right after `args` is rewritten. A subclass that renders through
+    `__format__` or `__repr__`, or whose `__str__` changes value after the
+    sample, is outside it, and `llm/base.py` says so where the guard lives. What
+    the sweep could not do and this can is cover a shape it was never told
+    about, PROVIDED that shape shows itself through the sampled channel. The
+    cost is the subclass identity, and only in the case the sweep used to forbid
+    outright.
     """
     secret = "sk-ant-SECRETVALUE0123456789"
 
@@ -382,6 +387,97 @@ def test_a_failure_in_the_lines_the_guard_guards_cannot_skip_it():
                 type(excinfo.value), excinfo.value, excinfo.value.__traceback__
             )
         )
+        assert secret not in rendered, cls.__name__
+
+
+def test_nothing_the_exit_path_reads_can_escape_the_guard():
+    """THE CLOSED PROPERTY: no exit path reads anything off the caught object.
+
+    Three revisions each protected the last attribute they had been shown --
+    `args`, then `__notes__`, then `__cause__` on the guard's own replacement
+    exit -- because each fix enumerated shapes instead of naming the property.
+    `raise replacement from exc.__cause__` reads the object ON THE WAY OUT, so
+    an object that misbehaves there defeats the guard no matter how well the
+    lines above it are wrapped.
+
+    Two shapes make that read fail, and neither needs the message to be hidden
+    in any new way. Measured on the revision before this one: a `__cause__`
+    property that raises escaped as that exception, and a `__cause__` that is
+    not a `BaseException` escaped as `TypeError: exception causes must derive
+    from BaseException` -- both non-`LLMError`, both out of `cli.main`, and
+    `traceback.format_exception` could not even render the first one, because
+    it reads `__cause__` again.
+
+    A third shape is here because it is the one an `except LLMError: raise` arm
+    would have let through: a `__cause__` property raising an `LLMError`, which
+    such an arm would re-raise as if it were the intended replacement.
+    """
+    secret = "sk-ant-SECRETVALUE0123456789"
+
+    class _CauseRaises(LLMOutputError):
+        def __init__(self, message):
+            super().__init__(message)
+            self._cached = message
+
+        def __str__(self):
+            return self._cached
+
+        @property
+        def __cause__(self):
+            raise RuntimeError("cause explodes")
+
+    class _CauseIsNotAnException(LLMOutputError):
+        def __init__(self, message):
+            super().__init__(message)
+            self._cached = message
+
+        def __str__(self):
+            return self._cached
+
+        @property
+        def __cause__(self):
+            return "not an exception"
+
+    class _CauseRaisesAnLLMError(LLMOutputError):
+        def __init__(self, message):
+            super().__init__(message)
+            self._cached = message
+
+        def __str__(self):
+            return self._cached
+
+        @property
+        def __cause__(self):
+            raise LLMError(f"cause carries {secret}")
+
+    for cls in (_CauseRaises, _CauseIsNotAnException, _CauseRaisesAnLLMError):
+        def parse(_payload, _cls=cls):
+            raise _cls(f"upstream refused {secret}")
+
+        # NOT `pytest.raises`, and that is the point rather than a style choice.
+        # If the guard regresses, what escapes is an object whose `__cause__`
+        # raises -- and pytest formats an escaping exception, so it reads
+        # `__cause__` and the property explodes INSIDE the reporter. Measured:
+        # that is an `INTERNALERROR` which kills the whole session, so a real
+        # regression would abort the run instead of failing this test, and every
+        # test after it would go unrun. The facts are captured here and asserted
+        # after the object is out of scope, so a failure is an ordinary
+        # `AssertionError` that names the shape.
+        escaped_kind, is_llm_error, shown, rendered = None, None, "", ""
+        try:
+            parsed_under_redaction(parse, "payload", secret)
+        except BaseException as exc:  # noqa: BLE001 - the shape under test
+            escaped_kind = type(exc).__name__
+            is_llm_error = isinstance(exc, LLMError)
+            if is_llm_error:
+                shown = str(exc)
+                rendered = "".join(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
+
+        assert escaped_kind is not None, f"{cls.__name__}: nothing was raised"
+        assert is_llm_error, f"{cls.__name__} escaped as {escaped_kind}"
+        assert secret not in shown, cls.__name__
         assert secret not in rendered, cls.__name__
 
 

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1643,13 +1643,44 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
             print(f"  q{r['id']}: not translated - {r['reason']} (row unchanged)")
         else:
             print(f"  {format_question_outcome(r)}")
+    # #592. FOUR COUNTS, ENUMERATED RATHER THAN GENERALISED OVER, because the
+    # revision before this one wrote "every count here excludes the unrecorded
+    # dicts", fixed three of them, and left the fourth. Each is named with what
+    # it counts and whether it excludes:
+    #
+    #   translated      rows that say `translated`     excludes, vacuously:
+    #                                                  a suppressed run never
+    #                                                  reports `translated`
+    #   failures        rows that say translation_failed   EXCLUDES (this line)
+    #   not_translated  the unrecorded runs themselves     IS that set
+    #   for_review      rows holding a review verdict      excludes
+    #
+    # Every one of them is about ROWS, and `infrastructure_fault` is the only
+    # thing that says whether a row exists -- `status` cannot, because the
+    # suppressed and the recorded cases both report a status.
     translated = sum(1 for r in results if r["status"] == "translated")
-    failures = [r for r in results if r["status"] == "translation_failed"]
-    # #592. EVERY COUNT BELOW IS ABOUT ROWS, so every one of them has to exclude
-    # the dicts whose row was deliberately not written. `infrastructure_fault`
-    # is the only thing that says so -- `status` cannot, because the suppressed
-    # and the recorded cases both report a status.
     unrecorded = [r for r in results if r["infrastructure_fault"]]
+    # THE COUNT THIS REVISION FIXES. It read `status == "translation_failed"`
+    # with no exclusion, so a credential fault, an unknown provider or an
+    # unreachable provider printed "1 failed" over a row left `pending` -- and
+    # printed it directly under `q1: not translated ... (row unchanged)`, so one
+    # output block contradicted itself. Two shipped tests pinned the
+    # contradiction: one asserted that the row's vocabulary must not appear on a
+    # line about a row that was not written, then asserted the summary using it
+    # two lines later.
+    #
+    # ATTRIBUTION, both halves. `main` ALREADY printed "1 failed" over zero
+    # `translation_failed` rows for the POLICY population -- inherited from
+    # #591's suppression, and not fixed here. What this line had done was EXTEND
+    # that to the credential, unknown-provider and unreachable-provider
+    # populations, where main's count was true. So it was a true->false
+    # transition laid on top of a pre-existing false one, and only the first
+    # half is this change's to own.
+    failures = [
+        r
+        for r in results
+        if r["status"] == "translation_failed" and not r["infrastructure_fault"]
+    ]
     # review_required/no_answer/ambiguous are durable review verdicts, not
     # failures (#296): a question legitimately ending there is not a broken run.
     # They count as neither translated nor failed — but surface their number, so
@@ -1667,9 +1698,10 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
         if r["status"] in {"review_required", "no_answer", "ambiguous"}
         and not r["infrastructure_fault"]
     )
-    # The unrecorded runs already counted as failures are not counted twice: a
-    # `translation_failed` fault is reported as a failure, which is what it is.
-    not_translated = [r for r in unrecorded if r["status"] != "translation_failed"]
+    # ALL of them, with no status carve-out. An unrecorded run is the same
+    # physical event whatever status the flow reported for it, and splitting the
+    # set by status is what let one half escape the exclusion above.
+    not_translated = unrecorded
     # "translated {n} question(s)" is preserved verbatim as the prefix (callers
     # and tests read it); n is the count that genuinely translated, not the total.
     summary = f"translated {translated} question(s)"
@@ -1682,12 +1714,15 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     summary += f" -> {cfg.root / 'facts' / 'query.dl'}"
     print(summary)
     print("run the check to see answers (`verinote ui` → Report)")
-    # #592 WIDENED WHAT EXITS NONZERO, and the widening is the point of the rule.
-    # A run that could not reach the provider wrote nothing and answered nothing;
-    # `main` returned 0 for it because the row it wrote made the run look
-    # finished. There is no row now, so the exit code is the only durable report
-    # left and it has to carry the fault -- otherwise `verinote query` in a
-    # script reports success for a run that translated nothing.
+    # #592 WIDENED WHAT EXITS NONZERO, on ONE population: the empty-plan
+    # reinterpretation whose provider could not be reached. Credential, unknown
+    # provider and policy faults already exited 1 on `main` -- measured per
+    # population, not assumed -- so this is not a general 0->1 move.
+    #
+    # THE REASON IS THAT rc 0 WAS A FALSE CLAIM, not that rc is durable. An exit
+    # code is the least durable artifact here; it survives only as long as the
+    # shell that read it. What makes it wrong to return 0 is that 0 says the run
+    # did what it was asked, and this run translated nothing and wrote nothing.
     reported = failures + not_translated
     if reported:
         # Any translation_failed is a hard failure (#243): exit rc 1 and put the

--- a/verinote/cli.py
+++ b/verinote/cli.py
@@ -1655,8 +1655,10 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     #   not_translated  the unrecorded runs themselves     IS that set
     #   for_review      rows holding a review verdict      excludes
     #
-    # Every one of them is about ROWS, and `infrastructure_fault` is the only
-    # thing that says whether a row exists -- `status` cannot, because the
+    # Read the table, not a summary of it: three of the four count ROWS and
+    # `not_translated` counts the RUNS that produced none, which is why it is
+    # the one that does not "exclude" anything. `infrastructure_fault` is the
+    # only thing that says whether a row exists -- `status` cannot, because the
     # suppressed and the recorded cases both report a status.
     translated = sum(1 for r in results if r["status"] == "translated")
     unrecorded = [r for r in results if r["infrastructure_fault"]]
@@ -1669,13 +1671,17 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     # line about a row that was not written, then asserted the summary using it
     # two lines later.
     #
-    # ATTRIBUTION, both halves. `main` ALREADY printed "1 failed" over zero
-    # `translation_failed` rows for the POLICY population -- inherited from
-    # #591's suppression, and not fixed here. What this line had done was EXTEND
-    # that to the credential, unknown-provider and unreachable-provider
-    # populations, where main's count was true. So it was a true->false
-    # transition laid on top of a pre-existing false one, and only the first
-    # half is this change's to own.
+    # ATTRIBUTION. `main` printed "N failed" over `pending` rows for the POLICY
+    # population too -- inherited from #591's suppression, and older than #592.
+    # #592 then EXTENDED the same falsehood to the credential, unknown-provider
+    # and unreachable-provider populations, where the count had been true.
+    #
+    # THIS ONE LINE FIXES BOTH, which is more than #604 asked for and more than
+    # an earlier draft of this comment claimed. `policy_failed` is a disjunct of
+    # `infrastructure_fault`, so a policy fault is excluded here by the same
+    # predicate as the rest. Measured through the real command on a typed file
+    # the parser cannot read: "2 not translated", rc 1, rows `pending` -- where
+    # both `6cd66b8` and `c9b6836` said "2 failed" over the same `pending` rows.
     failures = [
         r
         for r in results
@@ -1723,6 +1729,11 @@ def cmd_query(cfg: Config, args: argparse.Namespace) -> int:
     # code is the least durable artifact here; it survives only as long as the
     # shell that read it. What makes it wrong to return 0 is that 0 says the run
     # did what it was asked, and this run translated nothing and wrote nothing.
+    #
+    # AND THE DURABLE GAP IS REAL AND FILED, not closed by this rc. Nothing
+    # anywhere records "attempted, provider out" after the process exits -- the
+    # row is `pending` and says only "waiting", which is the accepted cost of
+    # the #592 ruling. #606 tracks it; this line is not a substitute for it.
     reported = failures + not_translated
     if reported:
         # Any translation_failed is a hard failure (#243): exit rc 1 and put the

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -269,7 +269,24 @@ class AnthropicAdapter:
             # `LLMError` is the only class that can arrive. It is written this
             # way anyway, because the day `_render_prompt` grows a subclass exit
             # the alternative swallows it with no test red anywhere.
-            exc.args = (redact_secret(str(exc), self.cfg.api_key),)
+            #
+            # AND THE POST-CONDITION COMES WITH IT. Relabelling reaches
+            # `str(exc)` only while `str` is `BaseException.__str__`, so the
+            # same fail-open `parsed_under_redaction` guards exists here: a
+            # subclass caching or decorating its message would keep showing the
+            # unredacted text. This copy is a no-op for the same reason the
+            # class preservation is, and it is written for the same reason --
+            # the two clauses have to arrive together or the day one grows a
+            # subclass exit is the day the other leaks.
+            redacted = redact_secret(str(exc), self.cfg.api_key)
+            exc.args = (redacted,)
+            notes = getattr(exc, "__notes__", None)
+            if notes:
+                exc.__notes__ = [
+                    redact_secret(str(note), self.cfg.api_key) for note in notes
+                ]
+            if str(exc) != redacted:
+                raise LLMError(redacted) from exc.__cause__
             raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -254,13 +254,14 @@ class AnthropicAdapter:
         chain to. `_render_prompt` already hung the original failure on
         `__cause__` and `test_a_render_failure_keeps_the_original_error_as_the_cause`
         asserts on it; re-raising the same object carries that cause forward
-        untouched. The guard below has TWO replacement exits and they chain
-        differently, which is deliberate: the one that replaces an object whose
-        message could not be shown carries `from exc.__cause__`, re-attaching
-        the SAME cause the original held, so the assertion holds there too; the
-        one taken when the object's own `__str__` raised carries `from None`,
-        because an original nothing can read is not a cause worth rendering
-        underneath. Replacing the common-path `raise` with
+        untouched. The guard below has ONE replacement raise, and what it chains
+        to is decided inside the guard rather than at the raise: the original's
+        `__cause__` when that could be read and is an exception, and nothing
+        otherwise. So a replacement forced by an object whose message could not
+        be shown still re-attaches the SAME cause and the assertion holds there
+        too, while one forced by a `__str__` that raised chains to nothing --
+        an original nothing can read is not a cause worth rendering underneath.
+        Replacing the common-path `raise` with
         `raise LLMError(...) from exc` is the way to make that test fail: that
         buries the original behind a new wrapper.
         """
@@ -290,23 +291,34 @@ class AnthropicAdapter:
             # here would DEMOTE an `LLMOutputError` -- the mirror of the
             # promotion the primitive avoids, and the same #592 discriminator
             # either way.
+            #
+            # AND NO EXIT PATH READS THE OBJECT, which is the property rather
+            # than the list of attributes that have needed protecting so far.
+            # Everything touching `exc` is inside the one `try`, including the
+            # `__cause__` read, so a failure anywhere in it leaves as a clean
+            # replacement instead of as whatever the object threw.
             kind = LLMOutputError if isinstance(exc, LLMOutputError) else LLMError
+            redacted = "prompt render failed"
+            replacement = None
+            cause = None
             try:
                 redacted = redact_secret(str(exc), self.cfg.api_key)
-            except Exception:
-                raise kind("prompt render failed") from None
-            try:
                 exc.args = (redacted,)
                 notes = getattr(exc, "__notes__", None)
                 if notes:
                     exc.__notes__ = [
                         redact_secret(str(note), self.cfg.api_key) for note in notes
                     ]
-                settled = str(exc) == redacted
+                if str(exc) != redacted:
+                    replacement = kind(redacted)
+                    cause = exc.__cause__
+                    if not isinstance(cause, BaseException):
+                        cause = None
             except Exception:
-                settled = False
-            if not settled:
-                raise kind(redacted) from exc.__cause__
+                replacement = kind(redacted)
+                cause = None
+            if replacement is not None:
+                raise replacement from cause
             raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:

--- a/verinote/llm/anthropic_adapter.py
+++ b/verinote/llm/anthropic_adapter.py
@@ -250,12 +250,19 @@ class AnthropicAdapter:
         file -- so the fix is not "the render leaks", it is that these twelve
         stopped being redacted and are redacted again.
 
-        NO `from` CLAUSE, because there is nothing new to chain to.
-        `_render_prompt` already hung the original failure on `__cause__` and
-        `test_a_render_failure_keeps_the_original_error_as_the_cause` asserts on
-        it; re-raising the same object carries that cause forward untouched.
-        Replacing this with `raise LLMError(...) from exc` is the way to make
-        that test fail -- it would bury the original behind a new wrapper.
+        NO `from` CLAUSE ON THE COMMON PATH, because there is nothing new to
+        chain to. `_render_prompt` already hung the original failure on
+        `__cause__` and `test_a_render_failure_keeps_the_original_error_as_the_cause`
+        asserts on it; re-raising the same object carries that cause forward
+        untouched. The guard below has TWO replacement exits and they chain
+        differently, which is deliberate: the one that replaces an object whose
+        message could not be shown carries `from exc.__cause__`, re-attaching
+        the SAME cause the original held, so the assertion holds there too; the
+        one taken when the object's own `__str__` raised carries `from None`,
+        because an original nothing can read is not a cause worth rendering
+        underneath. Replacing the common-path `raise` with
+        `raise LLMError(...) from exc` is the way to make that test fail: that
+        buries the original behind a new wrapper.
         """
         try:
             return _render_prompt(self.cfg.root, prompt_id, **values)
@@ -278,15 +285,28 @@ class AnthropicAdapter:
             # class preservation is, and it is written for the same reason --
             # the two clauses have to arrive together or the day one grows a
             # subclass exit is the day the other leaks.
-            redacted = redact_secret(str(exc), self.cfg.api_key)
-            exc.args = (redacted,)
-            notes = getattr(exc, "__notes__", None)
-            if notes:
-                exc.__notes__ = [
-                    redact_secret(str(note), self.cfg.api_key) for note in notes
-                ]
-            if str(exc) != redacted:
-                raise LLMError(redacted) from exc.__cause__
+            # Same shape as `parsed_under_redaction`, including WHICH class the
+            # replacement carries. Raising a bare `LLMError` unconditionally
+            # here would DEMOTE an `LLMOutputError` -- the mirror of the
+            # promotion the primitive avoids, and the same #592 discriminator
+            # either way.
+            kind = LLMOutputError if isinstance(exc, LLMOutputError) else LLMError
+            try:
+                redacted = redact_secret(str(exc), self.cfg.api_key)
+            except Exception:
+                raise kind("prompt render failed") from None
+            try:
+                exc.args = (redacted,)
+                notes = getattr(exc, "__notes__", None)
+                if notes:
+                    exc.__notes__ = [
+                        redact_secret(str(note), self.cfg.api_key) for note in notes
+                    ]
+                settled = str(exc) == redacted
+            except Exception:
+                settled = False
+            if not settled:
+                raise kind(redacted) from exc.__cause__
             raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -151,24 +151,37 @@ def parsed_under_redaction(parse, payload, secret):
     made to, it does not leave this function; one of the same KIND carrying the
     redacted text does.
 
-    WHAT IT DOES NOT COVER, ENUMERATED RATHER THAN CLAIMED AWAY. The check reads
-    what `str(exc)` returns at the moment it runs, so it covers exactly what a
-    reader of `str(exc)` afterwards would see -- and no more. Four shapes are
-    outside it, each measured on this tree:
+    WHAT IT COVERS IS A CHANNEL AND AN INSTANT, not a list of shapes. It reads
+    `str(exc)` ONCE, immediately after mutating `args`, and compares it against
+    the text it wrote. So it covers exactly one rendering channel, sampled at
+    one moment. Everything outside that pair is outside the guard -- which is
+    the honest way to say it, because enumerating shapes is how the three
+    previous revisions each closed the case they had just been shown and left
+    the class open. The shapes below ILLUSTRATE the boundary; they do not
+    constitute it, and a shape nobody has thought of is outside it too if it
+    renders through another channel or changes after the sample.
 
-      1. a `__str__` whose value CHANGES after the check -- it can return the
-         redacted text once and the original afterwards, and the guard reads
-         once. "What the exception will show" is measured, not guaranteed.
-      2. `__repr__` -- a subclass rendering its own message there leaks through
-         `repr()`, which `args` never reaches.
-      3. a message the subclass also stored on an ordinary attribute; no general
-         mechanism reaches an arbitrary attribute.
-      4. `__cause__`, and this one needs no custom subclass at all. The chained
-         exception is never redacted, so a payload that makes a parser raise
-         `ValueError: could not convert string to float: '<key>'` puts the key
-         in `traceback.format_exception` above the redacted message. Measured
-         through the shipped `parse_facts`. It predates this guard and is not
-         narrowed by it.
+      ANOTHER CHANNEL. `args` feeds `str()`, and nothing else. A subclass
+      overriding `__format__` renders its own text through `f"{exc}"` --
+      68 such sites under `verinote/`, including `cli.py`'s four
+      `print(f"error: {exc}", file=sys.stderr)` -- and passes this guard
+      untouched, because `str(exc)` is clean and the original is re-raised.
+      That is the most reachable of these. `__repr__` is the same defect
+      through `repr()`, and is LESS reachable: zero `{exc!r}` sites exist.
+      An ordinary attribute is the same again, with no general mechanism able
+      to reach it.
+
+      ANOTHER INSTANT. A `__str__` whose value changes after the sample can
+      return the redacted text once and the original afterwards. "What the
+      exception will show" is measured here, not guaranteed.
+
+      AND `__cause__`, which needs no custom subclass at all: the chained
+      exception is never redacted, so a payload that makes a parser raise
+      `ValueError: could not convert string to float: '<key>'` puts the key in
+      `traceback.format_exception` above the redacted message. Measured through
+      the shipped `parse_facts`. It predates this guard and is not narrowed by
+      it -- the guard stops `__cause__` from ESCAPING unhandled, which is a
+      different property from redacting what it says.
 
     `__notes__` (PEP 678) IS covered -- redacted alongside `args` below, because
     it reaches `traceback.format_exception` and the rebuild used to drop it.
@@ -191,30 +204,46 @@ def parsed_under_redaction(parse, payload, secret):
         # `LLMError` into "the provider answered", which is the inverse of the
         # type destruction this function was changed to stop.
         kind = LLMOutputError if isinstance(exc, LLMOutputError) else LLMError
+        # THE CLOSED PROPERTY, stated once instead of enumerated shape by shape:
+        # NO EXIT PATH READS ANYTHING OFF THE CAUGHT OBJECT. Three revisions
+        # each fixed the last unprotected read and were shown a new one -- first
+        # `exc.args`, then `exc.__notes__`, then `exc.__cause__` on the guard's
+        # own replacement exit -- because the fix enumerated shapes instead of
+        # naming the property. Everything that touches `exc` is inside this
+        # `try`, INCLUDING the raises, so a failure anywhere in it leaves as a
+        # clean replacement rather than as whatever the object threw.
+        redacted = "provider output could not be read"
+        replacement = None
+        cause = None
         try:
             redacted = redact_secret(str(exc), secret)
-        except Exception:
-            # Its own `__str__` failed, so there is no text to redact and no way
-            # to know what it would print. `from None` suppresses the context so
-            # the unreadable original is not rendered underneath.
-            raise kind("provider output could not be read") from None
-        # EVERY MUTATING LINE IS INSIDE THE GUARD, because a guard placed after
-        # the lines it guards is skipped by a failure in them. Measured before
-        # this: a subclass whose `args` setter raises, or whose `__notes__` is a
-        # read-only property, took an `AttributeError` straight out of this
-        # function, past every `except LLMError` downstream -- carrying the key
-        # whenever the text that failed to be redacted still held it.
-        try:
             exc.args = (redacted,)
             notes = getattr(exc, "__notes__", None)
             if notes:
                 exc.__notes__ = [redact_secret(str(note), secret) for note in notes]
-            settled = str(exc) == redacted
+            if str(exc) != redacted:
+                # The object will not show what was redacted, so it will not
+                # leave; one of the same kind, carrying that text, will.
+                replacement = kind(redacted)
+                cause = exc.__cause__
+                if not isinstance(cause, BaseException):
+                    # `raise ... from` rejects a non-exception with a TypeError
+                    # that would escape this function entirely.
+                    cause = None
         except Exception:
-            settled = False
-        if not settled:
-            # The object will not show what was redacted, so it does not leave.
-            raise kind(redacted) from exc.__cause__
+            # Anything the object threw on the way: a setter that refused, a
+            # `__str__` or a `redact_secret` that raised, a `__cause__` property
+            # that raised. `except Exception` covers an `LLMError` raised from
+            # inside those reads too, which an `except LLMError: raise` arm
+            # would have let straight through.
+            replacement = kind(redacted)
+            cause = None
+        # NEITHER EXIT READS `exc`. `cause` was validated above, inside the
+        # guard; `replacement` was built there. That is the property, and it is
+        # what the three previous revisions kept re-establishing one attribute
+        # at a time.
+        if replacement is not None:
+            raise replacement from cause
         raise
 
 

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -102,8 +102,10 @@ def parsed_under_redaction(parse, payload, secret):
     exception in place and re-raising the SAME OBJECT fixes that while imposing
     nothing on the class: `exc.args = (redacted,)` reaches `str(exc)` because no
     `LLMError` here overrides `__str__`, and the class at any depth of
-    subclassing, every other attribute, and `__cause__` all survive because
-    nothing is constructed.
+    subclassing, every other attribute, and `__cause__` all survive because the
+    object is not rebuilt. On the paths where the guard below cannot vouch for
+    the object, a replacement IS constructed -- of the same kind, carrying only
+    the redacted text -- and that is the whole cost of the guard.
 
     RECONSTRUCTING WAS THE ALTERNATIVE AND IT WAS MEASURABLY WORSE. On a
     subclass of `LLMOutputError` taking a message AND a status code,
@@ -111,19 +113,28 @@ def parsed_under_redaction(parse, payload, secret):
     `TypeError` is not an `LLMError`, so every `except LLMError` downstream
     stops catching it -- while a subclass that did accept one argument crossed
     this line with its 429 silently replaced by its constructor default.
-    Relabelling has neither failure mode, so this function imposes no
-    constructor contract on `LLMError` subclasses.
+    Relabelling imposes no constructor contract on `LLMError` subclasses, which
+    is why this function needs no tripwire over them;
     `test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state` pins
-    that directly, on a subclass `__subclasses__()` could never have seen.
+    that directly, on a subclass `__subclasses__()` could never have seen. It is
+    not free of failure modes, though -- it has different ones, and the guard
+    below is what answers them.
 
-    BUT RELABELLING FAILS OPEN WHERE REBUILDING FAILED CLOSED, and that is what
-    the post-condition below is for. Rewriting `args` reaches `str(exc)` only
-    while `str` is `BaseException.__str__`. A subclass that defines `__str__` to
-    cache its message, or to decorate one, keeps returning the ORIGINAL text
-    after the rewrite -- measured: the key survives, in the one function whose
-    whole job is removing it. A decorating `__str__` also compounds, because the
+    RELABELLING FAILS OPEN WHERE REBUILDING FAILED CLOSED. Rewriting `args`
+    reaches `str(exc)` only while `str` is `BaseException.__str__`. A subclass
+    that defines `__str__` to CACHE its message keeps returning the ORIGINAL
+    text after the rewrite -- measured: the key survives, in the one function
+    whose whole job is removing it. A DECORATING `__str__` does not leak (its
+    decoration wraps the redacted text), but it compounds, because the
     already-decorated `str(exc)` is written back into `args[0]` on every pass.
-    The rebuild had neither problem because it never trusted the object.
+    And mutating the caught object can FAIL: a subclass whose `args` setter
+    raises, or whose `__notes__` is a read-only property, took an
+    `AttributeError` out of this function, past every `except LLMError`
+    downstream. Measured separately, because the two do not leak alike: the
+    `args` shape leaks the key every time, since the redaction never lands; the
+    `__notes__` shape leaks only when the note itself carries it, which is the
+    case the note redaction exists for. Both escape as a foreign exception. The
+    rebuild had none of these because it never touched the object.
 
     SO THE INVARIANT IS ENFORCED, NOT ASSUMED. An earlier revision guarded it
     with a static sweep over class definitions under `verinote/`; that sweep had
@@ -133,21 +144,34 @@ def parsed_under_redaction(parse, payload, secret):
     never include a subclass defined outside this package. A source sweep is the
     right instrument for a CONVENTION, which is what #438's producer-side check
     is. This is a CONFIDENTIALITY INVARIANT, so it is checked at the site, at
-    runtime, against the object actually being raised. If the redacted text is
-    not what the exception will show, the exception does not leave this function
-    -- a fresh `LLMOutputError` carrying the redacted text does. That costs the
-    subclass identity in exactly the case the sweep used to forbid outright, so
-    it costs nothing on the shipped tree, and it holds for shapes nobody has
-    enumerated.
+    runtime, against the object actually being raised, and EVERY MUTATING LINE
+    IS INSIDE THE GUARD -- a guard placed after the lines it guards is skipped
+    by a failure in them, which is how the `args`-setter and `__notes__` shapes
+    escaped before. If the object will not show the redacted text, or cannot be
+    made to, it does not leave this function; one of the same KIND carrying the
+    redacted text does.
 
-    WHAT IT DOES NOT COVER, measured rather than assumed. `__notes__` (PEP 678)
-    is redacted alongside `args` below, because it reaches
-    `traceback.format_exception` and the rebuild used to drop it. A message the
-    subclass also stored on an ordinary attribute survives, and no general
-    mechanism can reach that -- it is latent rather than live (nothing reads such
-    an attribute here, and the only shipped subclass has none), and it is the
-    reason the class docstring, not this function, is where a new subclass has to
-    be thought about.
+    WHAT IT DOES NOT COVER, ENUMERATED RATHER THAN CLAIMED AWAY. The check reads
+    what `str(exc)` returns at the moment it runs, so it covers exactly what a
+    reader of `str(exc)` afterwards would see -- and no more. Four shapes are
+    outside it, each measured on this tree:
+
+      1. a `__str__` whose value CHANGES after the check -- it can return the
+         redacted text once and the original afterwards, and the guard reads
+         once. "What the exception will show" is measured, not guaranteed.
+      2. `__repr__` -- a subclass rendering its own message there leaks through
+         `repr()`, which `args` never reaches.
+      3. a message the subclass also stored on an ordinary attribute; no general
+         mechanism reaches an arbitrary attribute.
+      4. `__cause__`, and this one needs no custom subclass at all. The chained
+         exception is never redacted, so a payload that makes a parser raise
+         `ValueError: could not convert string to float: '<key>'` puts the key
+         in `traceback.format_exception` above the redacted message. Measured
+         through the shipped `parse_facts`. It predates this guard and is not
+         narrowed by it.
+
+    `__notes__` (PEP 678) IS covered -- redacted alongside `args` below, because
+    it reaches `traceback.format_exception` and the rebuild used to drop it.
 
     `__cause__` IS INHERITED RATHER THAN SET. Every parser raises `... from exc`
     with the `json`/`Key`/`Type` error underneath, so re-raising the same object
@@ -160,14 +184,37 @@ def parsed_under_redaction(parse, payload, secret):
     try:
         return parse(payload)
     except LLMError as exc:
-        redacted = redact_secret(str(exc), secret)
-        exc.args = (redacted,)
-        notes = getattr(exc, "__notes__", None)
-        if notes:
-            exc.__notes__ = [redact_secret(str(note), secret) for note in notes]
-        if str(exc) != redacted:
+        # THE REPLACEMENT KEEPS THE KIND. `LLMOutputError` is #592's
+        # discriminator -- `output_unusable = isinstance(exc, LLMOutputError)`
+        # decides whether the question row records `translation_failed` or is
+        # suppressed -- so raising it unconditionally would PROMOTE a bare
+        # `LLMError` into "the provider answered", which is the inverse of the
+        # type destruction this function was changed to stop.
+        kind = LLMOutputError if isinstance(exc, LLMOutputError) else LLMError
+        try:
+            redacted = redact_secret(str(exc), secret)
+        except Exception:
+            # Its own `__str__` failed, so there is no text to redact and no way
+            # to know what it would print. `from None` suppresses the context so
+            # the unreadable original is not rendered underneath.
+            raise kind("provider output could not be read") from None
+        # EVERY MUTATING LINE IS INSIDE THE GUARD, because a guard placed after
+        # the lines it guards is skipped by a failure in them. Measured before
+        # this: a subclass whose `args` setter raises, or whose `__notes__` is a
+        # read-only property, took an `AttributeError` straight out of this
+        # function, past every `except LLMError` downstream -- carrying the key
+        # whenever the text that failed to be redacted still held it.
+        try:
+            exc.args = (redacted,)
+            notes = getattr(exc, "__notes__", None)
+            if notes:
+                exc.__notes__ = [redact_secret(str(note), secret) for note in notes]
+            settled = str(exc) == redacted
+        except Exception:
+            settled = False
+        if not settled:
             # The object will not show what was redacted, so it does not leave.
-            raise LLMOutputError(redacted) from exc.__cause__
+            raise kind(redacted) from exc.__cause__
         raise
 
 

--- a/verinote/llm/base.py
+++ b/verinote/llm/base.py
@@ -31,11 +31,14 @@ class LLMOutputError(LLMError):
     first. #592 records the second on the question row and only reports the
     first, and this class is what lets one `except LLMError` tell them apart.
 
-    THE DISCRIMINATOR IS WHETHER A RESPONSE ARRIVED, not whether it parsed. A
-    payload with no tool_use block, or a CLI payload that cannot be decoded, is
-    output that arrived and could not be used -- the provider was reached and
-    misbehaved, which is the one signal a user has that their provider is broken
-    rather than unconfigured.
+    THE DISCRIMINATOR IS WHETHER THE PROVIDER PRODUCED OUTPUT FOR THIS QUESTION,
+    not whether it was reachable and not whether the output parsed. A payload
+    with no tool_use block, or a CLI payload that cannot be decoded, is output
+    that arrived and could not be used. An HTTP 429 or 500 reaches the provider
+    and gets an answer of a kind, but not an answer to the question -- measured,
+    those are classified the other way, and "was it reached" would predict the
+    opposite. The signal a user gets is that their provider is broken rather
+    than unconfigured.
     """
 
 
@@ -109,9 +112,42 @@ def parsed_under_redaction(parse, payload, secret):
     stops catching it -- while a subclass that did accept one argument crossed
     this line with its 429 silently replaced by its constructor default.
     Relabelling has neither failure mode, so this function imposes no
-    constructor contract on `LLMError` subclasses and needs no tripwire over
-    them. `test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state`
-    pins that directly, on a subclass `__subclasses__()` could never have seen.
+    constructor contract on `LLMError` subclasses.
+    `test_parsed_under_redaction_preserves_a_deep_subclass_and_its_state` pins
+    that directly, on a subclass `__subclasses__()` could never have seen.
+
+    BUT RELABELLING FAILS OPEN WHERE REBUILDING FAILED CLOSED, and that is what
+    the post-condition below is for. Rewriting `args` reaches `str(exc)` only
+    while `str` is `BaseException.__str__`. A subclass that defines `__str__` to
+    cache its message, or to decorate one, keeps returning the ORIGINAL text
+    after the rewrite -- measured: the key survives, in the one function whose
+    whole job is removing it. A decorating `__str__` also compounds, because the
+    already-decorated `str(exc)` is written back into `args[0]` on every pass.
+    The rebuild had neither problem because it never trusted the object.
+
+    SO THE INVARIANT IS ENFORCED, NOT ASSUMED. An earlier revision guarded it
+    with a static sweep over class definitions under `verinote/`; that sweep had
+    measured blind spots it could not bound -- a base named through an import
+    alias, a class built by `type()`, `__str__` assigned after the class body, a
+    `__str__` nested inside an `if` in the class body -- and its scope could
+    never include a subclass defined outside this package. A source sweep is the
+    right instrument for a CONVENTION, which is what #438's producer-side check
+    is. This is a CONFIDENTIALITY INVARIANT, so it is checked at the site, at
+    runtime, against the object actually being raised. If the redacted text is
+    not what the exception will show, the exception does not leave this function
+    -- a fresh `LLMOutputError` carrying the redacted text does. That costs the
+    subclass identity in exactly the case the sweep used to forbid outright, so
+    it costs nothing on the shipped tree, and it holds for shapes nobody has
+    enumerated.
+
+    WHAT IT DOES NOT COVER, measured rather than assumed. `__notes__` (PEP 678)
+    is redacted alongside `args` below, because it reaches
+    `traceback.format_exception` and the rebuild used to drop it. A message the
+    subclass also stored on an ordinary attribute survives, and no general
+    mechanism can reach that -- it is latent rather than live (nothing reads such
+    an attribute here, and the only shipped subclass has none), and it is the
+    reason the class docstring, not this function, is where a new subclass has to
+    be thought about.
 
     `__cause__` IS INHERITED RATHER THAN SET. Every parser raises `... from exc`
     with the `json`/`Key`/`Type` error underneath, so re-raising the same object
@@ -124,7 +160,14 @@ def parsed_under_redaction(parse, payload, secret):
     try:
         return parse(payload)
     except LLMError as exc:
-        exc.args = (redact_secret(str(exc), secret),)
+        redacted = redact_secret(str(exc), secret)
+        exc.args = (redacted,)
+        notes = getattr(exc, "__notes__", None)
+        if notes:
+            exc.__notes__ = [redact_secret(str(note), secret) for note in notes]
+        if str(exc) != redacted:
+            # The object will not show what was redacted, so it does not leave.
+            raise LLMOutputError(redacted) from exc.__cause__
         raise
 
 

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -269,7 +269,24 @@ class OpenAIAdapter:
             # `LLMError` is the only class that can arrive. It is written this
             # way anyway, because the day `_render_prompt` grows a subclass exit
             # the alternative swallows it with no test red anywhere.
-            exc.args = (redact_secret(str(exc), self.cfg.api_key),)
+            #
+            # AND THE POST-CONDITION COMES WITH IT. Relabelling reaches
+            # `str(exc)` only while `str` is `BaseException.__str__`, so the
+            # same fail-open `parsed_under_redaction` guards exists here: a
+            # subclass caching or decorating its message would keep showing the
+            # unredacted text. This copy is a no-op for the same reason the
+            # class preservation is, and it is written for the same reason --
+            # the two clauses have to arrive together or the day one grows a
+            # subclass exit is the day the other leaks.
+            redacted = redact_secret(str(exc), self.cfg.api_key)
+            exc.args = (redacted,)
+            notes = getattr(exc, "__notes__", None)
+            if notes:
+                exc.__notes__ = [
+                    redact_secret(str(note), self.cfg.api_key) for note in notes
+                ]
+            if str(exc) != redacted:
+                raise LLMError(redacted) from exc.__cause__
             raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -7,6 +7,7 @@ from verinote.config import Config
 from verinote.llm.base import (
     ExtractedFact,
     LLMError,
+    LLMOutputError,
     parsed_under_redaction,
     redact_secret,
 )
@@ -250,12 +251,19 @@ class OpenAIAdapter:
         file -- so the fix is not "the render leaks", it is that these twelve
         stopped being redacted and are redacted again.
 
-        NO `from` CLAUSE, because there is nothing new to chain to.
-        `_render_prompt` already hung the original failure on `__cause__` and
-        `test_a_render_failure_keeps_the_original_error_as_the_cause` asserts on
-        it; re-raising the same object carries that cause forward untouched.
-        Replacing this with `raise LLMError(...) from exc` is the way to make
-        that test fail -- it would bury the original behind a new wrapper.
+        NO `from` CLAUSE ON THE COMMON PATH, because there is nothing new to
+        chain to. `_render_prompt` already hung the original failure on
+        `__cause__` and `test_a_render_failure_keeps_the_original_error_as_the_cause`
+        asserts on it; re-raising the same object carries that cause forward
+        untouched. The guard below has TWO replacement exits and they chain
+        differently, which is deliberate: the one that replaces an object whose
+        message could not be shown carries `from exc.__cause__`, re-attaching
+        the SAME cause the original held, so the assertion holds there too; the
+        one taken when the object's own `__str__` raised carries `from None`,
+        because an original nothing can read is not a cause worth rendering
+        underneath. Replacing the common-path `raise` with
+        `raise LLMError(...) from exc` is the way to make that test fail: that
+        buries the original behind a new wrapper.
         """
         try:
             return _render_prompt(self.cfg.root, prompt_id, **values)
@@ -278,15 +286,28 @@ class OpenAIAdapter:
             # class preservation is, and it is written for the same reason --
             # the two clauses have to arrive together or the day one grows a
             # subclass exit is the day the other leaks.
-            redacted = redact_secret(str(exc), self.cfg.api_key)
-            exc.args = (redacted,)
-            notes = getattr(exc, "__notes__", None)
-            if notes:
-                exc.__notes__ = [
-                    redact_secret(str(note), self.cfg.api_key) for note in notes
-                ]
-            if str(exc) != redacted:
-                raise LLMError(redacted) from exc.__cause__
+            # Same shape as `parsed_under_redaction`, including WHICH class the
+            # replacement carries. Raising a bare `LLMError` unconditionally
+            # here would DEMOTE an `LLMOutputError` -- the mirror of the
+            # promotion the primitive avoids, and the same #592 discriminator
+            # either way.
+            kind = LLMOutputError if isinstance(exc, LLMOutputError) else LLMError
+            try:
+                redacted = redact_secret(str(exc), self.cfg.api_key)
+            except Exception:
+                raise kind("prompt render failed") from None
+            try:
+                exc.args = (redacted,)
+                notes = getattr(exc, "__notes__", None)
+                if notes:
+                    exc.__notes__ = [
+                        redact_secret(str(note), self.cfg.api_key) for note in notes
+                    ]
+                settled = str(exc) == redacted
+            except Exception:
+                settled = False
+            if not settled:
+                raise kind(redacted) from exc.__cause__
             raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:

--- a/verinote/llm/openai_adapter.py
+++ b/verinote/llm/openai_adapter.py
@@ -255,13 +255,14 @@ class OpenAIAdapter:
         chain to. `_render_prompt` already hung the original failure on
         `__cause__` and `test_a_render_failure_keeps_the_original_error_as_the_cause`
         asserts on it; re-raising the same object carries that cause forward
-        untouched. The guard below has TWO replacement exits and they chain
-        differently, which is deliberate: the one that replaces an object whose
-        message could not be shown carries `from exc.__cause__`, re-attaching
-        the SAME cause the original held, so the assertion holds there too; the
-        one taken when the object's own `__str__` raised carries `from None`,
-        because an original nothing can read is not a cause worth rendering
-        underneath. Replacing the common-path `raise` with
+        untouched. The guard below has ONE replacement raise, and what it chains
+        to is decided inside the guard rather than at the raise: the original's
+        `__cause__` when that could be read and is an exception, and nothing
+        otherwise. So a replacement forced by an object whose message could not
+        be shown still re-attaches the SAME cause and the assertion holds there
+        too, while one forced by a `__str__` that raised chains to nothing --
+        an original nothing can read is not a cause worth rendering underneath.
+        Replacing the common-path `raise` with
         `raise LLMError(...) from exc` is the way to make that test fail: that
         buries the original behind a new wrapper.
         """
@@ -291,23 +292,34 @@ class OpenAIAdapter:
             # here would DEMOTE an `LLMOutputError` -- the mirror of the
             # promotion the primitive avoids, and the same #592 discriminator
             # either way.
+            #
+            # AND NO EXIT PATH READS THE OBJECT, which is the property rather
+            # than the list of attributes that have needed protecting so far.
+            # Everything touching `exc` is inside the one `try`, including the
+            # `__cause__` read, so a failure anywhere in it leaves as a clean
+            # replacement instead of as whatever the object threw.
             kind = LLMOutputError if isinstance(exc, LLMOutputError) else LLMError
+            redacted = "prompt render failed"
+            replacement = None
+            cause = None
             try:
                 redacted = redact_secret(str(exc), self.cfg.api_key)
-            except Exception:
-                raise kind("prompt render failed") from None
-            try:
                 exc.args = (redacted,)
                 notes = getattr(exc, "__notes__", None)
                 if notes:
                     exc.__notes__ = [
                         redact_secret(str(note), self.cfg.api_key) for note in notes
                     ]
-                settled = str(exc) == redacted
+                if str(exc) != redacted:
+                    replacement = kind(redacted)
+                    cause = exc.__cause__
+                    if not isinstance(cause, BaseException):
+                        cause = None
             except Exception:
-                settled = False
-            if not settled:
-                raise kind(redacted) from exc.__cause__
+                replacement = kind(redacted)
+                cause = None
+            if replacement is not None:
+                raise replacement from cause
             raise
 
     def extract_facts(self, *, source_text: str, schema_hint: str = "") -> list[ExtractedFact]:

--- a/verinote/pipeline/query.py
+++ b/verinote/pipeline/query.py
@@ -463,7 +463,11 @@ def _reinterpret_empty_plan(
             f"unavailable: llm error: {exc}"
         )
         # #592. THE THIRD `except LLMError` EXIT, and it shipped without this
-        # line for two revisions. `output_unusable` defaults to False, so
+        # line for THREE revisions -- counted per tag rather than remembered,
+        # by AST over the `_QueryFlowResult` constructions in this file rather
+        # than by grep, since a comment saying so would count itself: four
+        # constructions carry the keyword at revisions 1, 2 and 3, five from
+        # revision 4 on. `output_unusable` defaults to False, so
         # omitting it made `provider_failed and not output_unusable` true here
         # for every failure, and both consumers read that as an infrastructure
         # fault: an answer that ARRIVED off-schema was suppressed at the one
@@ -782,8 +786,12 @@ def translate_questions(
         # suppressed the policy-file case here and left the credential case
         # writing, which made this one line behave two opposite ways depending
         # on which infrastructure fault occurred. #592 settles it for all of
-        # them, and the rule is read off `question_outcome.py::_STATUS_META`
-        # rather than chosen: `translation_failed` is defined there as "The
+        # them, and the rule is ANCHORED IN `question_outcome.py::_STATUS_META`
+        # rather than chosen -- anchored rather than READ OFF, because that
+        # string is the display FALLBACK `question_outcome_view` renders only
+        # for a row carrying no reason, which is the wording
+        # tests/test_query_schema_policy_guard.py already carries and this copy
+        # did not. `translation_failed` is defined there as "The
         # provider output could not be used" -- a claim about the provider's
         # OUTPUT. When the provider was never reached, or translation was never
         # attempted because a policy file could not be read, there is no output


### PR DESCRIPTION
Closes #603. Closes #604.

두 결함 모두 #592 (`c9b6836`) 가 도입했고, 그 이슈의 게이트 라운드가 병합 전에
측정해 두었다.

## #603 — 리댁션 프리미티브가 fail-open 이다

`parsed_under_redaction` 이 재구성에서 재라벨로 바뀌면서, 메시지를 캐시하거나
`__str__` 을 오버라이드하는 서브클래스에서 API 키가 사용자에게 도달했다.
`main` 은 #592 이전에 새지 않았다.

소스 스윕(사각지대 최소 6개) 대신 **지점에서의 런타임 사후조건**으로 강제한다.
형태별 측정, 병합된 `main` 대 이 브랜치:

| 형태 | `main` | 이 PR |
|---|---|---|
| 캐싱 `__str__` | `str` 과 traceback 양쪽 유출 | 닫힘 |
| 데코레이팅 `__str__` | 접두 중복 | 단일 접두 |
| `__notes__` | traceback 으로 유출 | 닫힘 |
| 속성 보유 메시지 | 유출 | **여전히 유출 — 독스트링에 미커버 명시** |

## #604 — `verinote query` 가 `pending` 행 위에 `N failed` 를 출력한다

#592 는 `for_review` 를 고치고 **바로 옆 `failures` 를 남겼다.** 네 카운트를
열거하면: `translated` 공허하게 제외, `not_translated` 는 그 dict 들 자체,
`for_review` 제외, **`failures` 하지 않음.**

귀속을 나눈다 — 정책 모집단의 거짓은 #591 유산이고 이 PR 이 고치는 것이 아니며,
자격 증명·미지 프로바이더·도달 불가 모집단이 #592 가 만든 참→거짓 전이다.

거짓 문장 여섯도 함께 고친다. 그중 `llm/base.py` 는 #592 의 delta 밖에 있어
diff 기준 스윕으로는 보이지 않았다 — 주제 기준으로 훑었다.

## 측정

- **3558 passed, 12 skipped, 0 failed** · `uvx ruff@0.15.18` clean
- **33행 변이 행렬** — 전 행 합계 3558, `NameError` 0, 무판정 행 0, **0-red 행 0**
- #603 을 고정하는 행: `P1`(사후조건 삭제) 1, `P2`(`__notes__` 리댁션 삭제) 1,
  `G3`(재라벨→재구성) 5 중 배타 3 — #603 테스트 둘 포함
- #604: `F1` 3, `N1` 1, `N2`(rc) 7

`_rendered` 두 사본도 같은 절을 받되 오늘 도달 불가이므로 **행렬 행을 주지 않고
unpinned-because-unreachable 로 보고한다** — 0 으로 읽히는 행은 측정되지 않은
커버리지를 함의한다.

## `git log` 에 남은 것

#592 는 rebase-merge 되어 커밋 4개가 그대로 올라갔고, 그 메시지들에 게이트가
반증한 주장이 남아 있다 — `FOUR WRITERS` ×2, `only path returning` ×1,
`Every count in that summary is about ROWS` ×1, `C2 by 47` ×1. 병합된 히스토리를
다시 쓰는 것이 로그의 틀린 문장보다 나쁘므로 되돌리지 않고, 여기서 이름을 부른다.
트리 쪽 세 건(`only path returning`, `read off question_outcome`,
`for two revisions`)은 이 PR 이 고친다.
